### PR TITLE
Escape search keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/node_modules/
 **/coverage/
 **/.DS_Store
+**/.idea/
+**/.vs/

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ This release includes the following feature enhancements and bug fixes:
 - Refactored API request options for non-IAM endpoints (<https://github.com/aws/graph-explorer/pull/230>)
 - Enforced JSON response format for SPARQL queries (<https://github.com/aws/graph-explorer/pull/230>)
 - Bumped `vite` to `4.5.2` (<https://github.com/aws/graph-explorer/pull/233>)
+- Searching for text containing quotes now works.
 
 ## Release 1.5.0
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -38,6 +38,18 @@ describe("Gremlin > keywordSearchTemplate", () => {
     );
   });
 
+  it("Should escape the search term", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: '"JFK"',
+      searchByAttributes: ["code"],
+      exactMatch: true,
+    });
+
+    expect(template).toBe(
+      'g.V().or(has("code",\"\\"JFK\\"\")).range(0,10)'
+    );
+  });
+
   it("Should return a template for searched attributes matching with the search terms, and the ID token attribute", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -1,5 +1,6 @@
 import uniq from "lodash/uniq";
 import type { KeywordSearchRequest } from "../../useGEFetchTypes";
+import { escapeString } from "../../../utils";
 
 /**
  * @example
@@ -39,6 +40,8 @@ const keywordSearchTemplate = ({
   }
 
   if (Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById)) {
+    const escapedSearchTerm = escapeString(searchTerm);
+
     const orContent = uniq(
       (searchById && searchByAttributes.includes("__all")) ? ["_id", ...searchByAttributes] : searchByAttributes
     )
@@ -46,14 +49,14 @@ const keywordSearchTemplate = ({
       .map(attr => {
         if (attr === "_id") {
           if (exactMatch === true) {
-            return `has(id,"${searchTerm}")`;
+            return `has(id,"${escapedSearchTerm}")`;
           }
-          return `has(id,containing("${searchTerm}"))`;
+          return `has(id,containing("${escapedSearchTerm}"))`;
         }
         if (exactMatch === true) {
-          return `has("${attr}","${searchTerm}")`;
+          return `has("${attr}","${escapedSearchTerm}")`;
         }
-        return `has("${attr}",containing("${searchTerm}"))`;
+        return `has("${attr}",containing("${escapedSearchTerm}"))`;
       })
       .join(",");
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -1,5 +1,6 @@
 import uniq from "lodash/uniq";
 import type { KeywordSearchRequest } from "../../useGEFetchTypes";
+import { escapeString } from "../../../utils";
 
 /**
  * @example
@@ -37,6 +38,8 @@ const keywordSearchTemplate = ({
   }
 
   if (Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById)) {
+    const escapedSearchTerm = escapeString(searchTerm);
+
     const orContent = uniq(
       (searchById && searchByAttributes.includes("__all")) ? ["id", ...searchByAttributes] : searchByAttributes
     )
@@ -44,14 +47,14 @@ const keywordSearchTemplate = ({
       .map((attr: any) => {
         if (attr === "id") {
           if (exactMatch === true) {
-            return `v.\`~id\` = "${searchTerm}" `;
+            return `v.\`~id\` = "${escapedSearchTerm}" `;
           }
-          return `v.\`~id\` CONTAINS "${searchTerm}" `;
+          return `v.\`~id\` CONTAINS "${escapedSearchTerm}" `;
         }
         if (exactMatch === true) {
-          return `v.${attr} = "${searchTerm}" `;
+          return `v.${attr} = "${escapedSearchTerm}" `;
         }
-        return `v.${attr} CONTAINS "${searchTerm}" `;
+        return `v.${attr} CONTAINS "${escapedSearchTerm}" `;
       })
       .join(` OR `);
 

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/helpers.ts
@@ -1,3 +1,5 @@
+import { escapeString } from "../../../../utils";
+
 export const getSubjectClasses = (subjectClasses?: string[]) => {
   if (!subjectClasses?.length) {
     return "";
@@ -37,7 +39,9 @@ export const getFilterObject = (searchTerm?: string) => {
     return "";
   }
 
+  const escapedSearchTerm = escapeString(searchTerm);
+
   let filterBySearchTerm = "";
-  filterBySearchTerm = `FILTER (regex(str(?value), "${searchTerm}", "i"))`;
+  filterBySearchTerm = `FILTER (regex(str(?value), "${escapedSearchTerm}", "i"))`;
   return filterBySearchTerm;
 };

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearchTemplate.ts
@@ -1,4 +1,5 @@
 import { SPARQLKeywordSearchRequest } from "../types";
+import { escapeString } from "../../../utils";
 
 /**
  * @example
@@ -79,11 +80,13 @@ const keywordSearchTemplate = ({
       return "";
     }
 
+    const escapedSearchTerm = escapeString(searchTerm);
+
     let filterBySearchTerm = "";
     if (exactMatch === true) {
-      filterBySearchTerm = `FILTER (?value = "${searchTerm}"))`;
+      filterBySearchTerm = `FILTER (?value = "${escapedSearchTerm}"))`;
     } else {
-      filterBySearchTerm = `FILTER (regex(str(?value), "${searchTerm}", "i"))`;
+      filterBySearchTerm = `FILTER (regex(str(?value), "${escapedSearchTerm}", "i"))`;
     }
     return filterBySearchTerm;
   };

--- a/packages/graph-explorer/src/utils/escapeString.test.ts
+++ b/packages/graph-explorer/src/utils/escapeString.test.ts
@@ -1,0 +1,22 @@
+import escapeString from "./escapeString";
+
+describe("escapeString", () => {
+  it("Should handle empty strings", () => {
+    expect(escapeString(undefined)).toEqual("");
+    expect(escapeString("")).toEqual("");
+    expect(escapeString(" ")).toEqual(" ");
+  });
+
+  it("Should handle strings without quotes", () => {
+    expect(escapeString(" te st ")).toEqual(" te st ");
+    expect(escapeString("test")).toEqual("test");
+    expect(escapeString("t'est")).toEqual("t'est");
+  });
+
+  it("Should handle strings with quotes", () => {
+    expect(escapeString(' te"st ')).toEqual(' te\\"st ');
+    expect(escapeString('"test"')).toEqual('\\"test\\"');
+    expect(escapeString("\"t'est\"")).toEqual("\\\"t'est\\\"");
+  });
+
+});

--- a/packages/graph-explorer/src/utils/escapeString.ts
+++ b/packages/graph-explorer/src/utils/escapeString.ts
@@ -3,8 +3,6 @@ export const escapeString = (text?: string): string => {
     return "";
   }
 
-  console.log(text, text.includes('"') ? JSON.stringify(text).slice(1, -1) : text);
-
   return text.includes('"') ? JSON.stringify(text).slice(1, -1) : text;
 };
 

--- a/packages/graph-explorer/src/utils/escapeString.ts
+++ b/packages/graph-explorer/src/utils/escapeString.ts
@@ -1,0 +1,11 @@
+export const escapeString = (text?: string): string => {
+  if (!text) {
+    return "";
+  }
+
+  console.log(text, text.includes('"') ? JSON.stringify(text).slice(1, -1) : text);
+
+  return text.includes('"') ? JSON.stringify(text).slice(1, -1) : text;
+};
+
+export default escapeString;

--- a/packages/graph-explorer/src/utils/index.ts
+++ b/packages/graph-explorer/src/utils/index.ts
@@ -5,4 +5,5 @@ export { default as groupChildrenByType } from "./groupChildrenByType";
 export { default as memoize } from "./memoize";
 export { default as useClickOutside } from "./useClickOutside";
 export { default as sanitizeText } from "./sanitizeText";
+export { default as escapeString } from "./escapeString";
 export * from "./set";


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added escaping for search keywords. 
Searching for text containing quotes now works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.