### PR TITLE
updated inView to neighborsInView

### DIFF
--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -29,9 +29,9 @@ const NeighborsList = ({
         Neighbors ({vertex.data.neighborsCount})
       </div>
       {neighborsOptions.map(op => {
-        const inView =
+        const neighborsInView =
           vertex.data.neighborsCountByType[op.value] -
-          vertex.data.neighborsCountByType[op.value];
+          (vertex.data.__unfetchedNeighborCounts?.[op.value] ?? 0);
         return (
           <div key={op.value} className={pfx("node-item")}>
             <div className={pfx("vertex-type")}>
@@ -48,10 +48,11 @@ const NeighborsList = ({
               {op.label}
             </div>
             <div className={pfx("vertex-totals")}>
-              <Tooltip text={`${inView} ${op.label} in the Graph View`}>
+              <Tooltip
+                text={`${neighborsInView} ${op.label} in the Graph View`}
+              >
                 <Chip className={pfx("chip")} startAdornment={<VisibleIcon />}>
-                  {vertex.data.neighborsCountByType[op.value] -
-                    (vertex.data.__unfetchedNeighborCounts?.[op.value] ?? 0)}
+                  {neighborsInView}
                 </Chip>
               </Tooltip>
               <Chip className={pfx("chip")}>


### PR DESCRIPTION
Issue #34 

Description of changes:

This PR addresses a bug where the count of neighbors in the popup in Expand View sidebar shows an incorrect number. The issue was caused by a calculation error in the `inView` constant. 

Before this PR, the `inView` constant was calculated as follows:
```
const inView =
  vertex.data.neighborsCountByType[op.value] -
  vertex.data.neighborsCountByType[op.value];
```
This calculation resulted in an incorrect count of neighbors in the popup.

After this PR, the `inView` constant is calculated as follows:
```
const neighborsInView =
  vertex.data.neighborsCountByType[op.value] -
  (vertex.data.__unfetchedNeighborCounts?.[op.value] ?? 0);
```
This calculation correctly subtracts the number of unfetched neighbor counts from the total count of neighbors, resulting in an accurate count of neighbors in the popup.

This PR resolves the bug and ensures that the count of neighbors in the popup is displayed correctly.
![Pasted Graphic](https://github.com/aws/graph-explorer/assets/12927412/2bed2240-cb94-40f1-8383-5a2aa446fc6b)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.