### PR TITLE
Remove “__all” from query in SPARQL

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/helpers.ts
@@ -18,15 +18,16 @@ export const getSubjectClasses = (subjectClasses?: string[]) => {
 };
 
 export const getFilterPredicates = (predicates?: string[]) => {
-  if (!predicates?.length) {
+  const filteredPredicates = predicates?.filter(p => p !== "__all") || [];
+  if (!filteredPredicates.length) {
     return "";
   }
 
   let filterByAttributes = "";
   filterByAttributes += "FILTER (?predicate IN (";
-  predicates.forEach((p, i) => {
+  filteredPredicates.forEach((p, i) => {
     filterByAttributes += `<${p}>`;
-    if (i < predicates.length - 1) {
+    if (i < filteredPredicates.length - 1) {
       filterByAttributes += ", ";
     }
   });

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
@@ -74,6 +74,32 @@ describe("SPARQL > keywordSearchTemplate", () => {
     );
   });
 
+  it("Should return a template for searched attributes without the __all predicate", () => {
+    const template = keywordSearchTemplate({
+      subjectClasses: ["air:airport"],
+      searchTerm: "JFK",
+      predicates: ["air:city", "air:code", "__all"],
+      exactMatch: true,
+    });
+
+    expect(removeExtraWhitespace(template)).toBe(
+      removeExtraWhitespace(`
+        SELECT ?subject ?pred ?value ?class { 
+          ?subject ?pred ?value { 
+            SELECT DISTINCT ?subject ?class { 
+              ?subject a ?class ; ?predicate ?value . 
+              FILTER (?predicate IN (<air:city>, <air:code>))
+              FILTER (?class IN (<air:airport>))
+              FILTER (?value = "JFK")
+            } 
+            LIMIT 10 OFFSET 0 
+          } 
+          FILTER(isLiteral(?value)) 
+        }
+      `)
+    );
+  });
+
   it("Should return a template for the ID token attribute exactly matching the search term", () => {
     const template = keywordSearchTemplate({
       subjectClasses: ["air:airport"],


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

The "__all" predicates filter was being applied to the SPARQL query when chosen. It wasn't causing any harm, but it shouldn't be there.

This PR removes it and updates the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.