### PR TITLE
Add step to apply latest tag to docker image for releases

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -72,3 +72,16 @@ jobs:
           docker build --build-arg NEPTUNE_NOTEBOOK=true -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-$IMAGE_TAG .
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-$IMAGE_TAG
+
+      - name: Update latest tag for release
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag == 'release' }}
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: neptune
+          REPOSITORY: graph-explorer
+          IMAGE_TAG: ${{ steps.get-image-tag.outputs.image_tag }}
+        run: |
+          docker tag $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:latest
+          docker tag $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-$IMAGE_TAG $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-latest
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:latest
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-latest


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a step to the Docker workflow that will only be run when performing a release. This step will assign the `latest` tag to the build and push to the ECR repository.

## Validation

I tested this by running the workflow locally using [act](https://nektosact.com/introduction.html). I created a public ECR repo in my AWS account and used my own secrets to perform the push.

I verified the new step will not run when `image_tag != 'release'`. I also verified that when it does run for a release it will push both the version tag and the `latest` tag. It will also push the SageMaker build with the `sagemaker-latest` tag. It will replace any existing `latest` tags with the new version.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Addresses #315 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have run `pnpm run checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm run test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
