### PR TITLE
Bug/codecov

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./packages/graph-explorer/coverage"
           files: "*.info"
           verbose: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./packages/graph-explorer/coverage"
           files: "*.info"
-          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -42,4 +42,4 @@ jobs:
         with:
           directory: "./packages/graph-explorer/coverage"
           files: "*.info"
-          verbose: true
+        


### PR DESCRIPTION
### Issue:

Codecov failure during file upload is currently causing the CI pipeline to fail. This creates unnecessary disruptions to the development workflow, especially when the coverage report is generated successfully but not uploaded.

### Proposed Solution:

To address this issue, we have removed the `fail_ci_if_error: true` option from the GitHub Actions workflow. This option specifies whether the CI pipeline should fail when Codecov encounters errors during the upload process. By default, it is set to false, meaning the CI pipeline will not fail due to Codecov errors.

### Changes Made:

Removed the `fail_ci_if_error: true` option from the GitHub Actions workflow.

### Expected Outcome:

With this change, the CI pipeline will continue to run smoothly even if Codecov encounters issues during the upload process. The coverage report will still be generated, allowing developers to monitor and improve the test coverage over time without hindrance.

This enhancement will result in a more stable and reliable CI workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.