### PR TITLE
Add SageMaker support

### DIFF
--- a/.Dockerfile.sagemaker
+++ b/.Dockerfile.sagemaker
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+FROM amazonlinux:2
+ARG host
+WORKDIR /
+COPY . /graph-explorer/
+WORKDIR /graph-explorer
+RUN yum install -y curl
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
+RUN yum install -y nodejs
+RUN yum install -y openssl
+RUN npm install -g pnpm
+RUN pnpm install
+WORKDIR /graph-explorer/packages/graph-explorer-proxy-server/cert-info/
+### BEGIN CERT CREATION (The below portion is used to create the self-signed cert so that the workbench and proxy can communicate over https.)
+RUN sed -i "21s/$/ $host:*/" csr.conf
+RUN sed -i "8s/$/ $host:*/" cert.conf
+RUN openssl req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=Amazon Neptune/C=US/L=Seattle" -keyout rootCA.key -out rootCA.crt
+RUN openssl genrsa -out ./server.key 2048
+RUN openssl req -new -key ./server.key -out ./server.csr -config ./csr.conf
+RUN openssl x509 -req -in ./server.csr -CA ./rootCA.crt -CAkey ./rootCA.key -CAcreateserial -out ./server.crt -days 365 -sha256 -extfile ./cert.conf
+### END CERT CREATION
+WORKDIR /graph-explorer/
+ENV HOME=/graph-explorer
+RUN pnpm build
+RUN npm install serve -g
+EXPOSE 5173
+EXPOSE 8182
+CMD ["pnpm", "docker-run-build"]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "pnpm -F graph-explorer start",
     "build": "pnpm -F graph-explorer build",
     "start:proxy-server": "pnpm -F graph-explorer-proxy-server start",
-    "dev": "concurrently \"pnpm start:proxy-server\" \"pnpm start\""
+    "dev": "concurrently \"pnpm start:proxy-server\" \"pnpm start\"",
+    "docker-run-build": "concurrently \"pnpm start:proxy-server\" \"serve -p 5173 ./packages/graph-explorer/dist\""
   },
   "author": "amazon",
   "license": "Apache-2.0",

--- a/packages/graph-explorer/index.html
+++ b/packages/graph-explorer/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/favicon-16x16.png">
-    <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#FFFFFF">
+    <link rel="mask-icon" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/safari-pinned-tab.svg" color="#FFFFFF">
     <meta name="theme-color" content="#ffffff">
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
To run in SageMaker set `GRAPH_EXP_ENV_ROOT_FOLDER=/proxy/5173` inside of the .env file in the graph-explorer folder and run `docker build -f .Dockerfile.sagemaker --build-arg host={hostname-or-ip-address} -t graph-explorer .` and progress as normal from there.
