### PR TITLE
Fixed search UI crashing on node select/preview

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ The next release will include the following feature enhancements and bug fixes:
 - Added Default Connection support (https://github.com/aws/graph-explorer/pull/108)
 - Added query language indicators to created connections (https://github.com/aws/graph-explorer/pull/164)
 
+**Bug fixes**
+- Fixed search UI crashing on node select/preview (https://github.com/aws/graph-explorer/pull/177)
+
 ## Release 1.3.1
 
 This patch release includes bugfixes for Release 1.3.0.

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -354,6 +354,9 @@ const KeywordSearch = ({
                     ref={carouselRef}
                     slidesToShow={1}
                     className={pfx("carousel")}
+                    pagination={{
+                      el: `.swiper-pagination`
+                    }}
                   >
                     {Array.from(selection.state).map(nodeId => {
                       const node = searchResults.find(


### PR DESCRIPTION
Issue #, if available: #165

Description of changes:
- Fixed a bug where the keyword search handler failed to pass sufficient PaginationOptions to the details preview renderer  upon node selection.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.