### PR TITLE
Automatic setup of some common mocks

### DIFF
--- a/packages/graph-explorer/jest.config.ts
+++ b/packages/graph-explorer/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config = {
   moduleFileExtensions: ["js", "ts", "tsx", "json"],
   rootDir: "src",
   testRegex: ".test.ts$",
+  setupFilesAfterEnv: ["<rootDir>/utils/testing/setupTests.ts"],
   transformIgnorePatterns: [
     "node_modules/(?!(swiper|dom7)/)",
     "node_modules/(?!(react-dnd-html5-backend)/)",

--- a/packages/graph-explorer/src/components/Graph/hooks/useRenderBadges.ts
+++ b/packages/graph-explorer/src/components/Graph/hooks/useRenderBadges.ts
@@ -6,6 +6,7 @@ import type { AutoBoundingBox, BoundingBox } from "../../utils/canvas/types";
 import type { CytoscapeCanvas, CytoscapeType } from "../Graph.model";
 import getNodeBoundingBox from "../helpers/getNodeBoundingBox";
 import getZoomLevel from "../helpers/getZoomLevel";
+import { env } from "../../../utils";
 
 export type Badge = DrawBoxWithAdornmentOptions & {
   boundingBox: AutoBoundingBox;
@@ -73,7 +74,7 @@ const useRenderBadges = <TNodeData extends VertexData = VertexData>({
         layerRef.current = cy.cyCanvas({ zIndex: 20 });
         canvasRef.current = layerRef.current.getCanvas() ?? null;
       } catch (e) {
-        if (import.meta.env.DEV)
+        if (env.DEV)
           console.error(
             "If you want to render badges you need to install the " +
               "cytoscape-canvas plugin first, see the documentation " +

--- a/packages/graph-explorer/src/components/utils/canvas/drawImage.ts
+++ b/packages/graph-explorer/src/components/utils/canvas/drawImage.ts
@@ -1,3 +1,4 @@
+import { env } from "../../../utils";
 import colorizeSvg from "./colorizeSvg";
 import type { BoundingBox } from "./types";
 
@@ -33,7 +34,7 @@ async function fetchIcon(url: string): Promise<string | undefined> {
       return await response.text();
     }
   } catch (err) {
-    if (import.meta.env.DEV) {
+    if (env.DEV) {
       console.error(`Unable to fetch ${url}: ${err}`);
     }
   }

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -8,6 +8,7 @@ import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
 import { GraphSummary } from "./types";
 import { v4 } from "uuid";
 import { Explorer } from "../useGEFetchTypes";
+import { env } from "../../utils";
 
 function _gremlinFetch(connection: ConnectionConfig, options: any) {
   return async (queryTemplate: string) => {
@@ -44,7 +45,7 @@ export function createGremlinExplorer(connection: ConnectionConfig): Explorer {
         );
         summary = (response.payload.graphSummary as GraphSummary) || undefined;
       } catch (e) {
-        if (import.meta.env.DEV) {
+        if (env.DEV) {
           console.error("[Summary API]", e);
         }
       }

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -8,6 +8,7 @@ import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
 import { ConnectionConfig } from "../../core";
 import { DEFAULT_SERVICE_TYPE } from "../../utils/constants";
 import { Explorer } from "../useGEFetchTypes";
+import { env } from "../../utils";
 
 function _openCypherFetch(connection: ConnectionConfig, options: any) {
   return async (queryTemplate: string) => {
@@ -44,7 +45,7 @@ export function createOpenCypherExplorer(
             ? (response.payload.graphSummary as GraphSummary)
             : (response.graphSummary as GraphSummary)) || undefined;
       } catch (e) {
-        if (import.meta.env.DEV) {
+        if (env.DEV) {
           console.error("[Summary API]", e);
         }
       }

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -22,6 +22,7 @@ import {
 } from "./types";
 import { ConnectionConfig } from "../../core";
 import { v4 } from "uuid";
+import { env } from "../../utils";
 
 const replaceBlankNodeFromSearch = (
   blankNodes: BlankNodesMap,
@@ -165,7 +166,7 @@ export function createSparqlExplorer(
         );
         summary = (response.payload.graphSummary as GraphSummary) || undefined;
       } catch (e) {
-        if (import.meta.env.DEV) {
+        if (env.DEV) {
           console.error("[Summary API]", e);
         }
       }

--- a/packages/graph-explorer/src/core/ConfigurationProvider/fetchConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/fetchConfiguration.ts
@@ -1,3 +1,4 @@
+import { env } from "../../utils";
 import type { RawConfiguration } from "./types";
 
 const fetchConfiguration = async (
@@ -12,7 +13,7 @@ const fetchConfiguration = async (
     const rawData = await response.json();
     return rawData as RawConfiguration;
   } catch (e) {
-    if (import.meta.env.DEV) {
+    if (env.DEV) {
       console.error(e);
     }
   }

--- a/packages/graph-explorer/src/core/ConfigurationProvider/isConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/isConfiguration.ts
@@ -1,7 +1,8 @@
+import { env } from "../../utils";
 import type { ConfigurationContextProps } from "./types";
 
 const logDevError = (...args: Parameters<typeof console.error>) => {
-  if (import.meta.env.DEV) {
+  if (env.DEV) {
     console.error(...args);
   }
 };

--- a/packages/graph-explorer/src/core/StateProvider/StateProvider.tsx
+++ b/packages/graph-explorer/src/core/StateProvider/StateProvider.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from "react";
 import { RecoilRoot } from "recoil";
 import StateDebug from "./StateDebug";
+import { env } from "../../utils";
 
 const StateProvider = ({
   children,
@@ -8,7 +9,7 @@ const StateProvider = ({
   return (
     <RecoilRoot>
       {children}
-      {import.meta.env.DEV && <StateDebug />}
+      {env.DEV && <StateDebug />}
     </RecoilRoot>
   );
 };

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -6,6 +6,7 @@ import { createSparqlExplorer } from "../connector/sparql/sparqlExplorer";
 import { mergedConfigurationSelector } from "./StateProvider/configuration";
 import { selector } from "recoil";
 import { equalSelector } from "../utils/recoilState";
+import { env } from "../utils";
 
 /**
  * Active connection where the value will only change when one of the
@@ -83,7 +84,7 @@ export const loggerSelector = selector({
     }
 
     return new LoggerConnector(url, {
-      enable: import.meta.env.PROD,
+      enable: env.PROD,
     });
   },
 });

--- a/packages/graph-explorer/src/hooks/useEntities.test.ts
+++ b/packages/graph-explorer/src/hooks/useEntities.test.ts
@@ -12,12 +12,6 @@ import { activeConfigurationAtom } from "../core/StateProvider/configuration";
 import { Schema } from "../core";
 import { Entities } from "../core/StateProvider/entitiesSelector";
 
-jest.mock("localforage", () => ({
-  config: jest.fn(),
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-}));
-
 describe("useEntities", () => {
   beforeEach(() => {
     jest.resetAllMocks();

--- a/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
+++ b/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
@@ -6,7 +6,6 @@ import useNeighborsOptions from "./useNeighborsOptions";
 import { Vertex } from "../@types/entities";
 
 jest.mock("../core/ConfigurationProvider/useConfiguration");
-jest.mock("localforage");
 jest.mock("./useTextTransform");
 
 jest.mock("../core/ConfigurationProvider/ConfigurationProvider.tsx", () => ({

--- a/packages/graph-explorer/src/hooks/useTextTransform.test.ts
+++ b/packages/graph-explorer/src/hooks/useTextTransform.test.ts
@@ -3,8 +3,6 @@ import useTextTransform from "./useTextTransform";
 import { renderHook } from "@testing-library/react-hooks";
 import { useConfiguration } from "../core";
 
-jest.mock("localforage");
-
 jest.mock("../core/ConnectedProvider/ConnectedProvider.tsx", () => ({
   ConnectedProvider: ({ children }: any) => children,
 }));

--- a/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.test.ts
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.test.ts
@@ -7,12 +7,6 @@ import { TestableRootProviders } from "../../utils/testing/TestableRootProviders
 import { sample, sortBy } from "lodash";
 import { Schema } from "../../core";
 
-jest.mock("localforage", () => ({
-  config: jest.fn(),
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-}));
-
 /** Creates a config with the schema and makes it active, then renders the `useFiltersConfig` hook. */
 function renderFilterConfigHook(schema: Schema) {
   return renderHook(

--- a/packages/graph-explorer/src/modules/KeywordSearch/toAdvancedList.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/toAdvancedList.ts
@@ -1,5 +1,6 @@
 import groupBy from "lodash/groupBy";
 import type { AdvancedListItemType } from "../../components/AdvancedList";
+import { env } from "../../utils";
 
 export type AdvancedListOptions<TDatum extends object> = {
   getGroupLabel?(datum: TDatum): string;
@@ -43,7 +44,7 @@ const toAdvancedList = <TDatum extends object>(
           lisItems = lisItems.sort(sortFn);
         }
       } catch (e) {
-        if (import.meta.env.DEV) {
+        if (env.DEV) {
           console.error(e);
         }
       }

--- a/packages/graph-explorer/src/utils/env.ts
+++ b/packages/graph-explorer/src/utils/env.ts
@@ -1,0 +1,4 @@
+export const env = {
+  DEV: import.meta.env.DEV,
+  PROD: import.meta.env.PROD,
+};

--- a/packages/graph-explorer/src/utils/index.ts
+++ b/packages/graph-explorer/src/utils/index.ts
@@ -8,3 +8,4 @@ export { default as sanitizeText } from "./sanitizeText";
 export { DEFAULT_SERVICE_TYPE } from "./constants";
 export { default as escapeString } from "./escapeString";
 export * from "./set";
+export * from "./env";

--- a/packages/graph-explorer/src/utils/testing/setupTests.ts
+++ b/packages/graph-explorer/src/utils/testing/setupTests.ts
@@ -9,3 +9,10 @@ jest.mock("../env", () => {
     PROD: false,
   };
 });
+
+// Mock localforage
+jest.mock("localforage", () => ({
+  config: jest.fn(),
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));

--- a/packages/graph-explorer/src/utils/testing/setupTests.ts
+++ b/packages/graph-explorer/src/utils/testing/setupTests.ts
@@ -1,0 +1,11 @@
+/*
+ * Global Jest setup for all tests
+ */
+
+// Mock the env module
+jest.mock("../env", () => {
+  return {
+    DEV: true,
+    PROD: false,
+  };
+});


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I kept getting errors about the `import.meta.env.DEV` calls in our code. The common fix was to mock the code using that data. But a better approach is to mock the data itself.

Since this is needed globally, I've configured a global setup test file for mocks used everywhere. We can always opt out or override any of these mocked types if needed for specific tests.

I've also added the `localforage` mock since we always want that mocked when we are testing React state logic.

## Validation

- Run the tests

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
