### PR TITLE
Fix openCypher neighbor expansion and counts

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,12 @@
   (<https://github.com/aws/graph-explorer/pull/436>)
 - Add node expansion limit per connection
   (<https://github.com/aws/graph-explorer/pull/447>)
+- Fixed many bugs around neighbor expansion and counts for openCypher
+  (<https://github.com/aws/graph-explorer/pull/449>)
+  - Fixed expand limit to be type based when expanding from sidebar
+  - Fixed expand query to respect limit and offset properly so multiple
+    expansions return unique results
+  - Fixed expand query so all edges are returned between source and target nodes
 
 **Bug Fixes and Minor Changes**
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
@@ -1,3 +1,4 @@
+import normalize from "../../../utils/testing/normalize";
 import neighborsCountTemplate from "./neighborsCountTemplate";
 
 describe("OpenCypher > neighborsCountTemplate", () => {
@@ -7,8 +8,15 @@ describe("OpenCypher > neighborsCountTemplate", () => {
       idType: "string",
     });
 
-    expect(template).toBe(
-      'MATCH (v) -[e]- (t) WHERE ID(v) = "12" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count'
+    expect(normalize(template)).toBe(
+      normalize(
+        `
+          MATCH (v)-[]-(neighbor) 
+          WHERE ID(v) = "12" 
+          WITH DISTINCT neighbor 
+          RETURN labels(neighbor) AS vertexLabel, count(DISTINCT neighbor) AS count
+        `
+      )
     );
   });
 
@@ -19,8 +27,16 @@ describe("OpenCypher > neighborsCountTemplate", () => {
       limit: 20,
     });
 
-    expect(template).toBe(
-      'MATCH (v) -[e]- (t) WHERE ID(v) = "12" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count LIMIT 20'
+    expect(normalize(template)).toBe(
+      normalize(
+        `
+        MATCH (v)-[]-(neighbor) 
+        WHERE ID(v) = "12"
+        WITH DISTINCT neighbor 
+        LIMIT 20
+        RETURN labels(neighbor) AS vertexLabel, count(DISTINCT neighbor) AS count 
+        `
+      )
     );
   });
 
@@ -31,8 +47,15 @@ describe("OpenCypher > neighborsCountTemplate", () => {
       limit: 0,
     });
 
-    expect(template).toBe(
-      'MATCH (v) -[e]- (t) WHERE ID(v) = "12" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count'
+    expect(normalize(template)).toBe(
+      normalize(
+        `
+        MATCH (v)-[]-(neighbor)
+        WHERE ID(v) = "12"
+        WITH DISTINCT neighbor 
+        RETURN labels(neighbor) AS vertexLabel, count(DISTINCT neighbor) AS count
+        `
+      )
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import type { NeighborsCountRequest } from "../../useGEFetchTypes";
 
 /**
@@ -8,24 +9,21 @@ import type { NeighborsCountRequest } from "../../useGEFetchTypes";
  * ids = "44"
  * limit = 10
  *
- * MATCH (v) -[e]- (t)
+ * MATCH (v) -[]- (neighbor)
  * WHERE ID(v) = "44"
- * RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count
- * LIMIT 10
+ * WITH DISTINCT neighbor LIMIT 500
+ * RETURN labels(t) AS vertexLabel, count(neighbor) AS count
  *
  */
-const neighborsCountTemplate = ({
+export default function neighborsCountTemplate({
   vertexId,
   limit = 0,
-}: NeighborsCountRequest) => {
-  let template = "";
-  template = `MATCH (v) -[e]- (t) WHERE ID(v) = "${vertexId}" RETURN labels(t) AS vertexLabel, count(DISTINCT t) AS count`;
-
-  if (limit > 0) {
-    template += ` LIMIT ${limit}`;
-  }
-
-  return template;
-};
-
-export default neighborsCountTemplate;
+}: NeighborsCountRequest) {
+  return dedent`
+      MATCH (v)-[]-(neighbor)
+      WHERE ID(v) = "${vertexId}" 
+      WITH DISTINCT neighbor
+      ${limit > 0 ? `LIMIT ${limit}` : ``}
+      RETURN labels(neighbor) AS vertexLabel, count(DISTINCT neighbor) AS count
+    `;
+}

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -1,3 +1,4 @@
+import normalize from "../../../utils/testing/normalize";
 import oneHopTemplate from "./oneHopTemplate";
 
 describe("OpenCypher > oneHopTemplate", () => {
@@ -7,8 +8,15 @@ describe("OpenCypher > oneHopTemplate", () => {
       idType: "string",
     });
 
-    expect(template).toBe(
-      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt) AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))}) AS eObjects RETURN vObjects, eObjects'
+    expect(normalize(template)).toEqual(
+      normalize(`
+        MATCH (v)-[e]-(tgt)
+        WHERE ID(v) = "12"
+        WITH
+          collect(DISTINCT tgt) AS vObjects,
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects
+        RETURN vObjects, eObjects
+      `)
     );
   });
 
@@ -20,8 +28,15 @@ describe("OpenCypher > oneHopTemplate", () => {
       limit: 5,
     });
 
-    expect(template).toBe(
-      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..5] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..5] AS eObjects RETURN vObjects, eObjects'
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)-[e]-(tgt) 
+        WHERE ID(v) = "12" 
+        WITH 
+          collect(DISTINCT tgt)[..5] AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..5] AS eObjects 
+        RETURN vObjects, eObjects
+      `)
     );
   });
 
@@ -34,8 +49,55 @@ describe("OpenCypher > oneHopTemplate", () => {
       limit: 10,
     });
 
-    expect(template).toBe(
-      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..10] AS eObjects RETURN vObjects, eObjects'
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)-[e]-(tgt:country) 
+        WHERE ID(v) = "12" 
+        WITH 
+          collect(DISTINCT tgt)[..10] AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+        RETURN vObjects, eObjects
+      `)
+    );
+  });
+
+  it("Should return a template for many vertex types", () => {
+    const template = oneHopTemplate({
+      vertexId: "12",
+      idType: "string",
+      filterByVertexTypes: ["country", "continent", "airport", "person"],
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)-[e]-(tgt)
+        WHERE ID(v) = "12" AND (v:country OR v:continent OR v:airport OR v:person)
+        WITH
+          collect(DISTINCT tgt) AS vObjects,
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects
+        RETURN vObjects, eObjects
+      `)
+    );
+  });
+
+  it("Should return a template for specific edge type", () => {
+    const template = oneHopTemplate({
+      vertexId: "12",
+      idType: "string",
+      edgeTypes: ["locatedIn"],
+      offset: 5,
+      limit: 10,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)-[e:locatedIn]-(tgt) 
+        WHERE ID(v) = "12" 
+        WITH 
+          collect(DISTINCT tgt)[..10] AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+        RETURN vObjects, eObjects
+      `)
     );
   });
 
