### PR TITLE
Proxy server serving should match GRAPH_EXP_ENV_ROOT_FOLDER

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -39,7 +39,7 @@ dotenv.config({ path: "../graph-explorer/.env" });
 
   app.use(cors());
 
-  app.use("/explorer", express.static(path.join(__dirname, "../graph-explorer/dist")));
+  app.use(process.env.GRAPH_EXP_ENV_ROOT_FOLDER, express.static(path.join(__dirname, "../graph-explorer/dist")));
 
   const delay = (ms) => new Promise((resolve) => setTimeout(() => resolve(), ms));
 


### PR DESCRIPTION
Proxy server is currently serving static files on `/explorer`. 
Serving static files through express is  broken when using a custom .env value in `GRAPH_EXP_ENV_ROOT_FOLDER`
