### PR TITLE
Update Dockerfile base image to AL2022

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ The next release will include the following feature enhancements and bug fixes:
 - Added toggle for limit on retrieved vertex neighbors (https://github.com/aws/graph-explorer/pull/176)
 - Added SageMaker Notebook hosting documentation (https://github.com/aws/graph-explorer/pull/183)
 - Added ECS hosting documentation (https://github.com/aws/graph-explorer/pull/174)
+- Updated Dockerfile base image to AL2022 (https://github.com/aws/graph-explorer/pull/190)
 
 **Bug fixes**
 - Fixed search UI crashing on node select/preview (https://github.com/aws/graph-explorer/pull/177)


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Migrating the Dockerfile off AL2 in favor of AL2022 platform, due to standing [vulnerabilities](https://hub.docker.com/layers/library/amazonlinux/2/images/sha256-993d82940dba5370065dd5afb99fab56cdaf9f7b88800e88ddbd622678a6d3ea?context=explore) in the former.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.