@@ -52,8 +114,15 @@ describe("OpenCypher > oneHopTemplate", () => {
       limit: 10,
     });
 
-    expect(template).toBe(
-      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..10] AS eObjects RETURN vObjects, eObjects'
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)-[e]-(tgt:country) 
+        WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" 
+        WITH 
+          collect(DISTINCT tgt)[..10] AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+        RETURN vObjects, eObjects
+      `)
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -12,6 +12,9 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e]-(tgt)
         WHERE ID(v) = "12"
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        MATCH (v)-[e]-(tgt)
         WITH
           collect(DISTINCT tgt) AS vObjects,
           collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects
@@ -32,9 +35,14 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e]-(tgt) 
         WHERE ID(v) = "12" 
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        SKIP 5 
+        LIMIT 5
+        MATCH (v)-[e]-(tgt)
         WITH 
-          collect(DISTINCT tgt)[..5] AS vObjects, 
-          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..5] AS eObjects 
+          collect(DISTINCT tgt) AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects 
         RETURN vObjects, eObjects
       `)
     );
@@ -53,9 +61,14 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e]-(tgt:country) 
         WHERE ID(v) = "12" 
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        SKIP 5 
+        LIMIT 10
+        MATCH (v)-[e]-(tgt)
         WITH 
