### PR TITLE
Add Match Precision option to keyword search

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,6 +13,7 @@ on:
         default: 'latest'
   push:
     branches:
+      - Issue-149
       - main
 
 jobs:
@@ -66,7 +67,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           REGISTRY_ALIAS: neptune
           REPOSITORY: graph-explorer
-          IMAGE_TAG: ${{ steps.get-image-tag.outputs.image_tag }}
+          IMAGE_TAG: latest-dev # ${{ steps.get-image-tag.outputs.image_tag }}
         run: |
           docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -13,7 +13,6 @@ on:
         default: 'latest'
   push:
     branches:
-      - Issue-149
       - main
 
 jobs:
@@ -67,7 +66,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           REGISTRY_ALIAS: neptune
           REPOSITORY: graph-explorer
-          IMAGE_TAG: latest-dev # ${{ steps.get-image-tag.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.get-image-tag.outputs.image_tag }}
         run: |
           docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ The next release will include the following feature enhancements and bug fixes:
 **Features**
 - Added Default Connection support (https://github.com/aws/graph-explorer/pull/108)
 - Added query language indicators to created connections (https://github.com/aws/graph-explorer/pull/164)
+- Added match precision option to keyword search (https://github.com/aws/graph-explorer/pull/175)
 
 ## Release 1.3.1
 

--- a/packages/graph-explorer/src/connector/AbstractConnector.ts
+++ b/packages/graph-explorer/src/connector/AbstractConnector.ts
@@ -167,6 +167,10 @@ export type KeywordSearchRequest = {
    * Skip the given number of results.
    */
   offset?: number;
+  /**
+   * Only return exact attribute value matches.
+   */
+  exactMatch?: boolean;
 };
 
 export type KeywordSearchResponse = {

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -15,7 +15,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     expect(template).toBe('g.V().hasLabel("airport").range(0,10)');
   });
 
-  it("Should return a template for searched attributes matching with the search term", () => {
+  it("Should return a template for searched attributes containing the search term", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
       searchById: true,
@@ -24,6 +24,19 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(template).toBe(
       'g.V().or(has(id,containing("JFK")),has("city",containing("JFK")),has("code",containing("JFK"))).range(0,10)'
+    );
+  });
+
+  it("Should return a template for searched attributes exactly matching the search term", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchById: true,
+      searchByAttributes: ["city", "code"],
+      exactMatch: true,
+    });
+
+    expect(template).toBe(
+      'g.V().or(has(id,"JFK"),has("city","JFK"),has("code","JFK")).range(0,10)'
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -18,12 +18,23 @@ describe("Gremlin > keywordSearchTemplate", () => {
   it("Should return a template for searched attributes containing the search term", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
-      searchById: true,
       searchByAttributes: ["city", "code"],
     });
 
     expect(template).toBe(
       'g.V().or(has("city",containing("JFK")),has("code",containing("JFK"))).range(0,10)'
+    );
+  });
+
+  it("Should return a template for searched attributes exactly matching the search term", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchByAttributes: ["city", "code"],
+      exactMatch: true,
+    });
+
+    expect(template).toBe(
+      'g.V().or(has("city","JFK"),has("code","JFK")).range(0,10)'
     );
   });
 
