### PR TITLE
Ensure setEntities is not recreated on each render

### DIFF
--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -27,72 +27,72 @@ function getDefaultEdgeTypeConfig(edgeType: string): EdgeTypeConfig {
   };
 }
 
-const assembledConfigSelector = selector<ConfigurationContextProps | undefined>(
-  {
-    key: "assembled-config",
-    get: ({ get }) => {
-      const configuration = get(mergedConfigurationSelector);
-      if (!configuration) {
-        return;
-      }
+export const assembledConfigSelector = selector<
+  ConfigurationContextProps | undefined
+>({
+  key: "assembled-config",
+  get: ({ get }) => {
+    const configuration = get(mergedConfigurationSelector);
+    if (!configuration) {
+      return;
+    }
 
-      return {
-        ...configuration,
-        totalVertices: configuration.schema?.totalVertices ?? 0,
-        vertexTypes: configuration.schema?.vertices?.map(vt => vt.type) || [],
-        totalEdges: configuration.schema?.totalEdges ?? 0,
-        edgeTypes: configuration.schema?.edges?.map(et => et.type) || [],
-        getVertexTypeConfig(vertexType) {
-          const vtConfig = configuration?.schema?.vertices?.find(
-            v => v.type === vertexType
-          );
-          if (!vtConfig) {
-            return getDefaultVertexTypeConfig(vertexType);
-          }
+    return {
+      ...configuration,
+      totalVertices: configuration.schema?.totalVertices ?? 0,
+      vertexTypes: configuration.schema?.vertices?.map(vt => vt.type) || [],
+      totalEdges: configuration.schema?.totalEdges ?? 0,
+      edgeTypes: configuration.schema?.edges?.map(et => et.type) || [],
+      getVertexTypeConfig(vertexType) {
+        const vtConfig = configuration?.schema?.vertices?.find(
+          v => v.type === vertexType
+        );
+        if (!vtConfig) {
+          return getDefaultVertexTypeConfig(vertexType);
+        }
 
-          return vtConfig;
-        },
-        getVertexTypeAttributes(vertexTypes) {
-          const vtConfig = configuration?.schema?.vertices?.filter(v =>
-            vertexTypes.includes(v.type)
-          );
+        return vtConfig;
+      },
+      getVertexTypeAttributes(vertexTypes) {
+        const vtConfig = configuration?.schema?.vertices?.filter(v =>
+          vertexTypes.includes(v.type)
+        );
 
-          if (!vtConfig?.length) {
-            return [];
-          }
+        if (!vtConfig?.length) {
+          return [];
+        }
 
-          return uniqBy(
-            vtConfig.flatMap(v => v.attributes),
-            v => v.name
-          );
-        },
-        getVertexTypeSearchableAttributes(vertexType) {
-          const vtConfig = configuration?.schema?.vertices?.find(
-            v => v.type === vertexType
-          );
-          if (!vtConfig) {
-            return [];
-          }
+        return uniqBy(
+          vtConfig.flatMap(v => v.attributes),
+          v => v.name
+        );
+      },
+      getVertexTypeSearchableAttributes(vertexType) {
+        const vtConfig = configuration?.schema?.vertices?.find(
+          v => v.type === vertexType
+        );
+        if (!vtConfig) {
+          return [];
+        }
 
-          return vtConfig.attributes.filter(
-            attribute =>
-              attribute.searchable !== false && attribute.dataType === "String"
-          );
-        },
-        getEdgeTypeConfig(edgeType) {
-          const etConfig = configuration?.schema?.edges?.find(
-            e => e.type === edgeType
-          );
-          if (!etConfig) {
-            return getDefaultEdgeTypeConfig(edgeType);
-          }
+        return vtConfig.attributes.filter(
+          attribute =>
+            attribute.searchable !== false && attribute.dataType === "String"
+        );
+      },
+      getEdgeTypeConfig(edgeType) {
+        const etConfig = configuration?.schema?.edges?.find(
+          e => e.type === edgeType
+        );
+        if (!etConfig) {
+          return getDefaultEdgeTypeConfig(edgeType);
+        }
 
-          return etConfig;
-        },
-      };
-    },
-  }
-);
+        return etConfig;
+      },
+    };
+  },
+});
 
 export default function useConfiguration() {
   return useRecoilValue(assembledConfigSelector);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I discovered that `setEntities` was being recreated every time it was called because I needed to call it in a `useEffect`, which meant it needed to be in the dependency array. This led to an infinite loop that locks up the browser.

The main cause was the config value, which changes when the schema changes, which is changed when adding nodes and edges.

However, the config is in Recoil state. So I get the config value from Recoil snapshot instead of the hook. I also use the setter provided in the `useRecoilCallback` utility.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
- Add nodes to graph
- Expand nodes

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- #341 
- #339 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
