### PR TITLE
Reduce size of Docker image #103

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM amazonlinux:2
 WORKDIR /
 COPY . /graph-explorer/
 WORKDIR /graph-explorer
+# Keeping all the RUN commands on a single line reduces the number of layers and,
+# as a result, significantly reduces the final image size.
 RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash - && yum install -y nodejs openssl && npm install -g pnpm && pnpm install && rm -rf /var/cache/yum
 WORKDIR /graph-explorer/
 ENV HOME=/graph-explorer

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,7 @@ FROM amazonlinux:2
 WORKDIR /
 COPY . /graph-explorer/
 WORKDIR /graph-explorer
-RUN yum install -y curl
-RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
-RUN yum install -y nodejs
-RUN yum install -y openssl
-RUN npm install -g pnpm
-RUN pnpm install
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash - && yum install -y nodejs openssl && npm install -g pnpm && pnpm install && rm -rf /var/cache/yum
 WORKDIR /graph-explorer/
 ENV HOME=/graph-explorer
 RUN pnpm build


### PR DESCRIPTION
Issue #, if available: #103

Description of changes:
Changes the Dockerfile to perform all the `RUN` commands on one line thus reducing the number of layers and reducing the overall size of the Docker image by 1gb when built on Ubuntu. 1.67gb --> 675mb

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.