### PR TITLE
Refactor PG summary proxy routes

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -245,13 +245,26 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
     fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
   });
 
-  // GET endpoint to retrieve statistics summary.
+  // GET endpoint to retrieve PropertyGraph statistics summary for Neptune Analytics.
+  app.get("/summary", async (req, res, next) => {
+    const isIamEnabled = !!req.headers["aws-neptune-region"];
+    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+    const rawUrl = `${req.headers["graph-db-connection-url"]}/summary?mode=detailed`;
+
+    const requestOptions = {
+      method: "GET",
+    };
+
+    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+
+    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+  });
+
+  // GET endpoint to retrieve PropertyGraph statistics summary for Neptune DB.
   app.get("/pg/statistics/summary", async (req, res, next) => {
     const isIamEnabled = !!req.headers["aws-neptune-region"];
     const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-    const rawUrl = serviceType === NEPTUNE_ANALYTICS_SERVICE_TYPE
-      ? `${req.headers["graph-db-connection-url"]}/summary?mode=detailed`
-      : `${req.headers["graph-db-connection-url"]}/pg/statistics/summary?mode=detailed`;
+    const rawUrl = `${req.headers["graph-db-connection-url"]}/pg/statistics/summary?mode=detailed`;
 
     const requestOptions = {
       method: "GET",
@@ -264,15 +277,15 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
 
   // GET endpoint to retrieve RDF statistics summary.
   app.get("/rdf/statistics/summary", async (req, res, next) => {
+    const isIamEnabled = !!req.headers["aws-neptune-region"];
+    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
     const rawUrl = `${req.headers["graph-db-connection-url"]}/rdf/statistics/summary?mode=detailed`;
 
     const requestOptions = {
       method: "GET",
     };
 
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
     const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
 
     fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
   });

--- a/packages/graph-explorer/src/connector/openCypher/useOpenCypher.ts
+++ b/packages/graph-explorer/src/connector/openCypher/useOpenCypher.ts
@@ -7,12 +7,14 @@ import { GraphSummary } from "./types";
 import { useCallback } from "react";
 import useGEFetch from "../useGEFetch";
 import { ConnectionConfig, useConfiguration } from "../../core";
+import { DEFAULT_SERVICE_TYPE } from "../../utils/constants";
 
 
 const useOpenCypher = () => {
   const connection = useConfiguration()?.connection as ConnectionConfig | undefined;
   const useFetch = useGEFetch();
   const url = connection?.url;
+  const serviceType = connection?.serviceType || DEFAULT_SERVICE_TYPE;
 
   const _openCypherFetch = useCallback((options) => {
     return async (queryTemplate: string) => {
@@ -28,11 +30,15 @@ const useOpenCypher = () => {
     };
   }, [url, useFetch]);
 
-  const fetchSchemaFunc = useCallback(async (options) => {
+  const fetchSchemaFunc = useCallback(async (options: any) => {
     const ops = { ...options, disableCache: true };
+
     let summary;
     try {
-      const response = await useFetch.request(`${url}/pg/statistics/summary?mode=detailed`, {
+      const endpoint= serviceType === DEFAULT_SERVICE_TYPE
+        ? `${url}/pg/statistics/summary?mode=detailed`
+        : `${url}/summary?mode=detailed`
+      const response = await useFetch.request(endpoint, {
         method: "GET",
         ...ops
       });


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Refactored some Analytics connection sync logic: moved the service-based conditional to the OC connector, and added a separate ExpressJS route for the Analytics summary endpoint, matching the actual Neptune endpoint. This should help prevent some confusion when debugging service-specific sync issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.