### PR TITLE
Ensure attributes are updated in schema when entities are updated

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "[typescriptreact]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "jest.rootPath": "packages/graph-explorer/"
 }

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -3,7 +3,7 @@ import type { Edge } from "../../@types/entities";
 import { sanitizeText } from "../../utils";
 import { activeConfigurationAtom } from "./configuration";
 import isDefaultValue from "./isDefaultValue";
-import { schemaAtom, SchemaInference } from "./schema";
+import { schemaAtom } from "./schema";
 
 export type Edges = Array<Edge>;
 
@@ -52,25 +52,45 @@ export const edgesSelector = selector<Edges>({
     set(schemaAtom, prevSchemas => {
       const updatedSchemas = new Map(prevSchemas);
 
-      updatedSchemas.set(activeConfig, {
-        edges: newValue.reduce(
-          (schema, edge) => {
-            if (!schema.find(s => s.type === edge.data.type)) {
-              schema.push({
-                type: edge.data.type,
-                displayLabel: "",
-                attributes: Object.keys(edge.data.attributes).map(attr => ({
-                  name: attr,
-                  displayLabel: sanitizeText(attr),
-                  hidden: false,
-                })),
-              });
-            }
+      const updatedEdges = newValue.reduce((schema, edge) => {
+        // Find the edge type definition in the schema
+        const schemaEdge = schema.find(s => s.type === edge.data.type);
 
-            return schema;
-          },
-          activeSchema?.edges as SchemaInference["edges"]
-        ),
+        // Add edge to schema if it is missing
+        if (!schemaEdge) {
+          schema.push({
+            type: edge.data.type,
+            displayLabel: "",
+            attributes: Object.keys(edge.data.attributes).map(attr => ({
+              name: attr,
+              displayLabel: sanitizeText(attr),
+              hidden: false,
+            })),
+          });
+
+          // Since the edge type is new we can go ahead and return
+          return schema;
+        }
+
+        // Ensure the edge attributes are updated in the schema
+        const schemaAttributes = schemaEdge.attributes.map(a => a.name);
+        const missingAttributeNames = Object.keys(edge.data.attributes).filter(
+          name => !schemaAttributes.includes(name)
+        );
+
+        for (const attributeName of missingAttributeNames) {
+          schemaEdge.attributes.push({
+            name: attributeName,
+            displayLabel: sanitizeText(attributeName),
+            hidden: false,
+          });
+        }
+
+        return schema;
+      }, activeSchema?.edges ?? []);
+
+      updatedSchemas.set(activeConfig, {
+        edges: updatedEdges,
         vertices: activeSchema?.vertices || [],
         ...(activeSchema || {}),
       });

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -5,6 +5,8 @@ import {
   Schema,
   VertexTypeConfig,
 } from "../../core";
+import { Edge, Vertex } from "../../@types/entities";
+import { Entities } from "../../core/StateProvider/entitiesSelector";
 
 /*
 
@@ -38,6 +40,15 @@ export function createRandomBoolean(): boolean {
 }
 
 /**
+ * Creates a random integer.
+ * @param max The maximum value the random integer can have. Defaults to 100,000.
+ * @returns A random integer value from 0 to the max.
+ */
+export function createRandomInteger(max: number = 100000): number {
+  return Math.floor(Math.random() * max);
+}
+
+/**
  * Randomly creates a hex value for an RGB color.
  * @returns The hex string of the random color.
  */
@@ -66,6 +77,20 @@ export function randomlyUndefined<T>(value: T): T | undefined {
  */
 export function createArray<T>(length: number, factory: () => T): T[] {
   return Array.from({ length }, factory);
+}
+
+export function createRecord<TValue>(
+  length: number,
+  factory: () => { key: string; value: TValue }
+): Record<string, TValue> {
+  const result: Record<string, TValue> = {};
+
+  for (let i = 0; i < length; i++) {
+    const newEntry = factory();
+    result[newEntry.key] = newEntry.value;
+  }
+
+  return result;
 }
 
 /**
@@ -113,8 +138,8 @@ export function createRandomVertexTypeConfig(): VertexTypeConfig {
  * @returns A random Schema object.
  */
 export function createRandomSchema(): Schema {
-  const edges = createArray(6, createRandomEdgeTypeConfig);
-  const vertices = createArray(6, createRandomVertexTypeConfig);
+  const edges = createArray(3, createRandomEdgeTypeConfig);
+  const vertices = createArray(3, createRandomVertexTypeConfig);
   const schema: Schema = {
     edges,
     vertices,
@@ -122,4 +147,73 @@ export function createRandomSchema(): Schema {
     totalVertices: vertices.length,
   };
   return schema;
+}
+
+/**
+ * Creates random entities (nodes and edges).
+ * @returns A random Entities object.
+ */
+export function createRandomEntities(): Entities {
+  const nodes = createArray(3, createRandomVertex);
+  const edges = [
+    createRandomEdge(nodes[0], nodes[1]),
+    createRandomEdge(nodes[0], nodes[2]),
+    createRandomEdge(nodes[1], nodes[2]),
+
+    // Reverse edges
+    createRandomEdge(nodes[1], nodes[0]),
+    createRandomEdge(nodes[2], nodes[0]),
+    createRandomEdge(nodes[2], nodes[1]),
+  ];
+  return { nodes, edges };
+}
+
+/**
+ * Creates a random vertex.
+ * @returns A random Vertex object.
+ */
+export function createRandomVertex(): Vertex {
+  return {
+    data: {
+      id: createRandomName("VertexId"),
+      type: createRandomName("VertexType"),
+      attributes: createRecord(3, createRandomEntityAttribute),
+      neighborsCount: 0,
+      neighborsCountByType: {},
+    },
+  };
+}
+
+/**
+ * Creates a random edge.
+ * @returns A random Edge object.
+ */
+export function createRandomEdge(source: Vertex, target: Vertex): Edge {
+  return {
+    data: {
+      id: createRandomName("EdgeId"),
+      type: createRandomName("EdgeType"),
+      attributes: createRecord(3, createRandomEntityAttribute),
+      source: source.data.id,
+      sourceType: source.data.type,
+      target: target.data.id,
+      targetType: target.data.type,
+    },
+  };
+}
+
+/**
+ * Creates a random entity (vertex or edge) attribute.
+ * @returns A random entity attribute object.
+ */
+export function createRandomEntityAttribute(): {
+  key: string;
+  value: string | number;
+} {
+  return {
+    key: createRandomName("EntityAttribute"),
+    value: createRandomBoolean()
+      ? createRandomName("StringValue")
+      : createRandomInteger(),
+  };
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When entities are updated the logic in the setter was adding any node or edge types that were missing in the schema.

I've extended that logic to also add any attributes that are missing to the schema.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

### Node testing
1. Add node to graph
2. Take note of existing attributes on node in details pane
3. Add property to node
   ```
   g.V({Node ID}).property("added-prop", 123)
   ```
4. Clear graph
5. Add same node to graph
6. Notice new property in details pane

### Edge testing
1. Add node to graph
2. Expand node and select edge
4. Take note of existing attributes on edge in details pane
3. Add property to edge
   ```
   g.E({Edge ID}).property("added-prop", 123)
   ```
4. Clear graph
5. Add same node to graph
6. Expand
7. Select edge
8. Notice new property in details pane

## Related Issues

- Addresses #355 
- Fixes #349 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I've covered new added functionality with unit tests if necessary.
