### PR TITLE
Cancel queries gracefully

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -122,7 +122,10 @@ const retryFetch = async (
         return res;
       }
     } catch (err) {
-      if (i === refetchMaxRetries - 1) {
+      if (refetchMaxRetries === 1) {
+        // Don't log about retries if retrying is not used
+        throw err;
+      } else if (i === refetchMaxRetries - 1) {
         proxyLogger.error("!!Proxy Retry Fetch Reached Maximum Tries!!", err);
         throw err;
       } else {

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -191,19 +191,24 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
         return;
       }
       proxyLogger.debug(`Cancelling request ${queryId}...`);
-      return await retryFetch(
-        new URL(`${graphDbConnectionUrl}/sparql/status`),
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
+      try {
+        await retryFetch(
+          new URL(`${graphDbConnectionUrl}/sparql/status`),
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: `cancelQuery&queryId=${encodeURIComponent(queryId)}&silent=true`,
           },
-          body: `cancelQuery&queryId=${encodeURIComponent(queryId)}&silent=true`,
-        },
-        isIamEnabled,
-        region,
-        serviceType
-      );
+          isIamEnabled,
+          region,
+          serviceType
+        );
+      } catch (err) {
+        // Not really an error
+        proxyLogger.warn("Failed to cancel the query: " + err);
+      }
     }
 
     // Watch for a cancelled or aborted connection
@@ -265,13 +270,18 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
         return;
       }
       proxyLogger.debug(`Cancelling request ${queryId}...`);
-      return await retryFetch(
-        new URL(`${graphDbConnectionUrl}/gremlin/status?cancelQuery&queryId=${encodeURIComponent(queryId)}`),
-        { method: "GET" },
-        isIamEnabled,
-        region,
-        serviceType
-      );
+      try {
+        await retryFetch(
+          new URL(`${graphDbConnectionUrl}/gremlin/status?cancelQuery&queryId=${encodeURIComponent(queryId)}`),
+          { method: "GET" },
+          isIamEnabled,
+          region,
+          serviceType
+        );
+      } catch (err) {
+        // Not really an error
+        proxyLogger.warn("Failed to cancel the query: " + err);
+      }
     }
 
     // Watch for a cancelled or aborted connection

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -115,6 +115,7 @@ const retryFetch = async (
         const result = await res.json();
         proxyLogger.error("!!Request failure!!");
         proxyLogger.error("URL: " + url.href);
+        proxyLogger.error(`Response: ${res.status} - ${res.statusText}`);
         throw new Error("\n" + JSON.stringify(result, null, 2));
       } else {
         proxyLogger.debug("Successful response: " + res.statusText);

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -112,10 +112,10 @@ const retryFetch = async (
     try {
       const res = await fetch(url.href, options);
       if (!res.ok) {
-        const result = await res.json();
         proxyLogger.error("!!Request failure!!");
         proxyLogger.error("URL: " + url.href);
         proxyLogger.error(`Response: ${res.status} - ${res.statusText}`);
+        const result = await res.json();
         throw new Error("\n" + JSON.stringify(result, null, 2));
       } else {
         proxyLogger.debug("Successful response: " + res.statusText);


### PR DESCRIPTION
Issue #, if available: #265

Description of changes:

Fixes an issue where cancelling a query is not supported by the database server and the Graph Explorer server will crash.

Other changes:

- Skip logging about "max retries reached" if max retries is `1`
- Move error JSON deserialization after log statements in case it fails
- Log out response status and text on failed requests
- Log failed cancellations as warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.