### PR TITLE
Fix proxy issue with non-IAM connections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # graph-explorer Change Log
 
+## Release 1.3.1
+
+This patch release includes bugfixes for Release 1.3.0.
+
+**Bug fixes**
+- Fix proxy issue with non-IAM Neptune requests (https://github.com/aws/graph-explorer/pull/166)
+
 ## Release 1.3.0
 
 This release includes the following feature enhancements and bug fixes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Graph Explorer",
   "packageManager": "pnpm@7.9.3",
   "engines": {

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -72,6 +72,8 @@ const errorHandler = (error, request, response, next) => {
     new Promise((resolve) => setTimeout(() => resolve(), ms));
 
   const retryFetch = async (url, headers, retries = 1, retryDelay = 10000) => {
+    // remove the existing host headers, we want ensure that we are passing the DB endpoint hostname.
+    delete headers["host"];
     if (headers["aws-neptune-region"]) {
       data = await getIAMHeaders({
         host: url.hostname,
@@ -80,8 +82,6 @@ const errorHandler = (error, request, response, next) => {
         service: "neptune-db",
         region: headers["aws-neptune-region"]
       });
-      // remove the host header because it's not needed for IAM
-      delete headers["host"];
       headers = { ...headers, ...data };
     } 
     for (let i = 0; i < retries; i++) {

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "main": "node-server.js",
   "scripts": {

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Graph Explorer",
   "packageManager": "pnpm@7.9.3",
   "engines": {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed a bug where requests from Explorer to non IAM-enabled Neptune endpoints would fail in cases where HTTPS was enabled on the proxy, with the error: `Hostname/IP does not match certificate's altnames`.
- Bump Graph Explorer version to 1.3.1 for patch release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.