-          collect(DISTINCT tgt)[..10] AS vObjects, 
-          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+          collect(DISTINCT tgt) AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects 
         RETURN vObjects, eObjects
       `)
     );
@@ -72,6 +85,9 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e]-(tgt)
         WHERE ID(v) = "12" AND (v:country OR v:continent OR v:airport OR v:person)
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        MATCH (v)-[e]-(tgt)
         WITH
           collect(DISTINCT tgt) AS vObjects,
           collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects
@@ -93,9 +109,14 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e:locatedIn]-(tgt) 
         WHERE ID(v) = "12" 
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        SKIP 5 
+        LIMIT 10
+        MATCH (v)-[e:locatedIn]-(tgt)
         WITH 
-          collect(DISTINCT tgt)[..10] AS vObjects, 
-          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+          collect(DISTINCT tgt) AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects 
         RETURN vObjects, eObjects
       `)
     );
@@ -118,9 +139,14 @@ describe("OpenCypher > oneHopTemplate", () => {
       normalize(`
         MATCH (v)-[e]-(tgt:country) 
         WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" 
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        SKIP 5 
+        LIMIT 10
+        MATCH (v)-[e]-(tgt)
         WITH 
-          collect(DISTINCT tgt)[..10] AS vObjects, 
-          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })[..10] AS eObjects 
+          collect(DISTINCT tgt) AS vObjects, 
+          collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) }) AS eObjects 
         RETURN vObjects, eObjects
       `)
     );

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -8,7 +8,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt) AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)}) AS eObjects RETURN vObjects, eObjects'
+      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt) AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))}) AS eObjects RETURN vObjects, eObjects'
     );
   });
 
@@ -21,7 +21,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..5] AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})[..5] AS eObjects RETURN vObjects, eObjects'
+      'MATCH (v)-[e]-(tgt) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..5] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..5] AS eObjects RETURN vObjects, eObjects'
     );
   });
 
@@ -35,7 +35,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})[..10] AS eObjects RETURN vObjects, eObjects'
+      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..10] AS eObjects RETURN vObjects, eObjects'
     );
   });
 
