### PR TITLE
Update React Query v3 to TanStack Query v5

### DIFF
--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -45,6 +45,7 @@
     "@react-stately/overlays": "^3.6.6",
     "@react-stately/searchfield": "^3.5.2",
     "@tanstack/react-query": "^5.35.1",
+    "@tanstack/react-query-devtools": "^5.35.1",
     "color": "^3.2.1",
     "crypto-js": "^4.2.0",
     "cytoscape": "^3.29.2",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -44,6 +44,7 @@
     "@react-stately/list": "^3.10.4",
     "@react-stately/overlays": "^3.6.6",
     "@react-stately/searchfield": "^3.5.2",
+    "@tanstack/react-query": "^5.35.1",
     "color": "^3.2.1",
     "crypto-js": "^4.2.0",
     "cytoscape": "^3.29.2",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -71,7 +71,6 @@
     "react-dom": "^18.3.1",
     "react-inlinesvg": "^4.1.3",
     "react-laag": "^2.0.5",
-    "react-query": "^3.39.3",
     "react-router-dom": "^6.23.0",
     "react-slick": "^0.30.2",
     "react-table": "^7.8.0",

--- a/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
+++ b/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NotificationProvider } from "../../components/NotificationProvider";
 import Toast from "../../components/Toast";
 import AppStatusLoader from "../AppStatusLoader";

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useConfiguration } from "../core";
 import useConnector from "../core/ConnectorProvider/useConnector";
