### PR TITLE
Add expand limit to connection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
   (<https://github.com/aws/graph-explorer/pull/434>)
 - Improved scrolling behavior in expand sidebar
   (<https://github.com/aws/graph-explorer/pull/436>)
+- Add node expansion limit per connection
+  (<https://github.com/aws/graph-explorer/pull/447>)
 
 **Bug Fixes and Minor Changes**
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ defaults, and their descriptions.
   - `GRAPH_EXP_FETCH_REQUEST_TIMEOUT` - `240000` - Controls the timeout for the
     fetch request. Measured in milliseconds (i.e. 240000 is 240 seconds or 4
     minutes).
+  - `GRAPH_EXP_NODE_EXPANSION_LIMIT` - `None` - Controls the limit for node
+    counts and expansion queries.
 - Conditionally Required:
   - Required if `USING_PROXY_SERVER=True`
     - `GRAPH_CONNECTION_URL` - `None` - See
@@ -216,7 +218,8 @@ attributes:
   "GRAPH_EXP_HTTPS_CONNECTION": true,
   "PROXY_SERVER_HTTPS_CONNECTION": true,
   // Measured in milliseconds (i.e. 240000 is 240 seconds or 4 minutes)
-  "GRAPH_EXP_FETCH_REQUEST_TIMEOUT": 240000
+  "GRAPH_EXP_FETCH_REQUEST_TIMEOUT": 240000,
+  "GRAPH_EXP_NODE_EXPANSION_LIMIT": 500,
 }
 ```
 
@@ -246,6 +249,7 @@ docker run -p 80:80 -p 443:443 \
  --env SERVICE_TYPE=neptune-db \
  --env PROXY_SERVER_HTTPS_CONNECTION=true \
  --env GRAPH_EXP_FETCH_REQUEST_TIMEOUT=240000 \
+ --env GRAPH_EXP_NODE_EXPANSION_LIMIT=500 \
  graph-explorer
 ```
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
@@ -1,25 +1,25 @@
 import neighborsCountTemplate from "./neighborsCountTemplate";
 
 describe("Gremlin > neighborsCountTemplate", () => {
-  it("Should return a template for the given vertex id with default limit", () => {
+  it("Should return a template for the given vertex id", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
       idType: "string",
     });
 
     expect(template).toBe(
-      'g.V("12").both().limit(500).dedup().group().by(label).by(count())'
+      'g.V("12").both().dedup().group().by(label).by(count())'
     );
   });
 
-  it("Should return a template for the given vertex id with default limit and number type", () => {
+  it("Should return a template for the given vertex id with number type", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
       idType: "number",
     });
 
     expect(template).toBe(
-      "g.V(12L).both().limit(500).dedup().group().by(label).by(count())"
+      "g.V(12L).both().dedup().group().by(label).by(count())"
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
@@ -13,7 +13,7 @@ import type { NeighborsCountRequest } from "../../useGEFetchTypes";
  */
 const neighborsCountTemplate = ({
   vertexId,
-  limit = 500,
+  limit = 0,
   idType,
 }: NeighborsCountRequest) => {
   let template = "";

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
@@ -9,7 +9,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(template).toBe(
       'g.V("12").project("vertices", "edges")' +
-        ".by(both().dedup().range(0, 10).fold())" +
+        ".by(both().dedup().fold())" +
         ".by(bothE().dedup().fold())"
     );
   });
@@ -22,7 +22,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(template).toBe(
       'g.V(12L).project("vertices", "edges")' +
-        ".by(both().dedup().range(0, 10).fold())" +
+        ".by(both().dedup().fold())" +
         ".by(bothE().dedup().fold())"
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
@@ -131,10 +131,10 @@ const oneHopTemplate = ({
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
-  limit = 10,
+  limit = 0,
   offset = 0,
 }: Omit<NeighborsRequest, "vertexType">): string => {
-  const range = `.range(${offset}, ${offset + limit})`;
+  const range = limit > 0 ? `.range(${offset}, ${offset + limit})` : "";
   let template = "";
   if (idType === "number") {
     template = `g.V(${vertexId}L)`;

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
@@ -1,14 +1,14 @@
 import neighborsCountTemplate from "./neighborsCountTemplate";
 
 describe("OpenCypher > neighborsCountTemplate", () => {
-  it("Should return a template for the given vertex id with default limit", () => {
+  it("Should return a template for the given vertex id", () => {
     const template = neighborsCountTemplate({
       vertexId: "12",
       idType: "string",
     });
 
     expect(template).toBe(
-      'MATCH (v) -[e]- (t) WHERE ID(v) = "12" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count LIMIT 500'
+      'MATCH (v) -[e]- (t) WHERE ID(v) = "12" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count'
     );
   });
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
@@ -16,7 +16,7 @@ import type { NeighborsCountRequest } from "../../useGEFetchTypes";
  */
 const neighborsCountTemplate = ({
   vertexId,
-  limit = 500,
+  limit = 0,
 }: NeighborsCountRequest) => {
   let template = "";
   template = `MATCH (v) -[e]- (t) WHERE ID(v) = "${vertexId}" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count`;

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -8,7 +8,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})[..10] AS eObjects RETURN vObjects, eObjects'
+      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt) AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)}) AS eObjects RETURN vObjects, eObjects'
     );
   });
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
@@ -106,7 +106,7 @@ const oneHopTemplate = ({
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
-  limit = 10,
+  limit = 0,
 }: Omit<NeighborsRequest, "vertexType">): string => {
   let template = `MATCH (v)`;
 
@@ -137,7 +137,9 @@ const oneHopTemplate = ({
     template += `AND ${filterCriteriaTemplate} `;
   }
 
-  template += `WITH collect(DISTINCT tgt)[..${limit}] AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})[..${limit}] AS eObjects RETURN vObjects, eObjects`;
+  const limitTemplate = limit > 0 ? `[..${limit}]` : "";
+
+  template += `WITH collect(DISTINCT tgt)${limitTemplate} AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})${limitTemplate} AS eObjects RETURN vObjects, eObjects`;
 
   return template;
 };

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -42,14 +42,19 @@ export type NeighborCountsQueryResponse = {
  * @param explorer The service client to use for fetching the neighbors count.
  * @returns The count of neighbors for the given node as a total and per type.
  */
-export const neighborsCountQuery = (id: VertexId, explorer: Explorer | null) =>
+export const neighborsCountQuery = (
+  id: VertexId,
+  limit: number | undefined,
+  explorer: Explorer | null
+) =>
   queryOptions({
-    queryKey: ["neighborsCount", id, explorer],
+    queryKey: ["neighborsCount", id, limit, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
       const result = await explorer?.fetchNeighborsCount({
         vertexId: id.toString(),
         idType: typeofVertexId(id),
+        limit,
       });
 
       if (!result) {

--- a/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighborsTemplate.ts
@@ -86,12 +86,7 @@ const oneHopNeighborsTemplate = ({
     return filter;
   };
 
-  const getLimit = () => {
-    if (limit === 0) {
-      return "";
-    }
-    return `LIMIT ${limit} OFFSET ${offset}`;
-  };
+  const limitTemplate = limit > 0 ? `LIMIT ${limit} OFFSET ${offset}` : "";
 
   return `
     SELECT ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
@@ -114,7 +109,7 @@ const oneHopNeighborsTemplate = ({
            ${getFilters()}
           }
         }
-        ${getLimit()}
+        ${limitTemplate}
       }
       FILTER(isLiteral(?value))
     }

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -19,7 +19,15 @@ const globalMockFetch = () => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   global.fetch = jest.fn(async (url: string) => {
-    const response = await import(RESPONSES_FILES_MAP[shortHash(url)]);
+    const key = shortHash(url);
+    const filePath = RESPONSES_FILES_MAP[key];
+    if (!filePath) {
+      throw new Error(
+        `Failed to find a response file in the map for key '${key}'`,
+        { cause: { url } }
+      );
+    }
+    const response = await import(filePath);
     return Promise.resolve({
       json: () => {
         return Promise.resolve(response);

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -8,11 +8,11 @@ const RESPONSES_FILES_MAP: Record<string, string> = {
   "7062d2e": `${GREMLIN}/edges-labels-and-counts.json`,
   "35be2501": `${GREMLIN}/should-return-1-random-node.json`,
   "54fa1494": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
-  "77c63d2": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
+  e9e93b2: `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
   "37e14b1": `${GREMLIN}/should-return-all-neighbors-from-node-2018-counts.json`,
-  "308b4988": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
+  "5698a21a": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
   "40a4690b": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018-counts.json`,
-  "1614f686": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
+  "59bc2d43": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
 };
 
 const globalMockFetch = () => {

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -142,9 +142,14 @@ export type ConnectionConfig = {
   awsRegion?: string;
   /**
    * Number of milliseconds before aborting a request.
-   * By default, 60 seconds.
+   * By default, undefined.
    */
   fetchTimeoutMs?: number;
+  /**
+   * A default limit on the number of nodes that can be expanded in one query.
+   * By default, undefined.
+   */
+  nodeExpansionLimit?: number;
 };
 
 export type Schema = {

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -7,12 +7,13 @@ import { mergedConfigurationSelector } from "./StateProvider/configuration";
 import { selector } from "recoil";
 import { equalSelector } from "../utils/recoilState";
 import { env } from "../utils";
+import { ConnectionConfig } from "./ConfigurationProvider";
 
 /**
  * Active connection where the value will only change when one of the
  * properties we care about are changed.
  */
-const activeConnectionSelector = equalSelector({
+export const activeConnectionSelector = equalSelector({
   key: "activeConnection",
   get: ({ get }) => {
     const config = get(mergedConfigurationSelector);
@@ -33,7 +34,8 @@ const activeConnectionSelector = equalSelector({
       "awsAuthEnabled",
       "awsRegion",
       "fetchTimeoutMs",
-    ] as const;
+      "nodeExpansionLimit",
+    ] as (keyof ConnectionConfig)[];
     return every(attrs, attr => isEqual(latest[attr] as string, prior[attr]));
   },
 });

--- a/packages/graph-explorer/src/index.tsx
+++ b/packages/graph-explorer/src/index.tsx
@@ -68,6 +68,8 @@ const grabConfig = async (): Promise<RawConfiguration | undefined> => {
           defaultConnectionData.GRAPH_EXP_SERVICE_TYPE || DEFAULT_SERVICE_TYPE,
         fetchTimeoutMs:
           defaultConnectionData.GRAPH_EXP_FETCH_REQUEST_TIMEOUT || 240000,
+        nodeExpansionLimit:
+          defaultConnectionData.GRAPH_EXP_NODE_EXPANSION_LIMIT,
       },
     };
   } catch (error) {

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -159,7 +159,8 @@ const CreateConnection = ({
 
   const [hasError, setError] = useState(false);
   const onFormChange = useCallback(
-    (attribute: string) => (value: number | string | string[] | boolean) => {
+    (attribute: keyof ConnectionForm) =>
+      (value: number | string | string[] | boolean) => {
       if (attribute === "serviceType" && value === "neptune-graph") {
         setForm(prev => ({
           ...prev,

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -70,9 +70,9 @@ const CreateConnection = ({
   const pfx = withClassNamePrefix("ft");
 
   const configId = existingConfig?.id;
-  const disabledFields = existingConfig?.__fileBase
+  const disabledFields: (keyof ConnectionForm)[] = existingConfig?.__fileBase
     ? ["queryEngine", "url", "serviceType"]
-    : undefined;
+    : [];
   const initialData: ConnectionForm | undefined = existingConfig
     ? {
         ...(existingConfig.connection || {}),
@@ -212,7 +212,7 @@ const CreateConnection = ({
           onChange={onFormChange("name")}
           errorMessage={"Name is required"}
           validationState={hasError && !form.name ? "invalid" : "valid"}
-          isDisabled={disabledFields?.includes("name")}
+          isDisabled={disabledFields.includes("name")}
         />
         <Select
           label={"Graph Type"}
@@ -220,7 +220,7 @@ const CreateConnection = ({
           value={form.queryEngine}
           onChange={onFormChange("queryEngine")}
           isDisabled={
-            disabledFields?.includes("queryEngine") ||
+            disabledFields.includes("queryEngine") ||
             form.serviceType === "neptune-graph"
           }
         />
@@ -252,7 +252,7 @@ const CreateConnection = ({
             errorMessage={"URL is required"}
             placeholder={"https://example.com"}
             validationState={hasError && !form.url ? "invalid" : "valid"}
-            isDisabled={disabledFields?.includes("url")}
+            isDisabled={disabledFields.includes("url")}
           />
         </div>
         <div className={pfx("input-url")}>
@@ -317,7 +317,7 @@ const CreateConnection = ({
                 ]}
                 value={form.serviceType}
                 onChange={onFormChange("serviceType")}
-                isDisabled={disabledFields?.includes("serviceType")}
+                isDisabled={disabledFields.includes("serviceType")}
               />
             </div>
           </>

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -49,6 +49,19 @@ export type CreateConnectionProps = {
   onClose(): void;
 };
 
+function mapToConnection(data: Required<ConnectionForm>): ConnectionConfig {
+  return {
+    url: data.url,
+    queryEngine: data.queryEngine,
+    proxyConnection: data.proxyConnection,
+    graphDbUrl: data.graphDbUrl,
+    awsAuthEnabled: data.awsAuthEnabled,
+    serviceType: data.serviceType,
+    awsRegion: data.awsRegion,
+    fetchTimeoutMs: data.fetchTimeoutEnabled ? data.fetchTimeoutMs : undefined,
+  };
+}
+
 const CreateConnection = ({
   existingConfig,
   onClose,
@@ -76,16 +89,7 @@ const CreateConnection = ({
           const newConfig: RawConfiguration = {
             id: newConfigId,
             displayLabel: data.name,
-            connection: {
-              url: data.url,
-              queryEngine: data.queryEngine,
-              proxyConnection: data.proxyConnection,
-              graphDbUrl: data.graphDbUrl,
-              awsAuthEnabled: data.awsAuthEnabled,
-              serviceType: data.serviceType,
-              awsRegion: data.awsRegion,
-              fetchTimeoutMs: data.fetchTimeoutMs,
-            },
+            connection: mapToConnection(data),
           };
           set(configurationAtom, prevConfigMap => {
             const updatedConfig = new Map(prevConfigMap);
@@ -104,16 +108,7 @@ const CreateConnection = ({
             ...(currentConfig || {}),
             id: configId,
             displayLabel: data.name,
-            connection: {
-              url: data.url,
-              queryEngine: data.queryEngine,
-              proxyConnection: data.proxyConnection,
-              graphDbUrl: data.graphDbUrl,
-              awsAuthEnabled: data.awsAuthEnabled,
-              serviceType: data.serviceType,
-              awsRegion: data.awsRegion,
-              fetchTimeoutMs: data.fetchTimeoutMs,
-            },
+            connection: mapToConnection(data),
           });
           return updatedConfig;
         });

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -21,6 +21,10 @@ import { schemaAtom } from "../../core/StateProvider/schema";
 import useResetState from "../../core/StateProvider/useResetState";
 import { formatDate } from "../../utils";
 import defaultStyles from "./CreateConnection.styles";
+import {
+  DEFAULT_FETCH_TIMEOUT,
+  DEFAULT_NODE_EXPAND_LIMIT,
+} from "../../utils/constants";
 
 type ConnectionForm = {
   name?: string;
@@ -179,7 +183,7 @@ const CreateConnection = ({
           setForm(prev => ({
             ...prev,
             [attribute]: value,
-            ["fetchTimeoutMs"]: value ? 240000 : undefined,
+            ["fetchTimeoutMs"]: value ? DEFAULT_FETCH_TIMEOUT : undefined,
           }));
         } else if (
           attribute === "nodeExpansionLimitEnabled" &&
@@ -188,7 +192,9 @@ const CreateConnection = ({
           setForm(prev => ({
             ...prev,
             [attribute]: value,
-            ["nodeExpansionLimit"]: value ? 500 : undefined,
+            ["nodeExpansionLimit"]: value
+              ? DEFAULT_NODE_EXPAND_LIMIT
+              : undefined,
           }));
         } else {
           setForm(prev => ({

--- a/packages/graph-explorer/src/utils/constants.ts
+++ b/packages/graph-explorer/src/utils/constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_SERVICE_TYPE = "neptune-db";
+export const DEFAULT_FETCH_TIMEOUT = 240000;
+export const DEFAULT_NODE_EXPAND_LIMIT = 500;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a global node expansion limit to the connection.

- Default is off for new and existing connections
- Updated documentation for new environment value `GRAPH_EXP_NODE_EXPANSION_LIMIT`
- Ensure fetch neighbors and neighbor counts queries respect the limit
- Updated tests

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested limits respected across query engines
- Tested queries are refetched when limit changes
- Tested new and existing connections function as expected

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- Resolves #442 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
