### PR TITLE
Bump lodash versions in lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6408,7 +6408,7 @@ packages:
     resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
     dependencies:
       graphlib: 2.1.8
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: false
 
   /data-uri-to-buffer@4.0.1:
@@ -7605,7 +7605,7 @@ packages:
   /graphlib@2.1.8:
     resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
     dependencies:
-      lodash: 4.17.20
+      lodash: 4.17.21
     dev: false
 
   /hamt_plus@1.0.2:
@@ -8806,9 +8806,6 @@ packages:
   /lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
     dev: true
-
-  /lodash@4.17.20:
-    resolution: {integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==}
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}


### PR DESCRIPTION
Issue #, if available: CVE-2020-28500, CVE-2021-23337

Description of changes:
- Cleaned up remaining usages of `lodash` v4.17.20 in the base pnpm lockfile, mainly from chain dependencies of `cytoscape-dagre`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.