@@ -6,6 +6,7 @@ import useUpdateSchema from "./useUpdateSchema";
 
 const useUpdateVertexTypeCounts = (vertexType?: string) => {
   const config = useConfiguration();
+  const configId = config?.id;
   const connector = useConnector();
 
   const vertexConfig = useMemo(() => {
@@ -17,9 +18,9 @@ const useUpdateVertexTypeCounts = (vertexType?: string) => {
   }, [config, vertexType]);
 
   const updateSchemaState = useUpdateSchema();
-  useQuery(
-    ["fetchCountsByType", vertexConfig?.type],
-    () => {
+  const query = useQuery({
+    queryKey: ["fetchCountsByType", vertexConfig?.type],
+    queryFn: () => {
       if (vertexConfig?.total != null || vertexConfig?.type == null) {
         return;
       }
@@ -28,34 +29,34 @@ const useUpdateVertexTypeCounts = (vertexType?: string) => {
         label: vertexConfig?.type,
       });
     },
-    {
-      enabled: vertexConfig?.total == null && vertexConfig?.type != null,
-      onSuccess: response => {
-        if (!config?.id || !response) {
-          return;
-        }
+    enabled: vertexConfig?.total == null && vertexConfig?.type != null,
+  });
 
-        updateSchemaState(config.id, prevSchema => {
-          const vertexSchema = prevSchema?.vertices.find(
-            vertex => vertex.type === vertexType
-          );
-          if (!vertexSchema) {
-            return { ...(prevSchema || {}) };
-          }
-
-          vertexSchema.total = response.total;
-          return {
-            vertices: [
-              ...(prevSchema?.vertices.filter(
-                vertex => vertex.type !== vertexType
-              ) || []),
-              vertexSchema,
-            ],
-          };
-        });
-      },
+  // Sync the result over to the schema in Recoil state
+  useEffect(() => {
+    if (!configId || !query.data) {
+      return;
     }
-  );
+    const vertexTotal = query.data.total;
+
+    updateSchemaState(configId, prevSchema => {
+      const vertexSchema = prevSchema?.vertices.find(
+        vertex => vertex.type === vertexType
+      );
+      if (!vertexSchema) {
+        return { ...(prevSchema || {}) };
+      }
+      vertexSchema.total = vertexTotal;
+      return {
+        vertices: [
+          ...(prevSchema?.vertices.filter(
+            vertex => vertex.type !== vertexType
+          ) || []),
+          vertexSchema,
+        ],
+      };
+    });
+  }, [query.data, configId, updateSchemaState, vertexType]);
 };
 
 export default useUpdateVertexTypeCounts;

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useQuery } from "react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useConfiguration } from "../core";
 import useConnector from "../core/ConnectorProvider/useConnector";
 import useUpdateSchema from "./useUpdateSchema";

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -48,6 +48,7 @@ const useUpdateVertexTypeCounts = (vertexType?: string) => {
       }
       vertexSchema.total = vertexTotal;
       return {
+        ...prevSchema,
         vertices: [
           ...(prevSchema?.vertices.filter(
             vertex => vertex.type !== vertexType

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNotification } from "../../components/NotificationProvider";
 import { useConfiguration } from "../../core";
 import useConnector from "../../core/ConnectorProvider/useConnector";

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
@@ -3,7 +3,7 @@ import { useNotification } from "../../components/NotificationProvider";
 import { useConfiguration } from "../../core";
 import useConnector from "../../core/ConnectorProvider/useConnector";
 import usePrefixesUpdater from "../../hooks/usePrefixesUpdater";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { createDisplayError } from "../../utils/createDisplayError";
 
 export type SearchQueryRequest = {
@@ -47,14 +47,14 @@ export function useKeywordSearchQuery({
     ]
   );
 
-  const query = useQuery(
+  const query = useQuery({
     queryKey,
-    ({ signal }) => {
+    queryFn: async ({ signal }) => {
       if (!connector.explorer) {
         return;
       }
 
-      const promise = connector.explorer.keywordSearch(
+      return await connector.explorer.keywordSearch(
         {
           searchTerm: debouncedSearchTerm,
           vertexTypes,
@@ -64,25 +64,29 @@ export function useKeywordSearchQuery({
         },
         { signal }
       );
-      return promise;
     },
-    {
-      enabled: !!config && isOpen && !!connector.explorer,
-      onSuccess: response => {
-        if (!response) {
-          return;
-        }
-        updatePrefixes(response.vertices.map(v => v.data.id));
-      },
-      onError: (e: Error) => {
-        const displayError = createDisplayError(e);
-        enqueueNotification({
-          type: "error",
-          ...displayError,
-        });
-      },
+    enabled: !!config && isOpen && !!connector.explorer,
+  });
+
+  // Sync sparql prefixes
+  useEffect(() => {
+    if (!query.data) {
+      return;
     }
-  );
+    updatePrefixes(query.data.vertices.map(v => v.data.id));
+  }, [query.data, updatePrefixes]);
+
+  // Show errors
+  useEffect(() => {
+    if (!query.error) {
+      return;
+    }
+    const displayError = createDisplayError(query.error);
+    enqueueNotification({
+      type: "error",
+      ...displayError,
+    });
+  }, [query.error, enqueueNotification]);
 
   const cancelAll = useCallback(async () => {
     await queryClient.cancelQueries({

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import clone from "lodash/clone";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useQuery } from "react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   Link,
   useNavigate,

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import clone from "lodash/clone";
-import { useCallback, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   Link,
   useNavigate,
@@ -202,9 +202,9 @@ const DataExplorer = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
   }, [t, textTransform, vertexConfig?.attributes]);
 
   const updatePrefixes = usePrefixesUpdater();
-  const { data, isFetching } = useQuery(
-    ["keywordSearch", vertexType, pageIndex, pageSize],
-    () => {
+  const { data, isFetching } = useQuery({
+    queryKey: ["keywordSearch", vertexType, pageIndex, pageSize],
+    queryFn: () => {
       if (!vertexType || !connector.explorer) {
         return { vertices: [] } as KeywordSearchResponse;
       }
@@ -215,20 +215,17 @@ const DataExplorer = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
         offset: pageIndex * pageSize,
       });
     },
-    {
-      keepPreviousData: true,
-      enabled: Boolean(vertexType) && Boolean(connector.explorer),
-      onSuccess: response => {
-        if (!response) {
-          return;
-        }
+    placeholderData: keepPreviousData,
+    enabled: Boolean(vertexType) && Boolean(connector.explorer),
+  });
 
-        updatePrefixes(
-          response.vertices.map((v: { data: { id: any } }) => v.data.id)
-        );
-      },
+  useEffect(() => {
+    if (!data) {
+      return;
     }
-  );
+
+    updatePrefixes(data.vertices.map((v: { data: { id: any } }) => v.data.id));
+  }, [data, updatePrefixes]);
 
   const setUserStyling = useSetRecoilState(userStylingAtom);
   const onDisplayNameChange = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@react-stately/searchfield':
         specifier: ^3.5.2
         version: 3.5.2(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.35.1
+        version: 5.35.1(react@18.3.1)
       color:
         specifier: ^3.2.1
         version: 3.2.1
@@ -4410,6 +4413,19 @@ packages:
     resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
     dependencies:
       tslib: 2.6.2
+
+  /@tanstack/query-core@5.35.1:
+    resolution: {integrity: sha512-0Dnpybqb8+ps6WgqBnqFEC+1F/xLvUosRAq+wiGisTgolOZzqZfkE2995dEXmhuzINiTM7/a6xSGznU0NIvBkw==}
+    dev: false
+
+  /@tanstack/react-query@5.35.1(react@18.3.1):
+    resolution: {integrity: sha512-i2T7m2ffQdNqlX3pO+uMsnQ0H4a59Ens2GxtlMsRiOvdSB4SfYmHb27MnvFV8rGmtWRaa4gPli0/rpDoSS5LbQ==}
+    peerDependencies:
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-core': 5.35.1
+      react: 18.3.1
+    dev: false
 
   /@testing-library/dom@7.31.2:
     resolution: {integrity: sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,9 +222,6 @@ importers:
       react-laag:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@18.3.1)(react@18.3.1)
-      react-query:
-        specifier: ^3.39.3
-        version: 3.39.3(react-dom@18.3.1)(react@18.3.1)
       react-router-dom:
         specifier: ^6.23.0
         version: 6.23.0(react-dom@18.3.1)(react@18.3.1)
@@ -5482,14 +5479,10 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  /big-integer@1.6.52:
-    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
-    engines: {node: '>=0.6'}
-    dev: false
 
   /body-parser@1.20.2:
     resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
@@ -5534,6 +5527,7 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -5547,19 +5541,6 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
-
-  /broadcast-channel@3.7.0:
-    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
-    dependencies:
-      '@babel/runtime': 7.24.5
-      detect-node: 2.1.0
-      js-sha3: 0.8.0
-      microseconds: 0.2.0
-      nano-time: 1.0.0
-      oblivious-set: 1.0.0
-      rimraf: 3.0.2
-      unload: 2.2.0
-    dev: false
 
   /browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
@@ -5831,6 +5812,7 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
 
   /content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -6219,10 +6201,6 @@ packages:
 
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-    dev: false
-
-  /detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
     dev: false
 
   /diff-sequences@26.6.2:
@@ -7088,6 +7066,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fs@0.0.1-security:
     resolution: {integrity: sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==}
@@ -7189,6 +7168,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7447,6 +7427,7 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -8275,10 +8256,6 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
-  /js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: false
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8569,13 +8546,6 @@ packages:
       tmpl: 1.0.5
     dev: true
 
-  /match-sorter@6.3.4:
-    resolution: {integrity: sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==}
-    dependencies:
-      '@babel/runtime': 7.24.5
-      remove-accents: 0.5.0
-    dev: false
-
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -8610,10 +8580,6 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: true
-
-  /microseconds@0.2.0:
-    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
-    dev: false
 
   /mime-db@1.33.0:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
@@ -8662,6 +8628,7 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
 
   /minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
@@ -8688,12 +8655,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: false
-
-  /nano-time@1.0.0:
-    resolution: {integrity: sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==}
-    dependencies:
-      big-integer: 1.6.52
     dev: false
 
   /nanoid@3.3.7:
@@ -8826,10 +8787,6 @@ packages:
       es-object-atoms: 1.0.0
     dev: true
 
-  /oblivious-set@1.0.0:
-    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
-    dev: false
-
   /on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -8948,6 +8905,7 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-is-inside@1.0.2:
     resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
@@ -9493,25 +9451,6 @@ packages:
     resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
     dev: false
 
-  /react-query@3.39.3(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.24.5
-      broadcast-channel: 3.7.0
-      match-sorter: 6.3.4
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
   /react-redux@7.2.9(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==}
     peerDependencies:
@@ -9826,10 +9765,6 @@ packages:
       jsesc: 0.5.0
     dev: true
 
-  /remove-accents@0.5.0:
-    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
-    dev: false
-
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -9908,6 +9843,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
 
   /rollup@3.29.4:
     resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
@@ -10740,13 +10676,6 @@ packages:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
     dev: true
-
-  /unload@2.2.0:
-    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
-    dependencies:
-      '@babel/runtime': 7.24.5
-      detect-node: 2.1.0
-    dev: false
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.35.1
         version: 5.35.1(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.35.1
+        version: 5.35.1(@tanstack/react-query@5.35.1)(react@18.3.1)
       color:
         specifier: ^3.2.1
         version: 3.2.1
@@ -4416,6 +4419,21 @@ packages:
 
   /@tanstack/query-core@5.35.1:
     resolution: {integrity: sha512-0Dnpybqb8+ps6WgqBnqFEC+1F/xLvUosRAq+wiGisTgolOZzqZfkE2995dEXmhuzINiTM7/a6xSGznU0NIvBkw==}
+    dev: false
+
+  /@tanstack/query-devtools@5.32.1:
+    resolution: {integrity: sha512-7Xq57Ctopiy/4atpb0uNY5VRuCqRS/1fi/WBCKKX6jHMa6cCgDuV/AQuiwRXcKARbq2OkVAOrW2v4xK9nTbcCA==}
+    dev: false
+
+  /@tanstack/react-query-devtools@5.35.1(@tanstack/react-query@5.35.1)(react@18.3.1):
+    resolution: {integrity: sha512-G2TP8ekCo+C9IPdEswKB9mqG5pxV+DWq86lmNw/VbUpdyNwNFvKi7GdcqW1pLDi5al+zifSjGSO7QZ7zDMJcQg==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.35.1
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-devtools': 5.32.1
+      '@tanstack/react-query': 5.35.1(react@18.3.1)
+      react: 18.3.1
     dev: false
 
   /@tanstack/react-query@5.35.1(react@18.3.1):


### PR DESCRIPTION
Updates the app to use TanStack Query v5 instead of React Query v3.

There were a decent number of breaking changes in these versions. Luckily, our app doesn't use React Query extensively, so there were only a few areas that needed close attention.

## Discovered Bug

I also noticed and fixed a bug related to the vertex count logic. If you start on the connections screen and do a fresh sync you'll see the total node & edge counts. Then go in to one of the node types in the data explorer. When you come back to the connection screen the total counts are zeroed out.

This issue existed before the changes in this PR. But I fixed it anyway.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verify query and paging works in the data explorer
- Verify keyword search in graph explorer works
- Verify vertex counts are properly updated

## Related Issues

- Addresses #334 
- Completes #357 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I've covered new added functionality with unit tests if necessary.
