### PR TITLE
Fix search bottom bar UI

### DIFF
--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
@@ -111,6 +111,8 @@ const defaultStyles =
         margin-top: 0;
         width: 100%;
         display: flex;
+        flex-direction: row;
+        gap: ${theme.spacing["2x"]};
         padding: ${theme.spacing["2x"]};
         justify-content: space-between;
         align-items: center;
@@ -120,24 +122,14 @@ const defaultStyles =
         border-top: solid 1px ${theme.palette.border};
 
         .${pfx}-footer-text {
-          padding: ${theme.spacing["2x"]} 0;
           color: ${theme.palette.text.secondary};
           font-size: ${theme.typography.sizes["xs"]};
+          flex-grow: 1;
+          text-wrap: balance;
         }
 
-        .${pfx}-actions-button {
-          display: inline-flex;
-          box-shadow: none;
-          &:not(:last-child) {
-            margin-right: ${theme.spacing["2x"]};
-          }
-          padding-right: ${theme.spacing["2x"]};
-          > svg {
-            font-size: ${theme.typography.sizes["lg"]};
-          }
-        }
-        .${pfx}-icon-button-name {
-          padding-left: ${theme.spacing.base};
+        .${pfx}-refuse-shrink {
+          flex-shrink: 0;
         }
       }
     }

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -19,6 +19,7 @@ import {
   Select,
   VertexIcon,
   Checkbox,
+  Button,
 } from "../../components";
 import { CarouselRef } from "../../components/Carousel/Carousel";
 import HumanReadableNumberFormatter from "../../components/HumanReadableNumberFormatter";
@@ -413,29 +414,24 @@ const KeywordSearch = ({
             <Checkbox
               isSelected={neighborsLimit}
               onChange={onNeighborsLimitChange}
+              className={pfx("refuse-shrink")}
             >
-              <div className={pfx("neighbors-limit-checkbox")}>
-                Limit Neighbors?
-              </div>
+              Limit Neighbors?
             </Checkbox>
-            <div>
-              <IconButton
-                className={pfx("actions-button")}
-                icon={<RemoveIcon />}
-                onPress={() => selection.clear()}
-              >
-                <div className={pfx("icon-button-name")}>Clear Selection</div>
-              </IconButton>
-              <IconButton
-                className={pfx("actions-button")}
-                icon={<AddCircleIcon />}
-                onPress={handleAddEntities}
-              >
-                <div className={pfx("icon-button-name")}>
-                  {addSelectedNodesMessage()}
-                </div>
-              </IconButton>
-            </div>
+            <Button
+              icon={<RemoveIcon />}
+              onPress={() => selection.clear()}
+              className={pfx("refuse-shrink")}
+            >
+              Clear Selection
+            </Button>
+            <Button
+              icon={<AddCircleIcon />}
+              onPress={handleAddEntities}
+              className={pfx("refuse-shrink")}
+            >
+              {addSelectedNodesMessage()}
+            </Button>
           </div>
         </Card>
       )}


### PR DESCRIPTION
Issue #, if available: #261

Description of changes:

- Arrange layout using flex and gaps
- Use `Button` component instead of `IconButton`

**Before**
![CleanShot 2024-03-08 at 10 24 29@2x](https://github.com/aws/graph-explorer/assets/212862/6e30f717-3505-44e0-a090-c5418545bcf8)

> **NOTE:** The "Clear Selected" button is currently in the hover state in this screenshot, showing the incorrect behavior it has today compared to other buttons.

**After**
![CleanShot 2024-03-08 at 10 23 58@2x](https://github.com/aws/graph-explorer/assets/212862/83f5281e-0104-457e-a002-0bede6f37599)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.