### PR TITLE
PR for Sometimes auto-expand fails with error & "findDOMNode is deprecated in StrictMode" error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,8 @@ The next release will include the following feature enhancements and bug fixes:
 
 **Bug fixes**
 
-- Fixed loading spinner rotation when synchronizing schema (<<https://github.com/aws/graph-explorer/pull/207>)
+- Fixed issue with Transition2 findDOMNode deprecation (<https://github.com/aws/graph-explorer/pull/211>
+- Fixed loading spinner rotation when synchronizing schema (<https://github.com/aws/graph-explorer/pull/207>)
 - Fixed highlight not persisting on selected graph element (<https://github.com/aws/graph-explorer/pull/187>)
 - Bumped @types/semver to 7.5.2 in lockfile
 

--- a/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
+++ b/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import { createContext, CSSProperties, FC, useCallback } from "react";
+import React, { createContext, CSSProperties, FC, useCallback } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { v4 } from "uuid";
 
@@ -132,6 +132,8 @@ export const NotificationProvider: FC<NotificationProviderProps> = ({
     [dispatchNotification]
   );
 
+  const nodeRef = React.useRef(null);
+
   return (
     <NotificationContext.Provider
       value={{
@@ -169,6 +171,7 @@ export const NotificationProvider: FC<NotificationProviderProps> = ({
           >
             {state.active.map(notification => (
               <CSSTransition
+                nodeRef={nodeRef}
                 key={notification.id}
                 timeout={200}
                 classNames={"item"}

--- a/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
+++ b/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/css";
-import React, { createContext, CSSProperties, FC, useCallback } from "react";
+import { createContext, CSSProperties, FC, useCallback, useRef } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { v4 } from "uuid";
 
@@ -132,7 +132,7 @@ export const NotificationProvider: FC<NotificationProviderProps> = ({
     [dispatchNotification]
   );
 
-  const nodeRef = React.useRef(null);
+  const nodeRef = useRef<HTMLElement>(null);
 
   return (
     <NotificationContext.Provider


### PR DESCRIPTION
Issue #43
Issue #146 

## Description of changes:

By using the nodeRef object instead of findDOMNode, we've avoided the warning message and updated the code to use the recommended approach.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.