### PR TITLE
Exclude ID from unrelated node attribute search in Gremlin/openCypher

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ The next release will include the following feature enhancements and bug fixes:
 **Features**
 - Added Default Connection support (https://github.com/aws/graph-explorer/pull/108)
 
+**Bug fixes**
+- Fixed Gremlin/openCypher matching ID property on all keyword searches (https://github.com/aws/graph-explorer/pull/169)
+
 ## Release 1.3.1
 
 This patch release includes bugfixes for Release 1.3.0.

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -15,11 +15,23 @@ describe("Gremlin > keywordSearchTemplate", () => {
     expect(template).toBe('g.V().hasLabel("airport").range(0,10)');
   });
 
-  it("Should return a template for searched attributes matching with the search term", () => {
+  it("Should return a template for searched attributes matching with the search terms", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
       searchById: true,
       searchByAttributes: ["city", "code"],
+    });
+
+    expect(template).toBe(
+      'g.V().or(has("city",containing("JFK")),has("code",containing("JFK"))).range(0,10)'
+    );
+  });
+
+  it("Should return a template for searched attributes matching with the search terms, and the ID token attribute", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchById: true,
+      searchByAttributes: ["city", "code", "__all"],
     });
 
     expect(template).toBe(

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -5,6 +5,7 @@ import type { KeywordSearchRequest } from "../../AbstractConnector";
  * @example
  * searchTerm = "JFK"
  * vertexTypes = ["airport"]
+ * searchById = false
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
@@ -37,8 +38,9 @@ const keywordSearchTemplate = ({
 
   if (Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById)) {
     const orContent = uniq(
-      searchById ? ["_id", ...searchByAttributes] : searchByAttributes
+        (searchById && searchByAttributes.includes("__all")) ? ["_id", ...searchByAttributes] : searchByAttributes
     )
+      .filter(attr => attr !== "__all")
       .map(attr => {
         if (attr === "_id") {
           return `has(id,containing("${searchTerm}"))`;

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -8,4 +8,40 @@ describe("OpenCypher > keywordSearchTemplate", () => {
 
     expect(template).toBe('MATCH (v:\`airport\`) RETURN v AS object SKIP 0 LIMIT 10');
   });
+
+  it("Should return a template for searched attributes matching with the search terms", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      searchTerm: "JFK",
+      searchById: true,
+      searchByAttributes: ["city", "code"],
+    });
+
+    expect(template).toBe(
+        'MATCH (v:`airport`) ' +
+        'WHERE v.city CONTAINS "JFK"  ' +
+        'OR v.code CONTAINS "JFK"   ' +
+        'RETURN v AS object ' +
+        'SKIP 0 LIMIT 10'
+    );
+  });
+
+  it("Should return a template for searched attributes matching with the search terms, and the ID token attribute", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      searchTerm: "JFK",
+      searchById: true,
+      searchByAttributes: ["city", "code", "__all"],
+    });
+
+    expect(template).toBe(
+        'MATCH (v:`airport`) ' +
+        'WHERE v.`~id` CONTAINS "JFK"  ' +
+        'OR v.city CONTAINS "JFK"  ' +
+        'OR v.code CONTAINS "JFK"   ' +
+        'RETURN v AS object ' +
+        'SKIP 0 LIMIT 10');
+  });
 });
+
+

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -5,6 +5,7 @@ import type { KeywordSearchRequest } from "../../AbstractConnector";
  * @example
  * searchTerm = "JFK"
  * vertexTypes = ["airport"]
+ * searchById = false
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
@@ -35,8 +36,9 @@ const keywordSearchTemplate = ({
 
   if (Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById)) {
     const orContent = uniq(
-      searchById ? ["id", ...searchByAttributes] : searchByAttributes
+        (searchById && searchByAttributes.includes("__all")) ? ["id", ...searchByAttributes] : searchByAttributes
     )
+      .filter(attr => attr !== "__all")
       .map((attr: any) => {
         if (attr === "id") {
           return `v.\`~id\` CONTAINS "${searchTerm}" `;

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -131,7 +131,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
     selectedVertexType === "__all" ? config?.vertexTypes : [selectedVertexType];
   const searchByAttributes =
     selectedAttribute === "__all"
-      ? uniq(searchableAttributes.map(attr => attr.name))
+      ? uniq(searchableAttributes.map(attr => attr.name).concat("__all"))
       : [selectedAttribute];
 
   const updatePrefixes = usePrefixesUpdater();


### PR DESCRIPTION
Issue #, if available: #168

Description of changes:
- Restricted Gremlin/openCypher keyword search matches on node ID to cases where the user has selected `Attribute`:`All`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.