### PR TITLE
Update Docker Tag to latest-SNAPSHOT for ERC Images

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -39,10 +39,10 @@ jobs:
             if ${{ inputs.image_tag == 'release'}}; then
               echo "image_tag=${{ steps.package-version.outputs.version }}" >> $GITHUB_OUTPUT
             else
-              echo "image_tag=latest" >> $GITHUB_OUTPUT
+              echo "image_tag=latest-SNAPSHOT" >> $GITHUB_OUTPUT
             fi
           else
-            echo "image_tag=latest" >> $GITHUB_OUTPUT
+            echo "image_tag=latest-SNAPSHOT" >> $GITHUB_OUTPUT
           fi
 
       - name: Configure AWS Credentials

--- a/additionaldocs/sagemaker/install-graph-explorer-lc.sh
+++ b/additionaldocs/sagemaker/install-graph-explorer-lc.sh
@@ -49,7 +49,7 @@ echo "Explorer IAM auth mode: ${IAM}"
 
 echo "Pulling and starting graph-explorer..."
 if [[ ${EXPLORER_VERSION} == "" ]]; then
-  EXPLORER_ECR_TAG=sagemaker-latest
+  EXPLORER_ECR_TAG=sagemaker-latest-SNAPSHOT
 else
   EXPLORER_ECR_TAG=sagemaker-${EXPLORER_VERSION}
 fi


### PR DESCRIPTION
Issue #, if available:

## Description of changes:

This Pull Request updates the tagging convention used in our GitHub Actions workflow for building and pushing Docker images. The `latest` tag is replaced with `latest-SNAPSHOT` to provide a clearer distinction between stable releases and the latest development snapshot of the ERC images. 

This naming convention aligns with common practices, making it easier to identify the nature of each image and ensuring a more organized and predictable tagging structure. By adopting this change, we are moving towards a more descriptive and developer-friendly tagging system for our Docker image repository.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
