### PR TITLE
Update README - connector caching mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ If either of the Graph Explorer or the proxy-server are served over an HTTPS con
 
 Note: To get rid of the “Not Secure” warning, see [Using self-signed certificates on Chrome](./additionaldocs/development.md#using-self-signed-certificates-on-chrome).
 
+### Connection Cache
+Setting up a new connection (or editing an existing connection) allows you to set two cache parameters.
+- The default cache store is configured to use the browser's IndexedDB which allows you to make use of data stored between sessions. However, it is possible to set the `memory` mode so that the cache lasts at most as long as the page is loaded.
+- The time that the data stored in the cache is also configurable, by default it has a lifetime of 10 minutes. In case you want to disable the cache, you can set this time to 0 milliseconds.
+
+The purpose of the cache is to avoid making multiple requests to the database with the same criteria. Therefore, a request with particular parameters will be cached at most the time set just with the response obtained.
+After that time, if the exact same request is made again, the response will be updated and stored again.
+
 ## Authentication
 
 Authentication for Amazon Neptune connections is enabled using the [SigV4 signing protocol](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).


### PR DESCRIPTION
*Issue 88*

*Description of changes:*

- Document connector caching mechanism. This PR depends on Blank Nodes opened PR (https://github.com/aws/graph-explorer/pull/32) which contains an undocumented caching mechanism.
