### PR TITLE
Refactor API request options for non IAM users, enforce JSON response format for SPARQL

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 ## Upcoming
 
+The next release will include the following feature enhancements and bug fixes:
+
+**Bug fixes**
+
+- Refactored API request options for non-IAM endpoints (<https://github.com/aws/graph-explorer/pull/230>)
+- Enforced JSON response format for SPARQL queries (<https://github.com/aws/graph-explorer/pull/230>)
+
 ## Release 1.5.0
 
 This release includes the following feature enhancements and bug fixes:

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -95,6 +95,15 @@ const retryFetch = async (
         headers: data.headers,
       };
     }
+    options = {
+      host: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+      service: "neptune-db",
+      method: options.method,
+      body: options.body ?? undefined,
+      headers: options.headers,
+    };
 
     try {
       const res = await fetch(url.href, options);
@@ -169,7 +178,9 @@ async function fetchData(res, next, url, options, isIamEnabled, region) {
     const rawUrl = `${req.headers["graph-db-connection-url"]}/sparql`;
     const requestOptions = {
       method: "POST",
-      // Properly encode the query to ensure it's safe for URL transport.
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
       body: `query=${encodeURIComponent(req.body.query)}`,
     };
     const isIamEnabled = !!req.headers["aws-neptune-region"];
@@ -190,6 +201,9 @@ async function fetchData(res, next, url, options, isIamEnabled, region) {
     const rawUrl = `${req.headers["graph-db-connection-url"]}/gremlin`;
     const requestOptions = {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify(body),
     };
 
@@ -211,6 +225,9 @@ async function fetchData(res, next, url, options, isIamEnabled, region) {
 
     const requestOptions = {
       method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
       body: `query=${encodeURIComponent(req.body.query)}`,
     };
 

--- a/packages/graph-explorer/src/connector/gremlin/useGremlin.ts
+++ b/packages/graph-explorer/src/connector/gremlin/useGremlin.ts
@@ -40,7 +40,7 @@ const useGremlin = () => {
         method: "GET",
         ...ops
       });
-      summary = response.payload.graphSummary as GraphSummary;
+      summary = response.payload.graphSummary as GraphSummary || undefined;
     } catch (e) {
       if (import.meta.env.DEV) {
         console.error("[Summary API]", e);

--- a/packages/graph-explorer/src/connector/openCypher/useOpenCypher.ts
+++ b/packages/graph-explorer/src/connector/openCypher/useOpenCypher.ts
@@ -36,7 +36,8 @@ const useOpenCypher = () => {
         method: "GET",
         ...ops
       });
-      summary = response.payload.graphSummary as GraphSummary;
+
+      summary = response.payload.graphSummary as GraphSummary || undefined;
     } catch (e) {
       if (import.meta.env.DEV) {
         console.error("[Summary API]", e);

--- a/packages/graph-explorer/src/connector/sparql/useSPARQL.ts
+++ b/packages/graph-explorer/src/connector/sparql/useSPARQL.ts
@@ -118,6 +118,7 @@ const useSPARQL = (blankNodes: BlankNodesMap) => {
       return useFetch.request(`${url}/sparql`, {
         method: 'POST',
         headers: {
+          "accept": "application/json",
           'Content-Type': 'application/x-www-form-urlencoded',
         },
         body,
@@ -135,7 +136,7 @@ const useSPARQL = (blankNodes: BlankNodesMap) => {
         method: "GET",
         ...ops
       });
-      summary = response.payload.graphSummary as GraphSummary;
+      summary = response.payload.graphSummary as GraphSummary || undefined;
     } catch (e) {
       if (import.meta.env.DEV) {
         console.error("[Summary API]", e);


### PR DESCRIPTION
Issue #, if available: #229 

Description of changes:

- Added options for non IAM calls, to fix issues with openCypher and SPARQL connections using proxy server.
- Enforce JSON `Accept` header for SPARQL.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.