### PR TITLE
Change no IAM role attached error code

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -57,7 +57,7 @@ dotenv.config({ path: "../graph-explorer/.env" });
       console.error("Credentials undefined. Trying refresh.");
       creds = await getCredentials();
       if (creds === undefined) {
-        throw new Error("Credentials undefined after refresh. Check that you have proper access and that the credentials should work.")
+        throw new Error("Credentials still undefined. Check that the environment has an appropriate IAM role that trusts it and that it has sufficient read permissions to connect to Neptune.")
       }
     }
     reqObjects = await getRequestObjects(req.headers["graph-db-connection-url"], req.headers["aws-neptune-region"]);


### PR DESCRIPTION
Changes the error code provided when the credentials are undefined after refresh due to not having an IAM role attached.