### PR TITLE
Add "accept" header to requests from proxy server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ This release includes the following feature enhancements and bug fixes:
 - Fixed uploaded SVG rendering in graph (<https://github.com/aws/graph-explorer/pull/296>)
 - Fixed search bar hover color (<https://github.com/aws/graph-explorer/pull/293>)
 - Fixed Docker image tagging in GitHub workflows (<https://github.com/aws/graph-explorer/pull/320>)
+- Fixed non-JSON response from SwissLipids (<https://github.com/aws/graph-explorer/pull/395>)
 - Improved monorepo configuration (<https://github.com/aws/graph-explorer/pull/305>)
 - Updated database query abstractions (<https://github.com/aws/graph-explorer/pull/366>) (<https://github.com/aws/graph-explorer/pull/367>) (<https://github.com/aws/graph-explorer/pull/365>)
 - Improved the GitHub templates for issues and pull requests (<https://github.com/aws/graph-explorer/pull/281>) (<https://github.com/aws/graph-explorer/pull/332>) (<https://github.com/aws/graph-explorer/pull/362>)

--- a/packages/graph-explorer-proxy-server/node-server.js
+++ b/packages/graph-explorer-proxy-server/node-server.js
@@ -200,6 +200,7 @@ app.post("/sparql", async (req, res, next) => {
           method: "POST",
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json"
           },
           body: `cancelQuery&queryId=${encodeURIComponent(queryId)}&silent=true`,
         },
@@ -243,6 +244,7 @@ app.post("/sparql", async (req, res, next) => {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json"
     },
     body,
   };
@@ -306,6 +308,7 @@ app.post("/gremlin", async (req, res, next) => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "Accept": "application/json",
     },
     body: JSON.stringify(body),
   };
@@ -327,6 +330,7 @@ app.post("/openCypher", async (req, res, next) => {
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
     },
     body: `query=${encodeURIComponent(req.body.query)}`,
   };


### PR DESCRIPTION
The proxy server always assumes a response in JSON format, but that is not always the default response type.

This change makes it explicit that we want a JSON response by adding it to the headers:

```js
headers: {
  "Content-Type": "application/x-www-form-urlencoded",
  "Accept": "application/json"
},
```

## Validation

- Verified with Neptune, all languages
- Verified with https://beta.sparql.swisslipids.org

<img width="643" alt="Screenshot 2024-05-14 at 3 01 31 PM" src="https://github.com/aws/graph-explorer/assets/212862/61ceb40e-3c71-46a8-bfe6-29daa017152a">

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- Addresses #393 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
