### PR TITLE
Add toggle option for limit on retrieved vertex neighbors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ The next release will include the following feature enhancements and bug fixes:
 **Features**
 - Added Default Connection support (https://github.com/aws/graph-explorer/pull/108)
 - Added query language indicators to created connections (https://github.com/aws/graph-explorer/pull/164)
+- Add toggle for limit on retrieved vertex neighbors (https://github.com/aws/graph-explorer/pull/176)
 
 ## Release 1.3.1
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
@@ -29,7 +29,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v) -[e]- (t) WHERE ID(v) = \"12\" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count LIMIT 0'
+      'MATCH (v) -[e]- (t) WHERE ID(v) = \"12\" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count'
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
@@ -18,7 +18,14 @@ const neighborsCountTemplate = ({
   vertexId,
   limit = 500,
 }: NeighborsCountRequest) => {
-  return `MATCH (v) -[e]- (t) WHERE ID(v) = \"${vertexId}\" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count LIMIT ${limit}`;
+  let template = "";
+  template = `MATCH (v) -[e]- (t) WHERE ID(v) = \"${vertexId}\" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count`;
+
+  if (limit > 0) {
+    template += ` LIMIT ${limit}`;
+  }
+
+  return template;
 };
 
 export default neighborsCountTemplate;

--- a/packages/graph-explorer/src/hooks/useFetchNode.ts
+++ b/packages/graph-explorer/src/hooks/useFetchNode.ts
@@ -8,21 +8,23 @@ const useFetchNode = () => {
   const connector = useConnector();
 
   const fetchNeighborsCount = useCallback(
-    (vertexId: string) => {
+    (vertexId: string, neighbors_limit: number) => {
       return connector.explorer?.fetchNeighborsCount({
         vertexId: vertexId,
+        limit: neighbors_limit,
       });
     },
     [connector.explorer]
   );
 
   return useCallback(
-    async (nodeOrNodes: Vertex | Vertex[]) => {
+    async (nodeOrNodes: Vertex | Vertex[], limit: number) => {
       const nodes = Array.isArray(nodeOrNodes) ? nodeOrNodes : [nodeOrNodes];
+      const neighbors_limit = limit;
 
       const results = await Promise.all(
         nodes.map(async node => {
-          const neighborsCount = await fetchNeighborsCount(node.data.id);
+          const neighborsCount = await fetchNeighborsCount(node.data.id, neighbors_limit);
           if (!neighborsCount) {
             return;
           }

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeDrop.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeDrop.ts
@@ -16,7 +16,7 @@ const useNodeDrop = () => {
       canDrop: monitor.canDrop(),
     }),
     drop: node => {
-      fetchNode(node, 1000000);
+      fetchNode(node, 0);
     },
   });
 

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeDrop.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeDrop.ts
@@ -16,7 +16,7 @@ const useNodeDrop = () => {
       canDrop: monitor.canDrop(),
     }),
     drop: node => {
-      fetchNode(node);
+      fetchNode(node, 1000000);
     },
   });
 

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -139,7 +139,7 @@ const KeywordSearch = ({
               size={"small"}
               variant={"text"}
               onPress={() => {
-                const numNeighborsLimit = neighborsLimit ? 500 : 1000000;
+                const numNeighborsLimit = neighborsLimit ? 500 : 0;
                 fetchNode(vertex, numNeighborsLimit);
                 setInputFocused(false);
               }}
@@ -194,7 +194,7 @@ const KeywordSearch = ({
     const nodes = nodeIdsToAdd
       .map(getNodeSearchedById)
       .filter(Boolean) as Vertex[];
-    const numNeighborsLimit = neighborsLimit ? 500 : 1000000;
+    const numNeighborsLimit = neighborsLimit ? 500 : 0;
     fetchNode(nodes, numNeighborsLimit);
     handleOnClose();
   };

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -1,7 +1,7 @@
-import { css, cx } from "@emotion/css";
-import { useClickOutside, useHotkeys } from "@mantine/hooks";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Vertex } from "../../@types/entities";
+import {css, cx} from "@emotion/css";
+import {useClickOutside, useHotkeys} from "@mantine/hooks";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import {Vertex} from "../../@types/entities";
 
 import {
   AddCircleIcon,
@@ -18,17 +18,13 @@ import {
   SearchSadIcon,
   Select,
   VertexIcon,
+  Checkbox,
 } from "../../components";
-import { CarouselRef } from "../../components/Carousel/Carousel";
+import {CarouselRef} from "../../components/Carousel/Carousel";
 import HumanReadableNumberFormatter from "../../components/HumanReadableNumberFormatter";
 import RemoveFromCanvasIcon from "../../components/icons/RemoveFromCanvasIcon";
-import {
-  fade,
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
-import { useEntities, useFetchNode, useSet } from "../../hooks";
+import {fade, useConfiguration, useWithTheme, withClassNamePrefix,} from "../../core";
+import {useEntities, useFetchNode, useSet} from "../../hooks";
 import useDisplayNames from "../../hooks/useDisplayNames";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
@@ -70,6 +66,8 @@ const KeywordSearch = ({
     selectedAttribute,
     attributesOptions,
     onAttributeOptionChange,
+    neighborsLimit,
+    onNeighborsLimitChange,
   } = useKeywordSearch({
     isOpen: isFocused,
   });
@@ -141,7 +139,8 @@ const KeywordSearch = ({
               size={"small"}
               variant={"text"}
               onPress={() => {
-                fetchNode(vertex);
+                const numNeighborsLimit = neighborsLimit ? 500 : 1000000;
+                fetchNode(vertex, numNeighborsLimit);
                 setInputFocused(false);
               }}
             />
@@ -159,6 +158,7 @@ const KeywordSearch = ({
     pfx,
     setEntities,
     fetchNode,
+    neighborsLimit,
   ]);
 
   const isTheNodeAdded = (nodeId: string): boolean => {
@@ -194,7 +194,8 @@ const KeywordSearch = ({
     const nodes = nodeIdsToAdd
       .map(getNodeSearchedById)
       .filter(Boolean) as Vertex[];
-    fetchNode(nodes);
+    const numNeighborsLimit = neighborsLimit ? 500 : 1000000;
+    fetchNode(nodes, numNeighborsLimit);
     handleOnClose();
   };
 
@@ -388,6 +389,12 @@ const KeywordSearch = ({
                 <HumanReadableNumberFormatter value={currentTotal} />
               )}
             </span>
+            <Checkbox
+              isSelected={neighborsLimit}
+              onChange={onNeighborsLimitChange}
+            >
+              <div className={pfx("neighbors-limit-checkbox")}>Limit Neighbors?</div>
+            </Checkbox>
             <div>
               <IconButton
                 className={pfx("actions-button")}

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -21,6 +21,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
   const debouncedSearchTerm = useDebounceValue(searchTerm, 1000);
   const [selectedVertexType, setSelectedVertexType] = useState("__all");
   const [selectedAttribute, setSelectedAttribute] = useState("__all");
+  const [neighborsLimit, setNeighborsLimit] = useState(true);
   const textTransform = useTextTransform();
 
   const vertexOptions = useMemo(() => {
@@ -48,6 +49,10 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
 
   const onAttributeOptionChange = useCallback((value: string | string[]) => {
     setSelectedAttribute(value as string);
+  }, []);
+
+  const onNeighborsLimitChange = useCallback(() => {
+    setNeighborsLimit(neighborsLimit => !neighborsLimit);
   }, []);
 
   const searchableAttributes = useMemo(() => {
@@ -141,6 +146,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
       debouncedSearchTerm,
       vertexTypes,
       searchByAttributes,
+      neighborsLimit,
       isMount,
       isOpen,
     ],
@@ -191,6 +197,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
 
   useEffect(() => {
     setSelectedAttribute("__all");
+    setNeighborsLimit(true);
   }, [selectedVertexType]);
 
   return {
@@ -205,6 +212,8 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
     selectedAttribute,
     attributesOptions,
     onAttributeOptionChange,
+    neighborsLimit,
+    onNeighborsLimitChange,
     searchResults: data?.vertices || [],
   };
 };


### PR DESCRIPTION
Issue #, if available: #172

Description of changes:
- Added a `Limit Neighbors?` checkbox element in the search UI. By default, this option will be checked, allowing for a maximum of 500 neighbors to be retrieved for each vertex added to the canvas. If unchecked by the user, no limit will be imposed on inserted vertices.

Example Usage:

![Screen Shot 2023-08-22 at 12 19 19 AM](https://github.com/aws/graph-explorer/assets/10456376/53bb1ccb-d07c-42b5-bc36-bd762f109def)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.