### PR TITLE
Moving self-signed SSL cert creation to docker entrypoint script.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ This release includes the following feature enhancements and bug fixes:
 * Support for blank nodes when visualizing graphs using the RDF data model (https://github.com/aws/graph-explorer/pull/48)
 * Enable Caching feature in the Connections UI which allows you to temporarily store data in the browser between sessions (https://github.com/aws/graph-explorer/pull/48)
 * Simplify the setup by consolidating the build and serving the graph-explorer through port (https://github.com/aws/graph-explorer/pull/52)
+* Moved self-signed SSL certificate creation to Docker entrypoint script (https://github.com/aws/graph-explorer/pull/56)
 
 **Bug fixes**
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1
 FROM amazonlinux:2
-ARG host
 WORKDIR /
 COPY . /graph-explorer/
 WORKDIR /graph-explorer
@@ -10,18 +9,10 @@ RUN yum install -y nodejs
 RUN yum install -y openssl
 RUN npm install -g pnpm
 RUN pnpm install
-WORKDIR /graph-explorer/packages/graph-explorer-proxy-server/cert-info/
-### BEGIN CERT CREATION (The below portion is used to create the self-signed cert so that the workbench and proxy can communicate over https.)
-RUN sed -i "21s/$/ $host:*/" csr.conf
-RUN sed -i "8s/$/ $host:*/" cert.conf
-RUN openssl req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=Amazon Neptune/C=US/L=Seattle" -keyout rootCA.key -out rootCA.crt
-RUN openssl genrsa -out ./server.key 2048
-RUN openssl req -new -key ./server.key -out ./server.csr -config ./csr.conf
-RUN openssl x509 -req -in ./server.csr -CA ./rootCA.crt -CAkey ./rootCA.key -CAcreateserial -out ./server.crt -days 365 -sha256 -extfile ./cert.conf
-### END CERT CREATION
 WORKDIR /graph-explorer/
 ENV HOME=/graph-explorer
 RUN pnpm build
 EXPOSE 443
 EXPOSE 80
-CMD ["pnpm", "start:proxy-server"]
+RUN chmod a+x ./docker-entrypoint.sh
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ There are many ways to deploy the Graph Explorer application. The following inst
 ### Steps to install Graph Explorer:
 
 1. To download the source project, run `git clone https://github.com/aws/graph-explorer/`. Navigate to the newly created `graph-explorer` directory.
-2. To build the image, run `docker build --build-arg host={hostname-or-ip-address} -t graph-explorer .` from the root directory. If you receive an error relating to the docker service not running, run `service docker start`.
-3. Run `docker run -p 80:80 -p 443:443 graph-explorer` to run the docker container.
+2. To build the image, run `docker build -t graph-explorer .` from the root directory. If you receive an error relating to the docker service not running, run `service docker start`.
+3. Run `docker run -p 80:80 -p 443:443 --env HOST={hostname-or-ip-address} graph-explorer` to run the docker container.
 4. Now, open a browser and type in the public URL of your EC2 instance accessing the explorer endpoint (e.g., `https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer`). You will receive a warning as the SSL certificate used is self-signed.
 5. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](#https-connections) section.
 6. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI. See below description on Connections UI to configure your first connection to Amazon Neptune.
+
+### Troubleshooting
+
+1. If the container does not start, or immediately stops, use `docker logs graph-explorer` to check the container console logs for any related error messages that might provide guidance on why graph-explorer did not start.
+2. If you are having issues connecting graph-explorer to your graph database, use your browser's Developer Tools feature to monitor both the browser console and network calls to determine if here are any errors related to connectivity.
 
 ## Features
 

--- a/additionaldocs/development.md
+++ b/additionaldocs/development.md
@@ -32,8 +32,8 @@ You can find a template for the following environment variables at `/packages/gr
 
 ### Using self-signed certificates with Docker
 
-- Self-signed certificates will use the hostname provided in the Docker build command, so unless you have specific requirements, there are no extra steps here besides providing the hostname.
-- If you would like to modify the certificate files, be aware that the Dockerfile is making automatic modifications on line 15 and 16, so you will need to remove these lines. 
+- Self-signed certificates will use the hostname provided in the `docker run` command, so unless you have specific requirements, there are no extra steps here besides providing the hostname.
+- If you would like to modify the certificate files, be aware that the Dockerfile will make automatic modifications on run, in lines 8 and 9 of the [entrypoint script](https://github.com/aws/graph-explorer/blob/main/docker-entrypoint.sh), so you will need to remove these lines.
 - If you only serve one of either the proxy server or Graph Explorer UI over an HTTPS connection and wish to download from the browser, you should navigate to the one served over HTTPS to download the certificate.
 - The other certificate files can also be found at /packages/graph-explorer-proxy-server/cert-info/ on the Docker container that is created. 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+if [ $(grep -e 'GRAPH_EXP_HTTPS_CONNECTION' ./packages/graph-explorer/.env | cut -d "=" -f 2) ]; then
+
+    if [ $HOST ]; then
+        echo "Generating new self-signed SSL cert using $HOST..."
+        cd /graph-explorer/packages/graph-explorer-proxy-server/cert-info/
+        sed -i "21s/$/ $HOST:*/" csr.conf
+        sed -i "8s/$/ $HOST:*/" cert.conf
+        openssl req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=Amazon Neptune/C=US/L=Seattle" -keyout rootCA.key -out rootCA.crt
+        openssl genrsa -out ./server.key 2048
+        openssl req -new -key ./server.key -out ./server.csr -config ./csr.conf
+        openssl x509 -req -in ./server.csr -CA ./rootCA.crt -CAkey ./rootCA.key -CAcreateserial -out ./server.crt -days 365 -sha256 -extfile ./cert.conf
+else
+        echo "No HOST environment variable specified."
+        if [ -f "./rootCA.key" ] && [ -f "./rootCA.crt" ] && [ -f "./rootCA.crt" ] && [ -f "./server.csr"] && [ -f "./server.crt"]; then
+            echo "Found existing self-signed SSL certificate. Re-using existing cert."
+    else
+            echo "No existing self-signed SSL certificate found. Please specify --env HOST=<hostname> during docker run command to create SSL cert."
+            exit 1
+        fi
+    fi
+
+else
+    echo "SSL disabled. Skipping self-signed certificate generation."
+    exit 1
+fi
+echo "Starting graph explorer..."
+pnpm -w start:proxy-server


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Removed self-signed SSL cert creation from Dockerfile and created a new entrypoint script for certs to be created when the container is launched.  This removes the need for a user to build a new container image for each deployment and allows them to set the hostname used by the SSL cert upon launching the container using a `HOST` environment variable.

Updated README.md to include the updated steps for container image build and launching a new container.  Also added a new Troubleshooting section to address common issues seen by users attempting to launch graph-explorer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.