### PR TITLE
Fix for database synchronization error caused by white spaces in the labels for gremlin requests

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/templates/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/edgesSchemaTemplate.ts
@@ -16,12 +16,7 @@ import { uniq } from "lodash";
 const edgesSchemaTemplate = ({ types }: { types: string[] }) => {
   const labels = uniq(types.flatMap(type => type.split("::")));
 
-  return `
-   g.E()
-     .project(${labels.map(l => `"${l}"`).join(",")})
-     ${labels.map(l => `.by(V().bothE("${l}").limit(1))`).join("\n")}
-     .limit(1)
-  `.replace(/(\t|\s)+|\n/g, "");
+  return `g.E().project(${labels.map(l => `"${l}"`).join(",")})${labels.map(l => `.by(V().bothE("${l}").limit(1))`).join("")}.limit(1)`;
 };
 
 export default edgesSchemaTemplate;

--- a/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
@@ -16,12 +16,7 @@ import { uniq } from "lodash";
 const verticesSchemaTemplate = ({ types }: { types: string[] }) => {
   const labels = uniq(types.flatMap(type => type.split("::")));
 
-  return `
-   g.V()
-     .project(${labels.map(l => `"${l}"`).join(",")})
-     ${labels.map(l => `.by(V().hasLabel("${l}").limit(1))`).join("")}
-     .limit(1)
-  `;
+  return `g.V().project(${labels.map(l => `"${l}"`).join(",")})${labels.map(l => `.by(V().hasLabel("${l}").limit(1))`).join("")}.limit(1)`;
 };
 
 export default verticesSchemaTemplate;

--- a/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
@@ -21,7 +21,7 @@ const verticesSchemaTemplate = ({ types }: { types: string[] }) => {
      .project(${labels.map(l => `"${l}"`).join(",")})
      ${labels.map(l => `.by(V().hasLabel("${l}").limit(1))`).join("")}
      .limit(1)
-  `.replace(/(\t|\s)+|\n/g, "");
+  `;
 };
 
 export default verticesSchemaTemplate;

--- a/packages/graph-explorer/src/utils/sanitizeText.ts
+++ b/packages/graph-explorer/src/utils/sanitizeText.ts
@@ -10,7 +10,6 @@ export const sanitizeText = (text?: string): string => {
   return String(text)
     .replace(/([A-Z]+)([A-Z][a-z])/gu, " $1 $2")
     .replace(/([a-z\d])([A-Z])/gu, "$1 $2")
-    .replace(/([a-zA-Z])(\d)/gu, "$1 $2")
     .replace(/[-_]/g, " ")
     .replace(/^./, function (str) {
       return str.toUpperCase();


### PR DESCRIPTION
Issue #57 and #83 

**Issue:**
Before being passed to the react logic, requests related to the schema synchronization on the connection page, would go through a filter that would go through a replace operation that would remove spaces. This removes the ability to use vertices or edges with a space in the label name via gremlin queries.

**Description of Changes:**

- Removes the regex replacement in the `packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts` file to avoid replacing whitespace that actually need to be urlEncoded in gremlin requests.

- Removes a line in `packages/graph-explorer/src/utils/sanitizeText.ts` that was causing any string of the format {string}{number} to be split into {string} {number}. This caused labels such as "Node1" to be considered the same as "Node 1" by the app and would prevent you from searching by type Node1 for example.

**How Has This Been Tested:**

- Have a regular connection with a Neptune instance
- Insert a vertex and edge whose names contain a space. Ex. "Object 1"
- In the json response from the `.groupcount` requests made during the schema synchronization for both Vertices and Edges, you would receive a type of "Object1" instead of "Object 1". After this fix, you should see "Object 1" showing as "Object 1" regardless of it being a vertex or edge label