### PR TITLE
Refactor Connector Part 2 - raw ID type map

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -6,6 +6,12 @@ export interface VertexData {
    */
   id: string;
   /**
+   * Data type for the node id.
+   * - For Gremlin, could be string or number
+   * - For openCypher and SPARQL, always string
+   */
+  idType: "string" | "number";
+  /**
    * Single vertex type.
    * - For PG, the node label
    * - For RDF, the resource class

--- a/packages/graph-explorer/src/connector/gremlin/mappers/detectIdType.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/detectIdType.ts
@@ -1,0 +1,17 @@
+import { GInt64 } from "../types";
+
+/**
+ * This function will detect the type of the id value passed in.
+ *
+ * This can be useful to optimize database queries.
+ *
+ * @param id The id value to investigate.
+ * @returns Either string or number.
+ */
+export function detectIdType(id: string | GInt64): "string" | "number" {
+  if (typeof id === "string") {
+    return "string";
+  }
+
+  return "number";
+}

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -1,6 +1,7 @@
 import type { Vertex } from "../../../@types/entities";
 import type { NeighborsCountResponse } from "../../useGEFetchTypes";
 import type { GVertex } from "../types";
+import { detectIdType } from "./detectIdType";
 import parsePropertiesValues from "./parsePropertiesValues";
 import toStringId from "./toStringId";
 
@@ -14,6 +15,7 @@ const mapApiVertex = (
   return {
     data: {
       id: toStringId(apiVertex["@value"].id),
+      idType: detectIdType(apiVertex["@value"].id),
       type: vt,
       types: labels,
       neighborsCount: neighborsCount?.totalCount || 0,

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
@@ -98,14 +98,11 @@ describe("Gremlin > fetchNeighbors", () => {
       },
     ];
 
-    const response = await fetchNeighbors(
-      mockGremlinFetch(),
-      {
-        vertexId: "2018",
-        vertexType: "airport",
-      },
-      new Map()
-    );
+    const response = await fetchNeighbors(mockGremlinFetch(), {
+      vertexId: "2018",
+      idType: "string",
+      vertexType: "airport",
+    });
 
     expect(response).toMatchObject({
       vertices: expectedVertices.map(v => ({
@@ -258,16 +255,13 @@ describe("Gremlin > fetchNeighbors", () => {
       },
     ];
 
-    const response = await fetchNeighbors(
-      mockGremlinFetch(),
-      {
-        vertexId: "2018",
-        vertexType: "airport",
-        filterByVertexTypes: ["airport"],
-        filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],
-      },
-      new Map()
-    );
+    const response = await fetchNeighbors(mockGremlinFetch(), {
+      vertexId: "2018",
+      idType: "string",
+      vertexType: "airport",
+      filterByVertexTypes: ["airport"],
+      filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],
+    });
 
     expect(response).toMatchObject({
       vertices: expectedVertices.map(v => ({

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.ts
@@ -28,11 +28,9 @@ type RawOneHopRequest = {
 
 const fetchNeighbors = async (
   gremlinFetch: GremlinFetch,
-  req: NeighborsRequest,
-  rawIds: Map<string, "string" | "number">
+  req: NeighborsRequest
 ): Promise<NeighborsResponse> => {
-  const idType = rawIds.get(req.vertexId) ?? "string";
-  const gremlinTemplate = oneHopTemplate({ ...req, idType });
+  const gremlinTemplate = oneHopTemplate(req);
   const data = await gremlinFetch<RawOneHopRequest>(gremlinTemplate);
 
   const verticesResponse =

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.test.ts
@@ -6,13 +6,10 @@ describe("Gremlin > fetchNeighborsCount", () => {
   beforeAll(globalMockFetch);
 
   it("Should return neighbors counts for node 2018", async () => {
-    const response = await fetchNeighborsCount(
-      mockGremlinFetch(),
-      {
-        vertexId: "123",
-      },
-      new Map()
-    );
+    const response = await fetchNeighborsCount(mockGremlinFetch(), {
+      vertexId: "123",
+      idType: "string",
+    });
 
     expect(response).toMatchObject({
       totalCount: 18,

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.ts
@@ -25,11 +25,9 @@ type RawNeighborsCountResponse = {
 
 const fetchNeighborsCount = async (
   gremlinFetch: GremlinFetch,
-  req: NeighborsCountRequest,
-  rawIds: Map<string, "string" | "number">
+  req: NeighborsCountRequest
 ): Promise<NeighborsCountResponse> => {
-  const idType = rawIds.get(req.vertexId) ?? "string";
-  const gremlinTemplate = neighborsCountTemplate({ ...req, idType });
+  const gremlinTemplate = neighborsCountTemplate(req);
   const data = await gremlinFetch<RawNeighborsCountResponse>(gremlinTemplate);
 
   const pairs = data.result.data["@value"]?.[0]?.["@value"] || [];

--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
@@ -6,13 +6,9 @@ describe("Gremlin > keywordSearch", () => {
   beforeAll(globalMockFetch);
 
   it("Should return 1 random node", async () => {
-    const keywordResponse = await keywordSearch(
-      mockGremlinFetch(),
-      {
-        limit: 1,
-      },
-      new Map()
-    );
+    const keywordResponse = await keywordSearch(mockGremlinFetch(), {
+      limit: 1,
+    });
 
     expect(keywordResponse).toMatchObject({
       vertices: [
@@ -44,16 +40,12 @@ describe("Gremlin > keywordSearch", () => {
   });
 
   it("Should return airports whose code matches with SFA", async () => {
-    const keywordResponse = await keywordSearch(
-      mockGremlinFetch(),
-      {
-        searchTerm: "SFA",
-        vertexTypes: ["airport"],
-        searchByAttributes: ["code"],
-        searchById: false,
-      },
-      new Map()
-    );
+    const keywordResponse = await keywordSearch(mockGremlinFetch(), {
+      searchTerm: "SFA",
+      vertexTypes: ["airport"],
+      searchByAttributes: ["code"],
+      searchById: false,
+    });
 
     expect(keywordResponse).toMatchObject({
       vertices: [

--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
@@ -4,9 +4,7 @@ import type {
   KeywordSearchResponse,
 } from "../../useGEFetchTypes";
 import isErrorResponse from "../../utils/isErrorResponse";
-import { detectIdType } from "../mappers/detectIdType";
 import mapApiVertex from "../mappers/mapApiVertex";
-import toStringId from "../mappers/toStringId";
 import keywordSearchTemplate from "../templates/keywordSearchTemplate";
 import type { GVertexList } from "../types";
 import { GremlinFetch } from "../types";
@@ -24,8 +22,7 @@ type RawKeySearchResponse = {
 
 const keywordSearch = async (
   gremlinFetch: GremlinFetch,
-  req: KeywordSearchRequest,
-  rawIds: Map<string, "string" | "number">
+  req: KeywordSearchRequest
 ): Promise<KeywordSearchResponse> => {
   const gremlinTemplate = keywordSearchTemplate(req);
   const data = await gremlinFetch<RawKeySearchResponse | ErrorResponse>(
@@ -37,10 +34,6 @@ const keywordSearch = async (
   }
 
   const vertices = data.result.data["@value"].map(value => {
-    rawIds.set(
-      toStringId(value["@value"].id),
-      detectIdType(value["@value"].id)
-    );
     return mapApiVertex(value);
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
@@ -4,11 +4,12 @@ import type {
   KeywordSearchResponse,
 } from "../../useGEFetchTypes";
 import isErrorResponse from "../../utils/isErrorResponse";
+import { detectIdType } from "../mappers/detectIdType";
 import mapApiVertex from "../mappers/mapApiVertex";
 import toStringId from "../mappers/toStringId";
 import keywordSearchTemplate from "../templates/keywordSearchTemplate";
 import type { GVertexList } from "../types";
-import { GInt64, GremlinFetch } from "../types";
+import { GremlinFetch } from "../types";
 
 type RawKeySearchResponse = {
   requestId: string;
@@ -19,14 +20,6 @@ type RawKeySearchResponse = {
   result: {
     data: GVertexList;
   };
-};
-
-const idType = (id: string | GInt64) => {
-  if (typeof id === "string") {
-    return "string";
-  }
-
-  return "number";
 };
 
 const keywordSearch = async (
@@ -44,7 +37,10 @@ const keywordSearch = async (
   }
 
   const vertices = data.result.data["@value"].map(value => {
-    rawIds.set(toStringId(value["@value"].id), idType(value["@value"].id));
+    rawIds.set(
+      toStringId(value["@value"].id),
+      detectIdType(value["@value"].id)
+    );
     return mapApiVertex(value);
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
@@ -4,6 +4,7 @@ describe("Gremlin > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id with default limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
     });
 
     expect(template).toBe(
@@ -11,9 +12,21 @@ describe("Gremlin > neighborsCountTemplate", () => {
     );
   });
 
+  it("Should return a template for the given vertex id with default limit and number type", () => {
+    const template = neighborsCountTemplate({
+      vertexId: "12",
+      idType: "number",
+    });
+
+    expect(template).toBe(
+      "g.V(12L).both().limit(500).dedup().group().by(label).by(count())"
+    );
+  });
+
   it("Should return a template for the given vertex id with defined limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
       limit: 20,
     });
 
@@ -25,6 +38,7 @@ describe("Gremlin > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id with no limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
       limit: 0,
     });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
@@ -14,8 +14,8 @@ import type { NeighborsCountRequest } from "../../useGEFetchTypes";
 const neighborsCountTemplate = ({
   vertexId,
   limit = 500,
-  idType = "string",
-}: NeighborsCountRequest & { idType?: "string" | "number" }) => {
+  idType,
+}: NeighborsCountRequest) => {
   let template = "";
   if (idType === "number") {
     template = `g.V(${vertexId}L).both()`;

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
@@ -4,6 +4,7 @@ describe("Gremlin > oneHopTemplate", () => {
   it("Should return a template for a simple vertex id", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
     });
 
     expect(template).toBe(
@@ -13,9 +14,23 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
+  it("Should return a template for a simple vertex id with number type", () => {
+    const template = oneHopTemplate({
+      vertexId: "12",
+      idType: "number",
+    });
+
+    expect(template).toBe(
+      'g.V(12L).project("vertices", "edges")' +
+        ".by(both().dedup().range(0, 10).fold())" +
+        ".by(bothE().dedup().fold())"
+    );
+  });
+
   it("Should return a template with an offset and limit", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       offset: 5,
       limit: 5,
     });
@@ -30,6 +45,7 @@ describe("Gremlin > oneHopTemplate", () => {
   it("Should return a template for specific vertex type", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       filterByVertexTypes: ["country"],
       offset: 5,
       limit: 10,
@@ -45,6 +61,7 @@ describe("Gremlin > oneHopTemplate", () => {
   it("Should return a template with specific filter criteria", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       filterByVertexTypes: ["country"],
       filterCriteria: [
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
@@ -127,15 +127,13 @@ const criterionTemplate = (criterion: Criterion): string => {
  */
 const oneHopTemplate = ({
   vertexId,
+  idType,
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
   limit = 10,
   offset = 0,
-  idType = "string",
-}: Omit<NeighborsRequest, "vertexType"> & {
-  idType?: "string" | "number";
-}): string => {
+}: Omit<NeighborsRequest, "vertexType">): string => {
   const range = `.range(${offset}, ${offset + limit})`;
   let template = "";
   if (idType === "number") {

--- a/packages/graph-explorer/src/connector/gremlin/useGremlin.ts
+++ b/packages/graph-explorer/src/connector/gremlin/useGremlin.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { ConnectionConfig, useConfiguration } from "../../core";
 import fetchNeighbors from "./queries/fetchNeighbors";
 import fetchNeighborsCount from "./queries/fetchNeighborsCount";
@@ -43,9 +43,6 @@ const useGremlin = (): Explorer => {
     | undefined;
 
   const url = connection?.url;
-  const _rawIdTypeMap = useMemo(() => {
-    return new Map<string, "string" | "number">();
-  }, []);
 
   const fetchSchemaFunc = useCallback(
     async (options?: any) => {
@@ -79,24 +76,16 @@ const useGremlin = (): Explorer => {
 
   const fetchNeighborsFunc = useCallback(
     (req: NeighborsRequest, options?: any) => {
-      return fetchNeighbors(
-        _gremlinFetch(connection, options),
-        req,
-        _rawIdTypeMap
-      );
+      return fetchNeighbors(_gremlinFetch(connection, options), req);
     },
-    [_rawIdTypeMap, connection]
+    [connection]
   );
 
   const fetchNeighborsCountFunc = useCallback(
     (req: NeighborsCountRequest, options?: any) => {
-      return fetchNeighborsCount(
-        _gremlinFetch(connection, options),
-        req,
-        _rawIdTypeMap
-      );
+      return fetchNeighborsCount(_gremlinFetch(connection, options), req);
     },
-    [_rawIdTypeMap, connection]
+    [connection]
   );
 
   const keywordSearchFunc = useCallback(
@@ -104,13 +93,9 @@ const useGremlin = (): Explorer => {
       options ??= {};
       options.queryId = v4();
 
-      return keywordSearch(
-        _gremlinFetch(connection, options),
-        req,
-        _rawIdTypeMap
-      );
+      return keywordSearch(_gremlinFetch(connection, options), req);
     },
-    [_rawIdTypeMap, connection]
+    [connection]
   );
 
   const explorer: Explorer = {

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -12,6 +12,7 @@ const mapApiVertex = (
   return {
     data: {
       id: apiVertex["~id"],
+      idType: "string",
       type: vt,
       types: labels,
       neighborsCount: neighborsCount?.totalCount || 0,

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
@@ -4,6 +4,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id with default limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
     });
 
     expect(template).toBe(
@@ -14,6 +15,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id with defined limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
       limit: 20,
     });
 
@@ -25,6 +27,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id with no limit", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
+      idType: "string",
       limit: 0,
     });
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -4,6 +4,7 @@ describe("OpenCypher > oneHopTemplate", () => {
   it("Should return a template for a simple vertex id", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
     });
 
     expect(template).toBe(
@@ -14,6 +15,7 @@ describe("OpenCypher > oneHopTemplate", () => {
   it("Should return a template with an offset and limit", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       offset: 5,
       limit: 5,
     });
@@ -26,6 +28,7 @@ describe("OpenCypher > oneHopTemplate", () => {
   it("Should return a template for specific vertex type", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       filterByVertexTypes: ["country"],
       offset: 5,
       limit: 10,
@@ -39,6 +42,7 @@ describe("OpenCypher > oneHopTemplate", () => {
   it("Should return a template with specific filter criteria", () => {
     const template = oneHopTemplate({
       vertexId: "12",
+      idType: "string",
       filterByVertexTypes: ["country"],
       filterCriteria: [
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -9,6 +9,7 @@ const mapRawResultToVertex = (
   return {
     data: {
       id: rawResult.uri,
+      idType: "string",
       type: rawResult.class,
       neighborsCount: neighborsCount?.totalCount || 0,
       neighborsCountByType: neighborsCount?.counts || {},

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -9,6 +9,11 @@ export type QueryOptions = RequestInit & {
   queryId?: string;
 };
 
+/**
+ * The type of the vertex ID.
+ */
+export type VertexIdType = "string" | "number";
+
 export type VertexSchemaResponse = Pick<
   VertexTypeConfig,
   | "type"
@@ -79,6 +84,10 @@ export type NeighborsRequest = {
    */
   vertexId: string;
   /**
+   * The type of the vertex ID.
+   */
+  idType: VertexIdType;
+  /**
    * Source vertex type.
    */
   vertexType: string;
@@ -121,6 +130,10 @@ export type NeighborsCountRequest = {
    * Source vertex ID.
    */
   vertexId: string;
+  /**
+   * The type of the vertex ID.
+   */
+  idType: VertexIdType;
   /**
    * Limit the number of results.
    * 0 = No limit.

--- a/packages/graph-explorer/src/hooks/useExpandNode.ts
+++ b/packages/graph-explorer/src/hooks/useExpandNode.ts
@@ -38,6 +38,7 @@ const useExpandNode = () => {
         result.vertices.map(async vertex => {
           const neighborsCount = await connector.explorer?.fetchNeighborsCount({
             vertexId: vertex.data.id,
+            idType: vertex.data.idType,
           });
 
           return {

--- a/packages/graph-explorer/src/hooks/useFetchNode.ts
+++ b/packages/graph-explorer/src/hooks/useFetchNode.ts
@@ -24,6 +24,7 @@ const useFetchNode = () => {
         nodes.map(async node => {
           const neighborsCount = await fetchNeighborsCount({
             vertexId: node.data.id,
+            idType: node.data.idType,
             limit: neighbors_limit,
           });
           if (!neighborsCount) {

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -218,6 +218,7 @@ const GraphViewer = ({
       setExpandVertexName(name);
       await expandNode({
         vertexId: vertexData.id,
+        idType: vertexData.idType,
         vertexType: vertexData.types?.join("::") ?? vertexData.type,
         limit: vertexData.neighborsCount,
         offset: 0,

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -48,6 +48,7 @@ const NodeExpandContent = ({
     setIsExpanding(true);
     await expandNode({
       vertexId: vertex.data.id,
+      idType: vertex.data.idType,
       vertexType: (vertex.data.types ?? [vertex.data.type])?.join("::"),
       filterByVertexTypes: [selectedType],
       filterCriteria: filters.map(filter => ({

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -176,6 +176,7 @@ export function createRandomVertex(): Vertex {
   return {
     data: {
       id: createRandomName("VertexId"),
+      idType: "string",
       type: createRandomName("VertexType"),
       attributes: createRecord(3, createRandomEntityAttribute),
       neighborsCount: 0,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This raw ID type map was being stored next to the connector state. It is a lookup for a vertex ID to its original type before it was mapped to a string.

Instead, I store this value on the `VertexData` instance. It should use the same or less memory and avoids all the strange state logic needed to maintain the map.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

- Part 2 of #335 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
