### PR TITLE
Sparql template cleanup

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -5316,3 +5316,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+------
+
+** dedent; version 1.5.3 -- https://github.com/dmnd/dedent
+Copyright Desmond Brand
+
+MIT License 
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -56,6 +56,7 @@
     "cytoscape-klay": "^3.1.4",
     "date-fns": "^2.30.0",
     "dayjs": "^1.11.11",
+    "dedent": "^1.5.3",
     "file-saver": "^2.0.5",
     "flat": "^5.0.2",
     "framer-motion": "^11.1.7",

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchBlankNodeNeighbors.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchBlankNodeNeighbors.ts
@@ -39,13 +39,13 @@ type RawNeighborsPredicatesResponse = {
   };
 };
 
-const fetchBlankNodeNeighborsPredicates = async (
+async function fetchBlankNodeNeighborsPredicates(
   sparqlFetch: SparqlFetch,
   subQuery: string,
   resourceURI: string,
   resourceClass: string,
   subjectURIs: string[]
-) => {
+) {
   const template = blankNodeSubjectPredicatesTemplate({
     subQuery,
     subjectURIs,
@@ -59,9 +59,9 @@ const fetchBlankNodeNeighborsPredicates = async (
 
     return mapOutgoingToEdge(resourceURI, resourceClass, result);
   });
-};
+}
 
-export const mapOneHop = (data: RawBlankNodeNeighborsResponse) => {
+export function mapOneHop(data: RawBlankNodeNeighborsResponse) {
   const groupBySubject = groupBy(
     data.results.bindings,
     result => result.subject.value
@@ -85,12 +85,12 @@ export const mapOneHop = (data: RawBlankNodeNeighborsResponse) => {
   return Object.values(mappedResults).map(result => {
     return mapRawResultToVertex(result);
   });
-};
+}
 
-const fetchBlankNodeNeighbors = async (
+export default async function fetchBlankNodeNeighbors(
   sparqlFetch: SparqlFetch,
   req: SPARQLBlankNodeNeighborsRequest
-): Promise<SPARQLBlankNodeNeighborsResponse> => {
+): Promise<SPARQLBlankNodeNeighborsResponse> {
   const neighborsTemplate = blankNodeOneHopNeighborsTemplate(req.subQuery);
   const neighbors = await sparqlFetch<
     RawBlankNodeNeighborsResponse | ErrorResponse
@@ -132,6 +132,4 @@ const fetchBlankNodeNeighbors = async (
       edges,
     },
   };
-};
-
-export default fetchBlankNodeNeighbors;
+}

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchNeighborsCount.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchNeighborsCount.ts
@@ -28,9 +28,9 @@ const fetchNeighborsCount = async (
   let totalCount = 0;
   const counts: Record<string, number> = {};
 
-  const incomingTemplate = neighborsCountTemplate(req);
-  const incomingData = await sparqlFetch<RawNeighborCount>(incomingTemplate);
-  incomingData.results.bindings.forEach(result => {
+  const template = neighborsCountTemplate(req);
+  const response = await sparqlFetch<RawNeighborCount>(template);
+  response.results.bindings.forEach(result => {
     const count = Number(result.count.value);
     counts[result.class.value] = count;
     totalCount += count;

--- a/packages/graph-explorer/src/connector/sparql/templates/classWithCountsTemplates.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/classWithCountsTemplates.ts
@@ -1,10 +1,10 @@
+import dedent from "dedent";
+
 // It returns the number of instances of the given class
-const classWithCountsTemplates = (className: string) => {
-  return `
+export default function classWithCountsTemplates(className: string) {
+  return dedent`
     SELECT (COUNT(?start) AS ?instancesCount) {
       ?start a <${className}>
     }
   `;
-};
-
-export default classWithCountsTemplates;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/classesWithCountsTemplates.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/classesWithCountsTemplates.ts
@@ -1,11 +1,11 @@
+import dedent from "dedent";
+
 // It returns a list of classes with the number of instances for each class
-const classesWithCountsTemplates = () => {
-  return `
+export default function classesWithCountsTemplates() {
+  return dedent`
     SELECT ?class  (COUNT(?start) AS ?instancesCount) {
       ?start a ?class
     }
     GROUP BY ?class
   `;
-};
-
-export default classesWithCountsTemplates;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
@@ -11,14 +11,14 @@ import {
  *
  * @see keywordSearchTemplate
  */
-const keywordSearchBlankNodesIdsTemplate = ({
+export default function keywordSearchBlankNodesIdsTemplate({
   searchTerm,
   subjectClasses = [],
   predicates = [],
   limit = 10,
   offset = 0,
   exactMatch = true,
-}: SPARQLKeywordSearchRequest): string => {
+}: SPARQLKeywordSearchRequest): string {
   return `
     SELECT DISTINCT ?bNode {
       ?bNode ?pred ?value {
@@ -35,6 +35,4 @@ const keywordSearchBlankNodesIdsTemplate = ({
       FILTER(isBlank(?bNode))
     }
   `;
-};
-
-export default keywordSearchBlankNodesIdsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLKeywordSearchRequest } from "../../types";
 import {
   getFilterObject,
@@ -36,15 +37,15 @@ import {
  *   FILTER(isLiteral(?value))
  * }
  */
-const keywordSearchTemplate = ({
+export default function keywordSearchTemplate({
   searchTerm,
   subjectClasses = [],
   predicates = [],
   limit = 10,
   offset = 0,
   exactMatch = false,
-}: SPARQLKeywordSearchRequest): string => {
-  return `
+}: SPARQLKeywordSearchRequest): string {
+  return dedent`
     SELECT ?subject ?pred ?value ?class {
       ?subject ?pred ?value {
         SELECT DISTINCT ?subject ?class {
@@ -59,6 +60,4 @@ const keywordSearchTemplate = ({
       FILTER(isLiteral(?value))
     }
   `;
-};
-
-export default keywordSearchTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/neighborsCount/blankNodeNeighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/neighborsCount/blankNodeNeighborsCountTemplate.ts
@@ -1,4 +1,5 @@
 import { SPARQLBlankNodeNeighborsCountRequest } from "../../types";
+import dedent from "dedent";
 
 /**
  * Count neighbors by class which are related with the given subject URI.
@@ -19,11 +20,11 @@ import { SPARQLBlankNodeNeighborsCountRequest } from "../../types";
  * }
  * GROUP BY ?bNode ?class
  */
-const blankNodeNeighborsCountTemplate = ({
+export default function blankNodeNeighborsCountTemplate({
   subQuery,
   limit = 0,
-}: SPARQLBlankNodeNeighborsCountRequest) => {
-  return `
+}: SPARQLBlankNodeNeighborsCountRequest) {
+  return dedent`
     SELECT ?bNode ?class (COUNT(?class) AS ?count) {
       ?subject a ?class {
         SELECT DISTINCT ?bNode ?subject ?class {
@@ -38,6 +39,4 @@ const blankNodeNeighborsCountTemplate = ({
     }
     GROUP BY ?bNode ?class
   `;
-};
-
-export default blankNodeNeighborsCountTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/neighborsCount/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/neighborsCount/neighborsCountTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLNeighborsCountRequest } from "../../types";
 
 /**
@@ -18,11 +19,11 @@ import { SPARQLNeighborsCountRequest } from "../../types";
  * }
  * GROUP BY ?class
  */
-const neighborsCountTemplate = ({
+export default function neighborsCountTemplate({
   resourceURI,
   limit = 0,
-}: SPARQLNeighborsCountRequest) => {
-  return `
+}: SPARQLNeighborsCountRequest) {
+  return dedent`
     SELECT ?class (COUNT(?class) AS ?count) {
       ?subject a ?class {
         SELECT DISTINCT ?subject ?class {
@@ -36,6 +37,4 @@ const neighborsCountTemplate = ({
     }
     GROUP BY ?class
   `;
-};
-
-export default neighborsCountTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/neighborsCountTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLNeighborsCountRequest } from "../types";
 
 /**
@@ -18,11 +19,11 @@ import { SPARQLNeighborsCountRequest } from "../types";
  * }
  * GROUP BY ?class
  */
-const neighborsCountTemplate = ({
+export default function neighborsCountTemplate({
   resourceURI,
   limit = 0,
-}: SPARQLNeighborsCountRequest) => {
-  return `
+}: SPARQLNeighborsCountRequest) {
+  return dedent`
     SELECT ?class (COUNT(?class) AS ?count) {
       ?subject a ?class {
         SELECT DISTINCT ?subject ?class {
@@ -36,6 +37,4 @@ const neighborsCountTemplate = ({
     }
     GROUP BY ?class
   `;
-};
-
-export default neighborsCountTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/blankNodeOneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/blankNodeOneHopNeighborsTemplate.ts
@@ -1,11 +1,13 @@
+import dedent from "dedent";
+
 /**
  * Fetch all neighbors and their predicates, values, and classes
  * given a blank node sub-query.
  *
  * @see oneHopNeighborsTemplate
  */
-const blankNodeOneHopNeighborsTemplate = (subQuery: string) => {
-  return `
+export default function blankNodeOneHopNeighborsTemplate(subQuery: string) {
+  return dedent`
 		SELECT ?bNode ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
 			?subject a     ?subjectClass ;
 							 ?pred ?value .
@@ -20,6 +22,4 @@ const blankNodeOneHopNeighborsTemplate = (subQuery: string) => {
 			FILTER(isLiteral(?value))
 		}
   `;
-};
-
-export default blankNodeOneHopNeighborsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLNeighborsRequest } from "../../types";
 import { getFilters, getLimit, getSubjectClasses } from "./helpers";
 
@@ -7,14 +8,14 @@ import { getFilters, getLimit, getSubjectClasses } from "./helpers";
  *
  * @see oneHopNeighborsTemplate
  */
-const oneHopNeighborsBlankNodesIdsTemplate = ({
+export default function oneHopNeighborsBlankNodesIdsTemplate({
   resourceURI,
   subjectClasses = [],
   filterCriteria = [],
   limit = 0,
   offset = 0,
-}: SPARQLNeighborsRequest) => {
-  return `
+}: SPARQLNeighborsRequest) {
+  return dedent`
     SELECT DISTINCT (?subject AS ?bNode) {
       BIND(<${resourceURI}> AS ?argument)
       ${getSubjectClasses(subjectClasses)}
@@ -35,6 +36,4 @@ const oneHopNeighborsBlankNodesIdsTemplate = ({
     }
     ${getLimit(limit, offset)}
   `;
-};
-
-export default oneHopNeighborsBlankNodesIdsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighbors/oneHopNeighborsTemplate.ts
@@ -1,5 +1,6 @@
 import { SPARQLNeighborsRequest } from "../../types";
 import { getFilters, getLimit, getSubjectClasses } from "./helpers";
+import dedent from "dedent";
 
 /**
  * Fetch all neighbors and their predicates, values, and classes.
@@ -50,14 +51,14 @@ import { getFilters, getLimit, getSubjectClasses } from "./helpers";
  *   FILTER(isLiteral(?value))
  * }
  */
-const oneHopNeighborsTemplate = ({
+export default function oneHopNeighborsTemplate({
   resourceURI,
   subjectClasses = [],
   filterCriteria = [],
   limit = 0,
   offset = 0,
-}: SPARQLNeighborsRequest): string => {
-  return `
+}: SPARQLNeighborsRequest): string {
+  return dedent`
     SELECT ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
       ?subject a     ?subjectClass;
                ?pred ?value {
@@ -83,6 +84,4 @@ const oneHopNeighborsTemplate = ({
       FILTER(isLiteral(?value))
     }
   `;
-};
-
-export default oneHopNeighborsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/oneHopNeighborsTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLNeighborsRequest } from "../types";
 
 /**
@@ -49,13 +50,13 @@ import { SPARQLNeighborsRequest } from "../types";
  *   FILTER(isLiteral(?value))
  * }
  */
-const oneHopNeighborsTemplate = ({
+export default function oneHopNeighborsTemplate({
   resourceURI,
   subjectClasses = [],
   filterCriteria = [],
   limit = 0,
   offset = 0,
-}: SPARQLNeighborsRequest): string => {
+}: SPARQLNeighborsRequest): string {
   const getSubjectClasses = () => {
     if (!subjectClasses?.length) {
       return "";
@@ -88,7 +89,7 @@ const oneHopNeighborsTemplate = ({
 
   const limitTemplate = limit > 0 ? `LIMIT ${limit} OFFSET ${offset}` : "";
 
-  return `
+  return dedent`
     SELECT ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
       ?subject a     ?subjectClass;
                ?pred ?value {
@@ -114,6 +115,4 @@ const oneHopNeighborsTemplate = ({
       FILTER(isLiteral(?value))
     }
   `;
-};
-
-export default oneHopNeighborsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/predicatesByClassTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/predicatesByClassTemplate.ts
@@ -1,6 +1,8 @@
+import dedent from "dedent";
+
 // Return all predicates which are connected from the given class
-const predicatesByClassTemplate = (props: { class: string }) => {
-  return `
+export default function predicatesByClassTemplate(props: { class: string }) {
+  return dedent`
     SELECT ?pred (SAMPLE(?object) as ?sample)
     WHERE {
       {
@@ -15,6 +17,4 @@ const predicatesByClassTemplate = (props: { class: string }) => {
     }
     GROUP BY ?pred
   `;
-};
-
-export default predicatesByClassTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/predicatesWithCountsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/predicatesWithCountsTemplate.ts
@@ -1,11 +1,11 @@
+import dedent from "dedent";
+
 /**
  * Fetch all distinct predicates to non-literals with counts
  */
-const predicatesWithCountsTemplate = () => {
-  return `
+export default function predicatesWithCountsTemplate() {
+  return dedent`
   SELECT ?predicate (COUNT(?predicate) as ?count) {
     [] ?predicate ?object FILTER(!isLiteral(?object))
   } GROUP BY ?predicate`;
-};
-
-export default predicatesWithCountsTemplate;
+}

--- a/packages/graph-explorer/src/connector/sparql/templates/subjectPredicatesTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/subjectPredicatesTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import { SPARQLNeighborsPredicatesRequest } from "../types";
 
 /**
@@ -27,10 +28,10 @@ import { SPARQLNeighborsPredicatesRequest } from "../types";
  *   }
  * }
  */
-const subjectPredicatesTemplate = ({
+export default function subjectPredicatesTemplate({
   resourceURI,
   subjectURIs = [],
-}: SPARQLNeighborsPredicatesRequest): string => {
+}: SPARQLNeighborsPredicatesRequest): string {
   const getSubjectURIs = () => {
     if (!subjectURIs?.length) {
       return "";
@@ -44,7 +45,7 @@ const subjectPredicatesTemplate = ({
     return classesValues;
   };
 
-  return `
+  return dedent`
     SELECT ?subject ?subjectClass ?predToSubject ?predFromSubject {
       BIND(<${resourceURI}> AS ?argument)
       ${getSubjectURIs()}
@@ -59,6 +60,4 @@ const subjectPredicatesTemplate = ({
       }
     }
   `;
-};
-
-export default subjectPredicatesTemplate;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       dayjs:
         specifier: ^1.11.11
         version: 1.11.11
+      dedent:
+        specifier: ^1.5.3
+        version: 1.5.3
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -5899,7 +5902,7 @@ packages:
     resolution: {integrity: sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0
+      vite: '>=4.5.3'
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.5)
@@ -7097,7 +7100,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-    dev: true
 
   /deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -7483,7 +7485,7 @@ packages:
   /esbuild-loader@2.21.0(webpack@5.91.0):
     resolution: {integrity: sha512-k7ijTkCT43YBSZ6+fBCW1Gin7s46RrJ0VQaM8qA7lq7W+OLsGgtLyFV8470FzYi/4TeDexniTBTPTwZUnXXR5g==}
     peerDependencies:
-      webpack: ^4.40.0 || ^5.0.0
+      webpack: '>=5.76.0'
     dependencies:
       esbuild: 0.16.17
       joycon: 3.1.1
@@ -11326,7 +11328,7 @@ packages:
       '@swc/core': '*'
       esbuild: '*'
       uglify-js: '*'
-      webpack: ^5.1.0
+      webpack: '>=5.76.0'
     peerDependenciesMeta:
       '@swc/core':
         optional: true


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Minor cleanup that doesn't change any critical logic.

- Adds `dedent` dependency which will remove indentation from strings
- Use dedent on SPARQL queries
- Convert closure expressions to functions

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Did a brief smoke test

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- #384 
- #344

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.