### PR TITLE
Fix expand sidebar scrolling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@
   (<https://github.com/aws/graph-explorer/pull/434>)
 - Added caching and retries to node expansion and neighbor counts
   (<https://github.com/aws/graph-explorer/pull/434>)
+- Improved scrolling behavior in expand sidebar
+  (<https://github.com/aws/graph-explorer/pull/436>)
 
 **Bug Fixes and Minor Changes**
 

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.styles.ts
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.styles.ts
@@ -8,6 +8,7 @@ const defaultStyles =
     height: 100%;
     display: flex;
     flex-direction: column;
+    overflow-y: scroll;
     background: ${theme.palette.background.default};
 
     .${pfx}-empty-panel-state {

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.styles.ts
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.styles.ts
@@ -10,8 +10,6 @@ const defaultStyles =
       padding: ${theme.spacing["4x"]};
       gap: ${theme.spacing["2x"]};
       border-bottom: solid 1px ${theme.palette.divider};
-      height: 30%;
-      overflow: auto;
 
       .${pfx}-title {
         font-weight: bold;

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -1,9 +1,16 @@
 import { cx } from "@emotion/css";
 import { Vertex } from "../../../@types/entities";
-import { Chip, Tooltip, VertexIcon, VisibleIcon } from "../../../components";
+import {
+  Button,
+  Chip,
+  Tooltip,
+  VertexIcon,
+  VisibleIcon,
+} from "../../../components";
 import { useWithTheme, withClassNamePrefix } from "../../../core";
 import useNeighborsOptions from "../../../hooks/useNeighborsOptions";
 import defaultStyles from "./NeighborsList.styles";
+import { useState } from "react";
 
 export type NeighborsListProps = {
   classNamePrefix?: string;
@@ -17,6 +24,10 @@ const NeighborsList = ({
   const styleWithTheme = useWithTheme();
   const pfx = withClassNamePrefix(classNamePrefix);
   const neighborsOptions = useNeighborsOptions(vertex);
+  const [showMore, setShowMore] = useState(false);
+  const maxStartingItems = 5;
+  const hasMore = neighborsOptions.length > maxStartingItems;
+  const extraCount = hasMore ? neighborsOptions.length - maxStartingItems : 0;
 
   return (
     <div
@@ -28,7 +39,7 @@ const NeighborsList = ({
       <div className={pfx("title")}>
         Neighbors ({vertex.data.neighborsCount})
       </div>
-      {neighborsOptions.map(op => {
+      {neighborsOptions.slice(0, showMore ? undefined : 5).map(op => {
         const neighborsInView =
           vertex.data.neighborsCountByType[op.value] -
           (vertex.data.__unfetchedNeighborCounts?.[op.value] ?? 0);
@@ -62,6 +73,14 @@ const NeighborsList = ({
           </div>
         );
       })}
+
+      {hasMore ? (
+        <Button variant="text" onPress={() => setShowMore(prev => !prev)}>
+          {showMore
+            ? `Hide ${extraCount} additional neighbors`
+            : `Show ${extraCount} additional neighbors`}
+        </Button>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The expand sidebar scrolling is annoying to use when vertical height is limited. It was using percentage heights for sections of the UI.

Instead, I allow the full content beneath the vertex header to be scrolled. The expand button will be in the bottom corner if there is enough height to accomplish that without scrolling. If not, the user will need to scroll for the expand button.

When there are more than 5 neighbors, A "show more" button will appear. When clicked, all the neighbors will show. The user can collapse it again.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Here is a 30 second video showing off this new behavior.

https://github.com/aws/graph-explorer/assets/212862/da47da08-e0fc-48df-9e45-3ef3e98b52ee



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