@@ -53,7 +53,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     });
 
     expect(template).toBe(
-      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})[..10] AS eObjects RETURN vObjects, eObjects'
+      'MATCH (v)-[e]-(tgt:country) WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" WITH collect(DISTINCT tgt)[..10] AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})[..10] AS eObjects RETURN vObjects, eObjects'
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
@@ -1,3 +1,4 @@
+import dedent from "dedent";
 import type { Criterion, NeighborsRequest } from "../../useGEFetchTypes";
 
 const criterionNumberTemplate = ({
@@ -108,40 +109,42 @@ const oneHopTemplate = ({
   filterCriteria = [],
   limit = 0,
 }: Omit<NeighborsRequest, "vertexType">): string => {
-  let template = `MATCH (v)`;
-
-  const formattedVertexTypes = filterByVertexTypes
-    .flatMap(type => type.split("::"))
-    .map(type => `v:${type}`)
-    .join(" OR ");
+  // List of possible vertex types
+  const formattedVertexTypes =
+    filterByVertexTypes.length > 1
+      ? `(${filterByVertexTypes
+          .flatMap(type => type.split("::"))
+          .map(type => `v:${type}`)
+          .join(" OR ")})`
+      : "";
   const formattedEdgeTypes = edgeTypes.map(type => `${type}`).join("|");
-
-  if (edgeTypes.length > 0) {
-    template += `-[e:${formattedEdgeTypes}]-`;
-  } else {
-    template += `-[e]-`;
-  }
-
-  if (filterByVertexTypes.length == 1) {
-    template += `(tgt:${filterByVertexTypes[0]}) WHERE ID(v) = "${vertexId}" `;
-  } else if (filterByVertexTypes.length > 1) {
-    template += `(tgt) WHERE ID(v) = "${vertexId}" AND ${formattedVertexTypes}`;
-  } else {
-    template += `(tgt) WHERE ID(v) = "${vertexId}" `;
-  }
-
-  const filterCriteriaTemplate = filterCriteria
-    ?.map(criterionTemplate)
-    .join(" AND ");
-  if (filterCriteriaTemplate) {
-    template += `AND ${filterCriteriaTemplate} `;
-  }
 
   const limitTemplate = limit > 0 ? `[..${limit}]` : "";
 
-  template += `WITH collect(DISTINCT tgt)${limitTemplate} AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})${limitTemplate} AS eObjects RETURN vObjects, eObjects`;
+  // Specify edge type if provided
+  const edgeMatch = edgeTypes.length > 0 ? `e:${formattedEdgeTypes}` : `e`;
 
-  return template;
+  // Specify node type for target if provided and only one
+  const targetMatch =
+    filterByVertexTypes.length == 1 ? `tgt:${filterByVertexTypes[0]}` : `tgt`;
+
+  // Combine all the WHERE conditions
+  const whereConditions = [
+    `ID(v) = "${vertexId}"`,
+    formattedVertexTypes,
+    ...(filterCriteria?.map(criterionTemplate) ?? []),
+  ]
+    .filter(Boolean)
+    .join(" AND ");
+
+  return dedent`
+    MATCH (v)-[${edgeMatch}]-(${targetMatch})
+    WHERE ${whereConditions}
+    WITH
+      collect(DISTINCT tgt)${limitTemplate} AS vObjects, 
+      collect({ edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e)) })${limitTemplate} AS eObjects
+    RETURN vObjects, eObjects
+  `;
 };
 
 export default oneHopTemplate;

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
@@ -139,7 +139,7 @@ const oneHopTemplate = ({
 
   const limitTemplate = limit > 0 ? `[..${limit}]` : "";
 
-  template += `WITH collect(DISTINCT tgt)${limitTemplate} AS vObjects, collect({edge: e, sourceType: labels(v), targetType: labels(tgt)})${limitTemplate} AS eObjects RETURN vObjects, eObjects`;
+  template += `WITH collect(DISTINCT tgt)${limitTemplate} AS vObjects, collect({edge: e, sourceType: labels(startNode(e)), targetType: labels(endNode(e))})${limitTemplate} AS eObjects RETURN vObjects, eObjects`;
 
   return template;
 };

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -103,13 +103,12 @@ function NeighborDetails({
               operator: "LIKE",
               value: filter.value,
             })),
-            // TODO - review limit and offset when data is not sorted
-            limit: limit ?? vertex.data.neighborsCount,
+            limit: limit || undefined,
             offset:
-              limit === null
-                ? 0
-                : vertex.data.neighborsCount -
-                  (vertex.data.__unfetchedNeighborCount ?? 0),
+              limit !== null && vertex.data.__unfetchedNeighborCounts
+                ? vertex.data.neighborsCountByType[selectedType] -
+                  vertex.data.__unfetchedNeighborCounts[selectedType]
+                : undefined,
           }}
         />
       </ModuleContainerFooter>

--- a/packages/graph-explorer/src/utils/testing/normalize.ts
+++ b/packages/graph-explorer/src/utils/testing/normalize.ts
@@ -1,0 +1,8 @@
+/**
+ * Reduces all whitespace in a string to a single space.
+ * @param str The string to be normalized.
+ * @returns A whitespace normalized string.
+ */
+export default function normalize(str: string) {
+  return str.replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes openCypher issues around neighbor expansion and neighbor counts.

- Fixes issue where neighbor query returned edges with the wrong type for source and target types
- Fixes neighbor count to respect limits
- Fixes limit and offset in neighbor query
- Fixes edges in neighbor query to return all edges between source and target nodes
- Fixes limit and offset calculations in expand side bar to use typed counts rather than total counts
- Better formatting of queries in logic and tests

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested many expansion options
- Tested multiple expansions with limit (paging results)
- Tested with bidirectional edges

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #389 
- Resolves #343 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
