### PR TITLE
Better error handling

### DIFF
--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -150,7 +150,7 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
       serviceType
     );
     const data = await response.json();
-    res.status(response.status || 200);
+    res.status(response.status);
     res.send(data);
   } catch (error) {
     next(error);

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -58,12 +58,16 @@ const errorHandler = (error, request, response, next) => {
     proxyLogger.error(error.message);
     proxyLogger.debug(error.stack);
   }
-  response.status(error.status || 500).send({
-    error: {
-      status: error.status || 500,
-      message: error.message || "Internal Server Error",
-    },
-  });
+  
+  response
+    .status(error.status || 500)
+    .json({
+      error: {
+        ...error,
+        status: error.status || 500,
+        message: error.message || "Internal Server Error",
+      },
+    });
 };
 
 // Function to retry fetch requests with exponential backoff.
@@ -115,8 +119,7 @@ const retryFetch = async (
         proxyLogger.error("!!Request failure!!");
         proxyLogger.error("URL: " + url.href);
         proxyLogger.error(`Response: ${res.status} - ${res.statusText}`);
-        const result = await res.json();
-        throw new Error("\n" + JSON.stringify(result, null, 2));
+        return res;
       } else {
         proxyLogger.debug("Successful response: " + res.statusText);
         return res;
@@ -147,302 +150,300 @@ async function fetchData(res, next, url, options, isIamEnabled, region, serviceT
       serviceType
     );
     const data = await response.json();
+    res.status(response.status || 200);
     res.send(data);
   } catch (error) {
     next(error);
   }
 }
 