@@ -36,19 +47,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(template).toBe(
       'g.V().or(has(id,containing("JFK")),has("city",containing("JFK")),has("code",containing("JFK"))).range(0,10)'
-    );
-  });
-
-  it("Should return a template for searched attributes exactly matching the search term", () => {
-    const template = keywordSearchTemplate({
-      searchTerm: "JFK",
-      searchById: true,
-      searchByAttributes: ["city", "code"],
-      exactMatch: true,
-    });
-
-    expect(template).toBe(
-      'g.V().or(has(id,"JFK"),has("city","JFK"),has("code","JFK")).range(0,10)'
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -8,6 +8,7 @@ import type { KeywordSearchRequest } from "../../AbstractConnector";
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
+ * exactMatch = false
  *
  * g.V()
  *  .hasLabel("airport")

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -24,6 +24,7 @@ const keywordSearchTemplate = ({
   searchByAttributes = [],
   limit = 10,
   offset = 0,
+  exactMatch = false,
 }: KeywordSearchRequest): string => {
   let template = "g.V()";
 
@@ -41,7 +42,13 @@ const keywordSearchTemplate = ({
     )
       .map(attr => {
         if (attr === "_id") {
+          if (exactMatch === true) {
+             return `has(id,"${searchTerm}")`;
+          }
           return `has(id,containing("${searchTerm}"))`;
+        }
+        if (exactMatch === true) {
+          return `has("${attr}","${searchTerm}")`;
         }
         return `has("${attr}",containing("${searchTerm}"))`;
       })

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -9,19 +9,34 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(template).toBe('MATCH (v:\`airport\`) RETURN v AS object SKIP 0 LIMIT 10');
   });
 
+  it("Should return a template for searched attributes containing the search term", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      searchTerm: "JFK",
+      searchByAttributes: ["city", "code"],
+      exactMatch: false,
+    });
+
+    expect(template).toBe(
+        'MATCH (v:`airport`) ' +
+        'WHERE v.city CONTAINS "JFK"  ' +
+        'OR v.code CONTAINS "JFK"   ' +
+        'RETURN v AS object ' +
+        'SKIP 0 LIMIT 10'
+    );
+  });
+
   it("Should return a template for searched attributes exactly matching with the search term", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       searchByAttributes: ["city", "code"],
       exactMatch: true,
     });
 
     expect(template).toBe(
         'MATCH (v:`airport`) ' +
-        'WHERE v.`~id` = "JFK"  ' +
-        'OR v.city = "JFK"  ' +
+        'WHERE v.city = "JFK"  ' +
         'OR v.code = "JFK"   ' +
         'RETURN v AS object ' +
         'SKIP 0 LIMIT 10'

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -8,4 +8,23 @@ describe("OpenCypher > keywordSearchTemplate", () => {
 
     expect(template).toBe('MATCH (v:\`airport\`) RETURN v AS object SKIP 0 LIMIT 10');
   });
+
+  it("Should return a template for searched attributes exactly matching with the search term", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      searchTerm: "JFK",
+      searchById: true,
+      searchByAttributes: ["city", "code"],
+      exactMatch: true,
+    });
+
+    expect(template).toBe(
+        'MATCH (v:`airport`) ' +
+        'WHERE v.`~id` = "JFK"  ' +
+        'OR v.city = "JFK"  ' +
+        'OR v.code = "JFK"   ' +
+        'RETURN v AS object ' +
+        'SKIP 0 LIMIT 10'
+    );
+  });
 });

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -24,6 +24,7 @@ const keywordSearchTemplate = ({
   searchByAttributes = [],
   limit = 10,
   offset = 0,
+  exactMatch = false,
 }: KeywordSearchRequest): string => {
   let template = "";
 
@@ -39,7 +40,13 @@ const keywordSearchTemplate = ({
     )
       .map((attr: any) => {
         if (attr === "id") {
+          if (exactMatch === true) {
+             return `v.\`~id\` = "${searchTerm}" `;
+          }
           return `v.\`~id\` CONTAINS "${searchTerm}" `;
+        }
+        if (exactMatch === true) {
+           return `v.${attr} = "${searchTerm}" `;
         }
         return `v.${attr} CONTAINS "${searchTerm}" `;
       })

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -8,6 +8,7 @@ import type { KeywordSearchRequest } from "../../AbstractConnector";
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
+ * exactMatch = false
  *
  * MATCH (v:airport)
  * WHERE

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearchTemplate.ts
@@ -10,6 +10,7 @@ import { SPARQLKeywordSearchRequest } from "../types";
  * ]
  * limit = 10
  * offset = 0
+ * exactMatch = False
  *
  * SELECT ?subject ?pred ?value ?class {
  *   ?subject ?pred ?value {
@@ -37,6 +38,7 @@ const keywordSearchTemplate = ({
   predicates = [],
   limit = 10,
   offset = 0,
+  exactMatch = false,
 }: SPARQLKeywordSearchRequest): string => {
   const getSubjectClasses = () => {
     if (!subjectClasses?.length) {
@@ -78,7 +80,11 @@ const keywordSearchTemplate = ({
     }
 
     let filterBySearchTerm = "";
-    filterBySearchTerm = `FILTER (regex(str(?value), "${searchTerm}", "i"))`;
+    if (exactMatch === true) {
+      filterBySearchTerm = `FILTER (?value = "${searchTerm}"))`;
+    } else {
+      filterBySearchTerm = `FILTER (regex(str(?value), "${searchTerm}", "i"))`;
+    }
     return filterBySearchTerm;
   };
 

--- a/packages/graph-explorer/src/hooks/translations/gremlin-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/gremlin-translations.json
@@ -31,7 +31,8 @@
   },
   "keyword-search": {
     "node-type": "Node Type",
-    "node-attribute": "Attribute"
+    "node-attribute": "Attribute",
+    "node-exact-match": "Match Precision"
   },
   "entities-filter": {
     "node-types": "Node Types",

--- a/packages/graph-explorer/src/hooks/translations/openCypher-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/openCypher-translations.json
@@ -31,7 +31,8 @@
     },
     "keyword-search": {
       "node-type": "Node Type",
-      "node-attribute": "Attribute"
+      "node-attribute": "Attribute",
+      "node-exact-match": "Match Precision"
     },
     "entities-filter": {
       "node-types": "Node Types",

--- a/packages/graph-explorer/src/hooks/translations/sparql-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/sparql-translations.json
@@ -31,7 +31,8 @@
   },
   "keyword-search": {
     "node-type": "Class",
-    "node-attribute": "Predicate"
+    "node-attribute": "Predicate",
+    "node-exact-match": "Match Precision"
   },
   "entities-filter": {
     "node-types": "Resource Types",

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -18,6 +18,7 @@ import {
   SearchSadIcon,
   Select,
   VertexIcon,
+  Checkbox,
 } from "../../components";
 import { CarouselRef } from "../../components/Carousel/Carousel";
 import HumanReadableNumberFormatter from "../../components/HumanReadableNumberFormatter";
@@ -70,6 +71,9 @@ const KeywordSearch = ({
     selectedAttribute,
     attributesOptions,
     onAttributeOptionChange,
+    exactMatch,
+    exactMatchOptions,
+    onExactMatchChange,
   } = useKeywordSearch({
     isOpen: isFocused,
   });
@@ -276,7 +280,7 @@ const KeywordSearch = ({
               options={vertexOptions}
               value={selectedVertexType}
               onChange={onVertexOptionChange}
-              menuWidth={200}
+              menuWidth={150}
             />
             <Select
               className={pfx("entity-select")}
@@ -286,7 +290,17 @@ const KeywordSearch = ({
               options={attributesOptions}
               value={selectedAttribute}
               onChange={onAttributeOptionChange}
-              menuWidth={200}
+              menuWidth={150}
+            />
+            <Select
+              className={pfx("entity-select")}
+              label={t("keyword-search.node-exact-match")}
+              labelPlacement={"inner"}
+              hideError={true}
+              options={exactMatchOptions}
+              value={exactMatch ? "Exact" : "Fuzzy"}
+              onChange={onExactMatchChange}
+              menuWidth={150}
             />
             <Input
               className={pfx("search-input")}

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -298,7 +298,7 @@ const KeywordSearch = ({
               labelPlacement={"inner"}
               hideError={true}
               options={exactMatchOptions}
-              value={exactMatch ? "Exact" : "Fuzzy"}
+              value={exactMatch ? "Exact" : "Partial"}
               onChange={onExactMatchChange}
               menuWidth={150}
             />

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -23,7 +23,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
   const [selectedAttribute, setSelectedAttribute] = useState("__all");
   const [exactMatch, setExactMatch] = useState(false);
   const textTransform = useTextTransform();
-  const exactMatchOptions = [{ label: "Exact", value: "Exact" }, { label: "Fuzzy", value: "Fuzzy" }];
+  const exactMatchOptions = [{ label: "Exact", value: "Exact" }, { label: "Partial", value: "Partial" }];
 
   const vertexOptions = useMemo(() => {
     const vertexOps =

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -156,6 +156,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
           vertexTypes,
           searchByAttributes,
           searchById: true,
+          exactMatch: false,
         },
         { abortSignal: controller.signal }
       ) as PromiseWithCancel<KeywordSearchResponse>;

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -21,7 +21,9 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
   const debouncedSearchTerm = useDebounceValue(searchTerm, 1000);
   const [selectedVertexType, setSelectedVertexType] = useState("__all");
   const [selectedAttribute, setSelectedAttribute] = useState("__all");
+  const [exactMatch, setExactMatch] = useState(false);
   const textTransform = useTextTransform();
+  const exactMatchOptions = [{ label: "Exact", value: "Exact" }, { label: "Fuzzy", value: "Fuzzy" }];
 
   const vertexOptions = useMemo(() => {
     const vertexOps =
@@ -48,6 +50,15 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
 
   const onAttributeOptionChange = useCallback((value: string | string[]) => {
     setSelectedAttribute(value as string);
+  }, []);
+
+  const onExactMatchChange = useCallback((value: string) => {
+    if (value === "Exact") {
+      setExactMatch(true);
+    }
+    else {
+      setExactMatch(false);
+    }
   }, []);
 
   const searchableAttributes = useMemo(() => {
@@ -141,6 +152,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
       debouncedSearchTerm,
       vertexTypes,
       searchByAttributes,
+      exactMatch,
       isMount,
       isOpen,
     ],
@@ -156,7 +168,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
           vertexTypes,
           searchByAttributes,
           searchById: true,
-          exactMatch: false,
+          exactMatch: exactMatch,
         },
         { abortSignal: controller.signal }
       ) as PromiseWithCancel<KeywordSearchResponse>;
@@ -192,6 +204,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
 
   useEffect(() => {
     setSelectedAttribute("__all");
+    setExactMatch(false);
   }, [selectedVertexType]);
 
   return {
@@ -206,6 +219,9 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
     selectedAttribute,
     attributesOptions,
     onAttributeOptionChange,
+    exactMatch,
+    exactMatchOptions,
+    onExactMatchChange,
     searchResults: data?.vertices || [],
   };
 };


### PR DESCRIPTION
Issue #, if available: #149

Description of changes:
- Added a new `Match Precision` drop-down field to the keyword search interface. Users can now choose to match using options:
  - a) `Exact`: Node must have an attribute value that matches the search keyword exactly. 
  - b) `Partial`: Node has an attribute value containing the search keyword. This option is identical to the old search behavior, and will remain as the default option.

Example usage:
- EDIT: `Fuzzy` option has been renamed to `Partial`.
![Screen Shot 2023-08-21 at 7 34 10 PM](https://github.com/aws/graph-explorer/assets/10456376/22e20387-9cac-4bac-aa18-9b3e06eed46d)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.