### PR TITLE
Add connection reset error message

### DIFF
--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -34,6 +34,14 @@ describe("createDisplayError", () => {
     });
   });
 
+  it("Should handle connection reset", () => {
+    const result = createDisplayError({ code: "ECONNRESET" });
+    expect(result).toStrictEqual({
+      title: "Connection reset",
+      message: "Please check your connection and try again.",
+    });
+  });
+
   it("Should handle connection refused as inner error", () => {
     const error = new Error("Some error message string", {
       cause: { code: "ECONNREFUSED" },
@@ -41,6 +49,17 @@ describe("createDisplayError", () => {
     const result = createDisplayError(error);
     expect(result).toStrictEqual({
       title: "Connection refused",
+      message: "Please check your connection and try again.",
+    });
+  });
+
+  it("Should handle connection reset as inner error", () => {
+    const error = new Error("Some error message string", {
+      cause: { code: "ECONNRESET" },
+    });
+    const result = createDisplayError(error);
+    expect(result).toStrictEqual({
+      title: "Connection reset",
       message: "Please check your connection and try again.",
     });
   });

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -27,6 +27,12 @@ export function createDisplayError(error: any): DisplayError {
         message: "Please check your connection and try again.",
       };
     }
+    if (error?.code === "ECONNRESET" || error?.cause?.code === "ECONNRESET") {
+      return {
+        title: "Connection reset",
+        message: "Please check your connection and try again.",
+      };
+    }
 
     // Server timeout
     if (


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a new display error for `ECONNRESET` code.

## Validation

I saw this error when trying to connect to a Neptune server that must be down. Other Neptune servers were working fine.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have run `pnpm run checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm run test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
