### PR TITLE
Fix double click behavior

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,7 +23,9 @@
 
 - Remove extraneous openCypher query when expanding nodes
   (<https://github.com/aws/graph-explorer/pull/431>)
-- Fix edge case where node badges are stale
+- Made double clicking a node easier
+  (<https://github.com/aws/graph-explorer/pull/453>)
+- Fixed edge case where node badges are stale
   (<https://github.com/aws/graph-explorer/pull/427>)
 - Fixed issue with Gremlin Server 3.7
   (<https://github.com/aws/graph-explorer/pull/411>)


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When double clicking a node it would not always register as a double click. I've updated the time delay for double clicks to be 300 ms and updated the algorithm to be more reliable.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified double clicking is much more reliable

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
