### PR TITLE
Use the Summary API to improve the schema synchronization performance

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -32,7 +32,7 @@ const getCredentials = async () => {
 };
 
 dotenv.config({ path: "../graph-explorer/.env" });
-  
+
 (async () => {
   let creds = await getCredentials();
   let requestSig;
@@ -64,23 +64,23 @@ dotenv.config({ path: "../graph-explorer/.env" });
     await getAuthHeaders(language, req, reqObjects[0], reqObjects[2]);
 
     return new Promise((resolve, reject) => {
-        
+
       const wrapper = (n) => {
         fetch(url, { headers: req.headers, })
           .then(async res => {
 
             if (!res.ok) {
-	            console.log("Response not ok");
+              console.log("Response not ok");
               const error = res.status
               return Promise.reject(error);
             } else {
-	            console.log("Response ok");
+              console.log("Response ok");
               resolve(res);
             }
           })
           .catch(async (err) => {
             console.log("Attempt Credential Refresh");
-	          creds = await getCredentials();
+            creds = await getCredentials();
             if (creds === undefined) {
               reject("Credentials undefined after credential refresh. Check that you have proper acccess")
             }
@@ -119,7 +119,7 @@ dotenv.config({ path: "../graph-explorer/.env" });
   }
 
   async function getAuthHeaders(language, req, endpoint_url, requestSig) {
-    let authHeaders 
+    let authHeaders
     if (language == "sparql") {
       authHeaders = await requestSig.requestAuthHeaders(
         endpoint_url.port,
@@ -147,9 +147,9 @@ dotenv.config({ path: "../graph-explorer/.env" });
     let data;
     try {
       response = await retryFetch(`${req.headers["graph-db-connection-url"]}/sparql?query=` +
-      encodeURIComponent(req.query.query) +
-      "&format=json", undefined, undefined, req, "sparql").then((res) => res)
-      
+        encodeURIComponent(req.query.query) +
+        "&format=json", undefined, undefined, req, "sparql").then((res) => res)
+
       data = await response.json();
       res.send(data);
     } catch (error) {
@@ -163,7 +163,35 @@ dotenv.config({ path: "../graph-explorer/.env" });
     let data;
     try {
       response = await retryFetch(`${req.headers["graph-db-connection-url"]}/?gremlin=` +
-      encodeURIComponent(req.query.gremlin), undefined, undefined, req, "gremlin").then((res) => res)
+        encodeURIComponent(req.query.gremlin), undefined, undefined, req, "gremlin").then((res) => res)
+
+      data = await response.json();
+      res.send(data);
+    } catch (error) {
+      next(error);
+      console.log(error);
+    }
+  });
+
+  app.get("/pg/statistics/summary", async (req, res, next) => {
+    let response;
+    let data;
+    try {
+      response = await retryFetch(`${req.headers["graph-db-connection-url"]}/pg/statistics/summary`, undefined, undefined, req, "gremlin").then((res) => res)
+
+      data = await response.json();
+      res.send(data);
+    } catch (error) {
+      next(error);
+      console.log(error);
+    }
+  });
+
+  app.get("/rdf/statistics/summary", async (req, res, next) => {
+    let response;
+    let data;
+    try {
+      response = await retryFetch(`${req.headers["graph-db-connection-url"]}/rdf/statistics/summary`, undefined, undefined, req, "gremlin").then((res) => res)
 
       data = await response.json();
       res.send(data);

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchVertexTypeCounts.ts
@@ -1,0 +1,33 @@
+import {
+  CountsByTypeRequest,
+  CountsByTypeResponse,
+} from "../../AbstractConnector";
+import vertexTypeCountTemplate from "../templates/vertexTypeCountTemplate";
+import { GInt64, GremlinFetch } from "../types";
+
+type RawCountsByTypeResponse = {
+  requestId: string;
+  status: {
+    message: string;
+    code: number;
+  };
+  result: {
+    data: {
+      "@type": "g:List";
+      "@value": Array<GInt64>;
+    };
+  };
+};
+
+const fetchVertexTypeCounts = async (
+  gremlinFetch: GremlinFetch,
+  req: CountsByTypeRequest
+): Promise<CountsByTypeResponse> => {
+  const template = vertexTypeCountTemplate(req.label);
+  const response = await gremlinFetch<RawCountsByTypeResponse>(template);
+  return {
+    total: response.result.data["@value"][0]["@value"],
+  };
+};
+
+export default fetchVertexTypeCounts;

--- a/packages/graph-explorer/src/connector/gremlin/templates/vertexTypeCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/vertexTypeCountTemplate.ts
@@ -1,0 +1,8 @@
+/**
+ * It returns a Gremlin template to number of vertices of a particular label
+ */
+const vertexTypeCountTemplate = (label: string) => {
+  return `g.V().hasLabel("${label}").count()`;
+};
+
+export default vertexTypeCountTemplate;

--- a/packages/graph-explorer/src/connector/gremlin/types.ts
+++ b/packages/graph-explorer/src/connector/gremlin/types.ts
@@ -71,3 +71,18 @@ export type GEdgeList = {
 export type GremlinFetch = <TResult = any>(
   queryTemplate: string
 ) => Promise<TResult>;
+
+export type GraphSummary = {
+  numNodes: number;
+  numEdges: number;
+  numNodeLabels: number;
+  numEdgeLabels: number;
+  nodeLabels: Array<string>;
+  edgeLabels: Array<string>;
+  numNodeProperties: number;
+  numEdgeProperties: number;
+  nodeProperties: Record<string, number>;
+  edgeProperties: Record<string, number>;
+  totalNodePropertyValues: number;
+  totalEdgePropertyValues: number;
+};

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchClassCounts.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchClassCounts.ts
@@ -1,0 +1,30 @@
+import {
+  CountsByTypeRequest,
+  CountsByTypeResponse,
+} from "../../AbstractConnector";
+import classWithCountsTemplates from "../templates/classWithCountsTemplates";
+import { RawValue, SparqlFetch } from "../types";
+
+type RawCountsByTypeResponse = {
+  results: {
+    bindings: [
+      {
+        instancesCount: RawValue;
+      }
+    ];
+  };
+};
+
+const fetchClassCounts = async (
+  sparqlFetch: SparqlFetch,
+  req: CountsByTypeRequest
+): Promise<CountsByTypeResponse> => {
+  const template = classWithCountsTemplates(req.label);
+  const response = await sparqlFetch<RawCountsByTypeResponse>(template);
+
+  return {
+    total: Number(response.results.bindings[0].instancesCount.value),
+  };
+};
+
+export default fetchClassCounts;

--- a/packages/graph-explorer/src/connector/sparql/templates/classWithCountsTemplates.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/classWithCountsTemplates.ts
@@ -1,0 +1,10 @@
+// It returns the number of instances of the given class
+const classWithCountsTemplates = (className: string) => {
+  return `
+    SELECT (COUNT(?start) AS ?instancesCount) {
+      ?start a <${className}>
+    }
+  `;
+};
+
+export default classWithCountsTemplates;

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -149,4 +149,14 @@ export type BlankNodeItem = {
     edges: Array<Edge>;
   };
 };
+
 export type BlankNodesMap = Map<string, BlankNodeItem>;
+
+export type GraphSummary = {
+  numDistinctSubjects: number;
+  numDistinctPredicates: number;
+  numQuads: number;
+  numClasses: number;
+  classes: Array<string>;
+  predicates: Array<Record<string, number>>;
+};

--- a/packages/graph-explorer/src/core/ConfigurationProvider/ConfigurationProvider.tsx
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/ConfigurationProvider.tsx
@@ -102,7 +102,9 @@ const ConfigurationProvider = ({
 
     return {
       ...(configuration || {}),
+      totalVertices: configuration.schema?.totalVertices ?? 0,
       vertexTypes: configuration.schema?.vertices?.map(vt => vt.type) || [],
+      totalEdges: configuration.schema?.totalEdges ?? 0,
       edgeTypes: configuration.schema?.edges?.map(et => et.type) || [],
       getVertexTypeConfig,
       getVertexTypeAttributes,

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -117,7 +117,7 @@ export type ConnectionConfig = {
    * Choose between gremlin or sparQL engines.
    * By default, it uses gremlin
    */
-  queryEngine?: "gremlin" | "sparql" | "open-cypher";
+  queryEngine?: "gremlin" | "sparql";
   /**
    * If the service is Neptune,
    * all requests should be sent through the nodejs proxy-server.

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -117,7 +117,7 @@ export type ConnectionConfig = {
    * Choose between gremlin or sparQL engines.
    * By default, it uses gremlin
    */
-  queryEngine?: "gremlin" | "sparql";
+  queryEngine?: "gremlin" | "sparql" | "open-cypher";
   /**
    * If the service is Neptune,
    * all requests should be sent through the nodejs proxy-server.
@@ -168,7 +168,9 @@ export type RawConfiguration = {
    * Database schema: types, names, labels, icons, ...
    */
   schema?: {
+    totalVertices: number;
     vertices: Array<VertexTypeConfig>;
+    totalEdges: number;
     edges: Array<EdgeTypeConfig>;
     lastUpdate?: Date;
     triedToSync?: boolean;
@@ -185,7 +187,9 @@ export type RawConfiguration = {
 };
 
 export type ConfigurationContextProps = RawConfiguration & {
+  totalVertices: number;
   vertexTypes: Array<string>;
+  totalEdges: number;
   edgeTypes: Array<string>;
   getVertexTypeConfig(vertexType: string): VertexTypeConfig | undefined;
   getVertexTypeAttributes(vertexTypes: string[]): Array<AttributeConfig>;

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -99,6 +99,8 @@ export const mergedConfigurationSelector = selector<RawConfiguration | null>({
             : undefined,
         triedToSync: currentSchema?.triedToSync,
         lastSyncFail: currentSchema?.lastSyncFail,
+        totalVertices: currentSchema?.totalVertices ?? 0,
+        totalEdges: currentSchema?.totalEdges ?? 0,
       },
     };
   },

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -13,6 +13,8 @@ export type SchemaInference = {
   lastUpdate?: Date;
   triedToSync?: boolean;
   lastSyncFail?: boolean;
+  totalVertices?: number;
+  totalEdges?: number;
 };
 
 export const schemaAtom = atom<Map<string, SchemaInference>>({

--- a/packages/graph-explorer/src/hooks/useEntitiesCounts.ts
+++ b/packages/graph-explorer/src/hooks/useEntitiesCounts.ts
@@ -5,6 +5,10 @@ const useEntitiesCounts = () => {
   const config = useConfiguration();
 
   const totalNodes = useMemo(() => {
+    if (config?.totalVertices != null) {
+      return config?.totalVertices;
+    }
+
     if (!config?.vertexTypes.length) {
       return null;
     }
@@ -24,6 +28,10 @@ const useEntitiesCounts = () => {
   }, [config]);
 
   const totalEdges = useMemo(() => {
+    if (config?.totalEdges != null) {
+      return config?.totalEdges;
+    }
+
     if (!config?.edgeTypes.length) {
       return null;
     }

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -1,11 +1,10 @@
 import { useCallback, useRef } from "react";
-import { useRecoilCallback } from "recoil";
 import { useNotification } from "../components/NotificationProvider";
 import { SchemaResponse } from "../connector/AbstractConnector";
 import useConfiguration from "../core/ConfigurationProvider/useConfiguration";
 import useConnector from "../core/ConnectorProvider/useConnector";
-import { schemaAtom } from "../core/StateProvider/schema";
 import usePrefixesUpdater from "./usePrefixesUpdater";
+import useUpdateSchema from "./useUpdateSchema";
 
 const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
   const config = useConfiguration();
@@ -15,26 +14,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
   const { enqueueNotification, clearNotification } = useNotification();
   const notificationId = useRef<string | null>(null);
 
-  const updateSchemaState = useRecoilCallback(
-    ({ set }) => (id: string, schema?: SchemaResponse) => {
-      set(schemaAtom, prevSchemaMap => {
-        const updatedSchema = new Map(prevSchemaMap);
-        const prevSchema = prevSchemaMap.get(id);
-
-        updatedSchema.set(id, {
-          vertices: schema?.vertices || prevSchema?.vertices || [],
-          edges: schema?.edges || prevSchema?.edges || [],
-          prefixes: prevSchema?.prefixes || [],
-          lastUpdate: !schema ? prevSchema?.lastUpdate : new Date(),
-          triedToSync: true,
-          lastSyncFail: !schema && !!prevSchema,
-        });
-        return updatedSchema;
-      });
-    },
-    []
-  );
-
+  const updateSchemaState = useUpdateSchema();
   return useCallback(
     async (abortSignal?: AbortSignal) => {
       if (!config || !connector.explorer) {

--- a/packages/graph-explorer/src/hooks/useUpdateSchema.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateSchema.ts
@@ -1,0 +1,64 @@
+import { useRecoilCallback } from "recoil";
+import { SchemaResponse } from "../connector/AbstractConnector";
+import { schemaAtom } from "../core/StateProvider/schema";
+
+const useUpdateSchema = () => {
+  return useRecoilCallback(
+    ({ set }) => (
+      id: string,
+      schema?:
+        | Partial<SchemaResponse>
+        | ((prevSchema?: SchemaResponse) => Partial<SchemaResponse>)
+    ) => {
+      set(schemaAtom, prevSchemaMap => {
+        const updatedSchema = new Map(prevSchemaMap);
+        const prevSchema = prevSchemaMap.get(id);
+
+        const currentSchema =
+          typeof schema === "function" ? schema(prevSchema) : schema;
+
+        // Preserve vertices counts
+        const vertices = (
+          currentSchema?.vertices ||
+          prevSchema?.vertices ||
+          []
+        ).map(vertex => {
+          const prevVertex = prevSchema?.vertices.find(
+            v => v.type === vertex.type
+          );
+          return {
+            ...vertex,
+            total: vertex.total ?? prevVertex?.total,
+          };
+        });
+
+        // Preserve edges counts
+        const edges = (currentSchema?.edges || prevSchema?.edges || []).map(
+          edge => {
+            const prevEdge = prevSchema?.edges.find(e => e.type === edge.type);
+            return {
+              ...edge,
+              total: edge.total ?? prevEdge?.total,
+            };
+          }
+        );
+
+        updatedSchema.set(id, {
+          totalVertices:
+            currentSchema?.totalVertices || prevSchema?.totalVertices || 0,
+          vertices,
+          totalEdges: currentSchema?.totalEdges || prevSchema?.totalEdges || 0,
+          edges,
+          prefixes: prevSchema?.prefixes || [],
+          lastUpdate: !currentSchema ? prevSchema?.lastUpdate : new Date(),
+          triedToSync: true,
+          lastSyncFail: !currentSchema && !!prevSchema,
+        });
+        return updatedSchema;
+      });
+    },
+    []
+  );
+};
+
+export default useUpdateSchema;

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { useQuery } from "react-query";
+import { useConfiguration } from "../core";
+import useConnector from "../core/ConnectorProvider/useConnector";
+import useUpdateSchema from "./useUpdateSchema";
+
+const useUpdateVertexTypeCounts = (vertexType?: string) => {
+  const config = useConfiguration();
+  const connector = useConnector();
+
+  const vertexConfig = useMemo(() => {
+    if (!vertexType) {
+      return;
+    }
+
+    return config?.getVertexTypeConfig(vertexType);
+  }, [config, vertexType]);
+
+  const updateSchemaState = useUpdateSchema();
+  useQuery(
+    ["fetchCountsByType", vertexConfig?.type],
+    () => {
+      if (vertexConfig?.total != null || vertexConfig?.type == null) {
+        return;
+      }
+
+      return connector.explorer?.fetchVertexCountsByType({
+        label: vertexConfig?.type,
+      });
+    },
+    {
+      enabled: vertexConfig?.total == null && vertexConfig?.type != null,
+      onSuccess: response => {
+        if (!config?.id || !response) {
+          return;
+        }
+
+        updateSchemaState(config.id, prevSchema => {
+          const vertexSchema = prevSchema?.vertices.find(
+            vertex => vertex.type === vertexType
+          );
+          if (!vertexSchema) {
+            return { ...(prevSchema || {}) };
+          }
+
+          vertexSchema.total = response.total;
+          return {
+            vertices: [
+              ...(prevSchema?.vertices.filter(
+                vertex => vertex.type !== vertexType
+              ) || []),
+              vertexSchema,
+            ],
+          };
+        });
+      },
+    }
+  );
+};
+
+export default useUpdateVertexTypeCounts;

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -47,11 +47,9 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
               {textTransform(displayLabel)}
             </div>
             <div className={pfx("nodes-count")}>
-              {t("connection-detail.nodes")}:{" "}
-              {vtConfig?.total ? (
+              {t("connection-detail.nodes")}: {vtConfig?.total == null && "~"}
+              {vtConfig?.total != null && (
                 <HumanReadableNumberFormatter value={vtConfig?.total} />
-              ) : (
-                "Unknown"
               )}
             </div>
           </div>

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -79,7 +79,7 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
     });
 
     return items;
-  }, [config, pfx, textTransform, t, navigate]);
+  }, [config, pfx, textTransform, navigate]);
 
   const [search, setSearch] = useState("");
 

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -46,12 +46,6 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
             <div className={pfx("node-title")}>
               {textTransform(displayLabel)}
             </div>
-            <div className={pfx("nodes-count")}>
-              {t("connection-detail.nodes")}: {vtConfig?.total == null && "~"}
-              {vtConfig?.total != null && (
-                <HumanReadableNumberFormatter value={vtConfig?.total} />
-              )}
-            </div>
           </div>
         ),
         icon: (

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -45,6 +45,7 @@ import useFetchNode from "../../hooks/useFetchNode";
 import usePrefixesUpdater from "../../hooks/usePrefixesUpdater";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
+import useUpdateVertexTypeCounts from "../../hooks/useUpdateVertexTypeCounts";
 import TopBarWithLogo from "../common/TopBarWithLogo";
 import defaultStyles from "./DataExplorer.styles";
 
@@ -68,6 +69,9 @@ const DataExplorer = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
   const connector = useConnector();
   const fetchNode = useFetchNode();
   const [entities] = useEntities({ disableFilters: true });
+
+  // Automatically updates counts if needed
+  useUpdateVertexTypeCounts(vertexType);
 
   const vertexConfig = useMemo(() => {
     if (!vertexType) {


### PR DESCRIPTION
# Summary API integration

The main aim of this PR is to reduce the synchronization time of the schema by using Neptune Summary API if it is available.

Description of changes:
- `fetchSchema` process tries to fetch some data, using the Summary API, related to the database structure:
  -  vertices types (classes),
  -  edges types (predicates),
  -  total number of vertices (total number of subjects),
  -  and total number of edges (total number of quads)
- If the above data is available, use them to fetch the vertices and edges attributes. By using the Summary API, the time of inferring the schema will be decreased. However, it does not return how many vertices or edges we have by type. So we speed up the process but lose the counts by type.
- If the Summary API is not available, the `fetchSchema` fallbacks to the previous process we had to infer the schema.

Now, if the `fetchSchema` process uses the Summary API, we will not have counts by type. So a new method has been added to the `AbstractConnector` contract, and its the implementations, in order to fetch the total number of nodes (subjects). It is the method called `fetchVertexCountsByType` and it is called when a user visits the Data Explorer section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.