### PR TITLE
Adds Default Connection Support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ COPY . /graph-explorer/
 WORKDIR /graph-explorer
 # Keeping all the RUN commands on a single line reduces the number of layers and,
 # as a result, significantly reduces the final image size.
-RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash - && yum install -y nodejs openssl && npm install -g pnpm && pnpm install && rm -rf /var/cache/yum
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash - && yum install -y nodejs openssl && npm install -g pnpm && pnpm install && rm -rf /var/cache/yum && chmod a+x ./process-environment.sh
 WORKDIR /graph-explorer/
 ENV HOME=/graph-explorer
-RUN pnpm build
 EXPOSE 443
 EXPOSE 80
 RUN chmod a+x ./docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ You can search, browse, expand, customize views of your graph data using Graph E
 ## Connections
 The Graph Explorer supports visualizing both **property graphs** and **RDF graphs**. You can connect to Amazon Neptune or you can also connect to open graph databases that implement an Apache TinkerPop Gremlin Server endpoint or the SPARQL 1.1 protocol, such as Blazegraph. For additional details on connecting to different graph databases, see [Connections](./additionaldocs/connections.md).
 
+### Providing a Default Connection 
+To provide a default connection such that initial loads of the graph explorer always result with the same starting connection, modify the `docker run ...` command to be `docker run -p 80:80 -p 443:443 --env HOST={hostname-or-ip-address} -v /path/to/config.json:/graph-explorer/config.json graph-explorer` or create a `config.json` file at the root of the project.
+
+The config.json file should provide values for the attributes in the example below:
+
+```
+{
+     "PUBLIC_OR_PROXY_ENDPOINT": "https://public-endpoint,
+     "GRAPH_CONNECTION_URL": "https://cluster-
+cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182,
+     "USING_PROXY_SERVER": "true,
+     "IAM": "true,
+     "AWS_REGION": "us-west-2,
+     "GRAPH_TYPE": "PG
+}
+```
+
 ## Development
 For development guidance, see [Development](./additionaldocs/development.md).
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ The config.json file should provide values for the attributes in the example bel
 
 ```
 {
-     "PUBLIC_OR_PROXY_ENDPOINT": "https://public-endpoint,
+     "PUBLIC_OR_PROXY_ENDPOINT": "https://public-endpoint",
      "GRAPH_CONNECTION_URL": "https://cluster-
-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182,
-     "USING_PROXY_SERVER": "true,
-     "IAM": "true,
-     "AWS_REGION": "us-west-2,
-     "GRAPH_TYPE": "PG
+cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182",
+     "USING_PROXY_SERVER": "true",
+     "IAM": "true",
+     "AWS_REGION": "us-west-2",
+     "GRAPH_TYPE": "gremlin" (Possible Values: "gremlin" or "sparql")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,17 +95,31 @@ You can search, browse, expand, customize views of your graph data using Graph E
 The Graph Explorer supports visualizing both **property graphs** and **RDF graphs**. You can connect to Amazon Neptune or you can also connect to open graph databases that implement an Apache TinkerPop Gremlin Server endpoint or the SPARQL 1.1 protocol, such as Blazegraph. For additional details on connecting to different graph databases, see [Connections](./additionaldocs/connections.md).
 
 ### Providing a Default Connection 
-To provide a default connection such that initial loads of the graph explorer always result with the same starting connection, modify the `docker run ...` command to be `docker run -p 80:80 -p 443:443 --env HOST={hostname-or-ip-address} -v /path/to/config.json:/graph-explorer/config.json graph-explorer` or create a `config.json` file at the root of the project.
+To provide a default connection such that initial loads of the graph explorer always result with the same starting connection, modify the `docker run ...` command to either take in a json configuration or runtime environment variables. A json configuration approach would look like `docker run -p 80:80 -p 443:443 --env HOST={hostname-or-ip-address} -v /path/to/config.json:/graph-explorer/config.json graph-explorer` or create a `config.json` file at the root of the project. An environment variable approach would look like `docker run -p 80:80 -p 443:443 --env HOST={hostname-or-ip-address} --env PUBLIC_OR_PROXY_ENDPOINT=https://public-endpoint --env GRAPH_TYPE=gremlin --env USING_PROXY_SERVER=true --env IAM=false --env GRAPH_CONNECTION_URL=https://cluster-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182 --env AWS_REGION=us-west-2 graph-explorer`. IF you provide both, the json approach will be prioritized.
 
