### PR TITLE
Gremlin Connector Timeout Fix when Fetching Vertex Schema upon Database Synchronization

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.test.ts
@@ -3,12 +3,18 @@ import verticesSchemaTemplate from "./verticesSchemaTemplate";
 describe("Gremlin > verticesSchemaTemplate", () => {
   it("Should return a template with the projection of each type", () => {
     const template = verticesSchemaTemplate({ types: ["airport", "country"] });
+    const expectedValue = 'g.V()' +
+        '.union(' +
+        '__.hasLabel("airport").limit(1),' +
+        '__.hasLabel("country").limit(1)' +
+        ')' +
+        '.fold()' +
+        '.project("airport","country")' +
+        '.by(unfold().hasLabel("airport"))' +
+        '.by(unfold().hasLabel("country"))'
 
     expect(template).toBe(
-      'g.V().project("airport","country")' +
-        '.by(V().hasLabel("airport").limit(1))' +
-        '.by(V().hasLabel("country").limit(1))' +
-        ".limit(1)"
+        expectedValue
     );
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/verticesSchemaTemplate.ts
@@ -8,15 +8,19 @@ import { uniq } from "lodash";
  * types = ["route", "contain"]
  *
  * g.V()
+ *  .union(
+ *    __.hasLabel("airport").limit(1),
+ *    __.hasLabel("country").limit(1)
+ *  )
+ *  .fold()
  *  .project("airport","country")
- *  .by(V().hasLabel("airport").limit(1))
- *  .by(V().hasLabel("country").limit(1))
- *  .limit(1)
+ *  .by(unfold().hasLabel("airport"))
+ *  .by(unfold().hasLabel("country"))
  */
 const verticesSchemaTemplate = ({ types }: { types: string[] }) => {
   const labels = uniq(types.flatMap(type => type.split("::")));
 
-  return `g.V().project(${labels.map(l => `"${l}"`).join(",")})${labels.map(l => `.by(V().hasLabel("${l}").limit(1))`).join("")}.limit(1)`;
+  return `g.V().union(${labels.map(l => `__.hasLabel("${l}").limit(1)`).join(",")}).fold().project(${labels.map(l => `"${l}"`).join(",")})${labels.map(l => `.by(unfold().hasLabel("${l}"))`).join("")}`;
 };
 
 export default verticesSchemaTemplate;

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -2,7 +2,7 @@ import { shortHash } from "./shortHash";
 
 const GREMLIN = "../gremlin/queries/__mock";
 const RESPONSES_FILES_MAP: Record<string, string> = {
-  "3e5ee5ec": `${GREMLIN}/vertices-schema.json`,
+  "46b9d76b": `${GREMLIN}/vertices-schema.json`,
   "186857e1": `${GREMLIN}/vertices-labels-and-counts.json`,
   "5766be04": `${GREMLIN}/edges-schema.json`,
   "7062d2e": `${GREMLIN}/edges-labels-and-counts.json`,


### PR DESCRIPTION
Issue:

* [[Bug] Gremlin Connector Timeout when Fetching Vertex Schema upon Database Synchronizing #225](https://github.com/aws/graph-explorer/issues/225)

## Description of changes:

* Updated vertices schema template for the Gremlin Connector. This code change addresses the timeout issue of Gremlin Connector fetching vertex schema upon database synchronization.
* Updated unit test that checks the generation of the schema template for the Gremlin Connector.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.