### PR TITLE
Persist node/edge highlighting on selection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ The next release will include the following feature enhancements and bug fixes:
 - Fixed search UI crashing on node select/preview (https://github.com/aws/graph-explorer/pull/177)
 - Fixed Gremlin/openCypher matching ID property on all keyword searches (https://github.com/aws/graph-explorer/pull/169)
 - Resolved deprecation warnings in GitHub workflows (https://github.com/aws/graph-explorer/pull/181)
+- Fixed highlight not persisting on selected graph element (https://github.com/aws/graph-explorer/pull/187)
 
 ## Release 1.3.1
 

--- a/packages/graph-explorer/src/components/Graph/hooks/useManageElementsSelection.ts
+++ b/packages/graph-explorer/src/components/Graph/hooks/useManageElementsSelection.ts
@@ -87,7 +87,7 @@ export default function useManageElementsSelection(
   }, [options?.autounselectify, options?.disableSelectionEvents]);
 
   // Init cytoscape Select and unselect event handlers
-  const handlers = useRef<Handlers>({
+  const handlers = useRef<Handlers>(<Handlers>{
     onSelectedEdgesIdsChange,
     onSelectedGroupsIdsChange,
     onSelectedNodesIdsChange,
@@ -165,19 +165,19 @@ export default function useManageElementsSelection(
   useEntitySelection(
     cy,
     "node:selected[!__isGroupNode]",
-    selectedNodesIds,
+    selectedNodesIds!,
     isSelectionDisabled
   );
   useEntitySelection(
     cy,
     "node:selected[?__isGroupNode]",
-    selectedGroupsIds,
+    selectedGroupsIds!,
     isSelectionDisabled
   );
   useEntitySelection(
     cy,
     "edge:selected",
-    selectedEdgesIds,
+    selectedEdgesIds!,
     isSelectionDisabled
   );
 }

--- a/packages/graph-explorer/src/components/Graph/hooks/useManageStyles.ts
+++ b/packages/graph-explorer/src/components/Graph/hooks/useManageStyles.ts
@@ -26,16 +26,16 @@ export const getStyles = ({
   const rootStyles: cytoscape.StylesheetStyle[] = [];
 
   if (!hideDefaultNodeLabels) {
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "node[id]",
       style: { label: "data(id)" },
     });
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "node[label]",
       style: { label: "data(label)" },
     });
     if (defaultNodeLabelAttribute) {
-      rootStyles.push({
+      rootStyles.push(<cytoscape.StylesheetStyle>{
         selector: `node[${defaultNodeLabelAttribute}]`,
         style: { label: `data(${defaultNodeLabelAttribute})` },
       });
@@ -43,21 +43,21 @@ export const getStyles = ({
   }
 
   if (!hideDefaultEdgeLabels) {
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "edge[id]",
       style: { label: "data(id)" },
     });
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "edge[label]",
       style: { label: "data(label)" },
     });
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "edge[type]",
       style: { label: "data(type)" },
     });
 
     if (defaultEdgeLabelAttribute) {
-      rootStyles.push({
+      rootStyles.push(<cytoscape.StylesheetStyle>{
         selector: `edge[${defaultEdgeLabelAttribute}]`,
         style: { label: `data(${defaultEdgeLabelAttribute})` },
       });
@@ -68,7 +68,7 @@ export const getStyles = ({
     const stylesWithDefault = styles?.[selector]
       ? { ...style, ...styles?.[selector] }
       : style;
-    rootStyles.push({ selector, style: stylesWithDefault });
+    rootStyles.push(<cytoscape.StylesheetStyle>{selector, style: stylesWithDefault});
   }
 
   // Base styles
@@ -80,7 +80,7 @@ export const getStyles = ({
   }
 
   if (badgesEnabled === false) {
-    rootStyles.push({
+    rootStyles.push(<cytoscape.StylesheetStyle>{
       selector: "node",
       style: {
         label: "",


### PR DESCRIPTION
Issue #, if available: #179

Description of changes:
- Fixed an issue where clicking on a node or edge in the graph would fail to result in the element remaining highlighted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.