### PR TITLE
Default to empty object when vertices has no property

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/mappers/parsePropertiesValues.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/parsePropertiesValues.ts
@@ -5,7 +5,7 @@ const parsePropertiesValues = (
   properties: Record<string, GVertexProperty[]>
 ): Record<string, string | number> => {
   const parsedProps: Record<string, string | number> = {};
-  Object.values(properties).forEach(propertyArr => {
+  Object.values(properties || {}).forEach(propertyArr => {
     parsedProps[propertyArr[0]["@value"].label] = parseProperty(propertyArr[0]);
   });
 


### PR DESCRIPTION
*Description of changes:* 
If graph vertices has no property then the parsing fails. With this fix, we are defaulting to empty object if no properties are present. [Similar code](https://github.com/aws/graph-explorer/blob/637d26b21f99e387bee3ab8b3a1e193b91d89202/packages/graph-explorer/src/connector/gremlin/mappers/parseEdgePropertiesValues.ts#L8) is already present for parsing edge property values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