-The config.json file should provide values for the attributes in the example below:
+
+The set of valid ENV connection variables and their defaults:
+* Required:
+     * PUBLIC_OR_PROXY_ENDPOINT - None
+* Optional
+     * GRAPH_TYPE - PG (Property Graph)
+     * USING_PROXY_SERVER - False
+     * IAM - False
+* Conditionally Required:
+     * GRAPH_CONNECTION_URL - None 
+* Required if USING_PROXY_SERVER=True
+     * AWS_REGION - None
+* Required if USING_PROXY_SERVER=True and IAM=True
+
+
+The config.json file should provide values for the attributes at the top level as in the example below:
 
 ```
 {
      "PUBLIC_OR_PROXY_ENDPOINT": "https://public-endpoint",
-     "GRAPH_CONNECTION_URL": "https://cluster-
-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182",
-     "USING_PROXY_SERVER": "true",
-     "IAM": "true",
+     "GRAPH_CONNECTION_URL": "https://cluster-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182",
+     "USING_PROXY_SERVER": true, (Can be string or boolean)
+     "IAM": true, (Can be string or boolean)
      "AWS_REGION": "us-west-2",
      "GRAPH_TYPE": "gremlin" (Possible Values: "gremlin" or "sparql")
 }

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+./process-environment.sh
+
 if [ $(grep -e 'GRAPH_EXP_HTTPS_CONNECTION' ./packages/graph-explorer/.env | cut -d "=" -f 2) ]; then
 
     if [ $HOST ]; then
@@ -25,5 +27,8 @@ else
     echo "SSL disabled. Skipping self-signed certificate generation."
     exit 1
 fi
+
+echo "Building graph explorer..."
+pnpm -w build
 echo "Starting graph explorer..."
 pnpm -w start:proxy-server

--- a/packages/graph-explorer/src/index.tsx
+++ b/packages/graph-explorer/src/index.tsx
@@ -24,12 +24,12 @@ if (params.configFile) {
       import.meta.env.GRAPH_EXP_CONNECTION_NAME ||
       import.meta.env.GRAPH_EXP_CONNECTION_URL,
     connection: {
-      url: import.meta.env.GRAPH_EXP_CONNECTION_URL,
-      queryEngine:
-        (import.meta.env.GRAPH_EXP_CONNECTION_ENGINE as
-          | "gremlin"
-          | "sparql"
-          | undefined) || "gremlin",
+      url: import.meta.env.GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT || "",
+      queryEngine: (import.meta.env.GRAPH_EXP_GRAPH_TYPE === "gremlin" || import.meta.env.GRAPH_EXP_GRAPH_TYPE === "sparql") ? import.meta.env.GRAPH_EXP_GRAPH_TYPE : "gremlin",
+      proxyConnection: import.meta.env.GRAPH_EXP_USING_PROXY_SERVER || false,
+      graphDbUrl: import.meta.env.GRAPH_EXP_CONNECTION_URL || "",
+      awsAuthEnabled: import.meta.env.GRAPH_EXP_IAM || false,
+      awsRegion: import.meta.env.GRAPH_EXP_AWS_REGION || "",
     },
   };
 }

--- a/packages/graph-explorer/src/index.tsx
+++ b/packages/graph-explorer/src/index.tsx
@@ -25,10 +25,10 @@ if (params.configFile) {
       import.meta.env.GRAPH_EXP_CONNECTION_URL,
     connection: {
       url: import.meta.env.GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT || "",
-      queryEngine: (import.meta.env.GRAPH_EXP_GRAPH_TYPE === "gremlin" || import.meta.env.GRAPH_EXP_GRAPH_TYPE === "sparql") ? import.meta.env.GRAPH_EXP_GRAPH_TYPE : "gremlin",
-      proxyConnection: import.meta.env.GRAPH_EXP_USING_PROXY_SERVER || false,
+      queryEngine: (import.meta.env.GRAPH_EXP_GRAPH_TYPE.toLowerCase() === "gremlin" || import.meta.env.GRAPH_EXP_GRAPH_TYPE.toLowerCase() === "sparql") ? import.meta.env.GRAPH_EXP_GRAPH_TYPE.toLowerCase() : "gremlin",
+      proxyConnection: (import.meta.env.GRAPH_EXP_USING_PROXY_SERVER.toUpperCase() === "TRUE") ? true : false,
       graphDbUrl: import.meta.env.GRAPH_EXP_CONNECTION_URL || "",
-      awsAuthEnabled: import.meta.env.GRAPH_EXP_IAM || false,
+      awsAuthEnabled: (import.meta.env.GRAPH_EXP_IAM.toUpperCase() === "TRUE") ? true : false,
       awsRegion: import.meta.env.GRAPH_EXP_AWS_REGION || "",
     },
   };

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+if [ -f "./config.json" ]; then 
+
+    json=$(cat ./config.json)
+
+    PUBLIC_OR_PROXY_ENDPOINT=$(echo "$json" | grep -o '"PUBLIC_OR_PROXY_ENDPOINT":[^,}]*' | cut -d '"' -f 4)
+    GRAPH_TYPE=$(echo "$json" | grep -o '"GRAPH_TYPE":[^,}]*' | cut -d '"' -f 4)
+    USING_PROXY_SERVER=$(echo "$json" | grep -o '"USING_PROXY_SERVER":[^,}]*' | cut -d '"' -f 4)
+    IAM=$(echo "$json" | grep -o '"IAM":[^,}]*' | cut -d '"' -f 4)
+    GRAPH_CONNECTION_URL=$(echo "$json" | grep -o '"GRAPH_CONNECTION_URL":[^,}]*' | cut -d '"' -f 4)
+    AWS_REGION=$(echo "$json" | grep -o '"AWS_REGION":[^,}]*' | cut -d '"' -f 4)
+
+    # Update the .env file with the configuration values
+    if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
+        echo -e "\nPUBLIC_OR_PROXY_ENDPOINT=${PUBLIC_OR_PROXY_ENDPOINT}" >> ./packages/graph-explorer/.env
+
+        if [ -n "$GRAPH_TYPE" ]; then 
+            echo "GRAPH_TYPE=${GRAPH_TYPE}" >> ./packages/graph-explorer/.env
+        else 
+            echo "GRAPH_TYPE=PG" >> ./packages/graph-explorer/.env
+        fi
+
+        if [ -n "$USING_PROXY_SERVER" ]; then 
+            echo "USING_PROXY_SERVER=${USING_PROXY_SERVER}" >> ./packages/graph-explorer/.env
+        else 
+            echo "USING_PROXY_SERVER=false" >> ./packages/graph-explorer/.env
+        fi 
+
+        if [ -n "$IAM" ]; then 
+            echo "IAM=${IAM}" >> ./packages/graph-explorer/.env
+        else 
+            echo "IAM=false" >> ./packages/graph-explorer/.env
+        fi
+
+        echo "GRAPH_CONNECTION_URL=${GRAPH_CONNECTION_URL}" >> ./packages/graph-explorer/.env
+        echo "AWS_REGION=${AWS_REGION}" >> ./packages/graph-explorer/.env
+    fi
+fi 

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -4,36 +4,36 @@ if [ -f "./config.json" ]; then
 
     json=$(cat ./config.json)
 
-    PUBLIC_OR_PROXY_ENDPOINT=$(echo "$json" | grep -o '"PUBLIC_OR_PROXY_ENDPOINT":[^,}]*' | cut -d '"' -f 4)
-    GRAPH_TYPE=$(echo "$json" | grep -o '"GRAPH_TYPE":[^,}]*' | cut -d '"' -f 4)
-    USING_PROXY_SERVER=$(echo "$json" | grep -o '"USING_PROXY_SERVER":[^,}]*' | cut -d '"' -f 4)
-    IAM=$(echo "$json" | grep -o '"IAM":[^,}]*' | cut -d '"' -f 4)
-    GRAPH_CONNECTION_URL=$(echo "$json" | grep -o '"GRAPH_CONNECTION_URL":[^,}]*' | cut -d '"' -f 4)
-    AWS_REGION=$(echo "$json" | grep -o '"AWS_REGION":[^,}]*' | cut -d '"' -f 4)
+    PUBLIC_OR_PROXY_ENDPOINT=$(echo "$json" | grep -o '"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT":[^,}]*' | cut -d '"' -f 4)
+    GRAPH_TYPE=$(echo "$json" | grep -o '"GRAPH_EXP_GRAPH_TYPE":[^,}]*' | cut -d '"' -f 4)
+    USING_PROXY_SERVER=$(echo "$json" | grep -o '"GRAPH_EXP_USING_PROXY_SERVER":[^,}]*' | cut -d '"' -f 4)
+    IAM=$(echo "$json" | grep -o '"GRAPH_EXP_IAM":[^,}]*' | cut -d '"' -f 4)
+    GRAPH_CONNECTION_URL=$(echo "$json" | grep -o '"GRAPH_EXP_CONNECTION_URL":[^,}]*' | cut -d '"' -f 4)
+    AWS_REGION=$(echo "$json" | grep -o '"GRAPH_EXP_AWS_REGION":[^,}]*' | cut -d '"' -f 4)
 
     # Update the .env file with the configuration values
     if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
-        echo -e "\nPUBLIC_OR_PROXY_ENDPOINT=${PUBLIC_OR_PROXY_ENDPOINT}" >> ./packages/graph-explorer/.env
+        echo -e "\nGRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT=${PUBLIC_OR_PROXY_ENDPOINT}" >> ./packages/graph-explorer/.env
 
         if [ -n "$GRAPH_TYPE" ]; then 
-            echo "GRAPH_TYPE=${GRAPH_TYPE}" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_GRAPH_TYPE=${GRAPH_TYPE}" >> ./packages/graph-explorer/.env
         else 
-            echo "GRAPH_TYPE=PG" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_GRAPH_TYPE=PG" >> ./packages/graph-explorer/.env
         fi
 
         if [ -n "$USING_PROXY_SERVER" ]; then 
-            echo "USING_PROXY_SERVER=${USING_PROXY_SERVER}" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_USING_PROXY_SERVER=${USING_PROXY_SERVER}" >> ./packages/graph-explorer/.env
         else 
-            echo "USING_PROXY_SERVER=false" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_USING_PROXY_SERVER=false" >> ./packages/graph-explorer/.env
         fi 
 
         if [ -n "$IAM" ]; then 
-            echo "IAM=${IAM}" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_IAM=${IAM}" >> ./packages/graph-explorer/.env
         else 
-            echo "IAM=false" >> ./packages/graph-explorer/.env
+            echo "GRAPH_EXP_IAM=false" >> ./packages/graph-explorer/.env
         fi
 
-        echo "GRAPH_CONNECTION_URL=${GRAPH_CONNECTION_URL}" >> ./packages/graph-explorer/.env
-        echo "AWS_REGION=${AWS_REGION}" >> ./packages/graph-explorer/.env
+        echo "GRAPH_EXP_CONNECTION_URL=${GRAPH_CONNECTION_URL}" >> ./packages/graph-explorer/.env
+        echo "GRAPH_EXP_AWS_REGION=${AWS_REGION}" >> ./packages/graph-explorer/.env
     fi
 fi 

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -4,36 +4,36 @@ if [ -f "./config.json" ]; then
 
     json=$(cat ./config.json)
 
-    PUBLIC_OR_PROXY_ENDPOINT=$(echo "$json" | grep -o '"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT":[^,}]*' | cut -d '"' -f 4)
-    GRAPH_TYPE=$(echo "$json" | grep -o '"GRAPH_EXP_GRAPH_TYPE":[^,}]*' | cut -d '"' -f 4)
-    USING_PROXY_SERVER=$(echo "$json" | grep -o '"GRAPH_EXP_USING_PROXY_SERVER":[^,}]*' | cut -d '"' -f 4)
-    IAM=$(echo "$json" | grep -o '"GRAPH_EXP_IAM":[^,}]*' | cut -d '"' -f 4)
-    GRAPH_CONNECTION_URL=$(echo "$json" | grep -o '"GRAPH_EXP_CONNECTION_URL":[^,}]*' | cut -d '"' -f 4)
-    AWS_REGION=$(echo "$json" | grep -o '"GRAPH_EXP_AWS_REGION":[^,}]*' | cut -d '"' -f 4)
+    PUBLIC_OR_PROXY_ENDPOINT=$(echo "$json" | grep -o '"PUBLIC_OR_PROXY_ENDPOINT":[^,}]*' | cut -d '"' -f 4)
+    GRAPH_TYPE=$(echo "$json" | grep -o '"GRAPH_TYPE":[^,}]*' | cut -d '"' -f 4)
+    USING_PROXY_SERVER=$(echo "$json" | grep -o '"USING_PROXY_SERVER":[^,}]*' | cut -d ':' -f 2 | tr -d '[:space:]' | sed 's/"//g')
+    IAM=$(echo "$json" | grep -o '"IAM":[^,}]*' | cut -d ':' -f 2 | tr -d '[:space:]' | sed 's/"//g')
+    GRAPH_CONNECTION_URL=$(echo "$json" | grep -o '"CONNECTION_URL":[^,}]*' | cut -d '"' -f 4)
+    AWS_REGION=$(echo "$json" | grep -o '"AWS_REGION":[^,}]*' | cut -d '"' -f 4)
+fi
 
-    # Update the .env file with the configuration values
-    if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
-        echo -e "\nGRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT=${PUBLIC_OR_PROXY_ENDPOINT}" >> ./packages/graph-explorer/.env
+# Update the .env file with the configuration values
+if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
+    echo -e "\nGRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT=${PUBLIC_OR_PROXY_ENDPOINT}" >> ./packages/graph-explorer/.env
 
-        if [ -n "$GRAPH_TYPE" ]; then 
-            echo "GRAPH_EXP_GRAPH_TYPE=${GRAPH_TYPE}" >> ./packages/graph-explorer/.env
-        else 
-            echo "GRAPH_EXP_GRAPH_TYPE=PG" >> ./packages/graph-explorer/.env
-        fi
-
-        if [ -n "$USING_PROXY_SERVER" ]; then 
-            echo "GRAPH_EXP_USING_PROXY_SERVER=${USING_PROXY_SERVER}" >> ./packages/graph-explorer/.env
-        else 
-            echo "GRAPH_EXP_USING_PROXY_SERVER=false" >> ./packages/graph-explorer/.env
-        fi 
-
-        if [ -n "$IAM" ]; then 
-            echo "GRAPH_EXP_IAM=${IAM}" >> ./packages/graph-explorer/.env
-        else 
-            echo "GRAPH_EXP_IAM=false" >> ./packages/graph-explorer/.env
-        fi
-
-        echo "GRAPH_EXP_CONNECTION_URL=${GRAPH_CONNECTION_URL}" >> ./packages/graph-explorer/.env
-        echo "GRAPH_EXP_AWS_REGION=${AWS_REGION}" >> ./packages/graph-explorer/.env
+    if [ -n "$GRAPH_TYPE" ]; then 
+        echo "GRAPH_EXP_GRAPH_TYPE=${GRAPH_TYPE}" >> ./packages/graph-explorer/.env
+    else 
+        echo "GRAPH_EXP_GRAPH_TYPE=PG" >> ./packages/graph-explorer/.env
     fi
-fi 
+
+    if [ -n "$USING_PROXY_SERVER" ]; then 
+        echo "GRAPH_EXP_USING_PROXY_SERVER=${USING_PROXY_SERVER}" >> ./packages/graph-explorer/.env
+    else 
+        echo "GRAPH_EXP_USING_PROXY_SERVER=false" >> ./packages/graph-explorer/.env
+    fi 
+
+    if [ -n "$IAM" ]; then 
+        echo "GRAPH_EXP_IAM=${IAM}" >> ./packages/graph-explorer/.env
+    else 
+        echo "GRAPH_EXP_IAM=false" >> ./packages/graph-explorer/.env
+    fi
+
+    echo "GRAPH_EXP_CONNECTION_URL=${GRAPH_CONNECTION_URL}" >> ./packages/graph-explorer/.env
+    echo "GRAPH_EXP_AWS_REGION=${AWS_REGION}" >> ./packages/graph-explorer/.env
+fi


### PR DESCRIPTION
**Description:**
Modifies the docker build and run process by pushing the `pnpm build` command into the `docker-entrypoint.sh` file so that the `docker run` command can take environment variables and add them to the `.env` file before the build is created. This allows for a default connection to be provided. Currently supports a json called `config.json` provided via a volume mount or as individual variables provided via `--env`. See `README.md` for how to execute either option. From a process standpoint, the variables passed in either manner get processed and appended to the .env file in process-environment.sh so the build can use them.

**Testing:**
This was tested via local builds by providing the json solution, the --env solution, and providing both, in which case the json takes precedence. To test, make sure that your browser is not caching connections from one build to another. Opening an incognito window during testing makes for the easiest way to circumvent this.