### PR TITLE
Fix Neptune Analytics default connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ First, create a `config.json` file containing values for the connection attribut
      "IAM": true, (Can be string or boolean)
      "SERVICE_TYPE": "neptune-db",
      "AWS_REGION": "us-west-2",
-     "GRAPH_TYPE": "gremlin" (Possible Values: "gremlin", "sparql", "opencypher"),
+     "GRAPH_TYPE": "gremlin" (Possible Values: "gremlin", "sparql", "openCypher"),
      "GRAPH_EXP_HTTPS_CONNECTION": true (Can be string or boolean),
      "PROXY_SERVER_HTTPS_CONNECTION": true, (Can be string or boolean),
      "GRAPH_EXP_FETCH_REQUEST_TIMEOUT": 240000 (Can be number)

--- a/packages/graph-explorer/src/index.tsx
+++ b/packages/graph-explorer/src/index.tsx
@@ -63,7 +63,7 @@ const grabConfig = async (): Promise<RawConfiguration | undefined> => {
         graphDbUrl: defaultConnectionData.GRAPH_EXP_CONNECTION_URL || "",
         awsAuthEnabled: !!defaultConnectionData.GRAPH_EXP_IAM,
         awsRegion: defaultConnectionData.GRAPH_EXP_AWS_REGION || "",
-        serviceType: defaultConnectionData.SERVICE_TYPE || DEFAULT_SERVICE_TYPE,
+        serviceType: defaultConnectionData.GRAPH_EXP_SERVICE_TYPE || DEFAULT_SERVICE_TYPE,
         fetchTimeoutMs:
           defaultConnectionData.GRAPH_EXP_FETCH_REQUEST_TIMEOUT || 240000,
       },

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -39,12 +39,22 @@ else
   echo -e "\nGRAPH_EXP_HTTPS_CONNECTION=true" >> ./packages/graph-explorer/.env
 fi
 
-# Update the .env file with the configuration values
+# Update the default connection file with the configuration values
 if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
     echo -e "{\n\"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT\":\"${PUBLIC_OR_PROXY_ENDPOINT}\"," >> ./packages/graph-explorer/defaultConnection.json
 
+    if [ -n "$SERVICE_TYPE" ]; then
+        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"${SERVICE_TYPE}\"," >> ./packages/graph-explorer/defaultConnection.json
+    else
+        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"neptune-db\"," >> ./packages/graph-explorer/defaultConnection.json
+    fi
+
     if [ -n "$GRAPH_TYPE" ]; then 
         echo "\"GRAPH_EXP_GRAPH_TYPE\":\"${GRAPH_TYPE}\"," >> ./packages/graph-explorer/defaultConnection.json
+    else
+      if [ "$SERVICE_TYPE" == "neptune-graph" ]; then
+        echo "\"GRAPH_EXP_GRAPH_TYPE\":\"openCypher\"," >> ./packages/graph-explorer/defaultConnection.json
+      fi
     fi
     
     if [ -n "$USING_PROXY_SERVER" ]; then 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Fixed generation of default connection profiles via Docker run arguments when using Neptune Analytics..

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.