-(async () => {
-  app.use(errorHandler);
-  app.use(compression()); // Use compression middleware
-  app.use(cors());
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: true }));
+app.use(compression()); // Use compression middleware
+app.use(cors());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(
+  "/defaultConnection",
+  express.static(
+    path.join(__dirname, "../graph-explorer/defaultConnection.json")
+  )
+);
+if (process.env.NEPTUNE_NOTEBOOK !== "false") {
   app.use(
-    "/defaultConnection",
-    express.static(
-      path.join(__dirname, "../graph-explorer/defaultConnection.json")
-    )
+    "/explorer",
+    express.static(path.join(__dirname, "../graph-explorer/dist"))
   );
-  if (process.env.NEPTUNE_NOTEBOOK !== "false") {
-    app.use(
-      "/explorer",
-      express.static(path.join(__dirname, "../graph-explorer/dist"))
-    );
-  } else {
-    app.use(
-      process.env.GRAPH_EXP_ENV_ROOT_FOLDER,
-      express.static(path.join(__dirname, "../graph-explorer/dist"))
-    );
-  }
-  // POST endpoint for SPARQL queries.
-  app.post("/sparql", async (req, res, next) => {
-    // Gather info from the headers
-    const queryId = req.headers["queryid"];
-    const graphDbConnectionUrl = req.headers["graph-db-connection-url"];
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+} else {
+  app.use(
+    process.env.GRAPH_EXP_ENV_ROOT_FOLDER,
+    express.static(path.join(__dirname, "../graph-explorer/dist"))
+  );
+}
+// POST endpoint for SPARQL queries.
+app.post("/sparql", async (req, res, next) => {
+  // Gather info from the headers
+  const queryId = req.headers["queryid"];
+  const graphDbConnectionUrl = req.headers["graph-db-connection-url"];
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
 
-    /// Function to cancel long running queries if the client disappears before completion
-    async function cancelQuery() {
-      if (!queryId) {
-        return;
-      }
-      proxyLogger.debug(`Cancelling request ${queryId}...`);
-      try {
-        await retryFetch(
-          new URL(`${graphDbConnectionUrl}/sparql/status`),
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/x-www-form-urlencoded",
-            },
-            body: `cancelQuery&queryId=${encodeURIComponent(queryId)}&silent=true`,
-          },
-          isIamEnabled,
-          region,
-          serviceType
-        );
-      } catch (err) {
-        // Not really an error
-        proxyLogger.warn("Failed to cancel the query: " + err);
-      }
+  /// Function to cancel long running queries if the client disappears before completion
+  async function cancelQuery() {
+    if (!queryId) {
+      return;
     }
-
-    // Watch for a cancelled or aborted connection
-    req.on("close", async () => {
-      if (req.complete) {
-        return;
-      }
-
-      await cancelQuery();
-    });
-    res.on("close", async () => {
-      if (res.writableFinished) {
-        return;
-      }
-      await cancelQuery();
-    });
-
-    // Validate the input before making any external calls.
-    if (!req.body.query) {
-      return res
-        .status(400)
-        .send({ error: "[Proxy]SPARQL: Query not provided" });
-    }
-    const rawUrl = `${graphDbConnectionUrl}/sparql`;
-    let body = `query=${encodeURIComponent(req.body.query)}`;
-    if (queryId) {
-      body += `&queryId=${encodeURIComponent(queryId)}`;
-    }
-    const requestOptions = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body,
-    };
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  // POST endpoint for Gremlin queries.
-  app.post("/gremlin", async (req, res, next) => {
-    // Gather info from the headers
-    const queryId = req.headers["queryid"];
-    const graphDbConnectionUrl = req.headers["graph-db-connection-url"];
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-
-    // Validate the input before making any external calls.
-    if (!req.body.query) {
-      return res
-        .status(400)
-        .send({ error: "[Proxy]Gremlin: query not provided" });
-    }
-
-    /// Function to cancel long running queries if the client disappears before completion
-    async function cancelQuery() {
-      if (!queryId) {
-        return;
-      }
-      proxyLogger.debug(`Cancelling request ${queryId}...`);
-      try {
-        await retryFetch(
-          new URL(`${graphDbConnectionUrl}/gremlin/status?cancelQuery&queryId=${encodeURIComponent(queryId)}`),
-          { method: "GET" },
-          isIamEnabled,
-          region,
-          serviceType
-        );
-      } catch (err) {
-        // Not really an error
-        proxyLogger.warn("Failed to cancel the query: " + err);
-      }
-    }
-
-    // Watch for a cancelled or aborted connection
-    req.on("close", async () => {
-      if (req.complete) {
-        return;
-      }
-      await cancelQuery();
-    });
-    res.on("close", async () => {
-      if (res.writableFinished) {
-        return;
-      }
-      await cancelQuery();
-    });
-
-    const body = { gremlin: req.body.query, queryId };
-    const rawUrl = `${graphDbConnectionUrl}/gremlin`;
-    const requestOptions = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    };
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  // POST endpoint for openCypher queries.
-  app.post("/openCypher", async (req, res, next) => {
-    // Validate the input before making any external calls.
-    if (!req.body.query) {
-      return res
-        .status(400)
-        .send({ error: "[Proxy]OpenCypher: query not provided" });
-    }
-
-    const rawUrl = `${req.headers["graph-db-connection-url"]}/openCypher`;
-    const requestOptions = {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: `query=${encodeURIComponent(req.body.query)}`,
-    };
-
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  // GET endpoint to retrieve PropertyGraph statistics summary for Neptune Analytics.
-  app.get("/summary", async (req, res, next) => {
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-    const rawUrl = `${req.headers["graph-db-connection-url"]}/summary?mode=detailed`;
-
-    const requestOptions = {
-      method: "GET",
-    };
-
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  // GET endpoint to retrieve PropertyGraph statistics summary for Neptune DB.
-  app.get("/pg/statistics/summary", async (req, res, next) => {
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-    const rawUrl = `${req.headers["graph-db-connection-url"]}/pg/statistics/summary?mode=detailed`;
-
-    const requestOptions = {
-      method: "GET",
-    };
-
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  // GET endpoint to retrieve RDF statistics summary.
-  app.get("/rdf/statistics/summary", async (req, res, next) => {
-    const isIamEnabled = !!req.headers["aws-neptune-region"];
-    const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
-    const rawUrl = `${req.headers["graph-db-connection-url"]}/rdf/statistics/summary?mode=detailed`;
-
-    const requestOptions = {
-      method: "GET",
-    };
-
-    const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
-
-    fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
-  });
-
-  app.get("/logger", (req, res, next) => {
-    let message;
-    let level;
+    proxyLogger.debug(`Cancelling request ${queryId}...`);
     try {
-      if (req.headers["level"] === undefined) {
-        throw new Error("No log level passed.");
-      } else {
-        level = req.headers["level"];
-      }
-      if (req.headers["message"] === undefined) {
-        throw new Error("No log message passed.");
-      } else {
-        message = req.headers["message"].replaceAll("\\", "");
-      }
-      if (level.toLowerCase() === "error") {
-        proxyLogger.error(message);
-      } else if (level.toLowerCase() === "warn") {
-        proxyLogger.warn(message);
-      } else if (level.toLowerCase() === "info") {
-        proxyLogger.info(message);
-      } else if (level.toLowerCase() === "debug") {
-        proxyLogger.debug(message);
-      } else if (level.toLowerCase() === "trace") {
-        proxyLogger.trace(message);
-      } else {
-        throw new Error("Tried to log to an unknown level.");
-      }
-      res.send("Log received.");
-    } catch (error) {
-      next(error);
+      await retryFetch(
+        new URL(`${graphDbConnectionUrl}/sparql/status`),
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: `cancelQuery&queryId=${encodeURIComponent(queryId)}&silent=true`,
+        },
+        isIamEnabled,
+        region,
+        serviceType
+      );
+    } catch (err) {
+      // Not really an error
+      proxyLogger.warn("Failed to cancel the query: " + err);
     }
+  }
+
+  // Watch for a cancelled or aborted connection
+  req.on("close", async () => {
+    if (req.complete) {
+      return;
+    }
+
+    await cancelQuery();
   });
-  app.use(errorHandler);
-  // Start the server on port 80 or 443 (if HTTPS is enabled)
-  if (process.env.NEPTUNE_NOTEBOOK === "true") {
-    app.listen(9250, async () => {
+  res.on("close", async () => {
+    if (res.writableFinished) {
+      return;
+    }
+    await cancelQuery();
+  });
+
+  // Validate the input before making any external calls.
+  if (!req.body.query) {
+    return res
+      .status(400)
+      .send({ error: "[Proxy]SPARQL: Query not provided" });
+  }
+  const rawUrl = `${graphDbConnectionUrl}/sparql`;
+  let body = `query=${encodeURIComponent(req.body.query)}`;
+  if (queryId) {
+    body += `&queryId=${encodeURIComponent(queryId)}`;
+  }
+  const requestOptions = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  };
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+// POST endpoint for Gremlin queries.
+app.post("/gremlin", async (req, res, next) => {
+  // Gather info from the headers
+  const queryId = req.headers["queryid"];
+  const graphDbConnectionUrl = req.headers["graph-db-connection-url"];
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+
+  // Validate the input before making any external calls.
+  if (!req.body.query) {
+    return res
+      .status(400)
+      .send({ error: "[Proxy]Gremlin: query not provided" });
+  }
+
+  /// Function to cancel long running queries if the client disappears before completion
+  async function cancelQuery() {
+    if (!queryId) {
+      return;
+    }
+    proxyLogger.debug(`Cancelling request ${queryId}...`);
+    try {
+      await retryFetch(
+        new URL(`${graphDbConnectionUrl}/gremlin/status?cancelQuery&queryId=${encodeURIComponent(queryId)}`),
+        { method: "GET" },
+        isIamEnabled,
+        region,
+        serviceType
+      );
+    } catch (err) {
+      // Not really an error
+      proxyLogger.warn("Failed to cancel the query: " + err);
+    }
+  }
+
+  // Watch for a cancelled or aborted connection
+  req.on("close", async () => {
+    if (req.complete) {
+      return;
+    }
+    await cancelQuery();
+  });
+  res.on("close", async () => {
+    if (res.writableFinished) {
+      return;
+    }
+    await cancelQuery();
+  });
+
+  const body = { gremlin: req.body.query, queryId };
+  const rawUrl = `${graphDbConnectionUrl}/gremlin`;
+  const requestOptions = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  };
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+// POST endpoint for openCypher queries.
+app.post("/openCypher", async (req, res, next) => {
+  // Validate the input before making any external calls.
+  if (!req.body.query) {
+    return res
+      .status(400)
+      .send({ error: "[Proxy]OpenCypher: query not provided" });
+  }
+
+  const rawUrl = `${req.headers["graph-db-connection-url"]}/openCypher`;
+  const requestOptions = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: `query=${encodeURIComponent(req.body.query)}`,
+  };
+
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+// GET endpoint to retrieve PropertyGraph statistics summary for Neptune Analytics.
+app.get("/summary", async (req, res, next) => {
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+  const rawUrl = `${req.headers["graph-db-connection-url"]}/summary?mode=detailed`;
+
+  const requestOptions = {
+    method: "GET",
+  };
+
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+// GET endpoint to retrieve PropertyGraph statistics summary for Neptune DB.
+app.get("/pg/statistics/summary", async (req, res, next) => {
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+  const rawUrl = `${req.headers["graph-db-connection-url"]}/pg/statistics/summary?mode=detailed`;
+
+  const requestOptions = {
+    method: "GET",
+  };
+
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+// GET endpoint to retrieve RDF statistics summary.
+app.get("/rdf/statistics/summary", async (req, res, next) => {
+  const isIamEnabled = !!req.headers["aws-neptune-region"];
+  const serviceType = isIamEnabled ? (req.headers["service-type"] ?? DEFAULT_SERVICE_TYPE) : "";
+  const rawUrl = `${req.headers["graph-db-connection-url"]}/rdf/statistics/summary?mode=detailed`;
+
+  const requestOptions = {
+    method: "GET",
+  };
+
+  const region = isIamEnabled ? req.headers["aws-neptune-region"] : "";
+
+  fetchData(res, next, rawUrl, requestOptions, isIamEnabled, region, serviceType);
+});
+
+app.get("/logger", (req, res, next) => {
+  let message;
+  let level;
+  try {
+    if (req.headers["level"] === undefined) {
+      throw new Error("No log level passed.");
+    } else {
+      level = req.headers["level"];
+    }
+    if (req.headers["message"] === undefined) {
+      throw new Error("No log message passed.");
+    } else {
+      message = req.headers["message"].replaceAll("\\", "");
+    }
+    if (level.toLowerCase() === "error") {
+      proxyLogger.error(message);
+    } else if (level.toLowerCase() === "warn") {
+      proxyLogger.warn(message);
+    } else if (level.toLowerCase() === "info") {
+      proxyLogger.info(message);
+    } else if (level.toLowerCase() === "debug") {
+      proxyLogger.debug(message);
+    } else if (level.toLowerCase() === "trace") {
+      proxyLogger.trace(message);
+    } else {
+      throw new Error("Tried to log to an unknown level.");
+    }
+    res.send("Log received.");
+  } catch (error) {
+    next(error);
+  }
+});
+
+// Plugin the error handler after the routes
+app.use(errorHandler);
+
+// Start the server on port 80 or 443 (if HTTPS is enabled)
+if (process.env.NEPTUNE_NOTEBOOK === "true") {
+  app.listen(9250, () => {
+    proxyLogger.info(
+      `\tProxy available at port 9250 for Neptune Notebook instance`
+    );
+  });
+} else if (
+  process.env.PROXY_SERVER_HTTPS_CONNECTION !== "false" &&
+  fs.existsSync("../graph-explorer-proxy-server/cert-info/server.key") &&
+  fs.existsSync("../graph-explorer-proxy-server/cert-info/server.crt")
+) {
+  const options = {
+    key: fs.readFileSync("./cert-info/server.key"),
+    cert: fs.readFileSync("./cert-info/server.crt"),
+  };
+  https.createServer(options, app)
+    .listen(443, () => {
+      proxyLogger.info(`Proxy server located at https://localhost`);
       proxyLogger.info(
-        `\tProxy available at port 9250 for Neptune Notebook instance`
+        `Graph Explorer live at: ${process.env.GRAPH_CONNECTION_URL}/explorer`
       );
     });
-  } else if (
-    process.env.PROXY_SERVER_HTTPS_CONNECTION !== "false" &&
-    fs.existsSync("../graph-explorer-proxy-server/cert-info/server.key") &&
-    fs.existsSync("../graph-explorer-proxy-server/cert-info/server.crt")
-  ) {
-    https
-      .createServer(
-        {
-          key: fs.readFileSync("./cert-info/server.key"),
-          cert: fs.readFileSync("./cert-info/server.crt"),
-        },
-        app
-      )
-      .listen(443, async () => {
-        proxyLogger.info(`Proxy server located at https://localhost`);
-        proxyLogger.info(
-          `Graph Explorer live at: ${process.env.GRAPH_CONNECTION_URL}/explorer`
-        );
-      });
-  } else {
-    app.listen(80, async () => {
-      proxyLogger.info(`Proxy server located at http://localhost`);
-    });
-  }
-})();
+} else {
+  app.listen(80, () => {
+    proxyLogger.info(`Proxy server located at http://localhost`);
+  });
+}

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
@@ -4,6 +4,7 @@ import { useConfiguration } from "../../core";
 import useConnector from "../../core/ConnectorProvider/useConnector";
 import usePrefixesUpdater from "../../hooks/usePrefixesUpdater";
 import { useCallback, useMemo } from "react";
+import { createDisplayError } from "../../utils/createDisplayError";
 
 export type SearchQueryRequest = {
   debouncedSearchTerm: string;
@@ -74,10 +75,10 @@ export function useKeywordSearchQuery({
         updatePrefixes(response.vertices.map(v => v.data.id));
       },
       onError: (e: Error) => {
+        const displayError = createDisplayError(e);
         enqueueNotification({
           type: "error",
-          title: "Something went wrong",
-          message: e.message,
+          ...displayError,
         });
       },
     }

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -1,0 +1,64 @@
+import { createDisplayError } from "./createDisplayError";
+
+const defaultResult = {
+  title: "Something went wrong",
+  message: "An error occurred. Please try again.",
+};
+
+describe("createDisplayError", () => {
+  it("Should handle empty object", () => {
+    const result = createDisplayError({});
+    expect(result).toStrictEqual(defaultResult);
+  });
+
+  it("Should handle null", () => {
+    const result = createDisplayError(null);
+    expect(result).toStrictEqual(defaultResult);
+  });
+
+  it("Should handle undefined", () => {
+    const result = createDisplayError(undefined);
+    expect(result).toStrictEqual(defaultResult);
+  });
+
+  it("Should handle string", () => {
+    const result = createDisplayError("Some error message string");
+    expect(result).toStrictEqual(defaultResult);
+  });
+
+  it("Should handle connection refused", () => {
+    const result = createDisplayError({ code: "ECONNREFUSED" });
+    expect(result).toStrictEqual({
+      title: "Connection refused",
+      message: "Please check your connection and try again.",
+    });
+  });
+
+  it("Should handle connection refused as inner error", () => {
+    const error = new Error("Some error message string", {
+      cause: { code: "ECONNREFUSED" },
+    });
+    const result = createDisplayError(error);
+    expect(result).toStrictEqual({
+      title: "Connection refused",
+      message: "Please check your connection and try again.",
+    });
+  });
+
+  it("Should handle AbortError", () => {
+    const result = createDisplayError({ name: "AbortError" });
+    expect(result).toStrictEqual({
+      title: "Request cancelled",
+      message: "The request exceeded the configured timeout length.",
+    });
+  });
+
+  it("Should handle deadline exceeded", () => {
+    const result = createDisplayError({ code: "TimeLimitExceededException" });
+    expect(result).toStrictEqual({
+      title: "Deadline exceeded",
+      message:
+        "Increase the query timeout in the DB cluster parameter group, or retry the request.",
+    });
+  });
+});

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -1,0 +1,52 @@
+export type DisplayError = {
+  title: string;
+  message: string;
+};
+
+const defaultDisplayError: DisplayError = {
+  title: "Something went wrong",
+  message: "An error occurred. Please try again.",
+};
+
+/**
+ * Attempts to convert the technicality of errors in to humane
+ * friendly errors that are suitable for display.
+ *
+ * @param error Any thrown error or error response.
+ * @returns A `DisplayError` that contains a title and message.
+ */
+export function createDisplayError(error: any): DisplayError {
+  if (typeof error === "object") {
+    // Bad connection configuration
+    if (
+      error?.code === "ECONNREFUSED" ||
+      error?.cause?.code === "ECONNREFUSED"
+    ) {
+      return {
+        title: "Connection refused",
+        message: "Please check your connection and try again.",
+      };
+    }
+
+    // Server timeout
+    if (
+      error?.code === "TimeLimitExceededException" ||
+      error?.cause?.code === "TimeLimitExceededException"
+    ) {
+      return {
+        title: "Deadline exceeded",
+        message:
+          "Increase the query timeout in the DB cluster parameter group, or retry the request.",
+      };
+    }
+
+    // Fetch timeout
+    if (error?.name === "AbortError") {
+      return {
+        title: "Request cancelled",
+        message: "The request exceeded the configured timeout length.",
+      };
+    }
+  }
+  return defaultDisplayError;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Improves the error handling within Graph Explorer and the proxy server in various ways.

### Client Side Changes
- Add `createDisplayError()` function to map errors to friendly errors that can be displayed to the user (this will grow over time)
- Use `createDisplayError()` in schema sync and keyword search
- Check if `response.ok` for any `useGEFetch()` requests and throw an error if it is not
- Attempt to decode error response bodies in a safe way

### Server Side Changes
- Move routes out of unnecessary async closure
- Remove duplicate `app.use(errorHandler)`
- Send error responses from the remote database through the proxy back to the client with minimal changes

## Validation

- When reviewing the code it will be useful to turn on the "ignore whitespace changes" feature in GitHub
- Added tests for errors I know about
- Disconnect VPC or wifi to get the connection refused error
- Set fetch timeout for connection to something low (e.g. 50 ms) to get the fetch timeout error
- Connect to large RDF dataset and do a keyword search with all nodes types, all predicates, and partial precision, then use a long series of characters in the query field (e.g. "aaaaaaaaaaaaa") to get the server timeout error

**Schema sync failure (connection refused)**

![CleanShot 2024-03-26 at 10 48 56@2x](https://github.com/aws/graph-explorer/assets/212862/305c5890-b483-4c18-bf0c-b7d8ac4aaf7b)

**Fetch timeout**

![CleanShot 2024-03-26 at 10 50 14@2x](https://github.com/aws/graph-explorer/assets/212862/943c5ed6-a6ba-466a-b607-41cd34b8b95f)

**Neptune long query server timeout**

![CleanShot 2024-03-26 at 10 52 50@2x](https://github.com/aws/graph-explorer/assets/212862/7960ea1c-f4bc-4655-95b6-7dcb735c3e55)


## Related Issues

Fixes issue #275 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm run checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm run test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
