### PR TITLE
Fix search bar hover color

### DIFF
--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
@@ -28,7 +28,6 @@ const defaultStyles =
           display: flex;
           align-items: center;
           color: ${theme.palette.text.secondary};
-          background: ${theme.palette.grey["200"]};
           padding-left: ${theme.spacing["2x"]};
         }
       }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes the background color on the results count text. This makes the background clear which allows the hover color to come through.

## Validation

1. Open search panel to get results
2. Close search panel
3. See non-hover result count in search bar
4. Hover over to see hover state

### Normal
![CleanShot 2024-04-02 at 16 14 48@2x](https://github.com/aws/graph-explorer/assets/212862/4a65d11e-8c78-45fb-82ff-a190f006c4d6)

### Hover
![CleanShot 2024-04-02 at 16 14 56@2x](https://github.com/aws/graph-explorer/assets/212862/c799499e-1183-4ad4-9696-09d957b0f93e)

## Related Issues

Fixes #291 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm run checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm run test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
