### PR TITLE
Expand the next 10 neighbors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
   (<https://github.com/aws/graph-explorer/pull/436>)
 - Add node expansion limit per connection
   (<https://github.com/aws/graph-explorer/pull/447>)
+- Double clicking a node will expand up to 10 neighbors each time
+  (<https://github.com/aws/graph-explorer/pull/455>)
 - Fixed many bugs around neighbor expansion and counts for openCypher
   (<https://github.com/aws/graph-explorer/pull/449>)
   - Fixed expand limit to be type based when expanding from sidebar


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When the user double clicks a node GE will now expand the next 10 nodes.

Before it would check if the neighbors count is greater than 10. If it is, then show the expand sidebar. If not, it expands.

Now it will always expand, but at most 10 items.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified with all three query engines
  - SPARQL still needs work on the query side, but that is happening in a different branch

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #318 
- Resolves #460 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
