### PR TITLE
Remove all class name prefix logic

### DIFF
--- a/packages/graph-explorer/src/components/AdvancedList/AdvancedList.styles.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/AdvancedList.styles.tsx
@@ -1,233 +1,230 @@
 import { css } from "@emotion/css";
 import { ThemeStyleFn } from "../../core";
 
-const listStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => {
-    const { palette, shape, advancedList } = theme;
-    const { primary, background, text, grey } = palette;
+const listStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => {
+  const { palette, shape, advancedList } = theme;
+  const { primary, background, text, grey } = palette;
 
-    return css`
-      display: flex;
-      flex-direction: column;
+  return css`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: ${advancedList?.background || isDarkTheme
+      ? palette.background.secondary
+      : palette.background.contrast};
+
+    color: ${advancedList?.color || text.primary};
+
+    .advanced-list-loading {
       width: 100%;
       height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-size: 40px;
+    }
+
+    .advanced-list-search-wrapper {
+      display: flex;
+      align-items: center;
+      .advanced-list-search-input {
+        flex: 2;
+      }
+
+      .advanced-list-category-select {
+        flex: 1;
+      }
+
+      .select {
+        min-width: 0;
+      }
+    }
+
+    .advanced-list-no-groups {
+      padding: 0 5px;
+    }
+
+    .advanced-list-item-wrapper {
+      padding: 5px;
+    }
+
+    .advanced-list-item {
+      user-select: auto;
+      border: 1px solid ${advancedList?.item?.borderColor || "transparent"};
+      border-radius: ${advancedList?.item?.borderRadius || shape.borderRadius};
       background-color: ${advancedList?.background || isDarkTheme
-        ? palette.background.secondary
-        : palette.background.contrast};
+        ? grey["800"]
+        : background.contrast};
+      padding: 0;
+      align-items: normal;
+      margin: 0 0 10px 0;
+      color: ${advancedList?.item?.color || text.primary};
 
-      color: ${advancedList?.color || text.primary};
+      &.advanced-list-item-selected {
+        background: ${advancedList?.item?.hover?.background || isDarkTheme
+          ? background.contrast
+          : background.default || "rgba(18, 142, 229, 0.05)"};
+        color: ${advancedList?.item?.hover?.color || text.primary};
+        border: solid 1px
+          ${advancedList?.item?.hover?.borderColor || primary.dark};
 
-      .${pfx}-advanced-list-loading {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        font-size: 40px;
-      }
-
-      .${pfx}-advanced-list-search-wrapper {
-        display: flex;
-        align-items: center;
-        .${pfx}-advanced-list-search-input {
-          flex: 2;
-        }
-
-        .${pfx}-advanced-list-category-select {
-          flex: 1;
-        }
-
-        .${pfx}-select {
-          min-width: 0;
+        .end-adornment {
+          color: ${advancedList?.item?.color || primary.main};
         }
       }
-
-      .${pfx}-advanced-list-no-groups {
-        padding: 0 5px;
+      &.advanced-list-item-active {
+        border: solid 2px
+          ${advancedList?.item?.hover?.borderColor || primary.dark};
       }
 
-      .${pfx}-advanced-list-item-wrapper {
-        padding: 5px;
+      .primary {
+        font-weight: 600;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        word-break: break-all;
+      }
+      .content {
+        flex: 1;
+        padding: 2.5px 0;
       }
 
-      .${pfx}-advanced-list-item {
-        user-select: auto;
-        border: 1px solid ${advancedList?.item?.borderColor || "transparent"};
+      .secondary {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        word-break: break-all;
+      }
+      .sidebar-highlight {
+        color: ${advancedList?.item?.highlight?.color || primary.main};
+        background: ${advancedList?.item?.highlight?.background ||
+        "transparent"};
+      }
+
+      &:hover {
+        background: ${advancedList?.item?.hover?.background || isDarkTheme
+          ? background.contrast
+          : background.default};
+        color: ${advancedList?.item?.hover?.color || "inherit"};
+        border: solid 1px
+          ${advancedList?.item?.hover?.borderColor || primary.dark};
+
+        .end-adornment {
+          color: ${advancedList?.item?.color || primary.main};
+        }
+      }
+
+      .end-adornment {
+        font-size: 20px;
+        color: ${advancedList?.item?.color || palette.border};
+      }
+
+      .content {
+        min-height: 44px;
         border-radius: ${advancedList?.item?.borderRadius ||
         shape.borderRadius};
-        background-color: ${advancedList?.background || isDarkTheme
-          ? grey["800"]
-          : background.contrast};
+        background: transparent;
+      }
+
+      .start-adornment {
+        color: ${advancedList?.item?.adornment?.color || primary.main};
+        font-size: 20px;
+        margin: 0;
+        background-color: ${advancedList?.item?.adornment?.background ||
+        background.secondary};
+        border-top-left-radius: ${advancedList?.item?.borderRadius ||
+        shape.borderRadius};
+        border-bottom-left-radius: ${advancedList?.item?.borderRadius ||
+        shape.borderRadius};
+        margin-right: 6px;
+      }
+    }
+
+    .advanced-list-item:last-child {
+      margin: 0;
+    }
+
+    .advanced-list-item-with-popover {
+      margin: 0 !important;
+    }
+
+    .advanced-list-item-wrapper {
+      margin-bottom: 10px;
+    }
+    .advanced-list-item-wrapper:last-child {
+      margin: 0;
+    }
+
+    .advanced-list-category {
+      border: none;
+      padding: 5px 0;
+
+      &.advanced-list-category {
+        padding: 0 0 5px 0;
+      }
+      .header-container {
         padding: 0;
-        align-items: normal;
-        margin: 0 0 10px 0;
-        color: ${advancedList?.item?.color || text.primary};
+        font-size: 14px;
+        font-weight: 500;
+        align-items: center;
+        background-color: ${advancedList?.category?.background ||
+        background.secondary};
+        height: 24px;
+        min-height: 24px;
+      }
 
-        &.${pfx}-advanced-list-item-selected {
-          background: ${advancedList?.item?.hover?.background || isDarkTheme
-            ? background.contrast
-            : background.default || "rgba(18, 142, 229, 0.05)"};
-          color: ${advancedList?.item?.hover?.color || text.primary};
-          border: solid 1px
-            ${advancedList?.item?.hover?.borderColor || primary.dark};
+      .title {
+        display: flex;
+        align-items: center;
+        line-height: 16px;
+        color: ${advancedList?.category?.color || isDarkTheme
+          ? text.secondary
+          : primary.dark};
+        padding: 0;
+        font-size: 12px;
 
-          .${pfx}-end-adornment {
-            color: ${advancedList?.item?.color || primary.main};
-          }
-        }
-        &.${pfx}-advanced-list-item-active {
-          border: solid 2px
-            ${advancedList?.item?.hover?.borderColor || primary.dark};
-        }
-
-        .${pfx}-primary {
-          font-weight: 600;
-          display: -webkit-box;
-          -webkit-line-clamp: 1;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-          word-break: break-all;
-        }
-        .${pfx}-content {
-          flex: 1;
-          padding: 2.5px 0;
-        }
-
-        .${pfx}-secondary {
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-          word-break: break-all;
-        }
-        .sidebar-highlight {
-          color: ${advancedList?.item?.highlight?.color || primary.main};
-          background: ${advancedList?.item?.highlight?.background ||
-          "transparent"};
-        }
-
-        &:hover {
-          background: ${advancedList?.item?.hover?.background || isDarkTheme
-            ? background.contrast
-            : background.default};
-          color: ${advancedList?.item?.hover?.color || "inherit"};
-          border: solid 1px
-            ${advancedList?.item?.hover?.borderColor || primary.dark};
-
-          .${pfx}-end-adornment {
-            color: ${advancedList?.item?.color || primary.main};
-          }
-        }
-
-        .${pfx}-end-adornment {
-          font-size: 20px;
-          color: ${advancedList?.item?.color || palette.border};
-        }
-
-        .${pfx}-content {
-          min-height: 44px;
-          border-radius: ${advancedList?.item?.borderRadius ||
-          shape.borderRadius};
-          background: transparent;
-        }
-
-        .${pfx}-start-adornment {
-          color: ${advancedList?.item?.adornment?.color || primary.main};
-          font-size: 20px;
-          margin: 0;
-          background-color: ${advancedList?.item?.adornment?.background ||
-          background.secondary};
-          border-top-left-radius: ${advancedList?.item?.borderRadius ||
-          shape.borderRadius};
-          border-bottom-left-radius: ${advancedList?.item?.borderRadius ||
-          shape.borderRadius};
-          margin-right: 6px;
+        svg {
+          font-size: 18px;
+          margin-right: 4px;
+          margin-top: 2px;
         }
       }
 
-      .${pfx}-advanced-list-item:last-child {
-        margin: 0;
+      .collapsible-container:not(.collapsed) {
+        padding: 12px;
       }
+    }
 
-      .${pfx}-advanced-list-item-with-popover {
-        margin: 0 !important;
+    .advanced-list-nogroup {
+      width: 100%;
+      height: 100%;
+      .advanced-list-item-wrapper {
+        padding: 0px;
       }
-
-      .${pfx}-advanced-list-item-wrapper {
-        margin-bottom: 10px;
-      }
-      .${pfx}-advanced-list-item-wrapper:last-child {
-        margin: 0;
-      }
-
-      .${pfx}-advanced-list-category {
-        border: none;
-        padding: 5px 0;
-
-        &.${pfx}-advanced-list-category {
-          padding: 0 0 5px 0;
-        }
-        .${pfx}-header-container {
-          padding: 0;
-          font-size: 14px;
-          font-weight: 500;
-          align-items: center;
-          background-color: ${advancedList?.category?.background ||
-          background.secondary};
-          height: 24px;
-          min-height: 24px;
-        }
-
-        .${pfx}-title {
-          display: flex;
-          align-items: center;
-          line-height: 16px;
-          color: ${advancedList?.category?.color || isDarkTheme
-            ? text.secondary
-            : primary.dark};
-          padding: 0;
-          font-size: 12px;
-
-          svg {
-            font-size: 18px;
-            margin-right: 4px;
-            margin-top: 2px;
-          }
-        }
-
-        .${pfx}-collapsible-container:not(.${pfx}-collapsed) {
-          padding: 12px;
-        }
-      }
-
-      .${pfx}-advanced-list-nogroup {
-        width: 100%;
-        height: 100%;
-        .${pfx}-advanced-list-item-wrapper {
-          padding: 0px;
-        }
-        .${pfx}-advanced-list-nogroup-item-wrapper {
-          padding: 5px 0;
-        }
-      }
-
-      .${pfx}-advanced-list-item-no-category {
+      .advanced-list-nogroup-item-wrapper {
         padding: 5px 0;
       }
+    }
 
-      .${pfx}-panel-empty-state-wrapper {
-        height: max(448px, 100%);
-      }
-    `;
-  };
+    .advanced-list-item-no-category {
+      padding: 5px 0;
+    }
+
+    .panel-empty-state-wrapper {
+      height: max(448px, 100%);
+    }
+  `;
+};
 
 const headerStyles =
-  (pfx: string, noSearchResults: boolean): ThemeStyleFn =>
+  (noSearchResults: boolean): ThemeStyleFn =>
   ({ theme, isDarkTheme }) => css`
     flex: 1;
     height: 100%;
-    .${pfx}-header-container {
+    .header-container {
       height: 48px;
       min-height: 48px;
       font-size: 16px;
@@ -239,11 +236,11 @@ const headerStyles =
         : theme.palette.background.default};
     }
 
-    .${pfx}-title {
+    .title {
       padding: 10px 0;
     }
 
-    > .${pfx}-content {
+    > .content {
       overflow: auto;
       height: 100%;
       background: ${noSearchResults
@@ -252,28 +249,26 @@ const headerStyles =
     }
   `;
 
-const footerStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    border-top: solid 1px ${theme.palette.border};
+const footerStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  border-top: solid 1px ${theme.palette.border};
 
-    .${pfx}-header-container {
-      height: 48px;
-      padding: 0 14px;
-      font-weight: 500;
-      align-items: center;
+  .header-container {
+    height: 48px;
+    padding: 0 14px;
+    font-weight: 500;
+    align-items: center;
 
-      background-color: ${isDarkTheme
-        ? theme.palette.background.secondary
-        : theme.palette.background.default};
-    }
+    background-color: ${isDarkTheme
+      ? theme.palette.background.secondary
+      : theme.palette.background.default};
+  }
 
-    .${pfx}-title {
-      padding: 10px 0;
-      color: ${theme.palette.text.secondary};
-      font-size: 14px;
-    }
-  `;
+  .title {
+    padding: 10px 0;
+    color: ${theme.palette.text.secondary};
+    font-size: 14px;
+  }
+`;
 
 const styles = {
   footerStyles,

--- a/packages/graph-explorer/src/components/AdvancedList/AdvancedList.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/AdvancedList.tsx
@@ -11,7 +11,7 @@ import type {
 import { Children, forwardRef, useEffect, useMemo, useState } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
 import { Virtuoso } from "react-virtuoso";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import useDebounceValue from "../../hooks/useDebounceValue";
 import LoadingSpinner from "../LoadingSpinner";
 import Section from "../Section/Section";
@@ -44,7 +44,6 @@ export type AdvancedListMouseEvent<E = HTMLElement> = (
 
 export type AdvancedListProps<T extends object> = {
   items: AdvancedListItemType<T>[];
-  classNamePrefix?: string;
   className?: string;
   selectedItemsIds?: string[];
   draggable?: boolean;
@@ -104,7 +103,6 @@ const AdvancedList = <T extends object>(
     items,
     className,
     children,
-    classNamePrefix = "ft",
     emptyState,
     onSearch,
     search,
@@ -135,7 +133,6 @@ const AdvancedList = <T extends object>(
   );
   const debouncedSearch = useDebounceValue(search, 300);
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const hasGroups = useMemo(() => {
     return items.some(item => !!item.items?.length);
   }, [items]);
@@ -195,8 +192,8 @@ const AdvancedList = <T extends object>(
     <>
       <div
         className={cx(
-          styleWithTheme(styles.listStyles(classNamePrefix)),
-          pfx("advanced-list"),
+          styleWithTheme(styles.listStyles),
+          "advanced-list",
           className
         )}
       >
@@ -206,11 +203,10 @@ const AdvancedList = <T extends object>(
             disableBorder
             title={
               hasHeader && (
-                <div className={pfx("advanced-list-search-wrapper")}>
+                <div className={"advanced-list-search-wrapper"}>
                   {children}
                   {onSearch && (
                     <SearchBar
-                      classNamePrefix={classNamePrefix}
                       types={typesOptions}
                       search={search}
                       searchPlaceholder={searchPlaceholder}
@@ -223,12 +219,9 @@ const AdvancedList = <T extends object>(
               )
             }
             disablePadding
-            classNamePrefix={classNamePrefix}
             className={cx(
-              styleWithTheme(
-                styles.headerStyles(classNamePrefix, noSearchResults)
-              ),
-              pfx("advanced-list-header")
+              styleWithTheme(styles.headerStyles(noSearchResults)),
+              "advanced-list-header"
             )}
           >
             {isGroupedListVisible && (
@@ -238,7 +231,6 @@ const AdvancedList = <T extends object>(
                 search={debouncedSearch}
                 category={category}
                 draggable={draggable}
-                classNamePrefix={classNamePrefix}
                 selectedItemsIds={selectedItemsIds}
                 onItemClick={onItemClick}
                 onItemMouseOver={onItemMouseOver}
@@ -254,7 +246,7 @@ const AdvancedList = <T extends object>(
               />
             )}
             {isPlainListVisible && (
-              <div className={pfx("advanced-list-nogroup")}>
+              <div className={"advanced-list-nogroup"}>
                 {!disableVirtualization && (
                   <Virtuoso
                     ref={ref}
@@ -263,9 +255,7 @@ const AdvancedList = <T extends object>(
                       const item = filteredItems[index];
                       return (
                         <div
-                          className={cx(
-                            pfx("advanced-list-nogroup-item-wrapper")
-                          )}
+                          className={cx("advanced-list-nogroup-item-wrapper")}
                         >
                           <ElementsListItem
                             item={item}
@@ -287,7 +277,6 @@ const AdvancedList = <T extends object>(
                             onMouseLeave={event =>
                               onItemMouseLeave?.(event, index)
                             }
-                            classNamePrefix={classNamePrefix}
                             draggable={draggable}
                             isSelected={
                               !!item.id && selectedItemsIds?.includes(item.id)
@@ -306,7 +295,7 @@ const AdvancedList = <T extends object>(
                 {disableVirtualization &&
                   filteredItems.map((item, index) => (
                     <div
-                      className={pfx("advanced-list-nogroup-item-wrapper")}
+                      className={"advanced-list-nogroup-item-wrapper"}
                       key={item.id}
                     >
                       <ElementsListItem
@@ -316,7 +305,6 @@ const AdvancedList = <T extends object>(
                             ? (event, item) => onItemClick?.(event, item, index)
                             : undefined
                         }
-                        classNamePrefix={classNamePrefix}
                         draggable={draggable}
                         isSelected={
                           !!item.id && selectedItemsIds?.includes(item.id)
@@ -334,13 +322,12 @@ const AdvancedList = <T extends object>(
           </Section>
         )}
         {isLoading && (
-          <div className={pfx("advanced-list-loading")}>
+          <div className={"advanced-list-loading"}>
             <LoadingSpinner />
           </div>
         )}
         {!hideEmptyState && !hasGroups && isEmpty && (
           <EmptyState
-            classNamePrefix={classNamePrefix}
             emptyState={emptyState}
             empty={search ? !items.length : false}
             noSearchResults={noSearchResults}
@@ -350,10 +337,9 @@ const AdvancedList = <T extends object>(
           <Footer
             count={filteredItems.length}
             total={itemsCount}
-            classNamePrefix={classNamePrefix}
             className={cx(
-              styleWithTheme(styles.footerStyles(classNamePrefix)),
-              pfx("advanced-list-footer")
+              styleWithTheme(styles.footerStyles),
+              "advanced-list-footer"
             )}
           />
         )}

--- a/packages/graph-explorer/src/components/AdvancedList/internalComponents/AdvancedListItem.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/internalComponents/AdvancedListItem.tsx
@@ -3,13 +3,11 @@ import type { DragEvent, MouseEvent, ReactNode, RefObject } from "react";
 import { useRef } from "react";
 import { useDrag } from "react-dnd";
 import { useHover } from "react-laag";
-import { withClassNamePrefix } from "../../../core";
 import { CodeIcon } from "../../icons";
 import ListItem from "../../ListItem";
 import type { AdvancedListItemType } from "../AdvancedList";
 
 type AdvancedListItemProps<T extends object> = {
-  classNamePrefix?: string;
   className?: string;
   onClick?: (
     event: MouseEvent<HTMLDivElement>,
@@ -51,7 +49,6 @@ type AdvancedListItemProps<T extends object> = {
 };
 
 const AdvancedListItem = <T extends object>({
-  classNamePrefix = "ft",
   onClick,
   onMouseOver,
   onMouseOut,
@@ -69,7 +66,6 @@ const AdvancedListItem = <T extends object>({
   hidePopover,
   renderPopover,
 }: AdvancedListItemProps<T>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const ref = useRef<HTMLDivElement>(null);
   const [{ isDragging }, dragRef] = useDrag({
     type: defaultItemType || "none",
@@ -93,11 +89,10 @@ const AdvancedListItem = <T extends object>({
         onMouseOut={event => onMouseOut?.(event, item)}
         onMouseEnter={event => onMouseEnter?.(event, item)}
         onMouseLeave={event => onMouseLeave?.(event, item)}
-        classNamePrefix={classNamePrefix}
-        className={cx(pfx("advanced-list-item"), item.className, {
-          [pfx("advanced-list-item-with-popover")]: isOver,
-          [pfx("advanced-list-item-selected")]: isSelected,
-          [pfx("advanced-list-item-active")]: isActive,
+        className={cx("advanced-list-item", item.className, {
+          ["advanced-list-item-with-popover"]: isOver,
+          ["advanced-list-item-selected"]: isSelected,
+          ["advanced-list-item-active"]: isActive,
         })}
         startAdornment={item.icon || <CodeIcon />}
         secondary={item.subtitle}
@@ -123,14 +118,14 @@ const AdvancedListItem = <T extends object>({
 
   if (!draggable) {
     return (
-      <div className={cx(className, pfx("advanced-list-item-wrapper"))}>
+      <div className={cx(className, "advanced-list-item-wrapper")}>
         {WrappedElement}
       </div>
     );
   }
 
   return (
-    <div className={pfx("advanced-list-item-wrapper")}>
+    <div className={"advanced-list-item-wrapper"}>
       <div ref={dragRef} className={className}>
         {WrappedElement}
       </div>

--- a/packages/graph-explorer/src/components/AdvancedList/internalComponents/AdvancedListWithGroups.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/internalComponents/AdvancedListWithGroups.tsx
@@ -4,7 +4,7 @@ import type { DragEvent, MouseEvent, ReactNode, Ref, RefObject } from "react";
 import { forwardRef, memo, useEffect, useMemo, useState } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
 import { GroupedVirtuoso } from "react-virtuoso";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import useDebounceValue from "../../../hooks/useDebounceValue";
 import { ChevronDownIcon, DetailsIcon, FileIcon } from "../../icons";
 import Section from "../../Section";
@@ -20,7 +20,7 @@ import Footer from "./Footer";
 type ElementsListWithGroupsProps<T extends object> = {
   ref?: Ref<VirtuosoHandle>;
   items: AdvancedListItemType<T>[];
-  classNamePrefix?: string;
+
   selectedItemsIds?: string[];
   draggable?: boolean;
   search?: string;
@@ -69,7 +69,7 @@ type ElementsListWithGroupsProps<T extends object> = {
 const AdvancedListWithGroups = <T extends object>(
   {
     items,
-    classNamePrefix = "ft",
+
     search,
     category = "all",
     draggable,
@@ -102,7 +102,7 @@ const AdvancedListWithGroups = <T extends object>(
     new Set()
   );
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
+
   const allGroups = useMemo(() => {
     const groupedItems = items.filter(el => !!el.items);
     const unGroupedItems = items.filter(el => !el.items);
@@ -195,7 +195,6 @@ const AdvancedListWithGroups = <T extends object>(
   if (showEmptyState) {
     return (
       <EmptyState
-        classNamePrefix={classNamePrefix}
         emptyState={emptyState}
         empty={!allItems.length}
         noSearchResults={!filteredItems.length}
@@ -248,10 +247,9 @@ const AdvancedListWithGroups = <T extends object>(
                     }}
                   />
                 }
-                classNamePrefix={classNamePrefix}
                 showWhenEmpty
-                className={cx(pfx("advanced-list-category"), {
-                  [pfx("advanced-list-category-first")]: index === 0,
+                className={cx("advanced-list-category", {
+                  ["advanced-list-category-first"]: index === 0,
                 })}
               />
             );
@@ -277,7 +275,6 @@ const AdvancedListWithGroups = <T extends object>(
                 onMouseEnter={event => onItemMouseEnter?.(event, index)}
                 onMouseLeave={event => onItemMouseLeave?.(event, index)}
                 group={group}
-                classNamePrefix={classNamePrefix}
                 draggable={draggable}
                 isSelected={
                   !!innerItem.id && selectedItemsIds?.includes(innerItem.id)
@@ -298,10 +295,9 @@ const AdvancedListWithGroups = <T extends object>(
         <Footer
           count={filteredItems.length}
           total={allItems.length}
-          classNamePrefix={classNamePrefix}
           className={cx(
-            styleWithTheme(styles.footerStyles(classNamePrefix)),
-            pfx("advanced-list-footer")
+            styleWithTheme(styles.footerStyles),
+            "advanced-list-footer"
           )}
         />
       )}

--- a/packages/graph-explorer/src/components/AdvancedList/internalComponents/EmptyState.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/internalComponents/EmptyState.tsx
@@ -36,7 +36,6 @@ const getEmptyStateItems = (
 export type EmptyStateProps = {
   empty: boolean;
   noSearchResults: boolean;
-  classNamePrefix?: string;
   className?: string;
   emptyState?: {
     noSearchResultsTitle?: ReactNode;
@@ -52,13 +51,11 @@ const EmptyState = ({
   empty,
   noSearchResults,
   emptyState,
-  classNamePrefix = "ft",
   className,
 }: EmptyStateProps) => {
   const state = getEmptyStateItems(empty, noSearchResults, emptyState);
   return (
     <PanelEmptyState
-      classNamePrefix={classNamePrefix}
       className={className}
       icon={state.icon}
       title={state.title}

--- a/packages/graph-explorer/src/components/AdvancedList/internalComponents/Footer.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/internalComponents/Footer.tsx
@@ -5,16 +5,14 @@ type FooterProps = {
   count: number;
   total: number;
   className: string;
-  classNamePrefix: string;
 };
 
-const Footer = ({ count, total, className, classNamePrefix }: FooterProps) => {
+const Footer = ({ count, total, className }: FooterProps) => {
   return (
     <Section
       showWhenEmpty
       title={`Showing ${count} of ${total}`}
       disablePadding
-      classNamePrefix={classNamePrefix}
       className={className}
     />
   );

--- a/packages/graph-explorer/src/components/AdvancedList/internalComponents/SearchBar.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/internalComponents/SearchBar.tsx
@@ -1,5 +1,4 @@
 import { memo } from "react";
-import { withClassNamePrefix } from "../../../core";
 import SearchIcon from "../../icons/SearchIcon";
 import Input from "../../Input";
 import type { SelectOption } from "../../Select";
@@ -9,7 +8,6 @@ type SearchBarProps = {
   types: SelectOption[];
   search?: string;
   searchPlaceholder?: string;
-  classNamePrefix?: string;
   onSearch: (search: string) => void;
   type: string;
   onTypeChange?: (type: string) => void;
@@ -22,13 +20,11 @@ const SearchBar = ({
   onSearch,
   onTypeChange,
   type,
-  classNamePrefix,
 }: SearchBarProps) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   return (
     <>
       <Input
-        className={pfx("advanced-list-search-input")}
+        className={"advanced-list-search-input"}
         value={search}
         aria-label="Search available items"
         onChange={onSearch}
@@ -41,7 +37,7 @@ const SearchBar = ({
       {!!types.length && onTypeChange && (
         <Select
           aria-label="select category"
-          className={pfx("advanced-list-category-select")}
+          className={"advanced-list-category-select"}
           options={types}
           value={type}
           onChange={value => onTypeChange?.(value as string)}

--- a/packages/graph-explorer/src/components/Card/Card.styles.ts
+++ b/packages/graph-explorer/src/components/Card/Card.styles.ts
@@ -3,26 +3,24 @@ import type { ProcessedTheme, ThemeStyleFn } from "../../core";
 
 type DefaultStylesProps = {
   elevation: 0 | 1 | 2 | 3 | 4;
-  classNamePrefix: string;
   disablePadding?: boolean;
   isDarkTheme?: boolean;
   transparent?: boolean;
 };
 
 const getStylesByElevation = (
-  classNamePrefix: string,
   elevation: 0 | 1 | 2 | 3 | 4,
   theme: ProcessedTheme,
   isDarkTheme?: boolean
 ) => css`
   box-shadow: ${!isDarkTheme ? shadowMap(theme)[elevation] : "none"};
-  &.${classNamePrefix}-card-elevation-0 {
+  &.card-elevation-0 {
     background-color: ${theme.card?.background?.elevation?.["0"] ||
     theme.card?.background?.base ||
     theme.palette.background.default};
   }
 
-  &.${classNamePrefix}-card-elevation-1 {
+  &.card-elevation-1 {
     background-color: ${theme.card?.background?.elevation?.["1"] ||
     theme.card?.background?.base ||
     isDarkTheme
@@ -30,7 +28,7 @@ const getStylesByElevation = (
       : theme.palette.background.default};
   }
 
-  &.${classNamePrefix}-card-elevation-2 {
+  &.card-elevation-2 {
     background-color: ${theme.card?.background?.elevation?.["2"] ||
     theme.card?.background?.base ||
     isDarkTheme
@@ -39,7 +37,7 @@ const getStylesByElevation = (
   }
 
   //elevation 3 and 4 is the same as elevation 2 because the grey-500 and grey-400 are way too light for the text to stand out
-  &.${classNamePrefix}-card-elevation-3 {
+  &.card-elevation-3 {
     background-color: ${theme.card?.background?.elevation?.["3"] ||
     theme.card?.background?.base ||
     isDarkTheme
@@ -47,7 +45,7 @@ const getStylesByElevation = (
       : theme.palette.background.default};
   }
 
-  &.${classNamePrefix}-card-elevation-4 {
+  &.card-elevation-4 {
     background-color: ${theme.card?.background?.elevation?.["4"] ||
     theme.card?.background?.base ||
     isDarkTheme
@@ -69,7 +67,6 @@ const shadowMap = (
 const defaultStyles =
   ({
     elevation,
-    classNamePrefix,
     disablePadding,
     transparent,
   }: DefaultStylesProps): ThemeStyleFn =>
@@ -85,9 +82,8 @@ const defaultStyles =
     theme.palette.background.default};
     box-shadow: ${!isDarkTheme ? shadowMap(theme)[elevation] : "none"};
     border: 1px solid ${isDarkTheme ? theme.palette.border : "transparent"};
-    ${!transparent &&
-    getStylesByElevation(classNamePrefix, elevation, theme, isDarkTheme)}
-    &.${classNamePrefix}-card-clickable {
+    ${!transparent && getStylesByElevation(elevation, theme, isDarkTheme)}
+    &.card-clickable {
       cursor: pointer;
       &:hover {
         border-color: ${theme.palette.primary.main};

--- a/packages/graph-explorer/src/components/Card/Card.tsx
+++ b/packages/graph-explorer/src/components/Card/Card.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from "react";
 import { forwardRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import defaultStyles from "./Card.styles";
 
 export interface CardProps
@@ -9,7 +9,6 @@ export interface CardProps
   id?: string;
   className?: string;
   elevation?: 0 | 1 | 2 | 3 | 4;
-  classNamePrefix?: string;
   transparent?: boolean;
   /**
    * Allows to remove the default padding.
@@ -22,7 +21,6 @@ export const Card = (
   {
     id,
     className,
-    classNamePrefix = "ft",
     children,
     elevation = 1,
     disablePadding,
@@ -32,7 +30,6 @@ export const Card = (
   }: PropsWithChildren<CardProps>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const styleWithTheme = useWithTheme();
   return (
     <div
@@ -42,16 +39,15 @@ export const Card = (
       className={cx(
         styleWithTheme(
           defaultStyles({
-            classNamePrefix,
             elevation,
             disablePadding,
             transparent,
           })
         ),
         className,
-        pfx(`card-elevation-${elevation}`),
+        `card-elevation-${elevation}`,
         {
-          [pfx("card-clickable")]: !!onClick,
+          ["card-clickable"]: !!onClick,
         }
       )}
       {...restProps}

--- a/packages/graph-explorer/src/components/Carousel/Carousel.tsx
+++ b/packages/graph-explorer/src/components/Carousel/Carousel.tsx
@@ -21,13 +21,12 @@ import {
   Swiper as SwiperClass,
   SwiperOptions,
 } from "swiper/types";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { ChevronLeftIcon, ChevronRightIcon } from "../icons";
 import { defaultStyles, navArrowsStyles } from "./Carousel.styles";
 
 export interface CarouselProps {
   className?: string;
-  classNamePrefix?: string;
   centerMode?: boolean;
   pagination?: PaginationOptions;
   draggable?: boolean;
@@ -46,19 +45,14 @@ const PrevArrow = forwardRef<
     className?: string;
     style?: CSSProperties;
     onClick?: MouseEventHandler<any> | undefined;
-    classNamePrefix?: string;
   }
->(({ className, onClick, style, classNamePrefix = "ft" }, ref) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
+>(({ className, onClick, style }, ref) => {
   const stylesWithTheme = useWithTheme();
 
   return (
     <div
       ref={ref}
-      className={cx(
-        stylesWithTheme(navArrowsStyles),
-        pfx("carousel-nav-arrow")
-      )}
+      className={cx(stylesWithTheme(navArrowsStyles), "carousel-nav-arrow")}
     >
       <ChevronLeftIcon
         className={cx(className)}
@@ -69,29 +63,24 @@ const PrevArrow = forwardRef<
   );
 });
 
-const NextArrow = forwardRef<
-  HTMLDivElement,
-  CustomArrowProps & { classNamePrefix?: string }
->(({ className, onClick, style, classNamePrefix = "ft" }, ref) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
-  const stylesWithTheme = useWithTheme();
+const NextArrow = forwardRef<HTMLDivElement, CustomArrowProps>(
+  ({ className, onClick, style }, ref) => {
+    const stylesWithTheme = useWithTheme();
 
-  return (
-    <div
-      ref={ref}
-      className={cx(
-        stylesWithTheme(navArrowsStyles),
-        pfx("carousel-nav-arrow")
-      )}
-    >
-      <ChevronRightIcon
-        className={cx(className)}
-        style={{ ...style }}
-        onClick={onClick}
-      />
-    </div>
-  );
-});
+    return (
+      <div
+        ref={ref}
+        className={cx(stylesWithTheme(navArrowsStyles), "carousel-nav-arrow")}
+      >
+        <ChevronRightIcon
+          className={cx(className)}
+          style={{ ...style }}
+          onClick={onClick}
+        />
+      </div>
+    );
+  }
+);
 
 export type CarouselRef = SwiperClass | undefined;
 

--- a/packages/graph-explorer/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/graph-explorer/src/components/Checkbox/Checkbox.styles.ts
@@ -2,82 +2,78 @@ import { css } from "@emotion/css";
 import { fade, ThemeStyleFn } from "../../core";
 import { CheckboxTheme } from "./Checkbox.model";
 
-export const checkboxStyles =
-  (pfx: string): ThemeStyleFn<CheckboxTheme> =>
-  ({ theme }) => {
-    const { forms, checkbox, palette } = theme;
-    return css`
-      margin-right: 4px;
-      cursor: pointer;
+export const checkboxStyles: ThemeStyleFn<CheckboxTheme> = ({ theme }) => {
+  const { forms, checkbox, palette } = theme;
+  return css`
+    margin-right: 4px;
+    cursor: pointer;
 
-      &.${pfx}-checkbox-readonly {
-        pointer-events: none;
-        cursor: auto;
-      }
-      &.${pfx}-checkbox-disabled {
-        filter: opacity(30%);
-        pointer-events: none;
-        cursor: not-allowed;
-      }
+    &.checkbox-readonly {
+      pointer-events: none;
+      cursor: auto;
+    }
+    &.checkbox-disabled {
+      filter: opacity(30%);
+      pointer-events: none;
+      cursor: not-allowed;
+    }
 
-      &.${pfx}-checkbox-selected {
-        rect:first-of-type {
-          fill: ${checkbox?.checked?.fill || palette.primary.main};
-          stroke: ${checkbox?.checked?.stroke || "none"};
-        }
-
-        path:first-of-type {
-          fill: ${checkbox?.checked?.tickColor || palette.primary.contrastText};
-        }
-      }
-
-      &.${pfx}-checkbox-indeterminate {
-        rect:first-of-type {
-          fill: ${checkbox?.indeterminate?.fill || palette.border};
-          stroke: ${checkbox?.indeterminate?.stroke || "none"};
-        }
-      }
-
-      &.${pfx}-checkbox-invalid {
-        rect:first-of-type {
-          stroke: ${checkbox?.error?.stroke || fade(palette.error.main, 0.7)};
-        }
-      }
+    &.checkbox-selected {
       rect:first-of-type {
-        fill: ${checkbox?.fill || "none"};
-        stroke: ${checkbox?.stroke || palette.border};
+        fill: ${checkbox?.checked?.fill || palette.primary.main};
+        stroke: ${checkbox?.checked?.stroke || "none"};
       }
 
       path:first-of-type {
-        fill: ${checkbox?.fill || palette.primary.contrastText};
+        fill: ${checkbox?.checked?.tickColor || palette.primary.contrastText};
       }
+    }
 
-      rect ~ rect {
-        stroke: ${checkbox?.focus?.outlineColor ||
-        forms?.focus?.outlineColor ||
-        palette.primary.main};
+    &.checkbox-indeterminate {
+      rect:first-of-type {
+        fill: ${checkbox?.indeterminate?.fill || palette.border};
+        stroke: ${checkbox?.indeterminate?.stroke || "none"};
       }
-    `;
-  };
+    }
 
-export const labelStyles =
-  (pfx: string): ThemeStyleFn<CheckboxTheme> =>
-  ({ theme }) => css`
-    display: flex;
-    align-items: center;
-    color: ${theme.checkbox?.label?.color ||
-    theme.forms?.label?.color ||
-    theme.palette.text.primary};
-    &.${pfx}-checkbox-label-invalid {
-      color: ${theme.checkbox?.error?.stroke ||
-      theme.forms?.error?.labelColor ||
-      theme.palette.error.main};
+    &.checkbox-invalid {
+      rect:first-of-type {
+        stroke: ${checkbox?.error?.stroke || fade(palette.error.main, 0.7)};
+      }
     }
-    &.${pfx}-checkbox-label-readonly {
-      pointer-events: none;
+    rect:first-of-type {
+      fill: ${checkbox?.fill || "none"};
+      stroke: ${checkbox?.stroke || palette.border};
     }
-    &.${pfx}-checkbox-label-disabled {
-      cursor: not-allowed;
+
+    path:first-of-type {
+      fill: ${checkbox?.fill || palette.primary.contrastText};
     }
-    cursor: pointer;
+
+    rect ~ rect {
+      stroke: ${checkbox?.focus?.outlineColor ||
+      forms?.focus?.outlineColor ||
+      palette.primary.main};
+    }
   `;
+};
+
+export const labelStyles: ThemeStyleFn<CheckboxTheme> = ({ theme }) => css`
+  display: flex;
+  align-items: center;
+  color: ${theme.checkbox?.label?.color ||
+  theme.forms?.label?.color ||
+  theme.palette.text.primary};
+  &.checkbox-label-invalid {
+    color: ${theme.checkbox?.error?.stroke ||
+    theme.forms?.error?.labelColor ||
+    theme.palette.error.main};
+  }
+  &.checkbox-label-readonly {
+    pointer-events: none;
+  }
+  &.checkbox-label-disabled {
+    cursor: not-allowed;
+  }
+  cursor: pointer;
+`;

--- a/packages/graph-explorer/src/components/Checkbox/Checkbox.tsx
+++ b/packages/graph-explorer/src/components/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import { VisuallyHidden } from "@react-aria/visually-hidden";
 import type { AriaCheckboxProps } from "@react-types/checkbox";
 import type { PropsWithChildren } from "react";
 import { useCallback, useRef } from "react";
-import { useTheme, useWithTheme, withClassNamePrefix } from "../../core";
+import { useTheme, useWithTheme } from "../../core";
 import { checkboxStyles, labelStyles } from "./Checkbox.styles";
 
 export enum CheckboxSizes {
@@ -20,7 +20,6 @@ export interface CheckboxProps
   size?: CheckboxSizes | keyof typeof CheckboxSizes;
   onChange: (isSelected: boolean) => void;
   className?: string;
-  classNamePrefix?: string;
 }
 
 const defaultSizeMap: Record<CheckboxSizes, number> = {
@@ -38,7 +37,6 @@ const NOOP = () => {};
 
 export const Checkbox = ({
   size = "md",
-  classNamePrefix = "ft",
   className,
   ...props
 }: PropsWithChildren<CheckboxProps>) => {
@@ -69,16 +67,15 @@ export const Checkbox = ({
   const isSelectedOrIndeterminate = isSelected || isIndeterminate;
   const computedSize = sizeMap[size] || 28;
 
-  const pfx = withClassNamePrefix(classNamePrefix);
   const styleWithTheme = useWithTheme();
   return (
     <label
       className={cx(
-        styleWithTheme(labelStyles(classNamePrefix)),
+        styleWithTheme(labelStyles),
         {
-          [pfx("checkbox-label-disabled")]: props.isDisabled,
-          [pfx("checkbox-label-readonly")]: props.isReadOnly,
-          [pfx("checkbox-label-invalid")]: props.validationState === "invalid",
+          ["checkbox-label-disabled"]: props.isDisabled,
+          ["checkbox-label-readonly"]: props.isReadOnly,
+          ["checkbox-label-invalid"]: props.validationState === "invalid",
         },
         className
       )}
@@ -89,12 +86,12 @@ export const Checkbox = ({
       <svg
         width={computedSize}
         height={computedSize}
-        className={cx(styleWithTheme(checkboxStyles(classNamePrefix)), {
-          [pfx("checkbox-selected")]: isSelected,
-          [pfx("checkbox-disabled")]: props.isDisabled,
-          [pfx("checkbox-readonly")]: props.isReadOnly,
-          [pfx("checkbox-indeterminate")]: props.isIndeterminate,
-          [pfx("checkbox-invalid")]: props.validationState === "invalid",
+        className={cx(styleWithTheme(checkboxStyles), {
+          ["checkbox-selected"]: isSelected,
+          ["checkbox-disabled"]: props.isDisabled,
+          ["checkbox-readonly"]: props.isReadOnly,
+          ["checkbox-indeterminate"]: props.isIndeterminate,
+          ["checkbox-invalid"]: props.validationState === "invalid",
         })}
         aria-hidden="true"
       >

--- a/packages/graph-explorer/src/components/CheckboxList/CheckboxList.styles.ts
+++ b/packages/graph-explorer/src/components/CheckboxList/CheckboxList.styles.ts
@@ -1,72 +1,70 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    &.${pfx}-checkbox-list {
+const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  &.checkbox-list {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+
+    .title {
+      padding: ${theme.spacing["2x"]} 0;
+      font-weight: bold;
+      font-size: ${theme.typography.sizes.xs};
+    }
+
+    .content {
+      position: relative;
       display: flex;
-      flex-grow: 1;
       flex-direction: column;
-      width: 100%;
-      height: 100%;
+      overflow: auto;
+      row-gap: ${theme.spacing["2x"]};
+      padding: ${theme.spacing["2x"]} 0 0;
+      border: solid 1px ${theme.palette.border};
+      border-radius: ${theme.shape.borderRadius};
+      margin-bottom: ${theme.spacing["4x"]};
+    }
 
-      .${pfx}-title {
-        padding: ${theme.spacing["2x"]} 0;
-        font-weight: bold;
-        font-size: ${theme.typography.sizes.xs};
-      }
-
-      .${pfx}-content {
-        position: relative;
-        display: flex;
-        flex-direction: column;
-        overflow: auto;
-        row-gap: ${theme.spacing["2x"]};
-        padding: ${theme.spacing["2x"]} 0 0;
-        border: solid 1px ${theme.palette.border};
-        border-radius: ${theme.shape.borderRadius};
-        margin-bottom: ${theme.spacing["4x"]};
-      }
-
-      .${pfx}-checkbox-container {
-        padding: 0 ${theme.spacing["2x"]};
-      }
-      .${pfx}-checkbox {
-        svg {
-          min-width: 28px;
-        }
-      }
-
-      .${pfx}-checkbox-content {
-        user-select: none;
-        width: 100%;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        word-break: break-word;
-        gap: ${theme.spacing["2x"]};
-      }
-
-      .${pfx}-icon {
-        > svg {
-          width: 16px;
-          height: 16px;
-          color: ${theme.palette.primary.main};
-        }
-      }
-
-      .${pfx}-selector {
-        user-select: none;
-        position: sticky;
-        bottom: 0;
-        background: ${isDarkTheme
-          ? theme.palette.background.secondary
-          : theme.palette.background.default};
-        border-top: solid 1px ${theme.palette.border};
-        padding-top: ${theme.spacing.base};
+    .checkbox-container {
+      padding: 0 ${theme.spacing["2x"]};
+    }
+    .checkbox {
+      svg {
+        min-width: 28px;
       }
     }
-  `;
+
+    .checkbox-content {
+      user-select: none;
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      word-break: break-word;
+      gap: ${theme.spacing["2x"]};
+    }
+
+    .icon {
+      > svg {
+        width: 16px;
+        height: 16px;
+        color: ${theme.palette.primary.main};
+      }
+    }
+
+    .selector {
+      user-select: none;
+      position: sticky;
+      bottom: 0;
+      background: ${isDarkTheme
+        ? theme.palette.background.secondary
+        : theme.palette.background.default};
+      border-top: solid 1px ${theme.palette.border};
+      padding-top: ${theme.spacing.base};
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/CheckboxList/CheckboxList.tsx
+++ b/packages/graph-explorer/src/components/CheckboxList/CheckboxList.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import { ReactNode } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import Checkbox from "../Checkbox/Checkbox";
 import defaultStyles from "./CheckboxList.styles";
 
@@ -12,10 +12,6 @@ export type CheckboxListItemProps = {
 };
 
 export type CheckboxListProps = {
-  /**
-   * Prefix for style classes.
-   */
-  classNamePrefix?: string;
   /**
    * Override or extend the styles applied to the component.
    */
@@ -48,7 +44,6 @@ export type CheckboxListProps = {
 };
 
 export const CheckboxList = ({
-  classNamePrefix = "ft",
   className,
   title,
   checkboxes,
@@ -57,7 +52,6 @@ export const CheckboxList = ({
   onChange,
   onChangeAll,
 }: CheckboxListProps) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const stylesWithTheme = useWithTheme();
 
   const numOfSelections = selectedIds.size;
@@ -69,35 +63,31 @@ export const CheckboxList = ({
 
   return (
     <div
-      className={cx(
-        stylesWithTheme(defaultStyles(classNamePrefix)),
-        pfx("checkbox-list"),
-        className
-      )}
+      className={cx(stylesWithTheme(defaultStyles), "checkbox-list", className)}
     >
-      {title && <div className={pfx("title")}>{title}</div>}
-      <div className={pfx("content")}>
+      {title && <div className={"title"}>{title}</div>}
+      <div className={"content"}>
         {checkboxes.map(checkbox => {
           return (
-            <div key={checkbox.id} className={pfx("checkbox-container")}>
+            <div key={checkbox.id} className={"checkbox-container"}>
               <Checkbox
                 aria-label={`checkbox for ${checkbox.id}`}
                 isSelected={selectedIds.has(checkbox.id)}
                 isDisabled={isDisabled || checkbox.isDisabled}
                 onChange={isSelected => onChange(checkbox.id, isSelected)}
-                className={pfx("checkbox")}
+                className={"checkbox"}
               >
-                <div className={pfx("checkbox-content")}>
+                <div className={"checkbox-content"}>
                   <div>{checkbox.text}</div>
-                  <div className={pfx("icon")}>{checkbox.endAdornment}</div>
+                  <div className={"icon"}>{checkbox.endAdornment}</div>
                 </div>
               </Checkbox>
             </div>
           );
         })}
         {onChangeAll && (
-          <div className={pfx("selector")}>
-            <div className={pfx("checkbox-container")}>
+          <div className={"selector"}>
+            <div className={"checkbox-container"}>
               <Checkbox
                 aria-label={"checkbox for all"}
                 isIndeterminate={
@@ -109,7 +99,7 @@ export const CheckboxList = ({
                   onChangeAll(isSelected);
                 }}
               >
-                <div className={pfx("checkbox-content")}>
+                <div className={"checkbox-content"}>
                   <div>
                     {numOfSelections} selected of {totalCheckboxes}
                   </div>

--- a/packages/graph-explorer/src/components/Chip/Chip.styles.ts
+++ b/packages/graph-explorer/src/components/Chip/Chip.styles.ts
@@ -14,8 +14,7 @@ const defaultStyles =
     variant: "info" | "success" | "error" | "warning",
     background?: string,
     color?: string,
-    size?: "xs" | "sm" | "md" | "lg",
-    pfx?: string
+    size?: "xs" | "sm" | "md" | "lg"
   ): ThemeStyleFn =>
   ({ theme }) => css`
     display: inline-flex;
@@ -34,7 +33,7 @@ const defaultStyles =
       : theme.chip?.variants?.[variant]?.background ||
         theme.palette[variant === "info" ? "primary" : variant].main};
 
-    &.${pfx}-chip-clickable {
+    &.chip-clickable {
       cursor: pointer;
       &:hover {
         color: ${color
@@ -50,7 +49,7 @@ const defaultStyles =
             )};
       }
     }
-    .${pfx}-chip-label {
+    .chip-label {
       overflow: hidden;
       text-overflow: ellipsis;
       padding: 0 ${theme.spacing.base};
@@ -58,7 +57,7 @@ const defaultStyles =
       white-space: nowrap;
     }
 
-    .${pfx}-icon-delete {
+    .icon-delete {
       padding: 0;
       color: ${fade(theme.palette.grey[600], 0.7)};
 

--- a/packages/graph-explorer/src/components/Chip/Chip.tsx
+++ b/packages/graph-explorer/src/components/Chip/Chip.tsx
@@ -6,14 +6,13 @@ import type {
   ReactNode,
 } from "react";
 import { forwardRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import IconButton from "../IconButton";
 import CloseIcon from "../icons/CloseIcon";
 import defaultStyles from "./Chip.styles";
 
 export interface ChipProps extends HTMLAttributes<HTMLDivElement> {
   className?: string;
-  classNamePrefix?: string;
   /* Takes precedence over variants and theme*/
   color?: string;
   /* Takes precedence over variants and theme*/
@@ -30,7 +29,6 @@ export const Chip = (
   {
     children,
     className,
-    classNamePrefix = "ft",
     color,
     background,
     size = "sm",
@@ -44,32 +42,29 @@ export const Chip = (
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   return (
     <div
       ref={ref}
       className={cx(
-        styleWithTheme(
-          defaultStyles(variant, background, color, size, classNamePrefix)
-        ),
-        pfx("chip"),
+        styleWithTheme(defaultStyles(variant, background, color, size)),
+        "chip",
         {
-          [pfx("chip-clickable")]: !!allProps.onClick,
-          [pfx("chip-deletable")]: !!onDelete,
+          ["chip-clickable"]: !!allProps.onClick,
+          ["chip-deletable"]: !!onDelete,
         },
         className
       )}
       {...allProps}
     >
       {startAdornment}
-      <span className={pfx("chip-label")}>{children}</span>
+      <span className={"chip-label"}>{children}</span>
       {endAdornment}
       {onDelete && (
         <IconButton
           rounded
           onPress={onDelete}
-          className={pfx("icon-delete")}
+          className={"icon-delete"}
           icon={deleteIcon || <CloseIcon />}
           variant="text"
           size="small"

--- a/packages/graph-explorer/src/components/ColorInput/ColorInput.style.ts
+++ b/packages/graph-explorer/src/components/ColorInput/ColorInput.style.ts
@@ -1,28 +1,24 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  () => css`
-    .${pfx}-color-input {
-      min-width: 105px;
-      position: relative;
-      .${pfx}-input {
-        margin: 0px;
-        .${pfx}-end-adornment {
-          height: 100%;
-        }
+const defaultStyles: ThemeStyleFn = () => css`
+  .color-input {
+    min-width: 105px;
+    position: relative;
+    .input {
+      margin: 0px;
+      .end-adornment {
+        height: 100%;
       }
     }
-  `;
+  }
+`;
 
-export const colorPickerStyle =
-  (): ThemeStyleFn =>
-  ({ theme }) => css`
-    background: ${theme.palette.background.default};
-    padding: ${theme.spacing["2x"]};
-    box-shadow: ${theme.shadow.lg};
-    border-radius: ${theme.shape.borderRadius};
-  `;
+export const colorPickerStyle: ThemeStyleFn = ({ theme }) => css`
+  background: ${theme.palette.background.default};
+  padding: ${theme.spacing["2x"]};
+  box-shadow: ${theme.shadow.lg};
+  border-radius: ${theme.shape.borderRadius};
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
+++ b/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import { ColorPicker, ColorPickerProps } from "@mantine/core";
 import { FC, useEffect, useState } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import {
   Input,
   InputProps,
@@ -14,13 +14,11 @@ import defaultStyles, { colorPickerStyle } from "./ColorInput.style";
 const validHexColorRegex = /^#([0-9a-f]{3}){1,2}$/i;
 
 export type ColorInputProps = Pick<InputProps, "label" | "labelPlacement"> & {
-  classNamePrefix?: string;
   startColor?: string;
   onChange(color: string): void;
 };
 
 const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
-  classNamePrefix = "ft",
   className,
   startColor = "#128ee5",
   onChange,
@@ -29,7 +27,6 @@ const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
   ...props
 }) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const [lastColor, setLastColor] = useState<string>(startColor);
   const [color, setColor] = useState<string>(startColor);
@@ -51,10 +48,8 @@ const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
   }, [startColor, color, lastColor, onChange]);
 
   return (
-    <div
-      className={cx(styleWithTheme(defaultStyles(classNamePrefix)), className)}
-    >
-      <div className={pfx("color-input")}>
+    <div className={cx(styleWithTheme(defaultStyles), className)}>
+      <div className={"color-input"}>
         <UseLayer
           onClose={() => setColorPickerOpen(false)}
           isOpen={colorPickerOpen}
@@ -65,8 +60,7 @@ const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
               label={label}
               labelPlacement={labelPlacement}
               aria-label="color-input"
-              classNamePrefix={classNamePrefix}
-              className={pfx("input")}
+              className={"input"}
               onClick={() => setColorPickerOpen(true)}
               type={"text"}
               value={color}
@@ -85,7 +79,7 @@ const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
             />
           </UseLayerTrigger>
           <UseLayerOverlay>
-            <div className={styleWithTheme(colorPickerStyle())}>
+            <div className={styleWithTheme(colorPickerStyle)}>
               <ColorPicker
                 onChange={(newColor: string) => setColor(newColor)}
                 value={color}

--- a/packages/graph-explorer/src/components/Graph/Graph.tsx
+++ b/packages/graph-explorer/src/components/Graph/Graph.tsx
@@ -13,7 +13,6 @@ import {
   useImperativeHandle,
   useState,
 } from "react";
-import { withClassNamePrefix } from "../../core";
 import type {
   Config,
   CytoscapeType,
@@ -48,12 +47,12 @@ cytoscape.use(d3Force);
 cytoscape.use(fcose);
 cyCanvas(cytoscape);
 
-const defaultStyles = (pfx: string) => css`
+const defaultStyles = () => css`
   width: 100%;
   height: 100%;
   position: relative;
   overflow: hidden;
-  .${pfx}-graph-container {
+  .graph-container {
     width: 100%;
     height: 100%;
     position: absolute;
@@ -81,7 +80,6 @@ export interface GraphProps<
   edges: GraphEdge[];
   //styling
   className?: string;
-  classNamePrefix?: string;
   styles?: {
     [selector: string]: StyleSelector;
   };
@@ -174,7 +172,6 @@ export const Graph = (
     onSelectedGroupsIdsChange,
     onSelectedEdgesIdsChange,
     className = "",
-    classNamePrefix = "ft",
     styles,
     onEdgeClick,
     onEdgeRightClick,
@@ -397,12 +394,11 @@ export const Graph = (
   const EmptyComponent = emptyComponent ? emptyComponent : EmptyState;
   const LoadingComponent = loadingComponent ? loadingComponent : GraphLoading;
 
-  const pfx = withClassNamePrefix(classNamePrefix);
   const isEmpty = !nodes.length && !edges.length;
   const isLoading = loading;
   return (
-    <div className={cx(defaultStyles(classNamePrefix), className)}>
-      <div className={pfx("graph-container")} ref={wrapperRefCb} />
+    <div className={cx(defaultStyles(), className)}>
+      <div className={"graph-container"} ref={wrapperRefCb} />
       {cy && children ? children(cy) : null}
       {isEmpty && !isLoading ? <EmptyComponent /> : null}
       {isLoading ? <LoadingComponent /> : null}

--- a/packages/graph-explorer/src/components/HumanReadableNumberFormatter/HumanReadableNumberFormatter.tsx
+++ b/packages/graph-explorer/src/components/HumanReadableNumberFormatter/HumanReadableNumberFormatter.tsx
@@ -1,7 +1,5 @@
 import { cx } from "@emotion/css";
-
 import { forwardRef } from "react";
-
 import { formatWithoutSymbol, getSymbolForNumber } from "./numberFormat";
 import {
   containerStyles,
@@ -18,7 +16,6 @@ export interface HumanReadableNumberFormatterProps {
   /* print rawValue */
   noFormat?: boolean;
   className?: string;
-  classNamePrefix?: string;
   unitPlacement?: "start" | "end";
 }
 
@@ -32,7 +29,6 @@ export const HumanReadableNumberFormatter = forwardRef<
       unit,
       maxFractionDigits = 2,
       className,
-      classNamePrefix = "ft",
       noFormat,
       unitPlacement = "end",
     },
@@ -44,22 +40,14 @@ export const HumanReadableNumberFormatter = forwardRef<
     return (
       <div ref={ref} className={cx(containerStyles(), className)}>
         {!!unit && unitPlacement === "start" && (
-          <div className={cx(unitStyles, `${classNamePrefix}-unit`)}>
-            {unit}
-          </div>
+          <div className={cx(unitStyles, `unit`)}>{unit}</div>
         )}
-        <div className={`${classNamePrefix}-number`}>
-          {!noFormat ? formattedValue : value}
-        </div>
+        <div className={`number`}>{!noFormat ? formattedValue : value}</div>
         {!noFormat && symbol && (
-          <div className={cx(symbolStyles, `${classNamePrefix}-symbol`)}>
-            {symbol}
-          </div>
+          <div className={cx(symbolStyles, `symbol`)}>{symbol}</div>
         )}
         {!!unit && unitPlacement === "end" && (
-          <div className={cx(unitStyles, `${classNamePrefix}-unit`)}>
-            {unit}
-          </div>
+          <div className={cx(unitStyles, `unit`)}>{unit}</div>
         )}
       </div>
     );

--- a/packages/graph-explorer/src/components/IconButton/IconButton.styles.ts
+++ b/packages/graph-explorer/src/components/IconButton/IconButton.styles.ts
@@ -340,65 +340,63 @@ export const defaultToggleButtonStyles =
     );
   };
 
-export const defaultBadgeStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-badge {
-      position: absolute;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-width: 16px;
-      height: 16px;
-      border-radius: 8px;
-      padding: 0 ${theme.spacing.base};
-      font-size: ${theme.typography.sizes.xs};
-      color: ${theme.palette.secondary.contrastText};
-      background: ${theme.palette.secondary.main};
+export const defaultBadgeStyles: ThemeStyleFn = ({ theme }) => css`
+  &.badge {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    border-radius: 8px;
+    padding: 0 ${theme.spacing.base};
+    font-size: ${theme.typography.sizes.xs};
+    color: ${theme.palette.secondary.contrastText};
+    background: ${theme.palette.secondary.main};
 
-      &.${pfx}-variant-undetermined {
-        min-width: 8px;
-        height: 8px;
-      }
+    &.variant-undetermined {
+      min-width: 8px;
+      height: 8px;
+    }
 
-      &.${pfx}-placement-bottom-right {
-        bottom: -6px;
-        right: -6px;
+    &.placement-bottom-right {
+      bottom: -6px;
+      right: -6px;
 
-        &.${pfx}-variant-undetermined {
-          bottom: 0;
-          right: 0;
-        }
-      }
-
-      &.${pfx}-placement-bottom-left {
-        bottom: -6px;
-        left: -2px;
-
-        &.${pfx}-variant-undetermined {
-          bottom: 0;
-          left: 0;
-        }
-      }
-
-      &.${pfx}-placement-top-right {
-        top: -6px;
-        right: -6px;
-
-        &.${pfx}-variant-undetermined {
-          top: 0;
-          right: 0;
-        }
-      }
-
-      &.${pfx}-placement-top-left {
-        top: -6px;
-        left: -2px;
-
-        &.${pfx}-variant-undetermined {
-          top: 0;
-          left: 0;
-        }
+      &.variant-undetermined {
+        bottom: 0;
+        right: 0;
       }
     }
-  `;
+
+    &.placement-bottom-left {
+      bottom: -6px;
+      left: -2px;
+
+      &.variant-undetermined {
+        bottom: 0;
+        left: 0;
+      }
+    }
+
+    &.placement-top-right {
+      top: -6px;
+      right: -6px;
+
+      &.variant-undetermined {
+        top: 0;
+        right: 0;
+      }
+    }
+
+    &.placement-top-left {
+      top: -6px;
+      left: -2px;
+
+      &.variant-undetermined {
+        top: 0;
+        left: 0;
+      }
+    }
+  }
+`;

--- a/packages/graph-explorer/src/components/IconButton/IconButton.tsx
+++ b/packages/graph-explorer/src/components/IconButton/IconButton.tsx
@@ -3,7 +3,7 @@ import { useButton } from "@react-aria/button";
 import type { AriaButtonProps } from "@react-types/button";
 import type { ElementType, ForwardedRef, ReactNode, RefObject } from "react";
 import { forwardRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import type { TooltipProps } from "../Tooltip";
 import Tooltip from "../Tooltip/Tooltip";
 import {
@@ -13,7 +13,6 @@ import {
 
 export interface IconButtonProps
   extends Omit<AriaButtonProps<ElementType<any>>, "elementType"> {
-  classNamePrefix?: string;
   className?: string;
   color?: "primary" | "error" | "info" | "success" | "warning";
   variant?: "filled" | "default" | "text";
@@ -32,7 +31,6 @@ export interface IconButtonProps
 
 export const IconButton = (
   {
-    classNamePrefix = "ft",
     tooltipText,
     tooltipPlacement,
     onClick,
@@ -51,7 +49,6 @@ export const IconButton = (
     ref as RefObject<HTMLButtonElement>
   );
   const styles = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const {
     className,
@@ -81,10 +78,10 @@ export const IconButton = (
       {Boolean(badge) && (
         <div
           className={cx(
-            styles(defaultBadgeStyles(classNamePrefix)),
-            pfx("badge"),
-            pfx(`variant-${badgeVariant}`),
-            pfx(`placement-${badgePlacement}`)
+            styles(defaultBadgeStyles),
+            "badge",
+            `variant-${badgeVariant}`,
+            `placement-${badgePlacement}`
           )}
         >
           {typeof badge !== "boolean" && badgeVariant === "determined" && badge}

--- a/packages/graph-explorer/src/components/Input/Input.styles.ts
+++ b/packages/graph-explorer/src/components/Input/Input.styles.ts
@@ -188,7 +188,6 @@ const getInnerLabelStyles = (
 export const inputContainerStyles =
   (
     labelPlacement: "top" | "left" | "inner",
-    classNamePrefix: string,
     size: "sm" | "md",
     isDisabled?: boolean,
     validationState?: "invalid" | "valid",
@@ -216,15 +215,15 @@ export const inputContainerStyles =
       ${isReadOnly ? "pointer-events: none" : ""};
       position: relative;
 
-      &.${classNamePrefix}-input-label-inner {
-        > .${classNamePrefix}-input-label {
+      &.input-label-inner {
+        > .input-label {
           font-size: 10px;
           pointer-events: none;
           ${getInnerLabelStyles(size, theme)}
         }
       }
 
-      > .${classNamePrefix}-input-label {
+      > .input-label {
         width: ${labelPlacement === "left" ? "150px" : "100%"};
         line-height: ${labelPlacement === "left" ? "0.75em" : "0.875em"};
         color: ${themeWithDefault?.label?.color};
@@ -232,13 +231,13 @@ export const inputContainerStyles =
         margin: ${labelPlacement === "left" ? "0 8px 0 0" : "0 0 8px 0"};
       }
 
-      .${classNamePrefix}-input-container {
+      .input-container {
         flex: 1;
         display: flex;
         position: relative;
       }
 
-      .${classNamePrefix}-start-adornment {
+      .start-adornment {
         position: absolute;
         left: ${getPaddingBySize(size, theme)};
         top: ${isTextArea
@@ -250,7 +249,7 @@ export const inputContainerStyles =
         color: ${themeWithDefault?.startAdornment?.color};
       }
 
-      .${classNamePrefix}-end-adornment {
+      .end-adornment {
         position: absolute;
         right: ${getPaddingBySize(size, theme)};
         top: ${isTextArea
@@ -262,7 +261,7 @@ export const inputContainerStyles =
         color: ${themeWithDefault?.endAdornment?.color};
       }
 
-      .${classNamePrefix}-clearButton {
+      .clearButton {
         position: absolute;
         right: ${getPaddingBySize(size, theme)};
         top: ${isTextArea
@@ -274,7 +273,7 @@ export const inputContainerStyles =
         color: ${themeWithDefault?.endAdornment?.color};
       }
 
-      .${classNamePrefix}-input {
+      .input {
         font-family: inherit;
         ${isTextArea && "height: 100px; resize: none;"}
         background-color: ${!isDisabled
@@ -300,7 +299,7 @@ export const inputContainerStyles =
           color: ${themeWithDefault?.placeholderColor};
         }
 
-        &:not(.${classNamePrefix}-input-disabled):hover {
+        &:not(.input-disabled):hover {
           background-color: ${themeWithDefault?.hover?.background};
           color: ${themeWithDefault?.hover?.color};
         }
@@ -312,7 +311,7 @@ export const inputContainerStyles =
         }
       }
 
-      .${classNamePrefix}-input-error {
+      .input-error {
         position: absolute;
         top: calc(100% - 6px);
         left: 0;

--- a/packages/graph-explorer/src/components/Input/Input.tsx
+++ b/packages/graph-explorer/src/components/Input/Input.tsx
@@ -10,7 +10,7 @@ import type {
   RefObject,
 } from "react";
 import { forwardRef, useRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { inputContainerStyles } from "./Input.styles";
 
 export interface BaseInputProps
@@ -21,7 +21,6 @@ export interface BaseInputProps
   label?: ReactNode;
   labelPlacement?: "top" | "left" | "inner";
   className?: string;
-  classNamePrefix?: string;
   errorMessage?: string;
   fullWidth?: boolean;
   hideError?: boolean;
@@ -54,7 +53,6 @@ const isNumberInput = (props: InputProps): props is NumberInputProps =>
 export const Input = (
   {
     labelPlacement = "top",
-    classNamePrefix = "ft",
     size = "md",
     fullWidth = false,
     hideError = false,
@@ -78,7 +76,6 @@ export const Input = (
     isReadOnly,
   } = props;
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const localRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
   const { labelProps, inputProps } = useTextField(
     {
@@ -107,7 +104,6 @@ export const Input = (
         styleWithTheme(
           inputContainerStyles(
             labelPlacement,
-            classNamePrefix,
             size,
             isDisabled,
             validationState,
@@ -120,28 +116,28 @@ export const Input = (
             noMargin
           )
         ),
-        pfx(`input-label-${labelPlacement}`),
-        pfx("input-wrapper"),
+        `input-label-${labelPlacement}`,
+        "input-wrapper",
         className
       )}
     >
       {label && (
-        <label className={pfx("input-label")} {...labelProps}>
+        <label className={"input-label"} {...labelProps}>
           {label}
         </label>
       )}
-      <div className={pfx("input-container")}>
+      <div className={"input-container"}>
         {!!startAdornment && (
-          <span className={pfx("start-adornment")}>{startAdornment}</span>
+          <span className={"start-adornment"}>{startAdornment}</span>
         )}
         {component === "input" && (
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           /*@ts-ignore*/
           <input
             {...clickHandlers}
-            className={cx(pfx("input"), {
-              [pfx("input-disabled")]: isDisabled,
-              [pfx("input-label-inner")]: labelPlacement === "inner",
+            className={cx("input", {
+              ["input-disabled"]: isDisabled,
+              ["input-label-inner"]: labelPlacement === "inner",
             })}
             min={isNumberInput(props) ? props.min : undefined}
             max={isNumberInput(props) ? props.max : undefined}
@@ -156,22 +152,20 @@ export const Input = (
           /*@ts-ignore*/
           <textarea
             {...clickHandlers}
-            className={cx(pfx("input"), {
-              [pfx("input-disabled")]: isDisabled,
-              [pfx("input-label-inner")]: labelPlacement === "inner",
+            className={cx("input", {
+              ["input-disabled"]: isDisabled,
+              ["input-label-inner"]: labelPlacement === "inner",
             })}
             ref={(ref as RefObject<HTMLTextAreaElement>) || localRef}
             {...inputProps}
           />
         )}
         {!!endAdornment && (
-          <span className={pfx("end-adornment")}>{endAdornment}</span>
+          <span className={"end-adornment"}>{endAdornment}</span>
         )}
-        {!!clearButton && (
-          <span className={pfx("clearButton")}>{clearButton}</span>
-        )}
+        {!!clearButton && <span className={"clearButton"}>{clearButton}</span>}
         {validationState === "invalid" && !!errorMessage && !hideError && (
-          <div className={pfx("input-error")}>{errorMessage}</div>
+          <div className={"input-error"}>{errorMessage}</div>
         )}
       </div>
     </div>

--- a/packages/graph-explorer/src/components/ListItem/ListItem.styles.ts
+++ b/packages/graph-explorer/src/components/ListItem/ListItem.styles.ts
@@ -2,76 +2,78 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 import type { ListItemTheme } from "./ListItem.model";
 
-const defaultStyles: (pfx: string) => ThemeStyleFn<ListItemTheme> =
-  pfx =>
-  ({ theme, isDarkTheme }) => css`
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+const defaultStyles: ThemeStyleFn<ListItemTheme> = ({
+  theme,
+  isDarkTheme,
+}) => css`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 
-    &.${pfx}-clickable {
-      cursor: pointer;
-      transition:
-        color 250ms ease,
-        background 250ms ease;
-      background: ${theme.listItem?.clickable?.background || isDarkTheme
-        ? theme.palette.background.secondary
-        : theme.palette.background.default};
-      color: ${theme.listItem?.clickable?.text || theme.palette.text.primary};
+  &.clickable {
+    cursor: pointer;
+    transition:
+      color 250ms ease,
+      background 250ms ease;
+    background: ${theme.listItem?.clickable?.background || isDarkTheme
+      ? theme.palette.background.secondary
+      : theme.palette.background.default};
+    color: ${theme.listItem?.clickable?.text || theme.palette.text.primary};
 
-      &.${pfx}-disabled {
+    &.disabled {
+      background: ${theme.listItem?.clickable?.disabled?.background};
+      color: ${theme.listItem?.clickable?.disabled?.text ||
+      theme.palette.text.disabled};
+      pointer-events: none;
+
+      .primary {
         background: ${theme.listItem?.clickable?.disabled?.background};
         color: ${theme.listItem?.clickable?.disabled?.text ||
         theme.palette.text.disabled};
         pointer-events: none;
-
-        .${pfx}-primary {
-          background: ${theme.listItem?.clickable?.disabled?.background};
-          color: ${theme.listItem?.clickable?.disabled?.text ||
-          theme.palette.text.disabled};
-          pointer-events: none;
-        }
-      }
-
-      :hover {
-        background: ${theme.listItem?.clickable?.hover?.background ||
-        theme.palette.background.contrast};
-        color: ${theme.listItem?.clickable?.hover?.text ||
-        theme.palette.text.primary};
       }
     }
 
-    .${pfx}-start-adornment, .${pfx}-end-adornment {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
-      align-items: center;
-      margin: 0 ${theme.spacing["2x"]};
-      min-width: 32px;
+    :hover {
+      background: ${theme.listItem?.clickable?.hover?.background ||
+      theme.palette.background.contrast};
+      color: ${theme.listItem?.clickable?.hover?.text ||
+      theme.palette.text.primary};
     }
+  }
 
-    .${pfx}-content {
-      flex-grow: 1;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      min-height: 48px;
-      color: ${theme.listItem?.primary?.text || theme.palette.text.primary};
-      background: ${theme.listItem?.primary?.background};
-    }
+  .start-adornment,
+  .end-adornment {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    margin: 0 ${theme.spacing["2x"]};
+    min-width: 32px;
+  }
 
-    .${pfx}-primary {
-      font-weight: normal;
-      color: ${theme.listItem?.primary?.text || theme.palette.text.primary};
-      background: ${theme.listItem?.primary?.background};
-    }
+  .content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 48px;
+    color: ${theme.listItem?.primary?.text || theme.palette.text.primary};
+    background: ${theme.listItem?.primary?.background};
+  }
 
-    .${pfx}-secondary {
-      font-size: 0.8rem;
-      color: ${theme.listItem?.secondary?.text || theme.palette.text.secondary};
-      background: ${theme.listItem?.secondary?.background};
-    }
-  `;
+  .primary {
+    font-weight: normal;
+    color: ${theme.listItem?.primary?.text || theme.palette.text.primary};
+    background: ${theme.listItem?.primary?.background};
+  }
+
+  .secondary {
+    font-size: 0.8rem;
+    color: ${theme.listItem?.secondary?.text || theme.palette.text.secondary};
+    background: ${theme.listItem?.secondary?.background};
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/ListItem/ListItem.tsx
+++ b/packages/graph-explorer/src/components/ListItem/ListItem.tsx
@@ -8,11 +8,10 @@ import type {
   ReactNode,
 } from "react";
 import { forwardRef, useCallback } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import defaultStyles from "./ListItem.styles";
 
 export interface ListItemProps extends HTMLAttributes<HTMLDivElement> {
-  classNamePrefix?: string;
   className?: string;
   /**
    * If true, adds onClick event and the proper styling to the root element.
@@ -42,7 +41,6 @@ export interface ListItemProps extends HTMLAttributes<HTMLDivElement> {
 export const ListItem = (
   {
     children,
-    classNamePrefix = "ft",
     className,
     clickable,
     onClick,
@@ -56,7 +54,6 @@ export const ListItem = (
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const actualOnClick = useCallback(
     (ev: MouseEvent<HTMLDivElement>) => {
@@ -75,24 +72,22 @@ export const ListItem = (
       onDragStart={onDragStart}
       draggable={!!onDragStart}
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        { [pfx("disabled")]: isDisabled },
-        { [pfx("clickable")]: clickable },
+        styleWithTheme(defaultStyles),
+        { ["disabled"]: isDisabled },
+        { ["clickable"]: clickable },
         className
       )}
       onClick={actualOnClick}
       {...allProps}
     >
       {startAdornment && (
-        <div className={pfx("start-adornment")}>{startAdornment}</div>
+        <div className={"start-adornment"}>{startAdornment}</div>
       )}
-      <div className={pfx("content")}>
-        <div className={pfx("primary")}>{children}</div>
-        <div className={pfx("secondary")}>{secondary}</div>
+      <div className={"content"}>
+        <div className={"primary"}>{children}</div>
+        <div className={"secondary"}>{secondary}</div>
       </div>
-      {endAdornment && (
-        <div className={pfx("end-adornment")}>{endAdornment}</div>
-      )}
+      {endAdornment && <div className={"end-adornment"}>{endAdornment}</div>}
     </div>
   );
 };

--- a/packages/graph-explorer/src/components/ModuleContainer/ModuleContainer.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/ModuleContainer.styles.ts
@@ -1,55 +1,53 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    &.${pfx}-module-container {
-      height: 100%;
-      overflow: hidden;
+const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  &.module-container {
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    background: ${theme.palette.background.secondary};
+    color: ${theme.palette.text.secondary};
+
+    > .content {
       display: flex;
       flex-direction: column;
-      background: ${theme.palette.background.secondary};
-      color: ${theme.palette.text.secondary};
+      flex-grow: 1;
+      overflow: hidden;
+    }
 
-      > .${pfx}-content {
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        overflow: hidden;
-      }
+    &.variant-default {
+      border-radius: 4px;
+      box-shadow: ${isDarkTheme ? "none" : theme.shadow.base};
+      border: ${isDarkTheme ? `solid 1px ${theme.palette.border}` : "none"};
+    }
 
-      &.${pfx}-variant-default {
-        border-radius: 4px;
-        box-shadow: ${isDarkTheme ? "none" : theme.shadow.base};
-        border: ${isDarkTheme ? `solid 1px ${theme.palette.border}` : "none"};
-      }
+    &.variant-sidebar {
+      border-radius: 0;
+      box-shadow: none;
+      border: ${isDarkTheme ? `solid 1px ${theme.palette.border}` : "none"};
+    }
 
-      &.${pfx}-variant-sidebar {
-        border-radius: 0;
-        box-shadow: none;
-        border: ${isDarkTheme ? `solid 1px ${theme.palette.border}` : "none"};
-      }
+    &.variant-widget {
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      box-shadow: none;
+      border: none;
+    }
 
-      &.${pfx}-variant-widget {
-        border-bottom-left-radius: 4px;
-        border-bottom-right-radius: 4px;
-        box-shadow: none;
-        border: none;
-      }
+    .loading {
+      display: flex;
+      height: 100%;
+      justify-content: center;
+      align-items: center;
 
-      .${pfx}-loading {
-        display: flex;
-        height: 100%;
-        justify-content: center;
-        align-items: center;
-
-        svg {
-          width: 48px;
-          height: 48px;
-        }
+      svg {
+        width: 48px;
+        height: 48px;
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/ModuleContainer/ModuleContainer.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/ModuleContainer.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import type { ForwardedRef, PropsWithChildren } from "react";
 import { forwardRef, useMemo } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import getChildOfType from "../../utils/getChildOfType";
 import getChildrenOfType from "../../utils/getChildrenOfType";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
@@ -11,7 +11,6 @@ import defaultStyles from "./ModuleContainer.styles";
 
 export type ModuleContainerProps = {
   id?: string;
-  classNamePrefix?: string;
   className?: string;
   /**
    * Variant allows to render the module to be attached in a sidebar
@@ -29,7 +28,6 @@ const ModuleContainer = (
   {
     id,
     children,
-    classNamePrefix = "ft",
     className,
     variant = "default",
     isLoading,
@@ -37,10 +35,9 @@ const ModuleContainer = (
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const rootClassname = useMemo(
-    () => styleWithTheme(defaultStyles(classNamePrefix)),
-    [classNamePrefix, styleWithTheme]
+    () => styleWithTheme(defaultStyles),
+    [styleWithTheme]
   );
 
   const headerContainerChildren = useMemo(() => {
@@ -74,15 +71,15 @@ const ModuleContainer = (
       id={id}
       className={cx(
         rootClassname,
-        pfx("module-container"),
-        pfx(`variant-${variant}`),
+        "module-container",
+        `variant-${variant}`,
         className
       )}
     >
       {headerContainerChildren}
-      <div className={pfx("content")}>
+      <div className={"content"}>
         {isLoading && (
-          <div className={pfx("loading")}>
+          <div className={"loading"}>
             <LoadingSpinner />
           </div>
         )}

--- a/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.styles.ts
@@ -1,56 +1,58 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    &.${pfx}-collapsed-actions, &.${pfx}-submenu {
-      padding: 0;
-      margin: 0;
-      border-radius: ${theme.shape.borderRadius};
+const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  &.collapsed-actions,
+  &.submenu {
+    padding: 0;
+    margin: 0;
+    border-radius: ${theme.shape.borderRadius};
 
-      .${pfx}-divider {
-        width: 60%;
-        height: 1px;
-        background: ${theme.palette.divider};
-        margin: ${theme.spacing["2x"]} auto;
+    .divider {
+      width: 60%;
+      height: 1px;
+      background: ${theme.palette.divider};
+      margin: ${theme.spacing["2x"]} auto;
+    }
+
+    .list-item {
+      border-radius: ${theme.shape.borderRadius};
+      font-size: ${theme.typography.sizes.xs};
+      padding-right: ${theme.spacing["2x"]};
+
+      .start-adornment,
+      .end-adornment {
+        font-size: ${theme.typography.sizes.lg};
+        color: ${theme.palette.grey[600]};
       }
 
-      .${pfx}-list-item {
-        border-radius: ${theme.shape.borderRadius};
-        font-size: ${theme.typography.sizes.xs};
-        padding-right: ${theme.spacing["2x"]};
+      .content {
+        min-height: 28px;
+        height: 28px;
+      }
 
-        .${pfx}-start-adornment, .${pfx}-end-adornment {
-          font-size: ${theme.typography.sizes.lg};
-          color: ${theme.palette.grey[600]};
-        }
+      .end-adornment {
+        min-width: 20px;
+        margin-right: 0px;
+      }
 
-        .${pfx}-content {
-          min-height: 28px;
-          height: 28px;
+      &.clickable:hover {
+        .start-adornment,
+        .end-adornment {
+          color: ${theme.palette.primary.main};
         }
-
-        .${pfx}-end-adornment {
-          min-width: 20px;
-          margin-right: 0px;
-        }
-
-        &.${pfx}-clickable:hover {
-          .${pfx}-start-adornment, .${pfx}-end-adornment {
-            color: ${theme.palette.primary.main};
-          }
-        }
-        &.${pfx}-submenu-is-open {
-          background-color: ${isDarkTheme
-            ? theme.palette.grey[700]
-            : theme.palette.grey[200]};
-          .${pfx}-start-adornment, .${pfx}-end-adornment {
-            color: ${theme.palette.primary.main};
-          }
+      }
+      &.submenu-is-open {
+        background-color: ${isDarkTheme
+          ? theme.palette.grey[700]
+          : theme.palette.grey[200]};
+        .start-adornment,
+        .end-adornment {
+          color: ${theme.palette.primary.main};
         }
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import { cloneElement, useState } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import Card from "../../Card";
 import ForwardIcon from "../../icons/ForwardIcon";
 import ListItem from "../../ListItem";
@@ -11,28 +11,20 @@ import defaultStyles from "./CollapsedActions.styles";
 import { Action } from "./ModuleContainerHeader";
 
 export type CollapsedActionsProps = {
-  classNamePrefix?: string;
   actions: (Action | "divider")[];
   onActionClick(action: string): void;
 };
 
 const CollapsedActions = ({
-  classNamePrefix = "ft",
   actions,
   onActionClick,
 }: CollapsedActionsProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const [open, setOpen] = useState(-1);
 
   return (
-    <Card
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("collapsed-actions")
-      )}
-    >
+    <Card className={cx(styleWithTheme(defaultStyles), "collapsed-actions")}>
       {actions.map((action, actionIndex) => {
         if (
           (actionIndex === 0 || actionIndex === actions.length - 1) &&
@@ -42,7 +34,7 @@ const CollapsedActions = ({
         }
 
         if (action === "divider") {
-          return <div key={actionIndex} className={pfx("divider")} />;
+          return <div key={actionIndex} className={"divider"} />;
         }
 
         if (action.collapsedItems) {
@@ -56,10 +48,9 @@ const CollapsedActions = ({
             >
               <UseLayerTrigger>
                 <ListItem
-                  classNamePrefix={"ft"}
-                  className={cx(pfx("list-item"), {
-                    [pfx("submenu-is-open")]: open === actionIndex,
-                    [pfx("submenu-is-disabled")]: action.isDisabled,
+                  className={cx("list-item", {
+                    ["submenu-is-open"]: open === actionIndex,
+                    ["submenu-is-disabled"]: action.isDisabled,
                   })}
                   clickable={!action.isDisabled}
                   startAdornment={action.icon}
@@ -74,7 +65,7 @@ const CollapsedActions = ({
               <UseLayerOverlay>
                 {cloneElement(action.collapsedItems, {
                   parentLayerSide: "left",
-                  className: styleWithTheme(defaultStyles(classNamePrefix)),
+                  className: styleWithTheme(defaultStyles),
                 })}
               </UseLayerOverlay>
             </UseLayer>
@@ -85,7 +76,7 @@ const CollapsedActions = ({
           <ListItem
             key={action.value}
             ref={action.ref}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={!action.isDisabled}
             onClick={() => {
               onActionClick(action.value);

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerFooter.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerFooter.styles.ts
@@ -1,24 +1,22 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-module-container-footer {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      width: 100%;
-      min-height: 42px;
-      padding: 0 ${theme.spacing["3x"]};
-      border-top: solid 1px ${theme.palette.border};
-      background-color: ${theme.palette.background.default};
-      color: ${theme.palette.text.primary};
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.module-container-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    min-height: 42px;
+    padding: 0 ${theme.spacing["3x"]};
+    border-top: solid 1px ${theme.palette.border};
+    background-color: ${theme.palette.background.default};
+    color: ${theme.palette.text.primary};
 
-      &.${pfx}-single-child {
-        justify-content: flex-end;
-      }
+    &.single-child {
+      justify-content: flex-end;
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerFooter.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerFooter.tsx
@@ -1,29 +1,26 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
 import { Children } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 
 import defaultStyles from "./ModuleContainerFooter.styles";
 
 export type ModuleContainerFooterProps = {
-  classNamePrefix?: string;
   className?: string;
 };
 
 const ModuleContainerFooter = ({
-  classNamePrefix = "ft",
   className,
   children,
 }: PropsWithChildren<ModuleContainerFooterProps>) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const numberOfChildren = Children.count(children);
   return (
     <div
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("module-container-footer"),
-        { [pfx("single-child")]: numberOfChildren === 1 },
+        styleWithTheme(defaultStyles),
+        "module-container-footer",
+        { ["single-child"]: numberOfChildren === 1 },
         className
       )}
     >

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.styles.ts
@@ -2,84 +2,80 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 import { fade } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-module-container-header {
-      display: flex;
-      align-items: center;
-      width: 100%;
-      min-height: 42px;
-      padding: 0 ${theme.spacing["2x"]} 0 ${theme.spacing["3x"]};
-      border-bottom: solid 1px ${theme.palette.border};
-      background-color: ${theme.palette.background.default};
-      color: ${theme.palette.text.primary};
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.module-container-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-height: 42px;
+    padding: 0 ${theme.spacing["2x"]} 0 ${theme.spacing["3x"]};
+    border-bottom: solid 1px ${theme.palette.border};
+    background-color: ${theme.palette.background.default};
+    color: ${theme.palette.text.primary};
 
-      .${pfx}-back-action {
-        margin-right: ${theme.spacing.base};
-      }
+    .back-action {
+      margin-right: ${theme.spacing.base};
+    }
 
-      .${pfx}-title-container {
-        > .${pfx}-title {
-          font-weight: bold;
-          display: -webkit-box;
-          -webkit-line-clamp: 1;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-        }
-        > .${pfx}-subtitle {
-          display: -webkit-box;
-          -webkit-line-clamp: 2;
-          -webkit-box-orient: vertical;
-          overflow: hidden;
-          font-size: ${theme.typography.sizes.xs};
-        }
+    .title-container {
+      > .title {
+        font-weight: bold;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
       }
-
-      .${pfx}-divider {
-        width: 1px;
-        height: 60%;
-        margin: auto ${theme.spacing["2x"]};
-        background-color: ${theme.palette.divider};
-      }
-
-      > .${pfx}-start-adornment {
-        display: flex;
-        align-items: center;
-        margin-right: ${theme.spacing["2x"]};
-      }
-
-      > .${pfx}-children-container {
-        flex-grow: 1;
-      }
-      > .${pfx}-actions-container {
-        height: 100%;
-        display: flex;
-        justify-content: flex-end;
-        align-items: center;
-      }
-
-      > .${pfx}-actions-container button:hover {
-        color: ${theme.palette.primary.main};
-      }
-
-      > .${pfx}-actions-container button:focus {
-        color: ${theme.palette.primary.main};
-        background-color: ${fade(theme.palette.primary.main, 0.2)};
+      > .subtitle {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        font-size: ${theme.typography.sizes.xs};
       }
     }
-  `;
+
+    .divider {
+      width: 1px;
+      height: 60%;
+      margin: auto ${theme.spacing["2x"]};
+      background-color: ${theme.palette.divider};
+    }
+
+    > .start-adornment {
+      display: flex;
+      align-items: center;
+      margin-right: ${theme.spacing["2x"]};
+    }
+
+    > .children-container {
+      flex-grow: 1;
+    }
+    > .actions-container {
+      height: 100%;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+    }
+
+    > .actions-container button:hover {
+      color: ${theme.palette.primary.main};
+    }
+
+    > .actions-container button:focus {
+      color: ${theme.palette.primary.main};
+      background-color: ${fade(theme.palette.primary.main, 0.2)};
+    }
+  }
+`;
 
 export default defaultStyles;
 
-export const buttonMenuListItem =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    font-size: ${theme.typography.sizes?.xs};
-    padding-right: ${theme.spacing["2x"]};
+export const buttonMenuListItem: ThemeStyleFn = ({ theme }) => css`
+  font-size: ${theme.typography.sizes?.xs};
+  padding-right: ${theme.spacing["2x"]};
 
-    .${pfx}-content {
-      min-height: 28px;
-      height: 28px;
-    }
-  `;
+  .content {
+    min-height: 28px;
+    height: 28px;
+  }
+`;

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.tsx
@@ -7,7 +7,7 @@ import type {
   RefObject,
 } from "react";
 import { forwardRef, Fragment, useMemo, useState } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import getChildrenOfType from "../../../utils/getChildrenOfType";
 import type { IconButtonProps } from "../../IconButton";
 import IconButton from "../../IconButton";
@@ -39,7 +39,6 @@ export type ActionItem = Action | "divider" | ReactNode;
 
 export type ModuleContainerHeaderProps = PropsWithChildren<{
   id?: string;
-  classNamePrefix?: string;
   className?: string;
   title: ReactNode;
   subtitle?: ReactNode;
@@ -64,7 +63,6 @@ const isActionType = (action: any): action is Action => {
 const ModuleContainerHeader = (
   {
     id,
-    classNamePrefix = "ft",
     className,
     title,
     subtitle,
@@ -81,7 +79,6 @@ const ModuleContainerHeader = (
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const [collapsedActionsOpen, setCollapsedActionsOpen] = useState(false);
 
   // Make the component controlled and uncontrolled
@@ -148,13 +145,13 @@ const ModuleContainerHeader = (
       id={id}
       ref={ref}
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("module-container-header"),
+        styleWithTheme(defaultStyles),
+        "module-container-header",
         className
       )}
     >
       {onBack && (
-        <div className={pfx("back-action")}>
+        <div className={"back-action"}>
           <IconButton
             tooltipText={"Go Back"}
             variant={"text"}
@@ -165,18 +162,18 @@ const ModuleContainerHeader = (
         </div>
       )}
       {startAdornment && (
-        <div className={pfx("start-adornment")}>{startAdornment}</div>
+        <div className={"start-adornment"}>{startAdornment}</div>
       )}
-      <div className={pfx("title-container")}>
-        <div className={pfx("title")}>{title}</div>
-        <div className={pfx("subtitle")}>{subtitle}</div>
+      <div className={"title-container"}>
+        <div className={"title"}>{title}</div>
+        <div className={"subtitle"}>{subtitle}</div>
       </div>
-      <div className={pfx("children-container")}>{nonActionsChildren}</div>
+      <div className={"children-container"}>{nonActionsChildren}</div>
       {actionsChildren}
-      <div className={pfx("actions-container")}>
+      <div className={"actions-container"}>
         {alwaysVisibleActions?.map((action, actionIndex) => {
           if (action === "divider") {
-            return <div key={actionIndex} className={pfx("divider")} />;
+            return <div key={actionIndex} className={"divider"} />;
           }
 
           if (isActionType(action)) {
@@ -217,7 +214,6 @@ const ModuleContainerHeader = (
             </UseLayerTrigger>
             <UseLayerOverlay>
               <CollapsedActions
-                classNamePrefix={classNamePrefix}
                 actions={collapsibleActions}
                 onActionClick={action => {
                   onActionClick?.(action);
@@ -230,8 +226,8 @@ const ModuleContainerHeader = (
       </div>
       {onClose && (
         <>
-          <div className={pfx("divider")} />
-          <div className={pfx("close-action")}>
+          <div className={"divider"} />
+          <div className={"close-action"}>
             <IconButton
               tooltipText={"Close"}
               variant={"text"}

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.styles.ts
@@ -2,48 +2,44 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 import { fade } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    &.${pfx}-module-container-header-actions {
-      height: 100%;
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-    }
+const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  &.module-container-header-actions {
+    height: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
 
-    &.${pfx}-module-container-header-actions > * {
-      margin-right: ${theme.spacing.base};
-    }
+  &.module-container-header-actions > * {
+    margin-right: ${theme.spacing.base};
+  }
 
-    &.${pfx}-module-container-header-actions button {
-      color: ${isDarkTheme ? theme.palette.grey[200] : theme.palette.grey[800]};
-    }
+  &.module-container-header-actions button {
+    color: ${isDarkTheme ? theme.palette.grey[200] : theme.palette.grey[800]};
+  }
 
-    &.${pfx}-module-container-header-actions button:hover {
-      color: ${theme.palette.primary.main};
-    }
+  &.module-container-header-actions button:hover {
+    color: ${theme.palette.primary.main};
+  }
 
-    &.${pfx}-module-container-header-actions button:focus {
-      color: ${theme.palette.primary.main};
-      background-color: ${fade(theme.palette.primary.main, 0.2)};
-    }
+  &.module-container-header-actions button:focus {
+    color: ${theme.palette.primary.main};
+    background-color: ${fade(theme.palette.primary.main, 0.2)};
+  }
 
-    &.${pfx}-module-container-header-actions button:disabled {
-      color: ${theme.palette.grey[500]};
-    }
-  `;
+  &.module-container-header-actions button:disabled {
+    color: ${theme.palette.grey[500]};
+  }
+`;
 
 export default defaultStyles;
 
-export const buttonMenuListItem =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    font-size: ${theme.typography.sizes?.xs};
-    padding-right: ${theme.spacing["2x"]};
+export const buttonMenuListItem: ThemeStyleFn = ({ theme }) => css`
+  font-size: ${theme.typography.sizes?.xs};
+  padding-right: ${theme.spacing["2x"]};
 
-    .${pfx}-content {
-      min-height: 28px;
-      height: 28px;
-    }
-  `;
+  .content {
+    min-height: 28px;
+    height: 28px;
+  }
+`;

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import { Fragment, useMemo, useState } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import IconButton from "../../IconButton";
 import MoreIcon from "../../icons/MoreIcon";
 import UseLayer, { UseLayerOverlay, UseLayerTrigger } from "../../UseLayer";
@@ -10,7 +10,6 @@ import defaultStyles from "./ModuleContainerHeaderActions.styles";
 
 export type ModuleContainerHeaderActionsProps = {
   variant?: "sidebar" | "default";
-  classNamePrefix?: string;
   actions?: Array<ActionItem>;
   onActionClick?(action: string): void;
   isCollapsedMenuOpen?: boolean;
@@ -26,7 +25,6 @@ const isActionType = (action: any): action is Action => {
 };
 
 const ModuleContainerHeaderActions = ({
-  classNamePrefix = "ft",
   variant,
   actions,
   onActionClick,
@@ -34,7 +32,6 @@ const ModuleContainerHeaderActions = ({
   onCollapsedMenuChange,
 }: ModuleContainerHeaderActionsProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const [collapsedActionsOpen, setCollapsedActionsOpen] = useState(false);
 
   // Make the component controlled and uncontrolled
@@ -82,13 +79,13 @@ const ModuleContainerHeaderActions = ({
   return (
     <div
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("module-container-header-actions")
+        styleWithTheme(defaultStyles),
+        "module-container-header-actions"
       )}
     >
       {alwaysVisibleActions?.map((action, actionIndex) => {
         if (action === "divider") {
-          return <div key={actionIndex} className={pfx("divider")} />;
+          return <div key={actionIndex} className={"divider"} />;
         }
 
         if (isActionType(action)) {
@@ -128,7 +125,6 @@ const ModuleContainerHeaderActions = ({
           </UseLayerTrigger>
           <UseLayerOverlay>
             <CollapsedActions
-              classNamePrefix={classNamePrefix}
               actions={collapsibleActions}
               onActionClick={action => {
                 onActionClick?.(action);

--- a/packages/graph-explorer/src/components/PanelEmptyState/PanelEmptyState.styles.ts
+++ b/packages/graph-explorer/src/components/PanelEmptyState/PanelEmptyState.styles.ts
@@ -75,7 +75,6 @@ const getStyleByVariant = (
 
 const styles =
   (
-    pfx: string,
     variant: "info" | "waiting" | "warning" | "error",
     size: "xs" | "sm" | "md" | "lg"
   ): ThemeStyleFn =>
@@ -89,24 +88,24 @@ const styles =
     height: 100%;
     z-index: 1;
 
-    &.${pfx}-panel-empty-state-horizontal {
+    &.panel-empty-state-horizontal {
       flex-direction: row;
-      .${pfx}-indicator-wrapper {
+      .indicator-wrapper {
         margin-bottom: 0;
         margin-right: 12px;
       }
-      .${pfx}-panel-empty-state-title {
+      .panel-empty-state-title {
         margin-bottom: 8px;
       }
-      .${pfx}-panel-empty-state-subtitle {
+      .panel-empty-state-subtitle {
         text-align: center;
       }
     }
 
-    .${pfx}-indicator-wrapper {
+    .indicator-wrapper {
       margin-bottom: 16px;
     }
-    .${pfx}-indicator {
+    .indicator {
       ${getStyleByVariant(variant, theme, isDarkTheme)};
       ${getIndicatorSize(size)};
       border-radius: 50%;
@@ -119,14 +118,14 @@ const styles =
       }
     }
 
-    .${pfx}-panel-empty-state-text-container {
+    .panel-empty-state-text-container {
       display: flex;
       flex-direction: column;
       justify-content: center;
       align-items: center;
     }
 
-    .${pfx}-panel-empty-state-title {
+    .panel-empty-state-title {
       margin: 0;
       margin-bottom: 4px;
       text-align: center;
@@ -137,7 +136,7 @@ const styles =
       font-weight: ${theme.emptyState?.panel?.title?.fontWeight || 500};
     }
 
-    .${pfx}-panel-empty-state-subtitle {
+    .panel-empty-state-subtitle {
       margin: 0;
       text-align: center;
       color: ${theme.emptyState?.panel?.subtitle?.color ||

--- a/packages/graph-explorer/src/components/PanelEmptyState/PanelEmptyState.tsx
+++ b/packages/graph-explorer/src/components/PanelEmptyState/PanelEmptyState.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren, ReactNode } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import Button from "../Button/Button";
 import styles from "./PanelEmptyState.styles";
 
@@ -10,7 +10,6 @@ export type PanelEmptyStateProps = {
   title?: ReactNode;
   subtitle?: ReactNode;
   className?: string;
-  classNamePrefix?: string;
   size?: "xs" | "sm" | "md" | "lg";
   onAction?: () => void;
   actionId?: string;
@@ -25,33 +24,31 @@ const PanelEmptyState = ({
   title,
   subtitle,
   className,
-  classNamePrefix = "ft",
   size = "md",
   actionId,
   onAction,
   actionLabel,
   layout = "vertical",
 }: PropsWithChildren<PanelEmptyStateProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const styleWithTheme = useWithTheme();
   return (
     <div
       className={cx(
         className,
-        pfx("panel-empty-state-wrapper"),
-        pfx(`panel-empty-state-${layout}`),
-        styleWithTheme(styles(classNamePrefix, variant, size))
+        "panel-empty-state-wrapper",
+        `panel-empty-state-${layout}`,
+        styleWithTheme(styles(variant, size))
       )}
     >
       {icon && (
-        <div className={pfx("indicator-wrapper")}>
-          <div className={pfx("indicator")}>{icon}</div>
+        <div className={"indicator-wrapper"}>
+          <div className={"indicator"}>{icon}</div>
         </div>
       )}
-      <div className={pfx("panel-empty-state-text-container")}>
-        {title && <h1 className={pfx("panel-empty-state-title")}>{title}</h1>}
+      <div className={"panel-empty-state-text-container"}>
+        {title && <h1 className={"panel-empty-state-title"}>{title}</h1>}
         {subtitle && (
-          <h2 className={pfx("panel-empty-state-subtitle")}>{subtitle}</h2>
+          <h2 className={"panel-empty-state-subtitle"}>{subtitle}</h2>
         )}
         {onAction && actionLabel && (
           <Button id={actionId} onPress={onAction} variant="text">

--- a/packages/graph-explorer/src/components/Section/Section.styles.ts
+++ b/packages/graph-explorer/src/components/Section/Section.styles.ts
@@ -2,14 +2,13 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
 type DefaultStylesProps = {
-  pfx: string;
   disablePadding?: boolean;
   disableBorder?: boolean;
   collapseAction?: "all" | "indicator";
 };
 
 const defaultStyles: (props: DefaultStylesProps) => ThemeStyleFn =
-  ({ pfx, disablePadding, disableBorder, collapseAction }) =>
+  ({ disablePadding, disableBorder, collapseAction }) =>
   ({ theme, isDarkTheme }) => css`
     display: flex;
     flex-direction: column;
@@ -23,7 +22,7 @@ const defaultStyles: (props: DefaultStylesProps) => ThemeStyleFn =
       border-bottom: none;
     }
 
-    .${pfx}-header-container {
+    .header-container {
       ${collapseAction === "all" ? "cursor: pointer;" : ""}
       display: flex;
       background: ${isDarkTheme
@@ -35,11 +34,11 @@ const defaultStyles: (props: DefaultStylesProps) => ThemeStyleFn =
       box-sizing: border-box;
     }
 
-    .${pfx}-title {
+    .title {
       flex-grow: 1;
     }
 
-    .${pfx}-collapse-action {
+    .collapse-action {
       display: flex;
       justify-content: center;
       align-items: center;
@@ -47,13 +46,13 @@ const defaultStyles: (props: DefaultStylesProps) => ThemeStyleFn =
       cursor: pointer;
     }
 
-    .${pfx}-collapsible-container {
+    .collapsible-container {
       flex-grow: 1;
       height: auto;
       padding: ${disablePadding ? 0 : `0 ${theme.spacing["2x"]}`};
     }
 
-    .${pfx}-collapsed {
+    .collapsed {
       height: 0;
       overflow: hidden;
     }

--- a/packages/graph-explorer/src/components/Section/Section.tsx
+++ b/packages/graph-explorer/src/components/Section/Section.tsx
@@ -6,13 +6,12 @@ import type {
   ReactNode,
 } from "react";
 import { Children, useMemo } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { ChevronDownIcon } from "../icons";
 import defaultStyles from "./Section.styles";
 
 export interface SectionProps
   extends Pick<HTMLAttributes<HTMLDivElement>, "style"> {
-  classNamePrefix?: string;
   className?: string;
   unmountOnCollapse?: boolean;
   /**
@@ -58,7 +57,6 @@ export interface SectionProps
 }
 
 export const Section = ({
-  classNamePrefix = "ft",
   className,
   children,
   title,
@@ -75,7 +73,6 @@ export const Section = ({
   ...styleProps
 }: PropsWithChildren<SectionProps>) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const headerContainer = useMemo(() => {
     if (!title && !collapsible) {
@@ -94,23 +91,23 @@ export const Section = ({
     );
     return (
       <div
-        className={pfx("header-container")}
+        className={"header-container"}
         onClick={ev =>
           collapseAction === "all" && onCollapseChange?.(!isCollapse, ev)
         }
       >
         {collapsible && collapseIndicatorPosition === "start" && (
           <div
-            className={pfx("collapse-action")}
+            className={"collapse-action"}
             onClick={ev => onCollapseChange?.(!isCollapse, ev)}
           >
             {collapseIndicator}
           </div>
         )}
-        <div className={pfx("title")}>{title}</div>
+        <div className={"title"}>{title}</div>
         {collapsible && collapseIndicatorPosition === "end" && (
           <div
-            className={pfx("collapse-action")}
+            className={"collapse-action"}
             onClick={ev => onCollapseChange?.(!isCollapse, ev)}
           >
             {collapseIndicator}
@@ -127,7 +124,6 @@ export const Section = ({
     isCollapse,
     reverse,
     title,
-    pfx,
   ]);
 
   // This allows to clean sections with conditional children or without them
@@ -146,8 +142,6 @@ export const Section = ({
       className={cx(
         styleWithTheme(
           defaultStyles({
-            pfx: classNamePrefix,
-            collapseAction,
             ...styleProps,
           })
         ),
@@ -157,11 +151,11 @@ export const Section = ({
     >
       {headerContainer}
       {Children.count(children) > 0 && (
-        <div className={pfx("content")}>
+        <div className={"content"}>
           {collapsible ? (
             <div
-              className={cx(pfx("collapsible-container"), {
-                [pfx("collapsed")]: isCollapse,
+              className={cx("collapsible-container", {
+                ["collapsed"]: isCollapse,
               })}
             >
               {unmountOnCollapse && isCollapse ? null : children}

--- a/packages/graph-explorer/src/components/Select/Select.styles.ts
+++ b/packages/graph-explorer/src/components/Select/Select.styles.ts
@@ -45,7 +45,6 @@ const getInnerLabelStyles = (
 
 type containerStylesParams = {
   labelPlacement: "top" | "left" | "inner";
-  classNamePrefix: string;
   size: "sm" | "md";
   validationState?: "invalid" | "valid";
   hideError?: boolean;
@@ -57,7 +56,6 @@ type containerStylesParams = {
 
 export const getStylesByVariantAndValidationState =
   (
-    classNamePrefix: string,
     variant: containerStylesParams["variant"],
     validationState: containerStylesParams["validationState"]
   ) =>
@@ -68,11 +66,11 @@ export const getStylesByVariantAndValidationState =
     )(variant);
     return css`
       cursor: pointer;
-      > .${classNamePrefix}-input-label {
+      > .input-label {
         color: ${themeWithDefault.label?.color};
       }
 
-      .${classNamePrefix}-select {
+      .select {
         color: ${themeWithDefault.color};
         border-radius: ${themeWithDefault.borderRadius};
         border: ${themeWithDefault.border};
@@ -91,11 +89,11 @@ export const getStylesByVariantAndValidationState =
         }
       }
 
-      .${classNamePrefix}-placeholder {
+      .placeholder {
         color: ${themeWithDefault.placeholderColor};
       }
 
-      .${classNamePrefix}-input-error {
+      .input-error {
         color: ${themeWithDefault.error?.errorColor};
       }
     `;
@@ -104,7 +102,6 @@ export const getStylesByVariantAndValidationState =
 export const selectContainerStyles =
   ({
     labelPlacement,
-    classNamePrefix,
     size,
     hideError,
     noMargin,
@@ -123,42 +120,42 @@ export const selectContainerStyles =
       margin-bottom: ${noMargin ? "0" : "14px"};
       cursor: pointer;
 
-      &.${classNamePrefix}-select-label-left {
+      &.select-label-left {
         flex-direction: row;
         align-items: center;
-        > .${classNamePrefix}-input-label {
+        > .input-label {
           width: 150px;
           line-height: 0.75em;
         }
       }
 
-      &.${classNamePrefix}-select-label-inner {
-        > .${classNamePrefix}-input-label {
+      &.select-label-inner {
+        > .input-label {
           font-size: 10px;
           pointer-events: none;
           ${getInnerLabelStyles(size, activeTheme)}
         }
       }
 
-      &.${classNamePrefix}-select-readonly {
+      &.select-readonly {
         pointer-events: none;
       }
 
-      > .${classNamePrefix}-input-label {
+      > .input-label {
         width: 100%;
         line-height: 0.875em;
         font-size: 0.875em;
         margin: 0 0 8px 0;
       }
 
-      .${classNamePrefix}-input-container {
+      .input-container {
         flex: 1;
         display: flex;
         position: relative;
       }
 
-      &.${classNamePrefix}-select-disabled {
-        .${classNamePrefix}-select {
+      &.select-disabled {
+        .select {
           filter: opacity(
             ${theme.select?.disabledOpacity ||
             theme.forms?.disabledOpacity ||
@@ -167,7 +164,7 @@ export const selectContainerStyles =
           pointer-events: none;
         }
       }
-      .${classNamePrefix}-select {
+      .select {
         font-family: inherit;
         text-align: left;
         cursor: pointer;
@@ -184,12 +181,12 @@ export const selectContainerStyles =
         )};
         flex: 1;
 
-        &.${classNamePrefix}-no-options {
+        &.no-options {
           padding-right: ${getPaddingBySize(size, activeTheme)};
         }
       }
 
-      .${classNamePrefix}-input-error {
+      .input-error {
         position: absolute;
         bottom: -14px;
         left: 0;
@@ -197,11 +194,10 @@ export const selectContainerStyles =
       }
 
       ${getStylesByVariantAndValidationState(
-        classNamePrefix,
         variant,
         validationState
       )(activeTheme)}
-      .${classNamePrefix}-dropdown-indicator {
+      .dropdown-indicator {
         position: absolute;
         right: calc(${getPaddingBySize(size, activeTheme)});
         top: ${labelPlacement === "inner" ? "calc(50% + 4px)" : "50%"};
@@ -212,10 +208,10 @@ export const selectContainerStyles =
         background-color: transparent;
         margin-right: 0;
 
-        .${classNamePrefix}-clear-button {
+        .clear-button {
           margin-right: -10px;
         }
-        .${classNamePrefix}-clear-button:hover {
+        .clear-button:hover {
           background-color: transparent;
         }
       }
@@ -231,53 +227,52 @@ const listStyles = () => css`
   outline: none;
 `;
 
-const listItemStyles =
-  (pfx: string) => (activeTheme: ActiveThemeType<ProcessedTheme>) => {
-    const themeWithDefault = getSelectThemeWithDefaults(
-      activeTheme,
-      "valid"
-    )("default");
+const listItemStyles = () => (activeTheme: ActiveThemeType<ProcessedTheme>) => {
+  const themeWithDefault = getSelectThemeWithDefaults(
+    activeTheme,
+    "valid"
+  )("default");
 
-    const { theme } = activeTheme;
-    return css`
-      background: ${themeWithDefault.list?.item?.background};
-      color: ${themeWithDefault.list?.item?.color};
-      padding: 8px;
-      display: flex;
-      align-items: center;
-      cursor: pointer;
-      outline: none;
+  const { theme } = activeTheme;
+  return css`
+    background: ${themeWithDefault.list?.item?.background};
+    color: ${themeWithDefault.list?.item?.color};
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    outline: none;
 
-      &:focus:not(.${pfx}-select-list-item-selected),
-      &.${pfx}-select-list-item-focused {
-        background: ${themeWithDefault.list?.item?.hover?.background};
-        color: ${themeWithDefault.list?.item?.hover?.color};
-      }
+    &:focus:not(.select-list-item-selected),
+    &.select-list-item-focused {
+      background: ${themeWithDefault.list?.item?.hover?.background};
+      color: ${themeWithDefault.list?.item?.hover?.color};
+    }
 
+    &:hover {
+      background: ${themeWithDefault.list?.item?.hover?.background};
+      color: ${themeWithDefault.list?.item?.hover?.color};
+    }
+
+    &.select-list-item-selected {
+      background: ${themeWithDefault.list?.item?.selected?.background};
+      color: ${themeWithDefault.list?.item?.selected?.color};
       &:hover {
-        background: ${themeWithDefault.list?.item?.hover?.background};
-        color: ${themeWithDefault.list?.item?.hover?.color};
-      }
-
-      &.${pfx}-select-list-item-selected {
         background: ${themeWithDefault.list?.item?.selected?.background};
         color: ${themeWithDefault.list?.item?.selected?.color};
-        &:hover {
-          background: ${themeWithDefault.list?.item?.selected?.background};
-          color: ${themeWithDefault.list?.item?.selected?.color};
-        }
       }
+    }
 
-      &.${pfx}-select-list-item-disabled {
-        pointer-events: none;
-        filter: opacity(
-          ${theme.forms?.disabledOpacity ||
-          theme?.select?.disabledOpacity ||
-          "40%"}
-        );
-      }
-    `;
-  };
+    &.select-list-item-disabled {
+      pointer-events: none;
+      filter: opacity(
+        ${theme.forms?.disabledOpacity ||
+        theme?.select?.disabledOpacity ||
+        "40%"}
+      );
+    }
+  `;
+};
 
 const itemStyles = () => css`
   display: flex;

--- a/packages/graph-explorer/src/components/Select/Select.tsx
+++ b/packages/graph-explorer/src/components/Select/Select.tsx
@@ -26,7 +26,6 @@ export type SelectProps = {
   ["aria-label"]?: string;
   labelPlacement?: "top" | "left" | "inner";
   className?: string;
-  classNamePrefix?: string;
   placeholder?: string;
   errorMessage?: string;
   hideError?: boolean;

--- a/packages/graph-explorer/src/components/Select/internalComponents/ListBox.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/ListBox.tsx
@@ -5,18 +5,16 @@ import type { ListState } from "@react-stately/list";
 import type { Node } from "@react-types/shared";
 import type { ForwardedRef, RefObject } from "react";
 import { forwardRef, useRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import styles from "../Select.styles";
 
 interface OptionProps<T> {
   item: Node<T>;
   state: ListState<T>;
-  classNamePrefix?: string;
 }
 
 interface ListBoxProps<T> extends AriaListBoxOptions<T> {
   state: ListState<T>;
-  classNamePrefix?: string;
 }
 
 // eslint-disable-next-line react/display-name
@@ -39,28 +37,18 @@ const ListBox = forwardRef(
         ref={ref}
       >
         {[...state.collection].map(item => (
-          <OptionItem
-            key={item.key}
-            classNamePrefix={props.classNamePrefix}
-            item={item}
-            state={state}
-          />
+          <OptionItem key={item.key} item={item} state={state} />
         ))}
       </ul>
     );
   }
 );
 
-const OptionItem = <T,>({
-  item,
-  state,
-  classNamePrefix = "ft",
-}: OptionProps<T>) => {
+const OptionItem = <T,>({ item, state }: OptionProps<T>) => {
   const ref = useRef<HTMLLIElement>(null);
 
   const itemDisabled = state.disabledKeys.has(item.key);
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const { optionProps, isSelected, isFocused, isDisabled } = useOption(
     {
@@ -75,22 +63,19 @@ const OptionItem = <T,>({
   return (
     <li
       className={cx(
-        styleWithTheme(styles.listItemStyles(classNamePrefix)),
-        pfx("select-list-item-wrapper"),
+        styleWithTheme(styles.listItemStyles()),
+        "select-list-item-wrapper",
         {
-          [pfx("select-list-item-disabled")]: isDisabled,
-          [pfx("select-list-item-selected")]: isSelected,
-          [pfx("select-list-item-focused")]: isFocused,
+          ["select-list-item-disabled"]: isDisabled,
+          ["select-list-item-selected"]: isSelected,
+          ["select-list-item-focused"]: isFocused,
         }
       )}
       {...optionProps}
       ref={ref}
     >
       <div
-        className={cx(
-          styleWithTheme(styles.itemStyles),
-          pfx("select-list-item")
-        )}
+        className={cx(styleWithTheme(styles.itemStyles), "select-list-item")}
       >
         {item.rendered}
       </div>

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectBox.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectBox.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { mergeRefs, useLayer } from "react-laag";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import IconButton from "../../IconButton";
 import { ChevronDownIcon } from "../../icons";
 import CloseIcon from "../../icons/CloseIcon";
@@ -34,7 +34,6 @@ const SelectBox = (
     isDisabled,
     isReadOnly,
     labelPlacement = "top",
-    classNamePrefix = "ft",
     size = "md",
     validationState,
     hideError,
@@ -64,8 +63,6 @@ const SelectBox = (
   const close = useCallback(() => {
     setMenuOpen(false);
   }, [setMenuOpen]);
-
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const selectedOptions = useMemo(() => {
     if (!props.selectedKeys) {
@@ -139,7 +136,6 @@ const SelectBox = (
         styleWithTheme(
           styles.selectContainerStyles({
             labelPlacement,
-            classNamePrefix,
             size,
             validationState,
             hideError,
@@ -148,13 +144,13 @@ const SelectBox = (
             clearable,
           })
         ),
-        pfx(`select-label-${labelPlacement}`),
-        pfx(`select-variant-${variant}`),
-        pfx(`select-size-${size}`),
-        pfx(`select-${validationState || "valid"}`),
+        `select-label-${labelPlacement}`,
+        `select-variant-${variant}`,
+        `select-size-${size}`,
+        `select-${validationState || "valid"}`,
         {
-          [pfx("select-disabled")]: isDisabled,
-          [pfx("select-readonly")]: isReadOnly,
+          ["select-disabled"]: isDisabled,
+          ["select-readonly"]: isReadOnly,
         },
         className
       )}
@@ -163,27 +159,27 @@ const SelectBox = (
         items.length > 0 && setMenuOpen(!menuOpen);
       }}
     >
-      {label && <label className={pfx("input-label")}>{label}</label>}
-      <div className={pfx("input-container")} aria-label={props["aria-label"]}>
+      {label && <label className={"input-label"}>{label}</label>}
+      <div className={"input-container"} aria-label={props["aria-label"]}>
         <button
           ref={mergeRefs(triggerProps.ref, ref)}
           type="button"
-          className={cx(pfx("select"), {
-            [pfx("no-options")]: items.length < 1,
-            [pfx("option-selected")]: selectedOptions !== "",
+          className={cx("select", {
+            ["no-options"]: items.length < 1,
+            ["option-selected"]: selectedOptions !== "",
           })}
         >
           {selectedOptions !== "" ? (
-            <span className={pfx("selection")}>{selectedOptions}</span>
+            <span className={"selection"}>{selectedOptions}</span>
           ) : (
-            <span className={pfx("placeholder")}>
+            <span className={"placeholder"}>
               {props.placeholder || "Select an option..."}
             </span>
           )}
-          <span className={pfx("dropdown-indicator")}>
+          <span className={"dropdown-indicator"}>
             {clearable && selectedOptions !== "" && (
               <IconButton
-                className={pfx("clear-button")}
+                className={"clear-button"}
                 as="span"
                 variant="text"
                 icon={<CloseIcon />}
@@ -199,7 +195,7 @@ const SelectBox = (
           </span>
         </button>
         {validationState === "invalid" && !!errorMessage && !hideError && (
-          <div className={pfx("input-error")}>{errorMessage}</div>
+          <div className={"input-error"}>{errorMessage}</div>
         )}
       </div>
       {items.length > 0 &&

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.styles.ts
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.styles.ts
@@ -2,33 +2,31 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../../core";
 import getSelectThemeWithDefaults from "../../utils/getThemeWithDefaultValues";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  activeTheme => {
-    const themeWithDefault = getSelectThemeWithDefaults(
-      activeTheme,
-      "valid"
-    )("default");
+const defaultStyles: ThemeStyleFn = activeTheme => {
+  const themeWithDefault = getSelectThemeWithDefaults(
+    activeTheme,
+    "valid"
+  )("default");
 
-    return css`
-      padding: ${activeTheme.theme.spacing["2x"]};
-      user-select: none;
-      margin: 0 ${activeTheme.theme.spacing["2x"]};
-      display: flex;
-      flex-direction: column;
+  return css`
+    padding: ${activeTheme.theme.spacing["2x"]};
+    user-select: none;
+    margin: 0 ${activeTheme.theme.spacing["2x"]};
+    display: flex;
+    flex-direction: column;
 
-      .${pfx}-select-header-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: ${themeWithDefault.list?.header?.title?.color};
-      }
+    .select-header-title {
+      font-size: 16px;
+      font-weight: 600;
+      color: ${themeWithDefault.list?.header?.title?.color};
+    }
 
-      .${pfx}-select-header-subtitle {
-        padding-top: ${activeTheme.theme.spacing.base};
-        font-size: 14px;
-        color: ${themeWithDefault.list?.header?.subtitle?.color};
-      }
-    `;
-  };
+    .select-header-subtitle {
+      padding-top: ${activeTheme.theme.spacing.base};
+      font-size: 14px;
+      color: ${themeWithDefault.list?.header?.subtitle?.color};
+    }
+  `;
+};
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.tsx
@@ -1,34 +1,27 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../../core";
+import { useWithTheme } from "../../../../core";
 import defaultStyles from "./SelectHeader.styles";
 
 interface SelectHeaderProps {
   className?: string;
-  classNamePrefix?: string;
   title?: string;
   subtitle?: string;
 }
 
 const SelectHeader = ({
-  classNamePrefix = "ft",
   className,
   title,
   subtitle,
 }: PropsWithChildren<SelectHeaderProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const styleWithTheme = useWithTheme();
   if (!title && !subtitle) {
     return null;
   }
   return (
-    <div
-      className={cx(styleWithTheme(defaultStyles(classNamePrefix)), className)}
-    >
-      {title && <div className={pfx("select-header-title")}>{title}</div>}
-      {subtitle && (
-        <div className={pfx("select-header-subtitle")}>{subtitle}</div>
-      )}
+    <div className={cx(styleWithTheme(defaultStyles), className)}>
+      {title && <div className={"select-header-title"}>{title}</div>}
+      {subtitle && <div className={"select-header-subtitle"}>{subtitle}</div>}
     </div>
   );
 };

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectListBox.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectListBox.tsx
@@ -12,7 +12,6 @@ import SelectHeader from "./SelectHeader/SelectHeader";
 type ListBoxProps<T> = ListProps<T> &
   Omit<SelectProps, "options" | "value" | "onChange"> & {
     items: Array<SelectOption>;
-    classNamePrefix?: string;
   };
 
 const SelectListBox = (props: ListBoxProps<SelectOption>) => {

--- a/packages/graph-explorer/src/components/Sidebar/Sidebar.styles.ts
+++ b/packages/graph-explorer/src/components/Sidebar/Sidebar.styles.ts
@@ -3,12 +3,10 @@ import type { ThemeStyleFn } from "../../core";
 import { fade } from "../../core";
 import { SidebarTheme } from "./Sidebar.model";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn<SidebarTheme> =>
-  ({ theme }) => {
-    const { sidebar, spacing, palette } = theme;
-    return css`
-    &.${pfx}-sidebar {
+const defaultStyles: ThemeStyleFn<SidebarTheme> = ({ theme }) => {
+  const { sidebar, spacing, palette } = theme;
+  return css`
+    &.sidebar {
       padding: ${spacing.base};
       height: 100%;
       display: flex;
@@ -17,19 +15,19 @@ const defaultStyles =
       background-color: ${fade(palette.primary.light, 0.2)};
       color: ${palette.text.primary};
 
-      .${pfx}-divider {
+      .divider {
         width: 60%;
         margin: ${spacing["2x"]} auto;
         height: 1px;
         background: ${palette.divider};
       }
 
-        &.${pfx}-active {
+        &.active {
           color: ${palette.primary.main};
         }
       }
 
-      .${pfx}-sidebar-button {
+      .sidebar-button {
         color: ${sidebar?.button?.color || palette.primary.dark};
         background-color: ${
           sidebar?.button?.background || fade(palette.primary.main, 0.2)
@@ -37,7 +35,7 @@ const defaultStyles =
         margin: ${spacing.base};
         padding: 0;
 
-        &.${pfx}-active {
+        &.active {
           color: ${sidebar?.button?.active?.color || palette.primary.dark};
           background-color: ${
             sidebar?.button?.active?.background ||
@@ -47,6 +45,6 @@ const defaultStyles =
       }
     }
   `;
-  };
+};
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/Sidebar/Sidebar.tsx
+++ b/packages/graph-explorer/src/components/Sidebar/Sidebar.tsx
@@ -1,12 +1,11 @@
 import { cx } from "@emotion/css";
 import type { ForwardedRef, PropsWithChildren } from "react";
 import { forwardRef } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import defaultStyles from "./Sidebar.styles";
 import SidebarButton from "./SidebarButton";
 
 export type SidebarProps = {
-  classNamePrefix?: string;
   className?: string;
 };
 
@@ -15,24 +14,15 @@ export type SidebarComposition = {
 };
 
 const Sidebar = (
-  {
-    children,
-    classNamePrefix = "ft",
-    className,
-  }: PropsWithChildren<SidebarProps>,
+  { children, className }: PropsWithChildren<SidebarProps>,
   ref?: ForwardedRef<HTMLDivElement>
 ) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   return (
     <div
       ref={ref}
-      className={cx(
-        stylesWithTheme(defaultStyles(classNamePrefix)),
-        pfx("sidebar"),
-        className
-      )}
+      className={cx(stylesWithTheme(defaultStyles), "sidebar", className)}
     >
       {children}
     </div>

--- a/packages/graph-explorer/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/graph-explorer/src/components/Sidebar/SidebarButton.tsx
@@ -1,6 +1,5 @@
 import { cx } from "@emotion/css";
 import type { ReactNode } from "react";
-import { withClassNamePrefix } from "../../core";
 import IconButton, { IconButtonProps } from "../IconButton";
 
 export type NavItem = {
@@ -13,21 +12,13 @@ export type SidebarButtonProps = {
   active?: boolean;
 } & Omit<IconButtonProps, "variant" | "rounded" | "tooltipPlacement">;
 
-const SidebarButton = ({
-  classNamePrefix = "ft",
-  className,
-  active,
-  ...props
-}: SidebarButtonProps) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
-
+const SidebarButton = ({ className, active, ...props }: SidebarButtonProps) => {
   return (
     <IconButton
       tooltipPlacement={"left-center"}
       variant={"text"}
       rounded={true}
-      classNamePrefix={classNamePrefix}
-      className={cx(pfx("sidebar-button"), active && pfx("active"), className)}
+      className={cx("sidebar-button", active && "active", className)}
       {...props}
     />
   );

--- a/packages/graph-explorer/src/components/Switch/Switch.styles.ts
+++ b/packages/graph-explorer/src/components/Switch/Switch.styles.ts
@@ -4,7 +4,7 @@ import { fade, ThemeStyleFn } from "../../core";
 import type { SwitchTheme } from "./Switch.model";
 
 export const defaultSwitchStyles =
-  (pfx: string, width: number): ThemeStyleFn<SwitchTheme> =>
+  (width: number): ThemeStyleFn<SwitchTheme> =>
   ({ theme }) => {
     const { switchTheme, palette } = theme;
     const trackWidth = width - 10;
@@ -16,11 +16,11 @@ export const defaultSwitchStyles =
       justify-content: center;
       align-items: center;
       padding: 4px 5px;
-      &.${pfx}-switch-on {
-        .${pfx}-switch-track {
+      &.switch-on {
+        .switch-track {
           background: ${switchTheme?.on?.background || palette.primary.main};
           justify-content: flex-end;
-          .${pfx}-switch-handle {
+          .switch-handle {
             transform: translateX(calc(${trackWidth - 2}px - 100% - 2px));
             color: ${switchTheme?.on?.iconColor || palette.primary.main};
             background-color: ${switchTheme?.on?.handleBackground ||
@@ -29,20 +29,20 @@ export const defaultSwitchStyles =
         }
       }
 
-      &.${pfx}-switch-off {
-        .${pfx}-switch-track {
+      &.switch-off {
+        .switch-track {
           justify-content: flex-start;
           background-color: ${switchTheme?.off?.background ||
           palette.grey["500"]};
-          .${pfx}-switch-handle {
+          .switch-handle {
             color: ${switchTheme?.off?.iconColor || palette.grey["500"]};
             background-color: ${switchTheme?.off?.handleBackground ||
             palette.common.white};
           }
         }
       }
-      &.${pfx}-switch-focused {
-        .${pfx}-switch-track {
+      &.switch-focused {
+        .switch-track {
           outline: 2px solid
             ${fade(
               switchTheme?.focus?.outlineColor || palette.primary.main,
@@ -51,9 +51,9 @@ export const defaultSwitchStyles =
         }
       }
 
-      &.${pfx}-switch-sm {
-        .${pfx}-switch-track {
-          .${pfx}-switch-handle {
+      &.switch-sm {
+        .switch-track {
+          .switch-handle {
             width: 36%;
             svg {
               font-size: 9px;
@@ -62,9 +62,9 @@ export const defaultSwitchStyles =
         }
       }
 
-      &.${pfx}-switch-lg {
-        .${pfx}-switch-track {
-          .${pfx}-switch-handle {
+      &.switch-lg {
+        .switch-track {
+          .switch-handle {
             width: 50%;
             svg {
               font-size: 15px;
@@ -72,7 +72,7 @@ export const defaultSwitchStyles =
           }
         }
       }
-      .${pfx}-switch-track {
+      .switch-track {
         cursor: pointer;
         height: 100%;
         width: 100%;
@@ -81,7 +81,7 @@ export const defaultSwitchStyles =
         position: relative;
         display: flex;
         align-items: center;
-        .${pfx}-switch-handle {
+        .switch-handle {
           width: 46%;
           left: 0;
           height: calc(100% - 4px);
@@ -100,7 +100,7 @@ export const defaultSwitchStyles =
         }
       }
 
-      &.${pfx}-switch-disabled {
+      &.switch-disabled {
         filter: opacity(
           ${switchTheme?.disabledOpacity ||
           theme.forms?.disabledOpacity ||
@@ -113,33 +113,33 @@ export const defaultSwitchStyles =
     `;
   };
 
-export const defaultSwitchLabelStyles =
-  (pfx: string): ThemeStyleFn<SwitchTheme> =>
-  ({ theme }) => {
-    const {
-      switchTheme,
-      palette: { text },
-      forms,
-    } = theme;
+export const defaultSwitchLabelStyles: ThemeStyleFn<SwitchTheme> = ({
+  theme,
+}) => {
+  const {
+    switchTheme,
+    palette: { text },
+    forms,
+  } = theme;
 
-    return css`
-      display: flex;
-      align-items: center;
-      cursor: pointer;
-      color: ${text.primary};
-      font-size: ${theme.typography.sizes?.sm};
+  return css`
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    color: ${text.primary};
+    font-size: ${theme.typography.sizes?.sm};
 
-      &.${pfx}-switch-label-disabled {
-        cursor: auto;
-        pointer-events: none;
-        filter: opacity(
-          ${switchTheme?.disabledOpacity || forms?.disabledOpacity || "50%"}
-        );
-      }
+    &.switch-label-disabled {
+      cursor: auto;
+      pointer-events: none;
+      filter: opacity(
+        ${switchTheme?.disabledOpacity || forms?.disabledOpacity || "50%"}
+      );
+    }
 
-      &.${pfx}-switch-label-readonly {
-        cursor: auto;
-        pointer-events: none;
-      }
-    `;
-  };
+    &.switch-label-readonly {
+      cursor: auto;
+      pointer-events: none;
+    }
+  `;
+};

--- a/packages/graph-explorer/src/components/Switch/Switch.tsx
+++ b/packages/graph-explorer/src/components/Switch/Switch.tsx
@@ -6,7 +6,7 @@ import { useSwitch } from "@react-aria/switch";
 import { VisuallyHidden } from "@react-aria/visually-hidden";
 import type { AriaSwitchProps } from "@react-types/switch";
 
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { defaultSwitchLabelStyles, defaultSwitchStyles } from "./Switch.styles";
 
 const sizeMap = {
@@ -26,7 +26,6 @@ const sizeMap = {
 
 export interface SwitchProps extends AriaSwitchProps {
   className?: string;
-  classNamePrefix?: string;
   size?: "sm" | "md" | "lg";
   isSelected: boolean;
   onChange: (isSelected: boolean) => void;
@@ -38,14 +37,7 @@ export interface SwitchProps extends AriaSwitchProps {
 // eslint-disable-next-line react/display-name
 export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   (
-    {
-      size = "md",
-      classNamePrefix = "ft",
-      labelPosition = "right",
-      onIcon,
-      offIcon,
-      ...props
-    },
+    { size = "md", labelPosition = "right", onIcon, offIcon, ...props },
     ref
   ) => {
     const { isSelected, onChange, className, isDisabled, isReadOnly } = props;
@@ -59,19 +51,14 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       ref as RefObject<HTMLInputElement>
     );
     const { isFocusVisible, focusProps } = useFocusRing();
-    const pfx = withClassNamePrefix(classNamePrefix);
     const styleWithTheme = useWithTheme();
     return (
       <label
         onClick={e => e.stopPropagation()}
-        className={cx(
-          className,
-          styleWithTheme(defaultSwitchLabelStyles(classNamePrefix)),
-          {
-            [pfx("switch-label-disabled")]: isDisabled,
-            [pfx("switch-label-readonly")]: isReadOnly,
-          }
-        )}
+        className={cx(className, styleWithTheme(defaultSwitchLabelStyles), {
+          ["switch-label-disabled"]: isDisabled,
+          ["switch-label-readonly"]: isReadOnly,
+        })}
       >
         <VisuallyHidden>
           <input
@@ -84,19 +71,17 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
         <div
           style={{ width: sizeMap[size].width, height: sizeMap[size].height }}
           className={cx(
-            styleWithTheme(
-              defaultSwitchStyles(classNamePrefix, sizeMap[size].width)
-            ),
-            isSelected ? pfx("switch-on") : pfx("switch-off"),
-            pfx(`switch-${size}`),
+            styleWithTheme(defaultSwitchStyles(sizeMap[size].width)),
+            isSelected ? "switch-on" : "switch-off",
+            `switch-${size}`,
             {
-              [pfx("switch-disabled")]: isDisabled,
-              [pfx("switch-focused")]: isFocusVisible,
+              ["switch-disabled"]: isDisabled,
+              ["switch-focused"]: isFocusVisible,
             }
           )}
         >
-          <div className={pfx("switch-track")}>
-            <div className={pfx("switch-handle")}>
+          <div className={"switch-track"}>
+            <div className={"switch-handle"}>
               {isSelected && onIcon} {!isSelected && offIcon}
             </div>
           </div>

--- a/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.styles.ts
+++ b/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.styles.ts
@@ -1,57 +1,55 @@
 import { css } from "@emotion/css";
 import { ThemeStyleFn } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => {
-    const { palette } = theme;
-    return css`
-      &.${pfx}-entities-tabular-header {
-        position: relative;
-        z-index: 100;
+const defaultStyles: ThemeStyleFn = ({ theme }) => {
+  const { palette } = theme;
+  return css`
+    &.entities-tabular-header {
+      position: relative;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+      width: 100%;
+      height: 42px;
+      min-height: 42px;
+      padding: 0 ${theme.spacing["3x"]};
+      border-bottom: solid 1px ${palette.divider};
+      background-color: ${palette.background.default};
+      color: ${palette.text.primary};
+
+      > .title {
         display: flex;
         align-items: center;
-        width: 100%;
-        height: 42px;
-        min-height: 42px;
-        padding: 0 ${theme.spacing["3x"]};
-        border-bottom: solid 1px ${palette.divider};
-        background-color: ${palette.background.default};
-        color: ${palette.text.primary};
+        font-weight: bold;
+        margin-right: ${theme.spacing["4x"]};
 
-        > .${pfx}-title {
-          display: flex;
-          align-items: center;
-          font-weight: bold;
-          margin-right: ${theme.spacing["4x"]};
-
-          > .${pfx}-icon {
-            font-size: 1.715em;
-            margin-right: ${theme.spacing["2x"]};
-          }
-        }
-
-        > .${pfx}-select-table {
-          display: flex;
-          align-items: center;
-          min-width: 200px;
-
-          > * {
-            margin-bottom: 0;
-          }
-        }
-
-        .${pfx}-space {
-          flex-grow: 1;
-        }
-
-        > .${pfx}-divider {
-          width: 2px;
-          height: 60%;
-          margin: auto ${theme.spacing.base};
-          background-color: ${palette.divider};
+        > .icon {
+          font-size: 1.715em;
+          margin-right: ${theme.spacing["2x"]};
         }
       }
-    `;
-  };
+
+      > .select-table {
+        display: flex;
+        align-items: center;
+        min-width: 200px;
+
+        > * {
+          margin-bottom: 0;
+        }
+      }
+
+      .space {
+        flex-grow: 1;
+      }
+
+      > .divider {
+        width: 2px;
+        height: 60%;
+        margin: auto ${theme.spacing.base};
+        background-color: ${palette.divider};
+      }
+    }
+  `;
+};
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import { ReactNode } from "react";
 
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import { GridIcon } from "../../icons";
 import Select from "../../Select";
 import { ExportControl } from "../controls";
@@ -23,25 +23,21 @@ const ModuleContainerTabularHeader = ({
   onTableChange,
   moduleName = "Table View",
 }: EntitiesTabularHeaderProps) => {
-  const pfx = withClassNamePrefix("ft");
   const styleWithTheme = useWithTheme();
 
   return (
     <div
-      className={cx(
-        styleWithTheme(defaultStyles("ft")),
-        pfx("entities-tabular-header")
-      )}
+      className={cx(styleWithTheme(defaultStyles), "entities-tabular-header")}
     >
-      <div className={pfx("title")}>
+      <div className={"title"}>
         {startAdornment ? (
-          <div className={pfx("start-adornment")}>{startAdornment}</div>
+          <div className={"start-adornment"}>{startAdornment}</div>
         ) : (
-          <GridIcon className={pfx("icon")} />
+          <GridIcon className={"icon"} />
         )}
         {moduleName}
       </div>
-      <div className={pfx("select-table")}>
+      <div className={"select-table"}>
         <Select
           aria-label={"Table"}
           value={selectedTable}
@@ -50,7 +46,7 @@ const ModuleContainerTabularHeader = ({
           hideError={true}
         />
       </div>
-      <div className={pfx("space")} />
+      <div className={"space"} />
       <ExportControl />
     </div>
   );

--- a/packages/graph-explorer/src/components/Tabular/Tabular.styles.ts
+++ b/packages/graph-explorer/src/components/Tabular/Tabular.styles.ts
@@ -6,7 +6,6 @@ import baseTheme from "./baseTheme";
 
 const defaultStyles =
   (
-    pfx: string,
     variant: "bordered" | "noBorders" = "bordered"
   ): ThemeStyleFn<TabularTheme> =>
   ({ theme, isDarkTheme }) => {
@@ -23,7 +22,7 @@ const defaultStyles =
       background: ${tabular?.background || palette.background.default};
       color: ${tabular?.color || palette.text.primary};
 
-      .${pfx}-table {
+      .table {
         flex-grow: 1;
         width: 100%;
         position: relative;
@@ -31,7 +30,7 @@ const defaultStyles =
         flex-direction: column;
       }
 
-      .${pfx}-headers {
+      .headers {
         box-sizing: border-box;
         width: fit-content;
         min-width: 100%;
@@ -42,18 +41,18 @@ const defaultStyles =
         ${variant === "noBorders" && `border-right: none; border-left: none;`}
         min-height: ${tabular?.header?.minHeight || baseTheme.header.minHeight};
 
-        .${pfx}-row:last-child {
+        .row:last-child {
           border-bottom: none;
         }
       }
 
-      .${pfx}-headers-sticky {
+      .headers-sticky {
         position: sticky;
         top: 0;
         z-index: 1;
       }
 
-      .${pfx}-row {
+      .row {
         box-sizing: border-box;
         min-height: ${tabular?.row?.minHeight || baseTheme.row.minHeight};
         border-bottom: ${variant === "bordered"
@@ -81,11 +80,11 @@ const defaultStyles =
         }
       }
 
-      .${pfx}-row-grow {
+      .row-grow {
         flex-grow: 1 !important;
       }
 
-      .${pfx}-row-selectable {
+      .row-selectable {
         background: ${tabular?.row?.selectable?.background ||
         baseTheme.row.selectable.background};
         color: ${tabular?.row?.selectable?.color ||
@@ -99,13 +98,13 @@ const defaultStyles =
         }
       }
 
-      .${pfx}-row-selected {
+      .row-selected {
         background: ${tabular?.row?.selected?.background ||
         fade(palette.primary.main, 0.25)};
         color: ${tabular?.row?.selected?.color || baseTheme.row.selected.color};
       }
 
-      .${pfx}-header {
+      .header {
         display: flex;
         flex-direction: column;
         padding: ${tabular?.header?.padding || baseTheme.header.padding};
@@ -120,7 +119,7 @@ const defaultStyles =
           border 250ms ease-in;
       }
 
-      .${pfx}-header-label {
+      .header-label {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -137,7 +136,7 @@ const defaultStyles =
         baseTheme.header.label.padding};
       }
 
-      .${pfx}-header-filter {
+      .header-filter {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
@@ -152,7 +151,7 @@ const defaultStyles =
         baseTheme.header.filter.padding};
       }
 
-      .${pfx}-header-resizing {
+      .header-resizing {
         background: ${tabular?.header?.resizing?.background ||
         palette.background.contrastSecondary};
         color: ${tabular?.header?.resizing?.color ||
@@ -161,7 +160,7 @@ const defaultStyles =
         `1px dashed ${palette.border}`};
       }
 
-      .${pfx}-header-label-sorter {
+      .header-label-sorter {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -172,7 +171,7 @@ const defaultStyles =
         baseTheme.header.sorter.opacity};
       }
 
-      .${pfx}-cell {
+      .cell {
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -185,27 +184,27 @@ const defaultStyles =
           : "none"};
       }
 
-      .${pfx}-cell-content {
+      .cell-content {
         width: 100%;
       }
 
-      .${pfx}-cell-overflow-ellipsis {
+      .cell-overflow-ellipsis {
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
-      .${pfx}-cell-overflow-truncate {
+      .cell-overflow-truncate {
         max-width: 100%;
         overflow: hidden;
       }
 
-      .${pfx}-cell-one-line {
+      .cell-one-line {
         word-break: keep-all;
         white-space: nowrap;
       }
 
-      .${pfx}-cell-resizing {
+      .cell-resizing {
         background: ${tabular?.row?.resizing?.background ||
         palette.background.contrastSecondary};
         color: ${tabular?.row?.resizing?.background ||
@@ -214,19 +213,21 @@ const defaultStyles =
         `1px dashed ${palette.border}`};
       }
 
-      .${pfx}-header-label-align-left, .${pfx}-cell-align-left {
+      .header-label-align-left,
+      .cell-align-left {
         flex-direction: row;
         justify-content: flex-start;
         text-align: left;
       }
 
-      .${pfx}-header-label-align-right, .${pfx}-cell-align-right {
+      .header-label-align-right,
+      .cell-align-right {
         flex-direction: row-reverse;
         justify-content: flex-start;
         text-align: right;
       }
 
-      .${pfx}-header-label-sortable {
+      .header-label-sortable {
         cursor: pointer;
         justify-content: space-between;
 
@@ -236,7 +237,7 @@ const defaultStyles =
             overflow: hidden;
           }
 
-          .${pfx}-header-label-sorter {
+          .header-label-sorter {
             color: ${tabular?.header?.sorter?.hover?.color ||
             baseTheme.header.sorter.hover.color};
             opacity: ${tabular?.header?.sorter?.hover?.opacity ||
@@ -245,25 +246,27 @@ const defaultStyles =
         }
       }
 
-      .${pfx}-header-label-sort-desc, .${pfx}-header-label-sort-asc {
+      .header-label-sort-desc,
+      .header-label-sort-asc {
         > div:first-child {
           max-width: calc(100% - 16px);
           overflow: hidden;
         }
       }
 
-      .${pfx}-header-overflow-ellipsis {
+      .header-overflow-ellipsis {
         max-width: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
-      .${pfx}-header-overflow-truncate {
+      .header-overflow-truncate {
         max-width: 100%;
         overflow: hidden;
       }
 
-      .${pfx}-col-resizer, .${pfx}-cell-resizer {
+      .col-resizer,
+      .cell-resizer {
         position: absolute;
         top: 0;
         right: 0;
@@ -272,7 +275,7 @@ const defaultStyles =
         z-index: 1;
       }
 
-      .${pfx}-body {
+      .body {
         width: fit-content;
         min-width: 100%;
         flex-grow: 1;

--- a/packages/graph-explorer/src/components/Tabular/Tabular.tsx
+++ b/packages/graph-explorer/src/components/Tabular/Tabular.tsx
@@ -11,7 +11,7 @@ import {
 import type { TableInstance } from "react-table";
 import useDeepCompareEffect from "use-deep-compare-effect";
 
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { useDeepMemo } from "../../hooks";
 import { getChildOfType } from "../../utils";
 
@@ -36,7 +36,6 @@ import useTabular from "./useTabular";
 export type TabularVariantType = "bordered" | "noBorders";
 
 export interface TabularProps<T extends object> extends TabularOptions<T> {
-  classNamePrefix?: string;
   className?: string;
 
   /**
@@ -57,7 +56,6 @@ export interface TabularProps<T extends object> extends TabularOptions<T> {
 export const Tabular = <T extends Record<string, unknown>>(
   {
     children,
-    classNamePrefix = "ft",
     className,
     data,
     disablePagination,
@@ -81,7 +79,6 @@ export const Tabular = <T extends Record<string, unknown>>(
 
   const tabularContentProps = {
     children,
-    classNamePrefix,
     className,
     data,
     disablePagination,
@@ -131,7 +128,6 @@ export const Tabular = <T extends Record<string, unknown>>(
 
 const TabularContent = <T extends Record<string, unknown>>({
   children,
-  classNamePrefix = "ft",
   className,
   tableInstance,
   disablePagination,
@@ -144,7 +140,6 @@ const TabularContent = <T extends Record<string, unknown>>({
 }: PropsWithChildren<
   TabularProps<T> & { tableInstance: TableInstance<T> }
 >) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { tableRef, headerControlsRef, headerControlsPosition } =
     useTabularControl();
   const [stickyHeaderTop, setStickyHeaderTop] = useState(0);
@@ -217,10 +212,7 @@ const TabularContent = <T extends Record<string, unknown>>({
   return (
     <div
       ref={tableRef}
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix, variant)),
-        className
-      )}
+      className={cx(styleWithTheme(defaultStyles(variant)), className)}
       style={{
         userSelect: tableInstance.state.columnResizing?.isResizingColumn
           ? "none"
@@ -228,10 +220,10 @@ const TabularContent = <T extends Record<string, unknown>>({
       }}
     >
       {headerControlsChildren}
-      <div {...getTableProps()} className={pfx("table")}>
+      <div {...getTableProps()} className={"table"}>
         <div
-          className={cx(pfx("headers"), {
-            [pfx("headers-sticky")]: !disableStickyHeader,
+          className={cx("headers", {
+            ["headers-sticky"]: !disableStickyHeader,
           })}
           style={{
             // Top is assigned depending on the header-controls visibility and height
@@ -247,7 +239,7 @@ const TabularContent = <T extends Record<string, unknown>>({
             />
           ))}
         </div>
-        <div {...getTableBodyProps()} className={pfx("body")}>
+        <div {...getTableBodyProps()} className={"body"}>
           {emptyBodyControlsChildren}
           {actualRows.map(row => {
             return (
@@ -267,10 +259,7 @@ const TabularContent = <T extends Record<string, unknown>>({
       {footerControlsChildren}
       {!footerControlsChildren && !disablePagination && (
         <TabularFooterControls variant={variant}>
-          <PaginationControl
-            classNamePrefix={classNamePrefix}
-            totalRows={rows.length}
-          />
+          <PaginationControl totalRows={rows.length} />
         </TabularFooterControls>
       )}
     </div>

--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
@@ -1,25 +1,21 @@
 import { cx } from "@emotion/css";
 
-import { withClassNamePrefix } from "../../core";
 import type { HeaderGroup, TableInstance } from "react-table";
 
 import { ArrowDown } from "../icons";
-import type { TabularProps } from "./Tabular";
 
 const TabularHeader = <T extends object>({
-  classNamePrefix = "ft",
   headerGroup,
   tableInstance,
-}: Pick<TabularProps<T>, "classNamePrefix"> & {
+}: {
   tableInstance: TableInstance<T>;
   headerGroup: HeaderGroup<T>;
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { state } = tableInstance;
   const { key, ...otherProps } = headerGroup.getHeaderGroupProps();
 
   return (
-    <div key={key} {...otherProps} className={pfx("row")}>
+    <div key={key} {...otherProps} className={"row"}>
       {headerGroup.headers.map(column => {
         const { key, style, ...restHeaderProps } = column.getHeaderProps(
           column.getSortByToggleProps({
@@ -32,8 +28,8 @@ const TabularHeader = <T extends object>({
           <div
             key={key}
             style={style}
-            className={cx(pfx("header"), {
-              [pfx("header-resizing")]:
+            className={cx("header", {
+              ["header-resizing"]:
                 column.isResizing ||
                 state.columnResizing?.isResizingColumn === column.id,
             })}
@@ -41,29 +37,26 @@ const TabularHeader = <T extends object>({
             <div
               {...restHeaderProps}
               className={cx(
-                pfx("header-label"),
-                pfx(`header-label-align-${column.align || "left"}`),
+                "header-label",
+                `header-label-align-${column.align || "left"}`,
                 {
-                  [pfx("header-label-sortable")]: column.canSort,
-                  [pfx(
-                    `header-label-sort-${column.isSortedDesc ? "desc" : "asc"}`
-                  )]: column.isSorted,
+                  ["header-label-sortable"]: column.canSort,
+                  [`header-label-sort-${column.isSortedDesc ? "desc" : "asc"}`]:
+                    column.isSorted,
                 }
               )}
             >
               <div
                 className={cx({
-                  [pfx("header-overflow-ellipsis")]:
-                    column.overflow === "ellipsis",
-                  [pfx("header-overflow-truncate")]:
-                    column.overflow === "truncate",
+                  ["header-overflow-ellipsis"]: column.overflow === "ellipsis",
+                  ["header-overflow-truncate"]: column.overflow === "truncate",
                 })}
               >
                 {column.render("Header")}
               </div>
               <div>
                 <div
-                  className={pfx("header-label-sorter")}
+                  className={"header-label-sorter"}
                   style={{
                     opacity: column.isSorted ? 1 : 0,
                     transform: column.isSortedDesc ? "unset" : "rotate(180deg)",
@@ -74,14 +67,12 @@ const TabularHeader = <T extends object>({
               </div>
             </div>
             {column.canFilter && (
-              <div className={pfx("header-filter")}>
-                {column.render("Filter")}
-              </div>
+              <div className={"header-filter"}>{column.render("Filter")}</div>
             )}
             {column.canResize && (
               <div
                 {...(column.getResizerProps?.() || {})}
-                className={pfx("col-resizer")}
+                className={"col-resizer"}
               />
             )}
           </div>

--- a/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
@@ -2,28 +2,22 @@ import { cx } from "@emotion/css";
 
 import { MouseEvent, useEffect, useState } from "react";
 import type { Row, TableInstance } from "react-table";
-import { withClassNamePrefix } from "../../core";
 
 import type { TabularProps } from "./Tabular";
 
 const TabularRow = <T extends object>({
-  classNamePrefix = "ft",
   fitRowsVertically,
   rowSelectionMode,
   row,
   tableInstance,
   onMouseOver,
   onMouseOut,
-}: Pick<
-  TabularProps<T>,
-  "classNamePrefix" | "fitRowsVertically" | "rowSelectionMode"
-> & {
+}: Pick<TabularProps<T>, "fitRowsVertically" | "rowSelectionMode"> & {
   tableInstance: TableInstance<T>;
   row: Row<T>;
   onMouseOver?(event: MouseEvent<HTMLDivElement>, row: Row<T>): void;
   onMouseOut?(event: MouseEvent<HTMLDivElement>, row: Row<T>): void;
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { prepareRow, state } = tableInstance;
   prepareRow(row);
 
@@ -49,10 +43,10 @@ const TabularRow = <T extends object>({
   return (
     <div
       {...rowProps}
-      className={cx(pfx("row"), {
-        [pfx("row-grow")]: fitRowsVertically,
-        [pfx("row-selectable")]: rowSelectionMode === "row",
-        [pfx("row-selected")]: row.isSelected,
+      className={cx("row", {
+        ["row-grow"]: fitRowsVertically,
+        ["row-selectable"]: rowSelectionMode === "row",
+        ["row-selected"]: row.isSelected,
       })}
       onClick={() =>
         rowSelectionMode === "row" && selectable && row.toggleRowSelected()
@@ -68,23 +62,17 @@ const TabularRow = <T extends object>({
           <div
             key={key}
             {...cellProps}
-            className={cx(
-              pfx("cell"),
-              pfx(`cell-align-${cell.column.align || "left"}`),
-              {
-                [pfx("cell-resizing")]:
-                  cell.column.isResizing ||
-                  state.columnResizing?.isResizingColumn === cell.column.id,
-              }
-            )}
+            className={cx("cell", `cell-align-${cell.column.align || "left"}`, {
+              ["cell-resizing"]:
+                cell.column.isResizing ||
+                state.columnResizing?.isResizingColumn === cell.column.id,
+            })}
           >
             <div
-              className={cx(pfx("cell-content"), {
-                [pfx("cell-overflow-ellipsis")]:
-                  cell.column.overflow === "ellipsis",
-                [pfx("cell-overflow-truncate")]:
-                  cell.column.overflow === "truncate",
-                [pfx("cell-one-line")]: cell.column.oneLine,
+              className={cx("cell-content", {
+                ["cell-overflow-ellipsis"]: cell.column.overflow === "ellipsis",
+                ["cell-overflow-truncate"]: cell.column.overflow === "truncate",
+                ["cell-one-line"]: cell.column.oneLine,
               })}
             >
               {cell.render("Cell")}
@@ -92,7 +80,7 @@ const TabularRow = <T extends object>({
             {cell.column.canResize && (
               <div
                 {...(cell.column.getResizerProps?.() || {})}
-                className={pfx("cell-resizer")}
+                className={"cell-resizer"}
               />
             )}
           </div>

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
@@ -1,4 +1,3 @@
-import { withClassNamePrefix } from "../../../../core";
 import { Draggable } from "react-beautiful-dnd";
 import { DragIcon } from "../../../icons";
 import Switch from "../../../Switch";
@@ -6,20 +5,16 @@ import type { TabularInstance } from "../../helpers/tableInstanceToTabularInstan
 import { useTabularControl } from "../../TabularControlsProvider";
 
 type ColumnItemProps<T extends Record<string, unknown>> = {
-  classNamePrefix: string;
   columnId: string;
   column: TabularInstance<T>["columns"][number];
   index: number;
 };
 
 const ColumnItem = <T extends Record<string, unknown>>({
-  classNamePrefix,
   columnId,
   column,
   index,
 }: ColumnItemProps<T>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
-
   const {
     instance: { visibleColumns, toggleHideColumn },
   } = useTabularControl();
@@ -30,22 +25,22 @@ const ColumnItem = <T extends Record<string, unknown>>({
         <div
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={pfx("column-item")}
+          className={"column-item"}
         >
-          <div className={pfx("column-item-switch")}>
+          <div className={"column-item-switch"}>
             <Switch
               size={"sm"}
               isSelected={visibleColumns[columnId] || false}
               onChange={() => toggleHideColumn(columnId)}
               isDisabled={column.definition?.unhideable}
             >
-              <div className={pfx("column-item-label")}>
+              <div className={"column-item-label"}>
                 {column.instance.render("Header")}
               </div>
             </Switch>
           </div>
           <div
-            className={pfx("column-item-drag-handler")}
+            className={"column-item-drag-handler"}
             {...provided.dragHandleProps}
           >
             <DragIcon />

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnSettingsControl.styles.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnSettingsControl.styles.ts
@@ -1,9 +1,9 @@
 import { css } from "@emotion/css";
 
-const defaultStyles = (pfx: string) => css`
+const defaultStyles = () => css`
   z-index: 1000;
 
-  .${pfx}-card {
+  .card {
     border-radius: 2px;
     margin: 0 4px;
     padding: 8px 4px 0 8px;
@@ -11,11 +11,11 @@ const defaultStyles = (pfx: string) => css`
     overflow-y: auto;
   }
 
-  .${pfx}-columns-list {
+  .columns-list {
     user-select: none;
   }
 
-  .${pfx}-column-item {
+  .column-item {
     display: flex;
     align-items: center;
     padding: 8px;
@@ -25,7 +25,7 @@ const defaultStyles = (pfx: string) => css`
     }
   }
 
-  .${pfx}-action-item {
+  .action-item {
     position: sticky;
     bottom: 0;
     display: flex;
@@ -35,16 +35,16 @@ const defaultStyles = (pfx: string) => css`
     border-top: solid 1px var(--palette-border);
   }
 
-  .${pfx}-column-item-switch {
+  .column-item-switch {
     flex-grow: 1;
   }
 
-  .${pfx}-column-item-label {
+  .column-item-label {
     font-size: 0.875rem;
     margin-right: var(--spacing-2x, 8px);
   }
 
-  .${pfx}-column-item-drag-handler {
+  .column-item-drag-handler {
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnSettingsControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnSettingsControl.tsx
@@ -3,7 +3,6 @@ import { useTabularControl } from "../../TabularControlsProvider";
 import ExternalColumnSettingsControl from "./ExternalColumnSettingsControl";
 
 type ExportControlProps = {
-  classNamePrefix?: string;
   className?: string;
   omittedColumnsIds?: string[];
 };

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
@@ -1,5 +1,4 @@
 import { css, cx } from "@emotion/css";
-import { withClassNamePrefix } from "../../../../core";
 import { useCallback, useState } from "react";
 import { DragDropContext, Droppable, DropResult } from "react-beautiful-dnd";
 import { useLayer } from "react-laag";
@@ -22,7 +21,6 @@ const rootStyles = () => css`
 
 interface ColumnOrderControlProps<T extends Record<string, unknown>> {
   instance: TabularInstance<T>;
-  classNamePrefix?: string;
   className?: string;
 }
 
@@ -35,10 +33,8 @@ const reorder = (list: string[], startIndex: number, endIndex: number) => {
 };
 
 export const ColumnSettingsControl = <T extends Record<string, unknown>>({
-  classNamePrefix = "ft",
   className,
 }: ColumnOrderControlProps<T>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const [isContentVisible, setIsContentVisible] = useState(false);
 
   const {
@@ -111,19 +107,16 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
         {...triggerProps}
       />
       {renderLayer(
-        <div
-          {...layerProps}
-          className={cx(defaultStyles(classNamePrefix), className)}
-        >
+        <div {...layerProps} className={cx(defaultStyles(), className)}>
           {isContentVisible && (
-            <Card className={pfx("card")}>
+            <Card className={"card"}>
               <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="columns-list">
                   {provided => (
                     <div
                       ref={provided.innerRef}
                       {...provided.droppableProps}
-                      className={pfx("columns-list")}
+                      className={"columns-list"}
                     >
                       {columnOrder.map((columnId, index) => {
                         const currentColumn = columns.find(
@@ -136,7 +129,6 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
                         return (
                           <ColumnItem
                             key={columnId}
-                            classNamePrefix={classNamePrefix}
                             index={index}
                             columnId={columnId}
                             column={currentColumn}
@@ -144,7 +136,7 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
                         );
                       })}
                       {provided.placeholder}
-                      <div className={pfx("action-item")}>
+                      <div className={"action-item"}>
                         <Button
                           variant={"text"}
                           size={"small"}

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExportControl.styles.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExportControl.styles.ts
@@ -1,9 +1,9 @@
 import { css } from "@emotion/css";
 
-const defaultStyles = (pfx: string) => css`
+const defaultStyles = () => css`
   z-index: 1000;
 
-  .${pfx}-card {
+  .card {
     border-radius: 2px;
     margin: 0 4px;
     padding: 16px;
@@ -11,12 +11,12 @@ const defaultStyles = (pfx: string) => css`
     overflow-y: auto;
   }
 
-  .${pfx}-title {
+  .title {
     padding: 8px 0;
     font-size: 0.75rem;
   }
 
-  .${pfx}-columns-container {
+  .columns-container {
     width: 90%;
     min-width: 200px;
     min-height: 32px;
@@ -30,7 +30,7 @@ const defaultStyles = (pfx: string) => css`
     border-radius: 4px;
   }
 
-  .${pfx}-actions {
+  .actions {
     padding: 8px 4px;
     display: flex;
     flex-direction: column;

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExportControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExportControl.tsx
@@ -4,7 +4,6 @@ import { useTabularControl } from "../../TabularControlsProvider";
 import { ExternalExportControl } from "./ExternalExportControl";
 
 type ExportControlProps = {
-  classNamePrefix?: string;
   className?: string;
   omittedColumnsIds?: string[];
 };

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
@@ -4,7 +4,6 @@ import { useCallback, useState } from "react";
 import { useLayer } from "react-laag";
 import { Row } from "react-table";
 
-import { withClassNamePrefix } from "../../../../core";
 import Button from "../../../Button";
 import Card from "../../../Card";
 import Checkbox from "../../../Checkbox";
@@ -25,14 +24,12 @@ const rootStyles = () => css`
 `;
 
 type ExportControlProps<T extends Record<string, unknown>> = {
-  classNamePrefix?: string;
   className?: string;
   omittedColumnsIds?: string[];
   instance: TabularInstance<T>;
 };
 
 export function ExternalExportControl<T extends Record<string, unknown>>({
-  classNamePrefix = "ft",
   className,
   omittedColumnsIds,
   instance,
@@ -63,13 +60,9 @@ export function ExternalExportControl<T extends Record<string, unknown>>({
         {...triggerProps}
       />
       {renderLayer(
-        <div
-          {...layerProps}
-          className={cx(defaultStyles(classNamePrefix), className)}
-        >
+        <div {...layerProps} className={cx(defaultStyles(), className)}>
           {isContentVisible && (
             <ExportOptionsModal
-              classNamePrefix={classNamePrefix}
               instance={instance}
               omittedColumnsIds={omittedColumnsIds}
             />
@@ -81,11 +74,9 @@ export function ExternalExportControl<T extends Record<string, unknown>>({
 }
 
 function ExportOptionsModal<T extends Record<string, unknown>>({
-  classNamePrefix,
   instance,
   omittedColumnsIds,
 }: ExportControlProps<T>) {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { rows, data, page, columns, columnOrder, visibleColumns } = instance;
   const [format, setFormat] = useState("csv");
   const [name, setName] = useState<string>("");
@@ -151,9 +142,9 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
   ]);
 
   return (
-    <Card className={pfx("card")}>
-      <div className={pfx("title")}>Export columns</div>
-      <div className={pfx("columns-container")}>
+    <Card className={"card"}>
+      <div className={"title"}>Export columns</div>
+      <div className={"columns-container"}>
         {columnOrder.map(columnId =>
           omittedColumnsIds?.includes(columnId) ||
           !visibleColumns[columnId] ? null : (
@@ -174,7 +165,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
           )
         )}
       </div>
-      <div className={pfx("title")}>Options</div>
+      <div className={"title"}>Options</div>
       <Checkbox
         aria-label={`Keep filtering and sorting`}
         isSelected={options["include-filters"]}
@@ -199,7 +190,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
       >
         Only current page
       </Checkbox>
-      <div className={pfx("title")}>Format</div>
+      <div className={"title"}>Format</div>
       <Select
         value={format}
         onChange={f => setFormat(f as string)}
@@ -211,14 +202,14 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
           { label: "JSON", value: "json" },
         ]}
       />
-      <div className={pfx("title")}>Save as</div>
+      <div className={"title"}>Save as</div>
       <Input
         aria-label={"Export name"}
         value={name}
         placeholder={`export-${new Date().getTime()}.${format}`}
         onChange={setName}
       />
-      <div className={pfx("actions")}>
+      <div className={"actions"}>
         <Button variant={"filled"} onPress={onExport}>
           Export
         </Button>

--- a/packages/graph-explorer/src/components/Tabular/controls/ExternalPaginationControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExternalPaginationControl.tsx
@@ -1,7 +1,6 @@
 import { css, cx } from "@emotion/css";
 
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
-import { withClassNamePrefix } from "../../../core";
 import Button from "../../Button";
 import HumanReadableNumberFormatter from "../../HumanReadableNumberFormatter";
 import IconButton from "../../IconButton";
@@ -14,7 +13,6 @@ import {
 import Select from "../../Select";
 
 export type PaginationControlProps = {
-  classNamePrefix?: string;
   className?: string;
   totalRows: number;
   pageIndex: number;
@@ -24,16 +22,16 @@ export type PaginationControlProps = {
   pageOptions?: number[];
 };
 
-const defaultStyles = (pfx: string) => css`
+const defaultStyles = () => css`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  .${pfx}-pagination-totals {
+  .pagination-totals {
     color: var(--palette-text-disabled, #838383);
   }
 
-  .${pfx}-pagination-controls {
+  .pagination-controls {
     display: flex;
     justify-content: flex-end;
     align-items: center;
@@ -46,18 +44,18 @@ const defaultStyles = (pfx: string) => css`
       margin-right: 0;
     }
 
-    .${pfx}-page-options-menu {
-      .ft-select {
+    .page-options-menu {
+      .select {
         min-width: 30px;
       }
-      .ft-input-label {
+      .input-label {
         width: 75px;
         font-size: 14px;
         margin: 0;
       }
     }
 
-    .${pfx}-page-viz {
+    .page-viz {
       display: flex;
       align-items: center;
       > * {
@@ -65,18 +63,18 @@ const defaultStyles = (pfx: string) => css`
       }
     }
 
-    .${pfx}-page-button {
+    .page-button {
       font-size: 14px;
       min-width: 24px;
       margin: 0 1px;
-      &.${pfx}-page-control {
+      &.page-control {
         > svg {
           width: 24px;
           height: 24px;
         }
         padding: 0;
       }
-      &.${pfx}-toggle-button-inactive {
+      &.toggle-button-inactive {
         background-color: transparent;
       }
     }
@@ -85,7 +83,6 @@ const defaultStyles = (pfx: string) => css`
 
 const DEFAULT_PAGE_OPTIONS = [10, 20, 50];
 export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
-  classNamePrefix = "ft",
   className,
   totalRows,
   pageIndex,
@@ -94,8 +91,6 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
   onPageSizeChange,
   pageOptions = DEFAULT_PAGE_OPTIONS,
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
-
   const [inputValue, setInputValue] = useState<number | null>(pageIndex + 1);
   const pageCount = Math.ceil(totalRows / pageSize);
 
@@ -143,22 +138,20 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
   }, [pageIndex, pageSize, totalRows]);
 
   return (
-    <div className={cx(defaultStyles(classNamePrefix), className)}>
+    <div className={cx(defaultStyles(), className)}>
       {totalRows > 0 && (
-        <div className={pfx("pagination-totals")}>
+        <div className={"pagination-totals"}>
           Displaying {pageRange} of{" "}
           <HumanReadableNumberFormatter value={totalRows} /> results
         </div>
       )}
-      {totalRows === 0 && (
-        <div className={pfx("pagination-totals")}>No results</div>
-      )}
+      {totalRows === 0 && <div className={"pagination-totals"}>No results</div>}
       {totalRows > 0 && (
-        <div className={pfx("pagination-controls")}>
+        <div className={"pagination-controls"}>
           <Select
             label="Page size:"
             labelPlacement="left"
-            className={pfx("page-options-menu")}
+            className={"page-options-menu"}
             options={pageOptions.map(pageOption => ({
               label: pageOption.toString(),
               value: pageOption.toString(),
@@ -172,7 +165,7 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={pageIndex - 1 < 0}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<SkipBackwardIcon />}
             onPress={() => onPageIndexChange(0)}
           />
@@ -180,16 +173,16 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={pageIndex - 1 < 0}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<BackwardIcon />}
             onPress={() => onPageIndexChange(pageIndex - 1)}
           />
-          <div className={pfx("page-viz")}>
+          <div className={"page-viz"}>
             {pagesToRender.map(page => {
               return (
                 <Button
                   key={page}
-                  className={pfx("page-button")}
+                  className={"page-button"}
                   variant={
                     pageIndex === parseInt(page) - 1 ? "filled" : "default"
                   }
@@ -205,14 +198,14 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={pageIndex + 1 >= pageCount}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<ForwardIcon />}
             onPress={() => onPageIndexChange(pageIndex + 1)}
           />
           <IconButton
             isDisabled={pageIndex + 1 >= pageCount}
             variant={"text"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<SkipForwardIcon />}
             onPress={() => onPageIndexChange(pageCount - 1)}
           />

--- a/packages/graph-explorer/src/components/Tabular/controls/GlobalFilterControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/GlobalFilterControl.tsx
@@ -7,24 +7,24 @@ import { SearchIcon } from "../../icons";
 import { Input } from "../../Input/Input";
 import { useTabularControl } from "../TabularControlsProvider";
 
-const defaultStyles = (pfx: string, isDarkTheme: boolean) => css`
+const defaultStyles = (isDarkTheme: boolean) => css`
   display: flex;
   align-items: center;
 
-  .${pfx}-input-root {
+  .input-root {
     width: 100%;
     margin: 0;
-    .${pfx}-input {
+    .input {
       margin: 0;
       width: 100%;
       box-sizing: border-box;
     }
 
-    .${pfx}-input:not(:hover):not(:focus):not(:active) {
+    .input:not(:hover):not(:focus):not(:active) {
       ${!isDarkTheme && `background-color: var(--palette-background-default);`}
     }
 
-    .${pfx}-start-adornment {
+    .start-adornment {
       color: ${cssVar(
         "--forms-input-color",
         "--palette-text-disabled",
@@ -39,10 +39,9 @@ export const GlobalFilterControl: FunctionComponent = () => {
   const { instance } = useTabularControl();
   const isDarkTheme = useIsDarkTheme();
   return (
-    <div className={defaultStyles("global-filter", isDarkTheme)}>
+    <div className={defaultStyles(isDarkTheme)}>
       <Input
         aria-label={"global filter"}
-        classNamePrefix={"global-filter"}
         className={"global-filter-input-root"}
         type={"text"}
         noMargin

--- a/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
@@ -1,7 +1,6 @@
 import { css, cx } from "@emotion/css";
 
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
-import { withClassNamePrefix } from "../../../core";
 import Button from "../../Button";
 import HumanReadableNumberFormatter from "../../HumanReadableNumberFormatter";
 import IconButton from "../../IconButton";
@@ -15,21 +14,20 @@ import Select from "../../Select";
 import { useTabularControl } from "../TabularControlsProvider";
 
 export type PaginationControlProps = {
-  classNamePrefix?: string;
   className?: string;
   totalRows: number;
 };
 
-const defaultStyles = (pfx: string) => css`
+const defaultStyles = () => css`
   display: flex;
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  .${pfx}-pagination-totals {
+  .pagination-totals {
     color: var(--palette-text-disabled, #838383);
   }
 
-  .${pfx}-pagination-controls {
+  .pagination-controls {
     display: flex;
     justify-content: flex-end;
     align-items: center;
@@ -42,18 +40,18 @@ const defaultStyles = (pfx: string) => css`
       margin-right: 0;
     }
 
-    .${pfx}-page-options-menu {
-      .ft-select {
+    .page-options-menu {
+      .select {
         min-width: 30px;
       }
-      .ft-input-label {
+      .input-label {
         width: 75px;
         font-size: 14px;
         margin: 0;
       }
     }
 
-    .${pfx}-page-viz {
+    .page-viz {
       display: flex;
       align-items: center;
       > * {
@@ -61,18 +59,18 @@ const defaultStyles = (pfx: string) => css`
       }
     }
 
-    .${pfx}-page-button {
+    .page-button {
       font-size: 14px;
       min-width: 24px;
       margin: 0 1px;
-      &.${pfx}-page-control {
+      &.page-control {
         > svg {
           width: 24px;
           height: 24px;
         }
         padding: 0;
       }
-      &.${pfx}-toggle-button-inactive {
+      &.toggle-button-inactive {
         background-color: transparent;
       }
     }
@@ -80,11 +78,9 @@ const defaultStyles = (pfx: string) => css`
 `;
 
 export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
-  classNamePrefix = "ft",
   className,
   totalRows,
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const {
     instance: {
       disablePagination,
@@ -149,22 +145,20 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
     return null;
   }
   return (
-    <div className={cx(defaultStyles(classNamePrefix), className)}>
+    <div className={cx(defaultStyles(), className)}>
       {totalRows > 0 && (
-        <div className={pfx("pagination-totals")}>
+        <div className={"pagination-totals"}>
           Displaying {pageRange} of{" "}
           <HumanReadableNumberFormatter value={totalRows} /> results
         </div>
       )}
-      {totalRows === 0 && (
-        <div className={pfx("pagination-totals")}>No results</div>
-      )}
+      {totalRows === 0 && <div className={"pagination-totals"}>No results</div>}
       {totalRows > 0 && (
-        <div className={pfx("pagination-controls")}>
+        <div className={"pagination-controls"}>
           <Select
             label="Page size:"
             labelPlacement="left"
-            className={pfx("page-options-menu")}
+            className={"page-options-menu"}
             options={pageOptions.map(pageOption => ({
               label: pageOption.toString(),
               value: pageOption.toString(),
@@ -178,7 +172,7 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={!canPreviousPage}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<SkipBackwardIcon />}
             onPress={() => gotoPage(0)}
           />
@@ -186,16 +180,16 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={!canPreviousPage}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<BackwardIcon />}
             onPress={previousPage}
           />
-          <div className={pfx("page-viz")}>
+          <div className={"page-viz"}>
             {pagesToRender.map(page => {
               return (
                 <Button
                   key={page}
-                  className={pfx("page-button")}
+                  className={"page-button"}
                   variant={
                     pageIndex === parseInt(page) - 1 ? "filled" : "default"
                   }
@@ -211,14 +205,14 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
             isDisabled={!canNextPage}
             variant={"text"}
             size={"small"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<ForwardIcon />}
             onPress={nextPage}
           />
           <IconButton
             isDisabled={!canNextPage}
             variant={"text"}
-            className={cx(pfx("page-button"), pfx("page-control"))}
+            className={cx("page-button", "page-control")}
             icon={<SkipForwardIcon />}
             onPress={() => gotoPage(pageCount - 1)}
           />

--- a/packages/graph-explorer/src/components/Tabular/controls/TabularEmptyBodyControls.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/TabularEmptyBodyControls.tsx
@@ -1,17 +1,15 @@
 import { css, cx } from "@emotion/css";
 
 import { FC, PropsWithChildren } from "react";
-import { withClassNamePrefix } from "../../../core";
 
 import { useTabularControl } from "../TabularControlsProvider";
 
 export type TabularEmptyBodyControlsProps = PropsWithChildren<{
-  classNamePrefix?: string;
   className?: string;
 }>;
 
-const defaultStyles = (pfx: string) => css`
-  &.${pfx}-body-controls {
+const defaultStyles = () => css`
+  &.body-controls {
     position: relative;
     display: flex;
     flex-direction: column;
@@ -25,9 +23,7 @@ const defaultStyles = (pfx: string) => css`
 const TabularEmptyBodyControls: FC<TabularEmptyBodyControlsProps> = ({
   children,
   className,
-  classNamePrefix = "ft",
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const {
     instance: { page },
   } = useTabularControl();
@@ -37,13 +33,7 @@ const TabularEmptyBodyControls: FC<TabularEmptyBodyControlsProps> = ({
   }
 
   return (
-    <div
-      className={cx(
-        defaultStyles(classNamePrefix),
-        pfx("body-controls"),
-        className
-      )}
-    >
+    <div className={cx(defaultStyles(), "body-controls", className)}>
       {children}
     </div>
   );

--- a/packages/graph-explorer/src/components/Tabular/controls/TabularFooterControls.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/TabularFooterControls.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from "@emotion/css";
 import { FC, PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import type { TabularVariantType } from "../Tabular";
 
 import type { ThemeStyleFn } from "../../../core/ThemeProvider/types";
@@ -8,7 +8,6 @@ import type { TabularTheme } from "../Tabular.model";
 import baseTheme from "../baseTheme";
 
 export type TabularFooterControlsProps = PropsWithChildren<{
-  classNamePrefix?: string;
   className?: string;
   variant?: TabularVariantType;
   /**
@@ -19,12 +18,12 @@ export type TabularFooterControlsProps = PropsWithChildren<{
 }>;
 
 const defaultStyles =
-  (pfx: string, variant?: TabularVariantType): ThemeStyleFn<TabularTheme> =>
+  (variant?: TabularVariantType): ThemeStyleFn<TabularTheme> =>
   ({ theme, isDarkTheme }) => {
     const { tabular, palette } = theme;
 
     return css`
-      &.${pfx}-footer-controls {
+      &.footer-controls {
         position: sticky;
         left: 0;
         width: 100%;
@@ -49,7 +48,7 @@ const defaultStyles =
         }
       }
 
-      &.${pfx}-footer-controls-sticky {
+      &.footer-controls-sticky {
         z-index: 3;
         // -1px fixes the border
         ${variant === "noBorders" ? "bottom: 0;" : "bottom: -1px;"}
@@ -60,21 +59,19 @@ const defaultStyles =
 const TabularFooterControls: FC<TabularFooterControlsProps> = ({
   children,
   className,
-  classNamePrefix = "ft",
   disableSticky,
   variant,
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const styleWithTheme = useWithTheme();
 
   return (
     <div
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix, variant)),
-        pfx("footer-controls"),
+        styleWithTheme(defaultStyles(variant)),
+        "footer-controls",
         className,
         {
-          [pfx("footer-controls-sticky")]: !disableSticky,
+          ["footer-controls-sticky"]: !disableSticky,
         }
       )}
     >

--- a/packages/graph-explorer/src/components/Tabular/controls/TabularHeaderControls.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/TabularHeaderControls.tsx
@@ -2,14 +2,13 @@ import { css, cx } from "@emotion/css";
 import { cssVar } from "../../../core/ThemeProvider/utils/lib";
 import { FC, PropsWithChildren, useEffect } from "react";
 import type { ThemeStyleFn } from "../../../core";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import type { TabularVariantType } from "../Tabular";
 
 import { useTabularControl } from "../TabularControlsProvider";
 import type { TabularTheme } from "../Tabular.model";
 
 export type TabularHeaderControlsProps = PropsWithChildren<{
-  classNamePrefix?: string;
   className?: string;
   variant?: TabularVariantType;
 
@@ -21,9 +20,9 @@ export type TabularHeaderControlsProps = PropsWithChildren<{
 }>;
 
 const defaultStyles =
-  (pfx: string, variant?: TabularVariantType): ThemeStyleFn<TabularTheme> =>
+  (variant?: TabularVariantType): ThemeStyleFn<TabularTheme> =>
   ({ theme, isDarkTheme }) => css`
-    &.${pfx}-header-controls {
+    &.header-controls {
       position: sticky;
       left: 0;
       display: flex;
@@ -72,7 +71,7 @@ const defaultStyles =
       }
     }
 
-    &.${pfx}-header-controls-sticky {
+    &.header-controls-sticky {
       z-index: 2;
       top: 0;
     }
@@ -81,11 +80,9 @@ const defaultStyles =
 const TabularHeaderControls: FC<TabularHeaderControlsProps> = ({
   children,
   className,
-  classNamePrefix = "ft",
   disableSticky,
   variant,
 }) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { headerControlsRef, setHeaderControlsPosition } = useTabularControl();
   useEffect(() => {
     setHeaderControlsPosition(disableSticky ? "initial" : "sticky");
@@ -95,11 +92,11 @@ const TabularHeaderControls: FC<TabularHeaderControlsProps> = ({
     <div
       ref={headerControlsRef}
       className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix, variant)),
-        pfx("header-controls"),
+        styleWithTheme(defaultStyles(variant)),
+        "header-controls",
         className,
         {
-          [pfx("header-controls-sticky")]: !disableSticky,
+          ["header-controls-sticky"]: !disableSticky,
         }
       )}
     >

--- a/packages/graph-explorer/src/components/Tabular/filters/SingleSelectFilter.tsx
+++ b/packages/graph-explorer/src/components/Tabular/filters/SingleSelectFilter.tsx
@@ -1,15 +1,14 @@
 import { css } from "@emotion/css";
 import type { ActiveThemeType, ProcessedTheme } from "../../../core";
-import { withClassNamePrefix } from "../../../core";
 import { useDeepMemo } from "../../../hooks";
 import type { ColumnInstance } from "react-table";
 
 import Select from "../../Select/Select";
 
-const defaultStyles = (pfx: string, isDarkTheme?: boolean) => css`
+const defaultStyles = (isDarkTheme?: boolean) => css`
   width: 100%;
 
-  .${pfx}-menu-root {
+  .menu-root {
     button {
       ${!isDarkTheme && `background-color: var(--palette-background-default)`}
     }
@@ -48,20 +47,14 @@ export const SingleSelectFilter =
       [options]
     );
 
-    const pfx = withClassNamePrefix("filter-type-select");
     return (
-      <div
-        className={defaultStyles(
-          "filter-type-select",
-          activeTheme?.isDarkTheme
-        )}
-      >
+      <div className={defaultStyles(activeTheme?.isDarkTheme)}>
         <Select
           aria-label={`filter select for ${id}`}
           size="sm"
           noMargin
           hideError
-          className={pfx("menu-root")}
+          className={"menu-root"}
           value={column.filterValue || "all"}
           onChange={option =>
             option === "all" ? setFilter(undefined) : setFilter(option)

--- a/packages/graph-explorer/src/components/Tabular/filters/TextFilter.tsx
+++ b/packages/graph-explorer/src/components/Tabular/filters/TextFilter.tsx
@@ -2,17 +2,16 @@ import { css } from "@emotion/css";
 import { ReactNode } from "react";
 import { ColumnInstance } from "react-table";
 
-import { withClassNamePrefix } from "../../../core";
 import type { ActiveThemeType, ProcessedTheme } from "../../../core";
 import { cssVar } from "../../../core/ThemeProvider/utils/lib";
 
 import { FilterIcon } from "../../icons";
 import Input from "../../Input";
 
-const defaultStyles = (pfx: string, isDarkTheme?: boolean) => css`
+const defaultStyles = (isDarkTheme?: boolean) => css`
   width: 100%;
-  .${pfx}-input-root {
-    .${pfx}-input {
+  .input-root {
+    .input {
       margin: 0;
       width: 100%;
       box-sizing: border-box;
@@ -20,7 +19,7 @@ const defaultStyles = (pfx: string, isDarkTheme?: boolean) => css`
     }
   }
 
-  .${pfx}-input-container .${pfx}-start-adornment {
+  .input-container .start-adornment {
     display: flex;
     align-items: center;
     color: ${cssVar("--forms-input-color", "--palette-text-disabled", "black")};
@@ -38,13 +37,11 @@ export const TextFilter =
   ({ placeholder, startAdornment }: TextFilterProps) => {
     // eslint-disable-next-line react/display-name
     return ({ column }: { column: ColumnInstance<T> }) => {
-      const pfx = withClassNamePrefix("text-filter");
       return (
-        <div className={defaultStyles("text-filter", activeTheme?.isDarkTheme)}>
+        <div className={defaultStyles(activeTheme?.isDarkTheme)}>
           <Input
             aria-label={`filter by ${column.id}`}
-            classNamePrefix={"text-filter"}
-            className={pfx("input-root")}
+            className={"input-root"}
             type={"text"}
             size="sm"
             noMargin
@@ -59,7 +56,7 @@ export const TextFilter =
                 : column.setFilter(undefined);
             }}
             startAdornment={
-              <div className={pfx("start-adornment")}>
+              <div className={"start-adornment"}>
                 {startAdornment || <FilterIcon />}
               </div>
             }

--- a/packages/graph-explorer/src/components/Toast/Toast.styles.ts
+++ b/packages/graph-explorer/src/components/Toast/Toast.styles.ts
@@ -1,93 +1,91 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    position: relative;
-    width: fit-content;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  position: relative;
+  width: fit-content;
 
-    .${pfx}-info {
+  .info {
+    background: ${theme.palette.primary.main};
+    color: ${theme.palette.primary.contrastText};
+    .icon {
       background: ${theme.palette.primary.main};
       color: ${theme.palette.primary.contrastText};
-      .${pfx}-icon {
-        background: ${theme.palette.primary.main};
-        color: ${theme.palette.primary.contrastText};
-      }
     }
+  }
 
-    .${pfx}-error {
+  .error {
+    background: ${theme.palette.error.main};
+    color: ${theme.palette.error.contrastText};
+    .icon {
       background: ${theme.palette.error.main};
       color: ${theme.palette.error.contrastText};
-      .${pfx}-icon {
-        background: ${theme.palette.error.main};
-        color: ${theme.palette.error.contrastText};
-      }
     }
+  }
 
-    .${pfx}-warning {
+  .warning {
+    background: ${theme.palette.warning.main};
+    color: ${theme.palette.warning.contrastText};
+    .icon {
       background: ${theme.palette.warning.main};
       color: ${theme.palette.warning.contrastText};
-      .${pfx}-icon {
-        background: ${theme.palette.warning.main};
-        color: ${theme.palette.warning.contrastText};
-      }
     }
+  }
 
-    .${pfx}-success {
+  .success {
+    background: ${theme.palette.success.main};
+    color: ${theme.palette.success.contrastText};
+    .icon {
       background: ${theme.palette.success.main};
       color: ${theme.palette.success.contrastText};
-      .${pfx}-icon {
-        background: ${theme.palette.success.main};
-        color: ${theme.palette.success.contrastText};
-      }
     }
+  }
 
-    .${pfx}-card {
-      flex-grow: 1;
-      display: flex;
-      padding: 0;
-      overflow: hidden;
-      flex-direction: row;
+  .card {
+    flex-grow: 1;
+    display: flex;
+    padding: 0;
+    overflow: hidden;
+    flex-direction: row;
+  }
+
+  .content {
+    margin: ${theme.spacing["2x"]};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 32px;
+  }
+
+  .title {
+    font-weight: bold;
+    margin-bottom: ${theme.spacing["2x"]};
+  }
+
+  .icon {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 32px;
+  }
+
+  .close-container {
+    padding: 4px;
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    width: 32px;
+
+    > div {
+      cursor: pointer;
     }
+  }
 
-    .${pfx}-content {
-      margin: ${theme.spacing["2x"]};
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      min-width: 32px;
-    }
-
-    .${pfx}-title {
-      font-weight: bold;
-      margin-bottom: ${theme.spacing["2x"]};
-    }
-
-    .${pfx}-icon {
-      flex-grow: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      width: 32px;
-    }
-
-    .${pfx}-close-container {
-      padding: 4px;
-      flex-grow: 1;
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      width: 32px;
-
-      > div {
-        cursor: pointer;
-      }
-    }
-
-    .${pfx}-close-container-no-title {
-      align-items: center;
-    }
-  `;
+  .close-container-no-title {
+    align-items: center;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/Toast/Toast.tsx
+++ b/packages/graph-explorer/src/components/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import { cx } from "@emotion/css";
 import { FC, PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import Card from "../Card";
 
 import { CheckIcon, CloseIcon, ErrorIcon, InfoIcon } from "../icons";
@@ -24,7 +24,6 @@ export type NotificationComponentProps = PropsWithChildren<{
 
 export interface ToastProps
   extends Omit<NotificationComponentProps, "message"> {
-  classNamePrefix?: string;
   className?: string;
 }
 
@@ -38,7 +37,6 @@ const icons: Record<"error" | "warning" | "info" | "success", typeof InfoIcon> =
 
 export const Toast: FC<ToastProps> = ({
   children,
-  classNamePrefix = "ft",
   className,
   type = "info",
   title,
@@ -46,25 +44,22 @@ export const Toast: FC<ToastProps> = ({
   onClose,
 }) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const Icon = icons[type];
   return (
-    <div
-      className={cx(stylesWithTheme(defaultStyles(classNamePrefix)), className)}
-    >
-      <Card className={cx(pfx("card"), pfx(type))} transparent>
-        <div className={pfx("icon")}>
+    <div className={cx(stylesWithTheme(defaultStyles), className)}>
+      <Card className={cx("card", type)} transparent>
+        <div className={"icon"}>
           <Icon width={24} height={24} />
         </div>
-        <div className={pfx("content")}>
-          {title && <div className={pfx("title")}>{title}</div>}
+        <div className={"content"}>
+          {title && <div className={"title"}>{title}</div>}
           {children}
         </div>
         {closeable && (
           <div
-            className={cx(pfx("close-container"), {
-              [pfx("close-container-no-title")]: !title,
+            className={cx("close-container", {
+              ["close-container-no-title"]: !title,
             })}
           >
             <div onClick={onClose} style={{ height: 16 }}>

--- a/packages/graph-explorer/src/components/UseLayer/UseLayer.styles.ts
+++ b/packages/graph-explorer/src/components/UseLayer/UseLayer.styles.ts
@@ -1,12 +1,12 @@
 import { css } from "@emotion/css";
 
-const defaultStyles = (pfx: string) => css`
-  &.${pfx}-trigger {
+const defaultStyles = () => css`
+  &.trigger {
     display: inline-block;
     width: 100%;
   }
 
-  &.${pfx}-overlay {
+  &.overlay {
     display: block;
   }
 `;

--- a/packages/graph-explorer/src/components/UseLayer/UseLayer.tsx
+++ b/packages/graph-explorer/src/components/UseLayer/UseLayer.tsx
@@ -3,7 +3,6 @@ import type { PropsWithChildren } from "react";
 import { forwardRef, useEffect, useMemo } from "react";
 import type { ArrowProps, LayerSide, UseLayerOptions } from "react-laag";
 import { Arrow, useLayer } from "react-laag";
-import { withClassNamePrefix } from "../../core";
 import getChildOfType from "../../utils/getChildOfType";
 import UseLayerOverlay from "./UseLayerOverlay";
 import UseLayerTrigger from "./UseLayerTrigger";
@@ -16,7 +15,6 @@ export type UseLayerProps = UseLayerOptions & {
   arrowProps?: ArrowProps;
   onClose?(): void;
   className?: string;
-  classNamePrefix?: string;
   onLayerSideChange?: (side: UseLayerSides) => void;
 };
 
@@ -29,7 +27,6 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
       showArrow,
       arrowProps,
       className,
-      classNamePrefix = "ft",
       onClose,
       placement,
       possiblePlacements,
@@ -53,8 +50,6 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
       auto: true,
       ...layerOptions,
     });
-
-    const pfx = withClassNamePrefix(classNamePrefix);
 
     useEffect(() => {
       onLayerSideChange?.(layerSide);
@@ -84,10 +79,10 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
       <div
         ref={ref}
         id={id}
-        className={cx(pfx("layer-container"), className)}
+        className={cx("layer-container", className)}
         style={{ display: "inline-block" }}
       >
-        <div {...triggerProps} className={pfx("trigger-container")}>
+        <div {...triggerProps} className={"trigger-container"}>
           {triggerChild}
         </div>
         {renderLayer(
@@ -97,10 +92,10 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
               ...layerProps.style,
               zIndex: 9999,
             }}
-            className={pfx("overlay-container")}
+            className={"overlay-container"}
           >
             {layerOptions.isOpen && (
-              <div className={pfx("overlay-inner-container")}>
+              <div className={"overlay-inner-container"}>
                 {showArrow && <Arrow {...layerArrowProps} {...arrowProps} />}
                 {overlayChild}
               </div>

--- a/packages/graph-explorer/src/components/UseLayer/UseLayerOverlay.tsx
+++ b/packages/graph-explorer/src/components/UseLayer/UseLayerOverlay.tsx
@@ -1,25 +1,17 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { withClassNamePrefix } from "../../core";
 import defaultStyles from "./UseLayer.styles";
 
 export type UseLayerOverlayProps = {
-  classNamePrefix?: string;
   className?: string;
 };
 
 const UseLayerOverlay = ({
-  classNamePrefix = "ft",
   className,
   children,
 }: PropsWithChildren<UseLayerOverlayProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   return (
-    <div
-      className={cx(defaultStyles(classNamePrefix), pfx("overlay"), className)}
-    >
-      {children}
-    </div>
+    <div className={cx(defaultStyles(), "overlay", className)}>{children}</div>
   );
 };
 

--- a/packages/graph-explorer/src/components/UseLayer/UseLayerTrigger.tsx
+++ b/packages/graph-explorer/src/components/UseLayer/UseLayerTrigger.tsx
@@ -1,24 +1,19 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { withClassNamePrefix } from "../../core";
 
 import defaultStyles from "./UseLayer.styles";
 
 export type UseLayerTriggerProps = {
-  classNamePrefix?: string;
   className?: string;
 };
 
 const UseLayerTrigger = ({
-  classNamePrefix = "ft",
   className,
   children,
 }: PropsWithChildren<UseLayerTriggerProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
-
   return (
     <div
-      className={cx(defaultStyles(classNamePrefix), pfx("trigger"), className)}
+      className={cx(defaultStyles(), "trigger", className)}
       onClick={e => e.stopPropagation()}
     >
       {children}

--- a/packages/graph-explorer/src/components/Workspace/Workspace.styles.ts
+++ b/packages/graph-explorer/src/components/Workspace/Workspace.styles.ts
@@ -1,126 +1,122 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const baseStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    width: 100%;
+const baseStyles: ThemeStyleFn = ({ theme }) => css`
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+  background-color: ${theme.palette.background.secondary};
+  flex-grow: 1;
+
+  &.layout-vertical {
+    > .container {
+      > .main {
+        > .content-footer-section {
+          > .content-section {
+            flex-direction: column;
+            padding: ${theme.spacing["2x"]};
+            row-gap: ${theme.spacing["2x"]};
+          }
+        }
+      }
+    }
+  }
+
+  &.layout-horizontal {
+    > .container {
+      > .main {
+        > .content-footer-section {
+          > .content-section {
+            flex-direction: row;
+            padding: ${theme.spacing["2x"]};
+            column-gap: ${theme.spacing["2x"]};
+          }
+        }
+      }
+    }
+  }
+
+  .space {
+    flex-grow: 1;
+  }
+
+  > .container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
     height: 100%;
     overflow: hidden;
-    display: flex;
-    flex-direction: row;
-    background-color: ${theme.palette.background.secondary};
-    flex-grow: 1;
 
-    &.${pfx}-layout-vertical {
-      > .${pfx}-container {
-        > .${pfx}-main {
-          > .${pfx}-content-footer-section {
-            > .${pfx}-content-section {
-              flex-direction: column;
-              padding: ${theme.spacing["2x"]};
-              row-gap: ${theme.spacing["2x"]};
-            }
-          }
-        }
-      }
-    }
-
-    &.${pfx}-layout-horizontal {
-      > .${pfx}-container {
-        > .${pfx}-main {
-          > .${pfx}-content-footer-section {
-            > .${pfx}-content-section {
-              flex-direction: row;
-              padding: ${theme.spacing["2x"]};
-              column-gap: ${theme.spacing["2x"]};
-            }
-          }
-        }
-      }
-    }
-
-    .${pfx}-space {
-      flex-grow: 1;
-    }
-
-    > .${pfx}-container {
+    .main {
       display: flex;
-      flex-direction: column;
+      flex-direction: row;
       flex-grow: 1;
       height: 100%;
-      overflow: hidden;
+      overflow: auto;
 
-      .${pfx}-main {
+      .content-footer-section {
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         flex-grow: 1;
         height: 100%;
         overflow: auto;
 
-        .${pfx}-content-footer-section {
-          display: flex;
-          flex-direction: column;
+        .content-section {
           flex-grow: 1;
           height: 100%;
           overflow: auto;
+        }
+      }
 
-          .${pfx}-content-section {
-            flex-grow: 1;
-            height: 100%;
-            overflow: auto;
-          }
+      .sidebar-section {
+        display: flex;
+        box-shadow: ${theme.shadow.left};
+        background: ${theme.palette.background.default};
+        > div:first-of-type {
+          box-shadow: ${theme.shadow.base};
         }
 
-        .${pfx}-sidebar-section {
-          display: flex;
-          box-shadow: ${theme.shadow.left};
-          background: ${theme.palette.background.default};
-          > div:first-of-type {
-            box-shadow: ${theme.shadow.base};
-          }
+        &.direction-row {
+          flex-direction: row;
+        }
+        &.direction-row-reverse {
+          flex-direction: row-reverse;
+        }
 
-          &.${pfx}-direction-row {
-            flex-direction: row;
-          }
-          &.${pfx}-direction-row-reverse {
-            flex-direction: row-reverse;
-          }
-
-          .${pfx}-sidebar-content {
-            height: 100%;
-            overflow-x: hidden;
-            transition: width 200ms ease-in-out;
-          }
+        .sidebar-content {
+          height: 100%;
+          overflow-x: hidden;
+          transition: width 200ms ease-in-out;
         }
       }
     }
-  `;
+  }
+`;
 
-const titleSectionStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    display: flex;
-    flex-direction: column;
+const titleSectionStyles: ThemeStyleFn = ({ theme }) => css`
+  display: flex;
+  flex-direction: column;
 
-    > .${pfx}-title {
-      font-weight: bold;
-      overflow: hidden;
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      -webkit-box-orient: vertical;
-    }
+  > .title {
+    font-weight: bold;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
 
-    > .${pfx}-subtitle {
-      overflow: hidden;
-      font-size: ${theme.typography.sizes.xs};
-      line-height: 1.25em;
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      -webkit-box-orient: vertical;
-      color: ${theme.palette.text.secondary};
-    }
-  `;
+  > .subtitle {
+    overflow: hidden;
+    font-size: ${theme.typography.sizes.xs};
+    line-height: 1.25em;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    color: ${theme.palette.text.secondary};
+  }
+`;
 
 const togglesSectionStyles: ThemeStyleFn = ({ theme }) => css`
   display: flex;

--- a/packages/graph-explorer/src/components/Workspace/Workspace.tsx
+++ b/packages/graph-explorer/src/components/Workspace/Workspace.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren, ReactElement } from "react";
 import { useMemo } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { getChildrenOfType } from "../../utils";
 import getChildOfType from "../../utils/getChildOfType";
 import WorkspaceFooter from "./components/WorkspaceFooter";
@@ -13,7 +13,6 @@ import styles from "./Workspace.styles";
 
 export type WorkspaceProps = {
   orientation?: "vertical" | "horizontal";
-  classNamePrefix?: string;
   className?: string;
 };
 
@@ -28,11 +27,9 @@ interface WorkspaceComposition {
 const Workspace = ({
   orientation = "vertical",
   children,
-  classNamePrefix = "ft",
   className,
 }: PropsWithChildren<WorkspaceProps>) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const topBarSection = useMemo(() => {
     return getChildrenOfType(
@@ -70,21 +67,21 @@ const Workspace = ({
   return (
     <div
       className={cx(
-        stylesWithTheme(styles.baseStyles("ft")),
+        stylesWithTheme(styles.baseStyles),
         className,
-        pfx("connected-toolkit-layout"),
-        pfx(`layout-${orientation}`)
+        "connected-toolkit-layout",
+        `layout-${orientation}`
       )}
     >
       {navBarSection}
-      <div className={pfx("container")}>
+      <div className={"container"}>
         {topBarSection}
-        <div className={pfx("main")}>
-          <div className={pfx("content-footer-section")}>
+        <div className={"main"}>
+          <div className={"content-footer-section"}>
             <div
               className={cx(
                 stylesWithTheme(styles.contentSectionStyles),
-                pfx("content-section")
+                "content-section"
               )}
             >
               {contentSection}
@@ -92,7 +89,7 @@ const Workspace = ({
             <div
               className={cx(
                 stylesWithTheme(styles.footerSectionStyles),
-                pfx("footer-section")
+                "footer-section"
               )}
             >
               {footerSection}

--- a/packages/graph-explorer/src/components/Workspace/components/HideNavBarLogo.style.ts
+++ b/packages/graph-explorer/src/components/Workspace/components/HideNavBarLogo.style.ts
@@ -2,57 +2,55 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 import { fade } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-navbar-logo {
-      position: relative;
-      background-color: ${theme.navBar?.header ||
-      fade(theme.palette.primary.dark, 0.5)};
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.navbar-logo {
+    position: relative;
+    background-color: ${theme.navBar?.header ||
+    fade(theme.palette.primary.dark, 0.5)};
+    height: 100%;
+    margin-right: ${theme.spacing["2x"]};
+
+    .navbar-logo-container {
+      transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
       height: 100%;
-      margin-right: ${theme.spacing["2x"]};
-
-      .${pfx}-navbar-logo-container {
-        transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
-        height: 100%;
-        aspect-ratio: 1/1;
-        overflow: hidden;
-        background-color: ${theme.palette.primary.dark};
-      }
-
-      .${pfx}-hide-logo {
-        transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
-        aspect-ratio: 1/1000;
-        opacity: 0;
-      }
-
-      .${pfx}-logo {
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        color: ${theme.palette.primary.contrastText};
-      }
-
-      .${pfx}-menu-logo {
-        position: absolute;
-        height: 100%;
-        width: 100%;
-        font-size: 30px;
-        background-color: ${theme.palette.primary.main};
-        color: ${theme.palette.primary.contrastText};
-        opacity: 0;
-        transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
-
-      .${pfx}-menu-logo:hover {
-        cursor: pointer;
-        opacity: 1;
-      }
+      aspect-ratio: 1/1;
+      overflow: hidden;
+      background-color: ${theme.palette.primary.dark};
     }
-  `;
+
+    .hide-logo {
+      transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
+      aspect-ratio: 1/1000;
+      opacity: 0;
+    }
+
+    .logo {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      color: ${theme.palette.primary.contrastText};
+    }
+
+    .menu-logo {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      font-size: 30px;
+      background-color: ${theme.palette.primary.main};
+      color: ${theme.palette.primary.contrastText};
+      opacity: 0;
+      transition: ${theme.navBar?.animation?.toggleMenuSpeed || "400ms"};
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .menu-logo:hover {
+      cursor: pointer;
+      opacity: 1;
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/components/Workspace/components/HideNavBarLogo.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/HideNavBarLogo.tsx
@@ -1,12 +1,11 @@
 import { cx } from "@emotion/css";
 import type { MouseEvent, ReactNode } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import { ConnectedIcon, MenuIcon } from "../../icons";
 import defaultStyles from "./HideNavBarLogo.style";
 
 export interface HideNavBarLogoProps {
   className?: string;
-  classNamePrefix?: string;
   logo?: ReactNode;
   isVisible?: boolean;
   onClick?(e: MouseEvent<HTMLDivElement>): void;
@@ -14,33 +13,27 @@ export interface HideNavBarLogoProps {
 
 const HideNavBarLogo = ({
   className,
-  classNamePrefix = "ft",
   logo,
   isVisible,
   onClick,
 }: HideNavBarLogoProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   return (
     <div
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("navbar-logo"),
-        className
-      )}
+      className={cx(styleWithTheme(defaultStyles), "navbar-logo", className)}
     >
       <div
-        className={cx(pfx("navbar-logo-container"), {
-          [pfx("hide-logo")]: !isVisible,
+        className={cx("navbar-logo-container", {
+          ["hide-logo"]: !isVisible,
         })}
         onClick={onClick}
       >
-        <div className={pfx("logo")}>
+        <div className={"logo"}>
           {logo || <ConnectedIcon width={"2em"} height={"2em"} />}
         </div>
         {!!onClick && (
-          <div className={cx(pfx("menu-logo"))}>
+          <div className={cx("menu-logo")}>
             <MenuIcon />
           </div>
         )}

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBar.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBar.tsx
@@ -1,7 +1,6 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren, ReactElement } from "react";
 import { useMemo } from "react";
-import { withClassNamePrefix } from "../../../core";
 import getChildOfType from "../../../utils/getChildOfType";
 import getChildrenOfType from "../../../utils/getChildrenOfType";
 import Sidebar from "../../Sidebar";
@@ -14,16 +13,13 @@ interface WorkspaceSideBarComposition {
 }
 
 export type WorkspaceSideBarProps = {
-  classNamePrefix?: string;
   direction?: "row" | "row-reverse";
 };
 
 const WorkspaceSideBar = ({
   children,
-  classNamePrefix = "ft",
   direction = "row",
 }: PropsWithChildren<WorkspaceSideBarProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const sidebarContent = useMemo(() => {
     return getChildOfType(
       children,
@@ -40,7 +36,7 @@ const WorkspaceSideBar = ({
   }, [children]);
 
   return (
-    <div className={cx(pfx("sidebar-section"), pfx(`direction-${direction}`))}>
+    <div className={cx("sidebar-section", `direction-${direction}`)}>
       <Sidebar>{sidebarActions}</Sidebar>
       {sidebarContent}
     </div>

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
@@ -1,25 +1,21 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { withClassNamePrefix } from "../../../core";
 
 export type WorkspaceSideBarContentProps = {
-  classNamePrefix?: string;
   className?: string;
   isOpen?: boolean;
   defaultWidth?: number | string;
 };
 
 const WorkspaceSideBarContent = ({
-  classNamePrefix = "ft",
   className,
   children,
   isOpen,
   defaultWidth = 350,
 }: PropsWithChildren<WorkspaceSideBarContentProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   return (
     <div
-      className={cx(pfx("sidebar-content"), className)}
+      className={cx("sidebar-content", className)}
       style={{
         width: isOpen ? defaultWidth : 0,
       }}

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBar.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBar.tsx
@@ -1,7 +1,7 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren, ReactElement } from "react";
 import { useMemo } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import { groupChildrenByType } from "../../../utils";
 import styles from "../Workspace.styles";
 import type { HideNavBarLogoProps } from "./HideNavBarLogo";
@@ -14,7 +14,6 @@ import WorkspaceTopBarVersion from "./WorkspaceTopBarVersion";
 
 export type WorkspaceTopBarProps = {
   className?: string;
-  classNamePrefix?: string;
   logo?: HideNavBarLogoProps["logo"];
   logoVisible?: HideNavBarLogoProps["logo"];
   onLogoClick?: HideNavBarLogoProps["onClick"];
@@ -30,14 +29,12 @@ interface WorkspaceTopBarComposition {
 
 const WorkspaceTopBar = ({
   className,
-  classNamePrefix,
   children,
   logo,
   logoVisible,
   onLogoClick,
 }: PropsWithChildren<WorkspaceTopBarProps>) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix || "ft");
 
   const childrenByType = useMemo(
     () =>
@@ -59,7 +56,7 @@ const WorkspaceTopBar = ({
     <div
       className={cx(
         stylesWithTheme(styles.topBarSectionStyles),
-        pfx("top-bar-container"),
+        "top-bar-container",
         className
       )}
     >
@@ -76,7 +73,7 @@ const WorkspaceTopBar = ({
         }
         {childrenByType[
           WorkspaceTopBarContent.displayName || WorkspaceTopBarContent.name
-        ] ?? <div className={pfx("space")} />}
+        ] ?? <div className={"space"} />}
         {
           childrenByType[
             WorkspaceTopBarVersion.displayName || WorkspaceTopBarVersion.name
@@ -97,7 +94,7 @@ const WorkspaceTopBar = ({
       <div
         className={cx(
           stylesWithTheme(styles.subBarStyles),
-          pfx("sub-bar-container")
+          "sub-bar-container"
         )}
       >
         {childrenByType.rest}

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarAdditionalControls.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarAdditionalControls.tsx
@@ -1,25 +1,23 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import styles from "../Workspace.styles";
 
 export type WorkspaceTopBarAdditionalControlsProps = {
   className?: string;
-  classNamePrefix?: string;
 };
 
 const WorkspaceTopBarAdditionalControls = ({
   className,
-  classNamePrefix = "ft",
   children,
 }: PropsWithChildren<WorkspaceTopBarAdditionalControlsProps>) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
+
   return (
     <div
       className={cx(
         stylesWithTheme(styles.additionalControlsSectionStyles),
-        pfx("additional-controls-section-container"),
+        "additional-controls-section-container",
         className
       )}
     >

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarContent.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarContent.tsx
@@ -1,25 +1,22 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import styles from "../Workspace.styles";
 
 export type WorkspaceTopBarContentProps = {
   className?: string;
-  classNamePrefix?: string;
 };
 
 const WorkspaceTopBarContent = ({
   className,
-  classNamePrefix = "ft",
   children,
 }: PropsWithChildren<WorkspaceTopBarContentProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const stylesWithTheme = useWithTheme();
   return (
     <div
       className={cx(
         stylesWithTheme(styles.topBarTitleContent),
-        pfx("top-bar-content"),
+        "top-bar-content",
         className
       )}
     >

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarTitle.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarTitle.tsx
@@ -1,13 +1,12 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren, ReactNode } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import IconButton from "../../IconButton";
 import ChevronLeftIcon from "../../icons/ChevronLeftIcon";
 import styles from "../Workspace.styles";
 
 export type WorkspaceTopBarTitleProps = {
   className?: string;
-  classNamePrefix?: string;
   title?: ReactNode;
   subtitle?: ReactNode;
   withBackButton?: boolean;
@@ -16,7 +15,6 @@ export type WorkspaceTopBarTitleProps = {
 
 const WorkspaceTopBarTitle = ({
   className,
-  classNamePrefix = "ft",
   withBackButton,
   onBack,
   title,
@@ -24,7 +22,7 @@ const WorkspaceTopBarTitle = ({
   children,
 }: PropsWithChildren<WorkspaceTopBarTitleProps>) => {
   const stylesWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
+
   return (
     <div
       className={cx(
@@ -41,12 +39,12 @@ const WorkspaceTopBarTitle = ({
       )}
       <div
         className={cx(
-          stylesWithTheme(styles.titleSectionStyles(classNamePrefix || "ft")),
-          pfx("title-section-container")
+          stylesWithTheme(styles.titleSectionStyles),
+          "title-section-container"
         )}
       >
-        {title && <div className={pfx("title")}>{title}</div>}
-        {subtitle && <div className={pfx("subtitle")}>{subtitle}</div>}
+        {title && <div className={"title"}>{title}</div>}
+        {subtitle && <div className={"subtitle"}>{subtitle}</div>}
       </div>
       {children}
     </div>

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarToggles.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarToggles.tsx
@@ -1,25 +1,22 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import styles from "../Workspace.styles";
 
 export type WorkspaceTopBarTogglesProps = {
   className?: string;
-  classNamePrefix?: string;
 };
 
 const WorkspaceTopBarToggles = ({
   className,
-  classNamePrefix = "ft",
   children,
 }: PropsWithChildren<WorkspaceTopBarTogglesProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const stylesWithTheme = useWithTheme();
   return (
     <div
       className={cx(
         stylesWithTheme(styles.togglesSectionStyles),
-        pfx("toggles-section-container"),
+        "toggles-section-container",
         className
       )}
     >

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarVersion.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceTopBarVersion.tsx
@@ -1,25 +1,22 @@
 import { cx } from "@emotion/css";
 import type { PropsWithChildren } from "react";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import styles from "../Workspace.styles";
 
 export type WorkspaceTopBarVersionProps = {
   className?: string;
-  classNamePrefix?: string;
 };
 
 const WorkspaceTopBarVersion = ({
   className,
-  classNamePrefix = "ft",
   children,
 }: PropsWithChildren<WorkspaceTopBarVersionProps>) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
   const stylesWithTheme = useWithTheme();
   return (
     <div
       className={cx(
         stylesWithTheme(styles.topBarTitleVersion),
-        pfx("top-bar-version"),
+        "top-bar-version",
         className
       )}
     >

--- a/packages/graph-explorer/src/core/ThemeProvider/ThemeProvider.tsx
+++ b/packages/graph-explorer/src/core/ThemeProvider/ThemeProvider.tsx
@@ -85,7 +85,7 @@ const ThemeProvider = <
       THEME?.mode === "dark" || initialTheme === "dark"
     );
 
-    const themeWithDefaults = { ...composedTheme, "ft-palette-opacity": "1" };
+    const themeWithDefaults = { ...composedTheme, "palette-opacity": "1" };
     const cssVariables = getCSSVariablesFromTheme(themeWithDefaults);
 
     return {
@@ -100,16 +100,16 @@ const ThemeProvider = <
     if (injectGlobal) {
       if (theme.theme.mode === "dark") {
         emotionInjectGlobal(
-          `body.ft-dark img{filter: brightness(.9) contrast(1.2);} body{color-scheme: dark;}`
+          `body.dark img{filter: brightness(.9) contrast(1.2);} body{color-scheme: dark;}`
         );
-        document.body.classList.add("ft-dark");
-        document.body.classList.remove("ft-light");
+        document.body.classList.add("dark");
+        document.body.classList.remove("light");
         return;
       }
 
-      emotionInjectGlobal(`body.ft-light{color-scheme: light;}`);
-      document.body.classList.add("ft-light");
-      document.body.classList.remove("ft-dark");
+      emotionInjectGlobal(`body.light{color-scheme: light;}`);
+      document.body.classList.add("light");
+      document.body.classList.remove("dark");
     }
   }, [theme.theme.mode, injectGlobal]);
 

--- a/packages/graph-explorer/src/core/ThemeProvider/index.ts
+++ b/packages/graph-explorer/src/core/ThemeProvider/index.ts
@@ -3,9 +3,6 @@ export { default as useTheme } from "./useTheme";
 export { default as useWithTheme } from "./useWithTheme";
 export { default as useIsDarkTheme } from "./useIsDarkTheme";
 
-// Class names utils
-export { default as withClassNamePrefix } from "./utils/withClassNamePrefix";
-
 // Color utils
 export { default as contrastColor } from "./utils/contrastColor";
 export { default as darken } from "./utils/darken";

--- a/packages/graph-explorer/src/core/ThemeProvider/utils/lib.ts
+++ b/packages/graph-explorer/src/core/ThemeProvider/utils/lib.ts
@@ -101,4 +101,4 @@ export const cssConditionalValue =
     return defaultValue;
   };
 
-export const isDarkMode = () => document.body.classList.contains("ft-dark");
+export const isDarkMode = () => document.body.classList.contains("dark");

--- a/packages/graph-explorer/src/core/ThemeProvider/utils/withClassNamePrefix.tsx
+++ b/packages/graph-explorer/src/core/ThemeProvider/utils/withClassNamePrefix.tsx
@@ -1,9 +1,0 @@
-import memoizeOne from "memoize-one";
-
-const withClassNamePrefix = memoizeOne(
-  (prefix = "ft") =>
-    (className: string) =>
-      `${prefix}-${className}`
-);
-
-export default withClassNamePrefix;

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.styles.ts
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.styles.ts
@@ -1,25 +1,23 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    display: contents;
-    height: 100%;
-    background: ${theme.palette.background.default};
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  display: contents;
+  height: 100%;
+  background: ${theme.palette.background.default};
 
-    .${pfx}-header-children {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      margin-right: ${theme.spacing["2x"]};
-    }
+  .header-children {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: ${theme.spacing["2x"]};
+  }
 
-    .${pfx}-item-switch {
-      display: flex;
-      min-width: 100px;
-      justify-content: flex-end;
-    }
-  `;
+  .item-switch {
+    display: flex;
+    min-width: 100px;
+    justify-content: flex-end;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../components";
 import { useNotification } from "../../components/NotificationProvider";
 import Switch from "../../components/Switch";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import {
   activeConfigurationAtom,
   configurationAtom,
@@ -38,7 +38,6 @@ const AvailableConnections = ({
   onModalChange,
 }: ConnectionDetailProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix("ft");
 
   const activeConfig = useRecoilValue(activeConfigurationAtom);
   const configuration = useRecoilValue(configurationAtom);
@@ -171,9 +170,9 @@ const AvailableConnections = ({
                 config.connection?.queryEngine || "gremlin"
               )}
             </Chip>
-            <div className={pfx("v-divider")} />
+            <div className={"v-divider"} />
             <Switch
-              className={pfx("item-switch")}
+              className={"item-switch"}
               labelPosition={"left"}
               isSelected={activeConfig === config.id}
               onChange={() => onActiveConfigChange(config.id)}
@@ -187,10 +186,10 @@ const AvailableConnections = ({
     });
 
     return items;
-  }, [activeConfig, configuration, isSync, onActiveConfigChange, pfx, t]);
+  }, [activeConfig, configuration, isSync, onActiveConfigChange, t]);
 
   return (
-    <ModuleContainer className={styleWithTheme(defaultStyles("ft"))}>
+    <ModuleContainer className={styleWithTheme(defaultStyles)}>
       <ModuleContainerHeader
         title={"Available connections"}
         actions={headerActions}
@@ -198,7 +197,7 @@ const AvailableConnections = ({
       />
 
       <AdvancedList
-        className={pfx("advanced-list")}
+        className={"advanced-list"}
         items={connectionItems}
         selectedItemsIds={[activeConfig || ""]}
       />

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -12,22 +12,17 @@ import {
   VertexIcon,
 } from "../../components";
 import HumanReadableNumberFormatter from "../../components/HumanReadableNumberFormatter";
-import { fade, useWithTheme, withClassNamePrefix } from "../../core";
+import { fade, useWithTheme } from "../../core";
 import { useConfiguration } from "../../core/ConfigurationProvider";
 import useEntitiesCounts from "../../hooks/useEntitiesCounts";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
 import defaultStyles from "./ConnectionDetail.styles";
 
-export type VertexDetailProps = {
-  classNamePrefix?: string;
-};
-
-const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
+const ConnectionData = () => {
   const config = useConfiguration();
   const navigate = useNavigate();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const { totalNodes, totalEdges } = useEntitiesCounts();
   const textTransform = useTextTransform();
   const t = useTranslations();
@@ -42,10 +37,8 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
         id: vt,
         title: displayLabel,
         titleComponent: (
-          <div className={pfx("advanced-list-item-title")}>
-            <div className={pfx("node-title")}>
-              {textTransform(displayLabel)}
-            </div>
+          <div className={"advanced-list-item-title"}>
+            <div className={"node-title"}>{textTransform(displayLabel)}</div>
           </div>
         ),
         icon: (
@@ -61,7 +54,7 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
           </div>
         ),
         className: css`
-          .ft-start-adornment {
+          .start-adornment {
             color: ${vtConfig?.color}!important;
             background: ${fade(vtConfig?.color, 0.3)}!important;
           }
@@ -79,7 +72,7 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
     });
 
     return items;
-  }, [config, pfx, textTransform, navigate]);
+  }, [config, textTransform, navigate]);
 
   const [search, setSearch] = useState("");
 
@@ -88,12 +81,12 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
   }, [config?.id]);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
-      <div className={pfx("info-bar")}>
-        <div className={pfx("item")}>
-          <div className={pfx("tag")}>{t("connection-detail.nodes")}</div>
-          <div className={pfx("value")}>
-            <Chip className={pfx("value-chip")}>
+    <div className={styleWithTheme(defaultStyles)}>
+      <div className={"info-bar"}>
+        <div className={"item"}>
+          <div className={"tag"}>{t("connection-detail.nodes")}</div>
+          <div className={"value"}>
+            <Chip className={"value-chip"}>
               <GraphIcon />
               {totalNodes != null && (
                 <HumanReadableNumberFormatter value={totalNodes} />
@@ -102,10 +95,10 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
             </Chip>
           </div>
         </div>
-        <div className={pfx("item")}>
-          <div className={pfx("tag")}>{t("connection-detail.edges")}</div>
-          <div className={pfx("value")}>
-            <Chip className={pfx("value-chip")}>
+        <div className={"item"}>
+          <div className={"tag"}>{t("connection-detail.edges")}</div>
+          <div className={"value"}>
+            <Chip className={"value-chip"}>
               <EdgeIcon />
               {totalEdges != null && (
                 <HumanReadableNumberFormatter value={totalEdges} />
@@ -119,7 +112,7 @@ const ConnectionData = ({ classNamePrefix = "ft" }: VertexDetailProps) => {
         searchPlaceholder={t("connection-detail.search-placeholder")}
         search={search}
         onSearch={setSearch}
-        className={pfx("advanced-list")}
+        className={"advanced-list"}
         items={verticesByTypeItems}
         emptyState={{
           noSearchResultsTitle: t("connection-detail.no-search-title"),

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.styles.ts
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.styles.ts
@@ -1,84 +1,82 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    display: contents;
-    height: 100%;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  display: contents;
+  height: 100%;
+  background: ${theme.palette.background.default};
+
+  .header-children {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: ${theme.spacing["2x"]};
+  }
+
+  .info-bar {
     background: ${theme.palette.background.default};
+    border-bottom: solid 1px ${theme.palette.divider};
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: ${theme.spacing["6x"]};
+    padding: ${theme.spacing["4x"]};
 
-    .${pfx}-header-children {
+    .item {
       display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      margin-right: ${theme.spacing["2x"]};
-    }
+      flex-direction: column;
+      gap: ${theme.spacing.base};
+      padding: 0 ${theme.spacing["2x"]};
 
-    .${pfx}-info-bar {
-      background: ${theme.palette.background.default};
-      border-bottom: solid 1px ${theme.palette.divider};
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: flex-start;
-      gap: ${theme.spacing["6x"]};
-      padding: ${theme.spacing["4x"]};
-
-      .${pfx}-item {
+      .tag {
         display: flex;
-        flex-direction: column;
+        align-items: center;
+        min-height: 24px;
+        font-size: ${theme.typography.sizes?.xs};
+        color: ${theme.palette.text.secondary};
         gap: ${theme.spacing.base};
-        padding: 0 ${theme.spacing["2x"]};
+      }
 
-        .${pfx}-tag {
-          display: flex;
-          align-items: center;
-          min-height: 24px;
-          font-size: ${theme.typography.sizes?.xs};
-          color: ${theme.palette.text.secondary};
-          gap: ${theme.spacing.base};
-        }
+      .value {
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing.base};
+        font-weight: ${theme.typography.weight?.bold};
+        color: ${theme.palette.text.primary};
+        word-break: break-all;
 
-        .${pfx}-value {
-          display: flex;
-          align-items: center;
-          gap: ${theme.spacing.base};
-          font-weight: ${theme.typography.weight?.bold};
-          color: ${theme.palette.text.primary};
-          word-break: break-all;
-
-          .${pfx}-value-chip {
-            > span {
-              display: flex;
-              align-items: center;
-              gap: ${theme.spacing.base};
-            }
-          }
-          .${pfx}-prefix-counter {
+        .value-chip {
+          > span {
             display: flex;
+            align-items: center;
             gap: ${theme.spacing.base};
           }
         }
+        .prefix-counter {
+          display: flex;
+          gap: ${theme.spacing.base};
+        }
       }
     }
+  }
 
-    .${pfx}-advanced-list-item-title {
-      display: flex;
-      gap: ${theme.spacing["4x"]};
+  .advanced-list-item-title {
+    display: flex;
+    gap: ${theme.spacing["4x"]};
 
-      .${pfx}-node-title {
-        min-width: 200px;
-        font-weight: ${theme.typography.weight?.bold};
-      }
-      .${pfx}-nodes-count {
-        color: ${theme.palette.text.secondary};
-        font-weight: ${theme.typography.weight?.base};
-      }
+    .node-title {
+      min-width: 200px;
+      font-weight: ${theme.typography.weight?.bold};
     }
-
-    .${pfx}-prefixes-list {
-      min-height: 400px;
+    .nodes-count {
+      color: ${theme.palette.text.secondary};
+      font-weight: ${theme.typography.weight?.base};
     }
-  `;
+  }
+
+  .prefixes-list {
+    min-height: 400px;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -13,11 +13,7 @@ import {
   SyncIcon,
   TrayArrowIcon,
 } from "../../components";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import {
   activeConfigurationAtom,
   configurationAtom,
@@ -70,7 +66,6 @@ const HEADER_ACTIONS = (
 
 const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix("ft");
   const config = useConfiguration();
   const t = useTranslations();
   const [edit, setEdit] = useState(false);
@@ -146,31 +141,29 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
   const lastSyncFail = config?.schema?.lastSyncFail === true;
 
   return (
-    <ModuleContainer className={styleWithTheme(defaultStyles("ft"))}>
+    <ModuleContainer className={styleWithTheme(defaultStyles)}>
       <ModuleContainerHeader
         title={config.displayLabel || config.id}
         startAdornment={<DatabaseIcon />}
         actions={HEADER_ACTIONS(isSync, config.__fileBase === true)}
         onActionClick={onActionClick}
       />
-      <div className={pfx("info-bar")}>
-        <div className={pfx("item")}>
-          <div className={pfx("tag")}>Type</div>
-          <div className={pfx("value")}>
-            {t("connection-detail.graph-type")}
-          </div>
+      <div className={"info-bar"}>
+        <div className={"item"}>
+          <div className={"tag"}>Type</div>
+          <div className={"value"}>{t("connection-detail.graph-type")}</div>
         </div>
-        <div className={pfx("item")}>
-          <div className={pfx("tag")}>URL</div>
-          <div className={pfx("value")}>{config.connection?.url}</div>
+        <div className={"item"}>
+          <div className={"tag"}>URL</div>
+          <div className={"value"}>{config.connection?.url}</div>
         </div>
         {!!lastSyncUpdate && (
-          <div className={pfx("item")}>
-            <div className={pfx("tag")}>
+          <div className={"item"}>
+            <div className={"tag"}>
               <div>Last Synchronization</div>
             </div>
             {!lastSyncFail && (
-              <div className={pfx("value")}>{formatDate(lastSyncUpdate)}</div>
+              <div className={"value"}>{formatDate(lastSyncUpdate)}</div>
             )}
             {!lastSyncUpdate && !lastSyncFail && (
               <Chip size={"sm"} variant={"warning"}>

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.styles.ts
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.styles.ts
@@ -1,33 +1,31 @@
 import { css } from "@emotion/css";
 import { ActiveThemeType, ProcessedTheme } from "../../core";
 
-const defaultStyles =
-  (pfx: string) =>
-  ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
-    .${pfx}-content {
-      background: ${theme.palette.background.default};
-    }
+const defaultStyles = ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
+  .content {
+    background: ${theme.palette.background.default};
+  }
 
-    .${pfx}-top-bar-title {
-      font-weight: bold;
-    }
+  .top-bar-title {
+    font-weight: bold;
+  }
 
-    .${pfx}-input-url {
-      margin-top: ${theme.spacing["4x"]};
-    }
+  .input-url {
+    margin-top: ${theme.spacing["4x"]};
+  }
 
-    .${pfx}-configuration-form {
-      width: 100%;
-      padding: ${theme.spacing["4x"]} ${theme.spacing.base};
-      background: ${theme.palette.background.default};
-    }
+  .configuration-form {
+    width: 100%;
+    padding: ${theme.spacing["4x"]} ${theme.spacing.base};
+    background: ${theme.palette.background.default};
+  }
 
-    .${pfx}-actions {
-      display: flex;
-      justify-content: space-between;
-      padding-top: ${theme.spacing["4x"]};
-      border-top: solid 1px ${theme.palette.divider};
-    }
-  `;
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    padding-top: ${theme.spacing["4x"]};
+    border-top: solid 1px ${theme.palette.divider};
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -11,7 +11,6 @@ import {
   ConnectionConfig,
   RawConfiguration,
   useWithTheme,
-  withClassNamePrefix,
 } from "../../core";
 import {
   activeConfigurationAtom,
@@ -76,7 +75,6 @@ const CreateConnection = ({
   onClose,
 }: CreateConnectionProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix("ft");
 
   const configId = existingConfig?.id;
   const disabledFields: (keyof ConnectionForm)[] = existingConfig?.__fileBase
@@ -229,8 +227,8 @@ const CreateConnection = ({
   }, [form, onClose, onSave, reset]);
 
   return (
-    <div className={styleWithTheme(defaultStyles("ft"))}>
-      <div className={pfx("configuration-form")}>
+    <div className={styleWithTheme(defaultStyles)}>
+      <div className={"configuration-form"}>
         <Input
           label={"Name"}
           value={form.name}
@@ -249,7 +247,7 @@ const CreateConnection = ({
             form.serviceType === "neptune-graph"
           }
         />
-        <div className={pfx("input-url")}>
+        <div className={"input-url"}>
           <Input
             data-autofocus={true}
             component={"textarea"}
@@ -272,7 +270,7 @@ const CreateConnection = ({
             isDisabled={disabledFields.includes("url")}
           />
         </div>
-        <div className={pfx("input-url")}>
+        <div className={"input-url"}>
           <Checkbox
             value={"proxyConnection"}
             checked={form.proxyConnection}
@@ -283,7 +281,7 @@ const CreateConnection = ({
           />
         </div>
         {form.proxyConnection && (
-          <div className={pfx("input-url")}>
+          <div className={"input-url"}>
             <Input
               data-autofocus={true}
               label={"Graph Connection URL"}
@@ -299,7 +297,7 @@ const CreateConnection = ({
           </div>
         )}
         {form.proxyConnection && (
-          <div className={pfx("input-url")}>
+          <div className={"input-url"}>
             <Checkbox
               value={"awsAuthEnabled"}
               checked={form.awsAuthEnabled}
@@ -312,7 +310,7 @@ const CreateConnection = ({
         )}
         {form.proxyConnection && form.awsAuthEnabled && (
           <>
-            <div className={pfx("input-url")}>
+            <div className={"input-url"}>
               <Input
                 data-autofocus={true}
                 label={"AWS Region"}
@@ -325,7 +323,7 @@ const CreateConnection = ({
                 }
               />
             </div>
-            <div className={pfx("input-url")}>
+            <div className={"input-url"}>
               <Select
                 label={"Service Type"}
                 options={[
@@ -340,7 +338,7 @@ const CreateConnection = ({
           </>
         )}
       </div>
-      <div className={pfx("configuration-form")}>
+      <div className={"configuration-form"}>
         <Checkbox
           value={"fetchTimeoutEnabled"}
           checked={form.fetchTimeoutEnabled}
@@ -363,7 +361,7 @@ const CreateConnection = ({
           }
         />
         {form.fetchTimeoutEnabled && (
-          <div className={pfx("input-url")}>
+          <div className={"input-url"}>
             <Input
               label="Fetch Timeout (ms)"
               type={"number"}
@@ -374,7 +372,7 @@ const CreateConnection = ({
           </div>
         )}
       </div>
-      <div className={pfx("configuration-form")}>
+      <div className={"configuration-form"}>
         <Checkbox
           value={"nodeExpansionLimitEnabled"}
           checked={form.nodeExpansionLimitEnabled}
@@ -397,7 +395,7 @@ const CreateConnection = ({
           }
         />
         {form.nodeExpansionLimitEnabled && (
-          <div className={pfx("input-url")}>
+          <div className={"input-url"}>
             <Input
               label="Node Expansion Limit"
               type="number"
@@ -408,7 +406,7 @@ const CreateConnection = ({
           </div>
         )}
       </div>
-      <div className={pfx("actions")}>
+      <div className={"actions"}>
         <Button variant={"default"} onPress={onClose}>
           Cancel
         </Button>

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.style.ts
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.style.ts
@@ -1,15 +1,13 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (): ThemeStyleFn =>
-  ({ theme }) => css`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    background: ${theme.palette.background.default};
-    height: 100%;
-    overflow: auto;
-  `;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: ${theme.palette.background.default};
+  height: 100%;
+  overflow: auto;
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
@@ -31,7 +31,7 @@ const EdgesStyling = ({
         title={t("edges-styling.title")}
         {...headerProps}
       />
-      <div className={styleWithTheme(defaultStyles())}>
+      <div className={styleWithTheme(defaultStyles)}>
         {config?.edgeTypes.map(edgeType => (
           <SingleEdgeStyling
             key={edgeType}

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.style.ts
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.style.ts
@@ -1,41 +1,39 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  display: flex;
+  flex-direction: column;
+  background: ${theme.palette.background.default};
+  gap: ${theme.spacing["2x"]};
+  padding: ${theme.spacing["2x"]} ${theme.spacing["4x"]};
+  border-bottom: solid 1px ${theme.palette.divider};
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  .title {
     display: flex;
-    flex-direction: column;
-    background: ${theme.palette.background.default};
+    justify-content: space-between;
     gap: ${theme.spacing["2x"]};
-    padding: ${theme.spacing["2x"]} ${theme.spacing["4x"]};
-    border-bottom: solid 1px ${theme.palette.divider};
-
-    &:last-of-type {
-      border-bottom: none;
+    .edge-name {
+      margin-bottom: ${theme.spacing.base};
+      max-width: 80%;
+      word-break: break-word;
     }
+  }
 
-    .${pfx}-title {
-      display: flex;
-      justify-content: space-between;
-      gap: ${theme.spacing["2x"]};
-      .${pfx}-edge-name {
-        margin-bottom: ${theme.spacing.base};
-        max-width: 80%;
-        word-break: break-word;
-      }
+  .label-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: ${theme.spacing["2x"]};
+
+    .label-display {
+      width: 100%;
     }
-
-    .${pfx}-label-container {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: ${theme.spacing["2x"]};
-
-      .${pfx}-label-display {
-        width: 100%;
-      }
-    }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -5,11 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { Button, Input, Select, StylingIcon } from "../../components";
 import ColorInput from "../../components/ColorInput/ColorInput";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import {
   ArrowStyle,
   EdgePreferences,
@@ -27,7 +23,6 @@ import defaultStyles from "./SingleEdgeStyling.style";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
 
 export type SingleEdgeStylingProps = {
-  classNamePrefix?: string;
   edgeType: string;
   opened: boolean;
   onOpen(): void;
@@ -35,7 +30,6 @@ export type SingleEdgeStylingProps = {
 };
 
 const SingleEdgeStyling = ({
-  classNamePrefix = "ft",
   edgeType,
   opened,
   onOpen,
@@ -44,7 +38,6 @@ const SingleEdgeStyling = ({
   const config = useConfiguration();
   const t = useTranslations();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const userStyling = useRecoilValue(userStylingAtom);
   const textTransform = useTextTransform();
@@ -159,13 +152,13 @@ const SingleEdgeStyling = ({
   }, [displayAs, debouncedChange]);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
-      <div className={pfx("title")}>
-        <div className={pfx("edge-name")}>{edgeType}</div>
+    <div className={styleWithTheme(defaultStyles)}>
+      <div className={"title"}>
+        <div className={"edge-name"}>{edgeType}</div>
       </div>
-      <div className={pfx("label-container")}>
+      <div className={"label-container"}>
         <Input
-          className={pfx("label-display")}
+          className={"label-display"}
           label={"Display As"}
           labelPlacement={"inner"}
           value={displayAs}
@@ -191,15 +184,15 @@ const SingleEdgeStyling = ({
             Customize <strong>{displayAs || edgeType}</strong>
           </div>
         }
-        className={styleWithTheme(modalDefaultStyles(classNamePrefix))}
+        className={styleWithTheme(modalDefaultStyles)}
         overlayProps={{
           backgroundOpacity: 0.1,
         }}
       >
-        <div className={pfx("container")}>
+        <div className={"container"}>
           <div>
             <p>Display Attributes</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <Select
                 label={"Display Name Attribute"}
                 labelPlacement={"inner"}
@@ -213,7 +206,7 @@ const SingleEdgeStyling = ({
           </div>
           <div>
             <p>Label Styling</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <ColorInput
                 label={"Color"}
                 labelPlacement={"inner"}
@@ -239,7 +232,7 @@ const SingleEdgeStyling = ({
             </div>
           </div>
           <div>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <ColorInput
                 label={"Border Color"}
                 labelPlacement={"inner"}
@@ -275,7 +268,7 @@ const SingleEdgeStyling = ({
           </div>
           <div>
             <p>Line Styling</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <ColorInput
                 label={"Color"}
                 labelPlacement={"inner"}
@@ -311,7 +304,7 @@ const SingleEdgeStyling = ({
           </div>
           <div>
             <p>Arrows Styling</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <Select
                 label={"Source"}
                 labelPlacement={"inner"}
@@ -336,7 +329,7 @@ const SingleEdgeStyling = ({
               />
             </div>
           </div>
-          <div className={pfx("actions")}>
+          <div className={"actions"}>
             <Button onPress={onUserPrefsReset}>Reset to Default</Button>
           </div>
         </div>

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStylingModal.style.ts
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStylingModal.style.ts
@@ -1,37 +1,35 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    div[role="presentation"] > div {
-      margin-top: auto;
-      margin-left: auto;
-      margin-bottom: 0;
-    }
-    .${pfx}-container {
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  div[role="presentation"] > div {
+    margin-top: auto;
+    margin-left: auto;
+    margin-bottom: 0;
+  }
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing["4x"]};
+
+    .attrs-container {
       display: flex;
-      flex-direction: column;
-      gap: ${theme.spacing["4x"]};
+      justify-content: space-between;
+      gap: ${theme.spacing["2x"]};
 
-      .${pfx}-attrs-container {
-        display: flex;
-        justify-content: space-between;
-        gap: ${theme.spacing["2x"]};
-
-        > * {
-          flex-grow: 1;
-          width: 100%;
-        }
-      }
-
-      .${pfx}-actions {
-        display: flex;
-        justify-content: flex-end;
-        padding-top: ${theme.spacing["2x"]};
-        border-top: solid 1px ${theme.palette.divider};
+      > * {
+        flex-grow: 1;
+        width: 100%;
       }
     }
-  `;
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      padding-top: ${theme.spacing["2x"]};
+      border-top: solid 1px ${theme.palette.divider};
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.styles.ts
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.styles.ts
@@ -4,34 +4,35 @@ import {
   ProcessedTheme,
 } from "../../core/ThemeProvider/types";
 
-const defaultStyles =
-  (pfx: string) =>
-  ({ theme, isDarkTheme }: ActiveThemeType<ProcessedTheme>) => css`
-    &.${pfx}-entities-filters {
-      width: 100%;
-      margin: 0;
-      padding: 0;
-      border: solid 1px ${isDarkTheme ? theme.palette.divider : "transparent"};
-      border-radius: ${theme.shape.borderRadius};
-      background: ${isDarkTheme
-        ? theme.palette.background.secondary
-        : theme.palette.background.default};
-    }
+const defaultStyles = ({
+  theme,
+  isDarkTheme,
+}: ActiveThemeType<ProcessedTheme>) => css`
+  &.entities-filters {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: solid 1px ${isDarkTheme ? theme.palette.divider : "transparent"};
+    border-radius: ${theme.shape.borderRadius};
+    background: ${isDarkTheme
+      ? theme.palette.background.secondary
+      : theme.palette.background.default};
+  }
 
-    .${pfx}-section-divider {
-      height: 1px;
-      min-height: 1px;
-      width: 100%;
-      margin: ${theme.spacing.base} auto;
-      background-color: ${theme.palette.divider};
-    }
+  .section-divider {
+    height: 1px;
+    min-height: 1px;
+    width: 100%;
+    margin: ${theme.spacing.base} auto;
+    background-color: ${theme.palette.divider};
+  }
 
-    .${pfx}-checkbox-list-container {
-      width: 90%;
-      margin: 0 auto;
-      min-height: auto;
-      max-height: 50%;
-    }
-  `;
+  .checkbox-list-container {
+    width: 90%;
+    margin: 0 auto;
+    min-height: auto;
+    max-height: 50%;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.tsx
@@ -5,7 +5,7 @@ import {
   ModuleContainer,
   ModuleContainerHeader,
 } from "../../components";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import useTranslations from "../../hooks/useTranslations";
 import defaultStyles from "./EntitiesFilter.styles";
 import useFiltersConfig from "./useFiltersConfig";
@@ -22,7 +22,6 @@ const EntitiesFilter = ({
   ...headerProps
 }: EntitiesFilterProps) => {
   const t = useTranslations();
-  const pfx = withClassNamePrefix("ft");
   const styleWithTheme = useWithTheme();
 
   const {
@@ -38,10 +37,7 @@ const EntitiesFilter = ({
 
   return (
     <ModuleContainer
-      className={cx(
-        styleWithTheme(defaultStyles("ft")),
-        pfx("entities-filters")
-      )}
+      className={cx(styleWithTheme(defaultStyles), "entities-filters")}
     >
       <ModuleContainerHeader
         title={title}
@@ -49,7 +45,7 @@ const EntitiesFilter = ({
         {...headerProps}
       />
       {connectionTypes.length > 0 && (
-        <div className={pfx("checkbox-list-container")}>
+        <div className={"checkbox-list-container"}>
           <CheckboxList
             title={t("entities-filter.edge-types")}
             selectedIds={selectedConnectionTypes}
@@ -59,9 +55,9 @@ const EntitiesFilter = ({
           />
         </div>
       )}
-      <div className={pfx("section-divider")} />
+      <div className={"section-divider"} />
       {vertexTypes.length > 0 && (
-        <div className={pfx("checkbox-list-container")}>
+        <div className={"checkbox-list-container"}>
           <CheckboxList
             title={t("entities-filter.node-types")}
             selectedIds={selectedVertexTypes}

--- a/packages/graph-explorer/src/modules/EntitiesTabular/EntitiesTabular.styles.ts
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/EntitiesTabular.styles.ts
@@ -1,30 +1,28 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core/ThemeProvider/types";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => {
-    const { palette } = theme;
+const defaultStyles: ThemeStyleFn = ({ theme }) => {
+  const { palette } = theme;
 
-    return css`
-      &.${pfx}-entities-tabular-module {
+  return css`
+    &.entities-tabular-module {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      flex-grow: 1;
+
+      > .card-root {
         position: relative;
         width: 100%;
         height: 100%;
-        flex-grow: 1;
-
-        > .${pfx}-card-root {
-          position: relative;
-          width: 100%;
-          height: 100%;
-          margin: 0;
-          padding: 0;
-          overflow: hidden;
-          background-color: ${palette.background.secondary};
-          border: solid 1px ${palette.border};
-        }
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        background-color: ${palette.background.secondary};
+        border: solid 1px ${palette.border};
       }
-    `;
-  };
+    }
+  `;
+};
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/EntitiesTabular/EntitiesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/EntitiesTabular.tsx
@@ -4,7 +4,7 @@ import { ModuleContainer } from "../../components";
 import type { TabularInstance } from "../../components/Tabular";
 import { ModuleContainerTabularHeader } from "../../components/Tabular";
 import TabularControlsProvider from "../../components/Tabular/TabularControlsProvider";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import useTranslations from "../../hooks/useTranslations";
 import { EdgesTabular, NodesTabular } from "./components";
 import defaultStyles from "./EntitiesTabular.styles";
@@ -16,7 +16,6 @@ enum TableId {
 
 const EntitiesTabular = () => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix("ft");
   const t = useTranslations();
 
   const [selectedTable, setSelectedTable] = useState<TableId>(TableId.nodes);
@@ -58,11 +57,7 @@ const EntitiesTabular = () => {
 
   return (
     <ModuleContainer
-      classNamePrefix={"ft"}
-      className={cx(
-        styleWithTheme(defaultStyles("ft")),
-        pfx("entities-tabular-module")
-      )}
+      className={cx(styleWithTheme(defaultStyles), "entities-tabular-module")}
     >
       {nodeInstance && edgeInstance && selectedTabularInstance && (
         <TabularControlsProvider tabularInstance={selectedTabularInstance}>

--- a/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
@@ -17,7 +17,7 @@ import {
   VertexIcon,
 } from "../../components";
 import EdgeIcon from "../../components/icons/EdgeIcon";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { useConfiguration } from "../../core/ConfigurationProvider";
 import fade from "../../core/ThemeProvider/utils/fade";
 import useDisplayNames from "../../hooks/useDisplayNames";
@@ -26,21 +26,14 @@ import { formatDate } from "../../utils";
 import defaultStyles from "./EntityDetail.styles";
 
 export type EdgeDetailProps = {
-  classNamePrefix?: string;
   edge: Edge;
   sourceVertex: Vertex;
   targetVertex: Vertex;
 };
 
-const EdgeDetail = ({
-  classNamePrefix = "ft",
-  edge,
-  sourceVertex,
-  targetVertex,
-}: EdgeDetailProps) => {
+const EdgeDetail = ({ edge, sourceVertex, targetVertex }: EdgeDetailProps) => {
   const config = useConfiguration();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const edgeConfig = useMemo(() => {
     return config?.getEdgeTypeConfig(edge.data.type);
@@ -75,67 +68,63 @@ const EdgeDetail = ({
   const { name: targetName } = getDisplayNames(targetVertex);
 
   return (
-    <div
-      className={styleWithTheme(
-        defaultStyles(classNamePrefix, edgeConfig?.lineColor)
-      )}
-    >
-      <div className={pfx("header")}>
-        <div className={pfx("icon")}>
+    <div className={styleWithTheme(defaultStyles(edgeConfig?.lineColor))}>
+      <div className={"header"}>
+        <div className={"icon"}>
           <EdgeIcon />
         </div>
-        <div className={pfx("content")}>
-          <div className={pfx("title")}>{textTransform(edge.data.type)}</div>
+        <div className={"content"}>
+          <div className={"title"}>{textTransform(edge.data.type)}</div>
           {config?.connection?.queryEngine !== "sparql" && (
             <div>{edge.data.id}</div>
           )}
         </div>
       </div>
-      <div className={cx(pfx("header"), pfx("source-vertex"))}>
+      <div className={cx("header", "source-vertex")}>
         <div
           className={cx(
-            pfx("start-line"),
-            pfx(`line-${edgeConfig?.lineStyle || "solid"}`)
+            "start-line",
+            `line-${edgeConfig?.lineStyle || "solid"}`
           )}
         >
           {edgeConfig?.sourceArrowStyle === "triangle" && (
-            <ArrowTriangle className={pfx("source-arrow-type")} />
+            <ArrowTriangle className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "triangle-tee" && (
-            <ArrowTriangleTee className={pfx("source-arrow-type")} />
+            <ArrowTriangleTee className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "circle-triangle" && (
-            <ArrowTriangleCircle className={pfx("source-arrow-type")} />
+            <ArrowTriangleCircle className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "triangle-cross" && (
-            <ArrowTriangleCross className={pfx("source-arrow-type")} />
+            <ArrowTriangleCross className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "triangle-backcurve" && (
-            <ArrowTriangleBackCurve className={pfx("source-arrow-type")} />
+            <ArrowTriangleBackCurve className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "tee" && (
-            <ArrowTee className={pfx("source-arrow-type")} />
+            <ArrowTee className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "vee" && (
-            <ArrowVee className={pfx("source-arrow-type")} />
+            <ArrowVee className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "square" && (
-            <ArrowSquare className={pfx("source-arrow-type")} />
+            <ArrowSquare className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "circle" && (
-            <ArrowCircle className={pfx("source-arrow-type")} />
+            <ArrowCircle className={"source-arrow-type"} />
           )}
           {edgeConfig?.sourceArrowStyle === "diamond" && (
-            <ArrowDiamond className={pfx("source-arrow-type")} />
+            <ArrowDiamond className={"source-arrow-type"} />
           )}
           {(edgeConfig?.sourceArrowStyle === "none" ||
             !edgeConfig?.sourceArrowStyle) && (
-            <ArrowNone className={pfx("source-arrow-type")} />
+            <ArrowNone className={"source-arrow-type"} />
           )}
         </div>
         {sourceVertexConfig?.iconUrl && (
           <div
-            className={pfx("icon")}
+            className={"icon"}
             style={{
               background: fade(sourceVertexConfig.color, 0.2),
               color: sourceVertexConfig.color,
@@ -147,58 +136,55 @@ const EdgeDetail = ({
             />
           </div>
         )}
-        <div className={pfx("content")}>
-          <div className={pfx("title")}>{sourceName}</div>
+        <div className={"content"}>
+          <div className={"title"}>{sourceName}</div>
           <div>
             {textTransform(sourceVertex?.data.type || sourceVertex?.data.id)}
           </div>
         </div>
       </div>
-      <div className={cx(pfx("header"), pfx("target-vertex"))}>
+      <div className={cx("header", "target-vertex")}>
         <div
-          className={cx(
-            pfx("end-line"),
-            pfx(`line-${edgeConfig?.lineStyle || "solid"}`)
-          )}
+          className={cx("end-line", `line-${edgeConfig?.lineStyle || "solid"}`)}
         >
           {(edgeConfig?.targetArrowStyle === "triangle" ||
             !edgeConfig?.targetArrowStyle) && (
-            <ArrowTriangle className={pfx("target-arrow-type")} />
+            <ArrowTriangle className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "triangle-tee" && (
-            <ArrowTriangleTee className={pfx("target-arrow-type")} />
+            <ArrowTriangleTee className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "circle-triangle" && (
-            <ArrowTriangleCircle className={pfx("target-arrow-type")} />
+            <ArrowTriangleCircle className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "triangle-cross" && (
-            <ArrowTriangleCross className={pfx("target-arrow-type")} />
+            <ArrowTriangleCross className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "triangle-backcurve" && (
-            <ArrowTriangleBackCurve className={pfx("target-arrow-type")} />
+            <ArrowTriangleBackCurve className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "tee" && (
-            <ArrowTee className={pfx("target-arrow-type")} />
+            <ArrowTee className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "vee" && (
-            <ArrowVee className={pfx("target-arrow-type")} />
+            <ArrowVee className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "square" && (
-            <ArrowSquare className={pfx("target-arrow-type")} />
+            <ArrowSquare className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "circle" && (
-            <ArrowCircle className={pfx("target-arrow-type")} />
+            <ArrowCircle className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "diamond" && (
-            <ArrowDiamond className={pfx("target-arrow-type")} />
+            <ArrowDiamond className={"target-arrow-type"} />
           )}
           {edgeConfig?.targetArrowStyle === "none" && (
-            <ArrowNone className={pfx("target-arrow-type")} />
+            <ArrowNone className={"target-arrow-type"} />
           )}
         </div>
         {targetVertexConfig?.iconUrl && (
           <div
-            className={pfx("icon")}
+            className={"icon"}
             style={{
               background: fade(targetVertexConfig.color, 0.2),
               color: targetVertexConfig.color,
@@ -210,31 +196,29 @@ const EdgeDetail = ({
             />
           </div>
         )}
-        <div className={pfx("content")}>
-          <div className={pfx("title")}>{targetName}</div>
+        <div className={"content"}>
+          <div className={"title"}>{targetName}</div>
           <div>
             {textTransform(targetVertex?.data.type || targetVertex?.data.id)}
           </div>
         </div>
       </div>
       {edgeConfig && sortedAttributes.length > 0 && (
-        <div className={pfx("properties")}>
-          <div className={pfx("title")}>Properties</div>
-          <div className={pfx("content")}>
+        <div className={"properties"}>
+          <div className={"title"}>Properties</div>
+          <div className={"content"}>
             {sortedAttributes.map(attribute => (
-              <div key={attribute.name} className={pfx("attribute")}>
-                <div className={pfx("attribute-name")}>
-                  {attribute.displayLabel}
-                </div>
+              <div key={attribute.name} className={"attribute"}>
+                <div className={"attribute-name"}>{attribute.displayLabel}</div>
                 {attribute.dataType !== "Date" && (
-                  <div className={pfx("attribute-value")}>
+                  <div className={"attribute-value"}>
                     {edge.data.attributes[attribute.name] == null
                       ? "---"
                       : String(edge.data.attributes[attribute.name])}
                   </div>
                 )}
                 {attribute.dataType === "Date" && (
-                  <div className={pfx("attribute-value")}>
+                  <div className={"attribute-value"}>
                     {formatDate(new Date(edge.data.attributes[attribute.name]))}
                   </div>
                 )}

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityAttribute.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityAttribute.tsx
@@ -1,35 +1,27 @@
-import { AttributeConfig, withClassNamePrefix } from "../../core";
+import { AttributeConfig } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
 import { formatDate } from "../../utils";
 
 export type EntityAttributeProps = {
-  classNamePrefix?: string;
   value: Date | string | number;
   attribute: AttributeConfig;
 };
 
-const EntityAttribute = ({
-  classNamePrefix = "ft",
-  value,
-  attribute,
-}: EntityAttributeProps) => {
-  const pfx = withClassNamePrefix(classNamePrefix);
+const EntityAttribute = ({ value, attribute }: EntityAttributeProps) => {
   const textTransform = useTextTransform();
 
   return (
-    <div key={attribute.name} className={pfx("attribute")}>
+    <div key={attribute.name} className={"attribute"}>
       <div>
-        <div className={pfx("attribute-name")}>
+        <div className={"attribute-name"}>
           <div>{attribute.displayLabel || textTransform(attribute.name)}</div>
         </div>
-        {value == null && <div className={pfx("attribute-value")}>---</div>}
+        {value == null && <div className={"attribute-value"}>---</div>}
         {!["Date", "g:Date"].includes(attribute.dataType || "") && value && (
-          <div className={pfx("attribute-value")}>{String(value)}</div>
+          <div className={"attribute-value"}>{String(value)}</div>
         )}
         {["Date", "g:Date"].includes(attribute.dataType || "") && value && (
-          <div className={pfx("attribute-value")}>
-            {formatDate(new Date(value))}
-          </div>
+          <div className={"attribute-value"}>{formatDate(new Date(value))}</div>
         )}
       </div>
     </div>

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityDetail.styles.ts
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityDetail.styles.ts
@@ -3,13 +3,13 @@ import type { ThemeStyleFn } from "../../core";
 import fade from "../../core/ThemeProvider/utils/fade";
 
 const defaultStyles =
-  (pfx: string, lineColor = "#b3b3b3"): ThemeStyleFn =>
+  (lineColor = "#b3b3b3"): ThemeStyleFn =>
   ({ theme }) => css`
     height: 100%;
     overflow: auto;
     background: ${theme.palette.background.default};
 
-    .${pfx}-header {
+    .header {
       position: sticky;
       top: 0;
       z-index: 1;
@@ -20,7 +20,7 @@ const defaultStyles =
       column-gap: ${theme.spacing["2x"]};
       border-bottom: solid 1px ${theme.palette.border};
 
-      .${pfx}-icon {
+      .icon {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -32,27 +32,27 @@ const defaultStyles =
         min-height: 36px;
       }
 
-      .${pfx}-content {
+      .content {
         word-break: break-word;
-        .${pfx}-title {
+        .title {
           font-weight: bold;
         }
       }
     }
 
-    .${pfx}-source-vertex {
+    .source-vertex {
       position: relative;
       z-index: 0;
       padding-left: calc(${theme.spacing["4x"]} + 48px);
 
-      .${pfx}-start-line {
+      .start-line {
         position: absolute;
         left: calc(${theme.spacing["4x"]} + 16px);
         top: 20%;
         height: 80%;
         width: 2px;
 
-        .${pfx}-source-arrow-type {
+        .source-arrow-type {
           position: absolute;
           top: -12px;
           left: -11px;
@@ -64,19 +64,19 @@ const defaultStyles =
       }
     }
 
-    .${pfx}-target-vertex {
+    .target-vertex {
       position: relative;
       z-index: 0;
       padding-left: calc(${theme.spacing["4x"]} + 48px);
 
-      .${pfx}-end-line {
+      .end-line {
         position: absolute;
         left: calc(${theme.spacing["4x"]} + 16px);
         top: -1px;
         height: 80%;
         width: 2px;
 
-        .${pfx}-target-arrow-type {
+        .target-arrow-type {
           position: absolute;
           bottom: -12px;
           left: -11px;
@@ -88,11 +88,11 @@ const defaultStyles =
       }
     }
 
-    .${pfx}-line-solid {
+    .line-solid {
       background: ${lineColor};
     }
 
-    .${pfx}-line-dashed {
+    .line-dashed {
       background-image: linear-gradient(
         ${lineColor} 70%,
         rgba(255, 255, 255, 0) 0%
@@ -102,7 +102,7 @@ const defaultStyles =
       background-repeat: repeat-y;
     }
 
-    .${pfx}-line-dotted {
+    .line-dotted {
       background-image: linear-gradient(
         ${lineColor} 50%,
         rgba(255, 255, 255, 0) 0%
@@ -112,26 +112,26 @@ const defaultStyles =
       background-repeat: repeat-y;
     }
 
-    .${pfx}-connections {
+    .connections {
       padding: ${theme.spacing["4x"]};
       border-bottom: solid 1px ${theme.palette.border};
 
-      .${pfx}-title {
+      .title {
         font-weight: bold;
       }
 
-      .${pfx}-chip {
+      .chip {
         padding: ${theme.spacing["2x"]};
         background: ${fade(theme.palette.primary.main, 0.2)};
         color: ${theme.palette.primary.main};
       }
 
-      .${pfx}-content {
+      .content {
         display: flex;
         margin-top: ${theme.spacing["2x"]};
         column-gap: ${theme.spacing["4x"]};
-        .${pfx}-item {
-          .${pfx}-chip {
+        .item {
+          .chip {
             padding: ${theme.spacing["2x"]};
             background: ${fade(theme.palette.primary.main, 0.2)};
             color: ${theme.palette.primary.main};
@@ -143,45 +143,46 @@ const defaultStyles =
       }
     }
 
-    .${pfx}-properties {
+    .properties {
       padding: ${theme.spacing["4x"]};
 
-      .${pfx}-title {
+      .title {
         font-weight: bold;
       }
 
-      .${pfx}-content {
+      .content {
         display: flex;
         flex-direction: column;
         margin-top: ${theme.spacing["2x"]};
 
-        .${pfx}-attribute {
+        .attribute {
           display: flex;
           align-items: center;
           justify-content: space-between;
           padding: ${theme.spacing["2x"]} 0;
 
-          .${pfx}-attribute-select {
+          .attribute-select {
             margin-bottom: 0;
             width: auto;
             min-width: 120px;
-            .${pfx}-select {
+            .select {
               padding: ${theme.spacing.base} 0 ${theme.spacing.base}
                 ${theme.spacing["2x"]};
               border-radius: 24px;
             }
-            .${pfx}-option-selected {
+            .option-selected {
               background: ${theme.palette.primary.main};
               color: ${theme.palette.primary.contrastText};
             }
-            .${pfx}-selection, .${pfx}-placeholder {
+            .selection,
+            .placeholder {
               margin-right: 24px;
             }
           }
 
           > div {
             width: 100%;
-            .${pfx}-attribute-name {
+            .attribute-name {
               display: flex;
               align-items: center;
               justify-content: space-between;
@@ -192,7 +193,7 @@ const defaultStyles =
                 word-break: break-word;
               }
             }
-            .${pfx}-attribute-value {
+            .attribute-value {
               word-break: break-word;
               font-weight: bold;
             }

--- a/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
@@ -1,7 +1,7 @@
 import difference from "lodash/difference";
 import { useMemo } from "react";
 import type { Vertex } from "../../@types/entities";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { useConfiguration } from "../../core/ConfigurationProvider";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
@@ -11,20 +11,17 @@ import defaultStyles from "./EntityDetail.styles";
 import VertexHeader from "../common/VertexHeader";
 
 export type VertexDetailProps = {
-  classNamePrefix?: string;
   hideNeighbors?: boolean;
   node: Vertex;
 };
 
 export default function NodeDetail({
-  classNamePrefix = "ft",
   node,
   hideNeighbors = false,
 }: VertexDetailProps) {
   const config = useConfiguration();
   const t = useTranslations();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const textTransform = useTextTransform();
 
   const vertexConfig = useMemo(() => {
@@ -58,14 +55,12 @@ export default function NodeDetail({
   ]);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
-      <VertexHeader vertex={node} classNamePrefix={classNamePrefix} />
-      {hideNeighbors != true && (
-        <NeighborsList vertex={node} classNamePrefix={classNamePrefix} />
-      )}
-      <div className={pfx("properties")}>
-        <div className={pfx("title")}>Properties</div>
-        <div className={pfx("content")}>
+    <div className={styleWithTheme(defaultStyles())}>
+      <VertexHeader vertex={node} />
+      {hideNeighbors != true && <NeighborsList vertex={node} />}
+      <div className={"properties"}>
+        <div className={"title"}>Properties</div>
+        <div className={"content"}>
           <EntityAttribute
             value={
               config?.connection?.queryEngine === "sparql"
@@ -78,7 +73,6 @@ export default function NodeDetail({
                 ? "Blank node ID"
                 : t("node-detail.node-id"),
             }}
-            classNamePrefix={classNamePrefix}
           />
           <EntityAttribute
             value={
@@ -91,14 +85,12 @@ export default function NodeDetail({
               name: "types",
               displayLabel: t("node-detail.node-type"),
             }}
-            classNamePrefix={classNamePrefix}
           />
           {sortedAttributes.map(attribute => (
             <EntityAttribute
               key={attribute.name}
               value={node.data.attributes[attribute.name]}
               attribute={attribute}
-              classNamePrefix={classNamePrefix}
             />
           ))}
         </div>

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -35,7 +35,6 @@ import {
 } from "../../core/StateProvider/nodes";
 import useWithTheme from "../../core/ThemeProvider/useWithTheme";
 import fade from "../../core/ThemeProvider/utils/fade";
-import withClassNamePrefix from "../../core/ThemeProvider/utils/withClassNamePrefix";
 import { useEntities, useExpandNode } from "../../hooks";
 import useTextTransform from "../../hooks/useTextTransform";
 import defaultStyles from "./GraphViewerModule.styles";
@@ -135,7 +134,6 @@ export default function GraphViewer({
   ...headerProps
 }: GraphViewerProps) {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix("ft");
 
   const graphRef = useRef<GraphRef | null>(null);
   const [entities, setEntities] = useEntities();
@@ -233,10 +231,7 @@ export default function GraphViewer({
   return (
     <div
       ref={dropAreaRef}
-      className={cx(
-        styleWithTheme(defaultStyles("ft")),
-        pfx("graph-viewer-module")
-      )}
+      className={cx(styleWithTheme(defaultStyles), "graph-viewer-module")}
       onContextMenu={onContextMenu}
     >
       <ModuleContainer>
@@ -247,7 +242,7 @@ export default function GraphViewer({
             >
               <div style={{ whiteSpace: "nowrap" }}>{title}</div>
               <Select
-                className={pfx("entity-select")}
+                className={"entity-select"}
                 label={"Layout"}
                 labelPlacement={"inner"}
                 hideError={true}
@@ -321,9 +316,9 @@ export default function GraphViewer({
         </div>
       </ModuleContainer>
       <div
-        className={cx(pfx("drop-overlay"), {
-          [pfx("drop-overlay-is-over")]: isOver,
-          [pfx("drop-overlay-can-drop")]: !isOver && canDrop,
+        className={cx("drop-overlay", {
+          ["drop-overlay-is-over"]: isOver,
+          ["drop-overlay-can-drop"]: !isOver && canDrop,
         })}
       />
     </div>
@@ -331,14 +326,13 @@ export default function GraphViewer({
 }
 
 function Legend({ onClose }: { onClose: () => void }) {
-  const pfx = withClassNamePrefix("ft");
   const config = useConfiguration();
   const textTransform = useTextTransform();
 
   return (
-    <Card className={pfx("legend-container")}>
+    <Card className={"legend-container"}>
       <ListItem
-        className={cx(pfx("legend-item"), pfx("legend-title"))}
+        className={cx("legend-item", "legend-title")}
         endAdornment={
           <IconButton
             icon={<CloseIcon />}
@@ -355,11 +349,11 @@ function Legend({ onClose }: { onClose: () => void }) {
         return (
           <ListItem
             key={vertexType}
-            className={pfx("legend-item")}
+            className={"legend-item"}
             startAdornment={
               vtConfig?.iconUrl && (
                 <div
-                  className={pfx("icon")}
+                  className={"icon"}
                   style={{
                     background: fade(vtConfig?.color, 0.2),
                     color: vtConfig?.color,

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewerModule.styles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewerModule.styles.ts
@@ -2,131 +2,129 @@ import { css } from "@emotion/css";
 import { ThemeStyleFn } from "../../core";
 import fade from "../../core/ThemeProvider/utils/fade";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-graph-viewer-module {
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.graph-viewer-module {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    flex-grow: 1;
+
+    .no-header {
+      top: 4px;
+    }
+
+    .entity-select {
+      flex-grow: 1;
+      min-width: 200px;
+      width: 100px;
+      margin-bottom: 0;
+      margin-left: ${theme.spacing["4x"]};
+    }
+
+    > .card-root {
       position: relative;
       width: 100%;
       height: 100%;
-      flex-grow: 1;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      background-color: ${theme.palette.background.secondary};
+      border: solid 1px ${theme.palette.border};
+    }
 
-      .${pfx}-no-header {
-        top: 4px;
+    .loading-container {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      bottom: var(--spacing-3x);
+      right: var(--spacing-3x);
+
+      > :first-child {
+        font-size: ${theme.typography.sizes?.xs};
+        color: ${theme.palette.background.contrastSecondary};
       }
+    }
 
-      .${pfx}-entity-select {
-        flex-grow: 1;
-        min-width: 200px;
-        width: 100px;
-        margin-bottom: 0;
-        margin-left: ${theme.spacing["4x"]};
-      }
+    .drop-overlay {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      top: 0;
+      left: 0;
+      z-index: ${theme.zIndex.panes};
+      pointer-events: none;
+      transition: background-color 250ms ease;
+      border-radius: ${theme.shape.borderRadius};
+    }
 
-      > .${pfx}-card-root {
-        position: relative;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-        padding: 0;
-        overflow: hidden;
-        background-color: ${theme.palette.background.secondary};
-        border: solid 1px ${theme.palette.border};
-      }
+    .drop-overlay-is-over {
+      background-color: ${fade(theme.palette.primary.main, 0.3)};
+    }
 
-      .${pfx}-loading-container {
-        position: absolute;
+    .drop-overlay-can-drop {
+      background-color: ${fade(theme.palette.secondary.main, 0.3)};
+    }
+
+    .expanding-overlay {
+      display: none;
+      color: ${theme.palette.text.primary};
+      background-color: ${fade(theme.palette.primary.main, 0.3)};
+
+      justify-content: flex-start;
+      align-items: flex-end;
+      padding: ${theme.spacing["4x"]};
+      font-weight: ${theme.typography.weight?.bold};
+
+      > div {
         display: flex;
         align-items: center;
-        bottom: var(--spacing-3x);
-        right: var(--spacing-3x);
+        color: ${theme.palette.primary.contrastText};
+      }
 
-        > :first-child {
-          font-size: ${theme.typography.sizes?.xs};
-          color: ${theme.palette.background.contrastSecondary};
+      &.visible {
+        display: flex;
+      }
+    }
+
+    .legend-container {
+      position: absolute;
+      overflow: auto;
+      height: calc(100% - ${theme.spacing["2x"]} - ${theme.spacing["2x"]});
+      min-width: 200px;
+      max-width: 400px;
+      z-index: ${theme.zIndex.panes};
+      bottom: ${theme.spacing["2x"]};
+      right: ${theme.spacing["2x"]};
+      row-gap: ${theme.spacing["2x"]};
+
+      .legend-title {
+        .content {
+          .primary {
+            font-weight: bold;
+          }
+        }
+        .end-adornment {
+          margin: 0;
         }
       }
-
-      .${pfx}-drop-overlay {
-        position: absolute;
-        height: 100%;
-        width: 100%;
-        top: 0;
-        left: 0;
-        z-index: ${theme.zIndex.panes};
-        pointer-events: none;
-        transition: background-color 250ms ease;
-        border-radius: ${theme.shape.borderRadius};
-      }
-
-      .${pfx}-drop-overlay-is-over {
-        background-color: ${fade(theme.palette.primary.main, 0.3)};
-      }
-
-      .${pfx}-drop-overlay-can-drop {
-        background-color: ${fade(theme.palette.secondary.main, 0.3)};
-      }
-
-      .${pfx}-expanding-overlay {
-        display: none;
-        color: ${theme.palette.text.primary};
-        background-color: ${fade(theme.palette.primary.main, 0.3)};
-
-        justify-content: flex-start;
-        align-items: flex-end;
-        padding: ${theme.spacing["4x"]};
-        font-weight: ${theme.typography.weight?.bold};
-
-        > div {
+      .legend-item {
+        .icon {
           display: flex;
           align-items: center;
-          color: ${theme.palette.primary.contrastText};
+          justify-content: center;
+          width: 24px;
+          height: 24px;
+          padding: ${theme.spacing.base};
+          border-radius: 12px;
+          color: ${theme.palette.primary.main};
+          background: ${fade(theme.palette.primary.main, 0.3)};
         }
-
-        &.${pfx}-visible {
-          display: flex;
-        }
-      }
-
-      .${pfx}-legend-container {
-        position: absolute;
-        overflow: auto;
-        height: calc(100% - ${theme.spacing["2x"]} - ${theme.spacing["2x"]});
-        min-width: 200px;
-        max-width: 400px;
-        z-index: ${theme.zIndex.panes};
-        bottom: ${theme.spacing["2x"]};
-        right: ${theme.spacing["2x"]};
-        row-gap: ${theme.spacing["2x"]};
-
-        .${pfx}-legend-title {
-          .${pfx}-content {
-            .${pfx}-primary {
-              font-weight: bold;
-            }
-          }
-          .${pfx}-end-adornment {
-            margin: 0;
-          }
-        }
-        .${pfx}-legend-item {
-          .${pfx}-icon {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            width: 24px;
-            height: 24px;
-            padding: ${theme.spacing.base};
-            border-radius: 12px;
-            color: ${theme.palette.primary.main};
-            background: ${fade(theme.palette.primary.main, 0.3)};
-          }
-          .${pfx}-content {
-            min-height: 24px;
-          }
+        .content {
+          min-height: 24px;
         }
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.styles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.styles.ts
@@ -2,100 +2,98 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 import { fade } from "../../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-context-menu {
-      .${pfx}-card-root {
-        min-width: 150px;
-        max-height: min(500px, 90vh);
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.context-menu {
+    .card-root {
+      min-width: 150px;
+      max-height: min(500px, 90vh);
+      margin: 0;
+      padding: 0;
+      overflow: auto;
+      border: none;
+    }
+
+    .title {
+      font-weight: ${theme.typography.weight?.bold};
+      font-size: ${theme.typography.sizes.xs};
+      padding: ${theme.spacing.base} ${theme.spacing["4x"]};
+    }
+
+    .list-item {
+      &.list-item-header {
+        .primary {
+          font-weight: ${theme.typography.weight?.bold};
+        }
+        background: ${fade(theme.palette.primary.main, 0.3)};
+      }
+      font-size: ${theme.typography.sizes.xs};
+
+      .content {
+        min-height: 28px;
+        height: 28px;
+        padding-right: ${theme.spacing["2x"]};
+      }
+
+      .list-item-chip {
+        font-size: ${theme.typography.sizes.xs};
+        height: 16px;
+      }
+
+      .start-adornment {
+        font-size: ${theme.typography.sizes.base};
+        color: ${theme.palette.text.disabled};
         margin: 0;
-        padding: 0;
-        overflow: auto;
-        border: none;
       }
 
-      .${pfx}-title {
-        font-weight: ${theme.typography.weight?.bold};
-        font-size: ${theme.typography.sizes.xs};
-        padding: ${theme.spacing.base} ${theme.spacing["4x"]};
-      }
-
-      .${pfx}-list-item {
-        &.${pfx}-list-item-header {
-          .${pfx}-primary {
-            font-weight: ${theme.typography.weight?.bold};
-          }
-          background: ${fade(theme.palette.primary.main, 0.3)};
+      .end-adornment {
+        pointer-events: auto;
+        color: ${theme.palette.grey[300]};
+        min-width: 20px;
+        margin-right: 0px;
+        svg {
+          font-size: ${theme.typography.sizes.xl};
         }
-        font-size: ${theme.typography.sizes.xs};
-
-        .${pfx}-content {
-          min-height: 28px;
-          height: 28px;
-          padding-right: ${theme.spacing["2x"]};
-        }
-
-        .${pfx}-list-item-chip {
-          font-size: ${theme.typography.sizes.xs};
-          height: 16px;
-        }
-
-        .${pfx}-start-adornment {
-          font-size: ${theme.typography.sizes.base};
-          color: ${theme.palette.text.disabled};
-          margin: 0;
-        }
-
-        .${pfx}-end-adornment {
-          pointer-events: auto;
-          color: ${theme.palette.grey[300]};
-          min-width: 20px;
-          margin-right: 0px;
-          svg {
-            font-size: ${theme.typography.sizes.xl};
-          }
-          .${pfx}-active-pin {
-            color: ${theme.palette.primary.main};
-          }
-        }
-
-        .${pfx}-primary-switch {
-          margin-left: ${theme.spacing["2x"]};
-        }
-
-        &.${pfx}-clickable:hover {
-          .${pfx}-start-adornment {
-            color: ${theme.palette.primary.main};
-          }
+        .active-pin {
+          color: ${theme.palette.primary.main};
         }
       }
 
-      .${pfx}-divider {
-        width: 100%;
-        height: 1px;
-        background-color: ${theme.palette.divider};
-      }
-      .${pfx}-card-root>.${pfx}-divider:first-child {
-        display: none;
+      .primary-switch {
+        margin-left: ${theme.spacing["2x"]};
       }
 
-      &.${pfx}-card-elevation-3 {
-        border: none;
-        background-color: transparent;
-      }
-
-      .${pfx}-divider + .${pfx}-divider {
-        display: none;
-      }
-
-      .${pfx}-global-divider:not(:first-child) {
-        width: 100%;
-        height: 2px;
-        margin: ${theme.spacing["2x"]} 0;
-        background-color: ${theme.palette.divider};
+      &.clickable:hover {
+        .start-adornment {
+          color: ${theme.palette.primary.main};
+        }
       }
     }
-  `;
+
+    .divider {
+      width: 100%;
+      height: 1px;
+      background-color: ${theme.palette.divider};
+    }
+    .card-root > .divider:first-child {
+      display: none;
+    }
+
+    &.card-elevation-3 {
+      border: none;
+      background-color: transparent;
+    }
+
+    .divider + .divider {
+      display: none;
+    }
+
+    .global-divider:not(:first-child) {
+      width: 100%;
+      height: 2px;
+      margin: ${theme.spacing["2x"]} 0;
+      background-color: ${theme.palette.divider};
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -19,7 +19,7 @@ import {
   ZoomInIcon,
   ZoomOutIcon,
 } from "../../../components/icons";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import { edgesSelectedIdsAtom } from "../../../core/StateProvider/edges";
 import { nodesSelectedIdsAtom } from "../../../core/StateProvider/nodes";
 import { userLayoutAtom } from "../../../core/StateProvider/userPreferences";
@@ -30,7 +30,6 @@ import useGraphGlobalActions from "../useGraphGlobalActions";
 import defaultStyles from "./ContextMenu.styles";
 
 export type ContextMenuProps = {
-  classNamePrefix?: string;
   className?: string;
   affectedNodesIds?: string[];
   affectedEdgesIds?: string[];
@@ -41,7 +40,6 @@ export type ContextMenuProps = {
 };
 
 const ContextMenu = ({
-  classNamePrefix = "ft",
   className,
   affectedNodesIds,
   affectedEdgesIds,
@@ -51,7 +49,6 @@ const ContextMenu = ({
   onEdgeCustomize,
 }: ContextMenuProps) => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const t = useTranslations();
   const [entities, setEntities] = useEntities();
   const [nodesSelectedIds, setNodesSelectedIds] =
@@ -186,24 +183,18 @@ const ContextMenu = ({
   if (affectedNode) {
     return (
       <div
-        className={cx(
-          styleWithTheme(defaultStyles(classNamePrefix)),
-          pfx("context-menu"),
-          className
-        )}
+        className={cx(styleWithTheme(defaultStyles), "context-menu", className)}
       >
-        <Card className={pfx("card-root")}>
+        <Card className={"card-root"}>
           <ListItem
-            classNamePrefix={"ft"}
-            className={cx(pfx("list-item"), pfx("list-item-header"))}
+            className={cx("list-item", "list-item-header")}
             startAdornment={<GraphIcon />}
           >
             {getDisplayNames(affectedNode)?.name}
           </ListItem>
-          <div className={pfx("divider")} />
+          <div className={"divider"} />
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -211,8 +202,7 @@ const ContextMenu = ({
             Details Panel
           </ListItem>
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={openSidebarPanel("expand")}
             startAdornment={<ExpandGraphIcon />}
@@ -220,8 +210,7 @@ const ContextMenu = ({
             Expand Panel
           </ListItem>
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={openSidebarPanel("nodes-styling", {
               nodeType: affectedNode.data.type,
@@ -230,10 +219,9 @@ const ContextMenu = ({
           >
             Customize Panel
           </ListItem>
-          <div className={pfx("divider")} />
+          <div className={"divider"} />
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={handleRemoveFromCanvas([affectedNode.data.id], [])}
             startAdornment={<RemoveFromCanvasIcon color={"red"} />}
@@ -248,24 +236,18 @@ const ContextMenu = ({
   if (affectedEdge) {
     return (
       <div
-        className={cx(
-          styleWithTheme(defaultStyles(classNamePrefix)),
-          pfx("context-menu"),
-          className
-        )}
+        className={cx(styleWithTheme(defaultStyles), "context-menu", className)}
       >
-        <Card className={pfx("card-root")}>
+        <Card className={"card-root"}>
           <ListItem
-            classNamePrefix={"ft"}
-            className={cx(pfx("list-item"), pfx("list-item-header"))}
+            className={cx("list-item", "list-item-header")}
             startAdornment={<EdgeIcon />}
           >
             {getDisplayNames(affectedEdge)?.name}
           </ListItem>
-          <div className={pfx("divider")} />
+          <div className={"divider"} />
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -273,8 +255,7 @@ const ContextMenu = ({
             Details Panel
           </ListItem>
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={openSidebarPanel("edges-styling", {
               edgeType: affectedEdge.data.type,
@@ -283,10 +264,9 @@ const ContextMenu = ({
           >
             Customize Panel
           </ListItem>
-          <div className={pfx("divider")} />
+          <div className={"divider"} />
           <ListItem
-            classNamePrefix={"ft"}
-            className={pfx("list-item")}
+            className={"list-item"}
             clickable={true}
             onClick={handleRemoveFromCanvas([], [affectedEdge.data.id])}
             startAdornment={<RemoveFromCanvasIcon color={"red"} />}
@@ -300,16 +280,11 @@ const ContextMenu = ({
 
   return (
     <div
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("context-menu"),
-        className
-      )}
+      className={cx(styleWithTheme(defaultStyles), "context-menu", className)}
     >
-      <Card className={pfx("card-root")}>
+      <Card className={"card-root"}>
         <ListItem
-          classNamePrefix={"ft"}
-          className={pfx("list-item")}
+          className={"list-item"}
           clickable={true}
           onClick={handleFitToFrame}
           startAdornment={<FitToFrameIcon />}
@@ -317,8 +292,7 @@ const ContextMenu = ({
           {nonEmptySelection ? "Fit Selection to Frame" : "Fit to Frame"}
         </ListItem>
         <ListItem
-          classNamePrefix={"ft"}
-          className={pfx("list-item")}
+          className={"list-item"}
           clickable={true}
           onClick={handleCenter}
           startAdornment={<CenterGraphIcon />}
@@ -326,18 +300,16 @@ const ContextMenu = ({
           {nonEmptySelection ? "Center Selection" : "Center"}
         </ListItem>
         <ListItem
-          classNamePrefix={"ft"}
-          className={pfx("list-item")}
+          className={"list-item"}
           clickable={true}
           onClick={handleDownloadScreenshot}
           startAdornment={<ScreenshotIcon />}
         >
           Download Screenshot
         </ListItem>
-        <div className={pfx("divider")} />
+        <div className={"divider"} />
         <ListItem
-          classNamePrefix={"ft"}
-          className={pfx("list-item")}
+          className={"list-item"}
           clickable={true}
           onClick={handleZoomIn}
           startAdornment={<ZoomInIcon />}
@@ -345,8 +317,7 @@ const ContextMenu = ({
           Zoom in
         </ListItem>
         <ListItem
-          classNamePrefix={"ft"}
-          className={pfx("list-item")}
+          className={"list-item"}
           clickable={true}
           onClick={handleZoomOut}
           startAdornment={<ZoomOutIcon />}
@@ -355,10 +326,9 @@ const ContextMenu = ({
         </ListItem>
         {selectedButNoAffected && (
           <>
-            <div className={pfx("divider")} />
+            <div className={"divider"} />
             <ListItem
-              classNamePrefix={"ft"}
-              className={pfx("list-item")}
+              className={"list-item"}
               clickable={true}
               onClick={handleRemoveFromCanvas(
                 Array.from(nodesSelectedIds),
@@ -372,10 +342,9 @@ const ContextMenu = ({
         )}
         {noSelectionOrNotAffected && (
           <>
-            <div className={pfx("divider")} />
+            <div className={"divider"} />
             <ListItem
-              classNamePrefix={"ft"}
-              className={pfx("list-item")}
+              className={"list-item"}
               clickable={true}
               onClick={handleRemoveAllFromCanvas}
               startAdornment={<RemoveFromCanvasIcon color={"red"} />}

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
@@ -1,138 +1,136 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme, isDarkTheme }) => css`
-    position: relative;
-    flex-grow: 1;
+const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
+  position: relative;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  justify-content: center;
+  max-width: 700px;
+
+  .bar-container {
     display: flex;
     flex-direction: row;
-    align-content: center;
-    justify-content: center;
-    max-width: 700px;
+    flex-grow: 1;
+    column-gap: ${theme.spacing["2x"]};
 
-    .${pfx}-bar-container {
+    .search-input {
+      flex-grow: 5;
+      width: unset;
+      margin-bottom: unset;
+
+      .results-adornment {
+        font-size: ${theme.typography.sizes?.xs};
+        height: 100%;
+        display: flex;
+        align-items: center;
+        color: ${theme.palette.text.secondary};
+        padding-left: ${theme.spacing["2x"]};
+      }
+    }
+
+    .entity-select {
+      flex-grow: 1;
+      min-width: 100px;
+      width: 100px;
+    }
+  }
+
+  .panel-container {
+    display: flex;
+    height: min(600px, 90vh);
+    overflow: hidden;
+    max-width: 700px;
+    padding-top: ${theme.spacing.base};
+    position: absolute;
+    width: 100vw;
+    z-index: ${theme.zIndex.popover};
+
+    .search-controls {
       display: flex;
       flex-direction: row;
-      flex-grow: 1;
+      height: 42px;
       column-gap: ${theme.spacing["2x"]};
 
-      .${pfx}-search-input {
+      .search-input {
         flex-grow: 5;
         width: unset;
-        margin-bottom: unset;
-
-        .${pfx}-results-adornment {
-          font-size: ${theme.typography.sizes?.xs};
-          height: 100%;
-          display: flex;
-          align-items: center;
-          color: ${theme.palette.text.secondary};
-          padding-left: ${theme.spacing["2x"]};
-        }
       }
 
-      .${pfx}-entity-select {
+      .entity-select {
         flex-grow: 1;
         min-width: 100px;
         width: 100px;
       }
     }
 
-    .${pfx}-panel-container {
+    .node-preview {
+      width: 50%;
+    }
+
+    .search-results {
+      align-items: center;
       display: flex;
-      height: min(600px, 90vh);
-      overflow: hidden;
-      max-width: 700px;
-      padding-top: ${theme.spacing.base};
-      position: absolute;
-      width: 100vw;
-      z-index: ${theme.zIndex.popover};
+      flex-grow: 1;
+      height: 0;
+      padding: ${theme.spacing["2x"]} 0;
 
-      .${pfx}-search-controls {
+      .search-results-grid {
         display: flex;
-        flex-direction: row;
-        height: 42px;
-        column-gap: ${theme.spacing["2x"]};
+        height: 100%;
+        width: 100%;
+        gap: ${theme.spacing.base};
 
-        .${pfx}-search-input {
-          flex-grow: 5;
-          width: unset;
-        }
-
-        .${pfx}-entity-select {
-          flex-grow: 1;
-          min-width: 100px;
-          width: 100px;
-        }
-      }
-
-      .${pfx}-node-preview {
-        width: 50%;
-      }
-
-      .${pfx}-search-results {
-        align-items: center;
-        display: flex;
-        flex-grow: 1;
-        height: 0;
-        padding: ${theme.spacing["2x"]} 0;
-
-        .${pfx}-search-results-grid {
-          display: flex;
-          height: 100%;
-          width: 100%;
-          gap: ${theme.spacing.base};
-
-          .${pfx}-search-results-advanced-list {
-            width: 300px;
-            background: ${theme.palette.background.default};
-            .${pfx}-advanced-list-item {
+        .search-results-advanced-list {
+          width: 300px;
+          background: ${theme.palette.background.default};
+          .advanced-list-item {
+            background: ${theme.palette.background.secondary};
+            .content {
               background: ${theme.palette.background.secondary};
-              .${pfx}-content {
-                background: ${theme.palette.background.secondary};
-              }
             }
           }
-
-          .${pfx}-carousel {
-            flex-grow: 1;
-            overflow: hidden;
-          }
-
-          .${pfx}-graph-remove-icon {
-            color: ${theme.palette.secondary.main};
-          }
         }
-      }
 
-      .${pfx}-actions-footer {
-        margin-top: 0;
-        width: 100%;
-        display: flex;
-        flex-direction: row;
-        gap: ${theme.spacing["2x"]};
-        padding: ${theme.spacing["2x"]};
-        justify-content: space-between;
-        align-items: center;
-        background-color: ${isDarkTheme
-          ? theme.palette.background.secondary
-          : theme.palette.background.default};
-        border-top: solid 1px ${theme.palette.border};
-
-        .${pfx}-footer-text {
-          color: ${theme.palette.text.secondary};
-          font-size: ${theme.typography.sizes["xs"]};
+        .carousel {
           flex-grow: 1;
-          text-wrap: balance;
+          overflow: hidden;
         }
 
-        .${pfx}-refuse-shrink {
-          flex-shrink: 0;
+        .graph-remove-icon {
+          color: ${theme.palette.secondary.main};
         }
       }
     }
-  `;
+
+    .actions-footer {
+      margin-top: 0;
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      gap: ${theme.spacing["2x"]};
+      padding: ${theme.spacing["2x"]};
+      justify-content: space-between;
+      align-items: center;
+      background-color: ${isDarkTheme
+        ? theme.palette.background.secondary
+        : theme.palette.background.default};
+      border-top: solid 1px ${theme.palette.border};
+
+      .footer-text {
+        color: ${theme.palette.text.secondary};
+        font-size: ${theme.typography.sizes["xs"]};
+        flex-grow: 1;
+        text-wrap: balance;
+      }
+
+      .refuse-shrink {
+        flex-shrink: 0;
+      }
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -23,12 +23,7 @@ import {
 import { CarouselRef } from "../../components/Carousel/Carousel";
 import HumanReadableNumberFormatter from "../../components/HumanReadableNumberFormatter";
 import RemoveFromCanvasIcon from "../../components/icons/RemoveFromCanvasIcon";
-import {
-  fade,
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { fade, useConfiguration, useWithTheme } from "../../core";
 import { useEntities, useFetchNode, useSet } from "../../hooks";
 import useDisplayNames from "../../hooks/useDisplayNames";
 import useTextTransform from "../../hooks/useTextTransform";
@@ -40,20 +35,15 @@ import toAdvancedList from "./toAdvancedList";
 import useKeywordSearch from "./useKeywordSearch";
 
 export type KeywordSearchProps = {
-  classNamePrefix?: string;
   className?: string;
 };
 
-const KeywordSearch = ({
-  classNamePrefix = "ft",
-  className,
-}: KeywordSearchProps) => {
+const KeywordSearch = ({ className }: KeywordSearchProps) => {
   const config = useConfiguration();
   const t = useTranslations();
   const fetchNode = useFetchNode();
   const [entities, setEntities] = useEntities();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [isFocused, setInputFocused] = useState(false);
@@ -104,7 +94,7 @@ const KeywordSearch = ({
         const { name, longName } = getDisplayNames(vertex);
         return {
           className: css`
-            .ft-start-adornment {
+            .start-adornment {
               background-color: ${fade(vtConfig?.color, 0.2)} !important;
               color: ${vtConfig?.color} !important;
             }
@@ -124,9 +114,7 @@ const KeywordSearch = ({
           ) ? (
             <IconButton
               tooltipText={"Remove from canvas"}
-              icon={
-                <RemoveFromCanvasIcon className={pfx("graph-remove-icon")} />
-              }
+              icon={<RemoveFromCanvasIcon className={"graph-remove-icon"} />}
               size={"small"}
               variant={"text"}
               onPress={() => {
@@ -161,7 +149,6 @@ const KeywordSearch = ({
     getDisplayNames,
     textTransform,
     entities.nodes,
-    pfx,
     setEntities,
     fetchNode,
   ]);
@@ -244,12 +231,12 @@ const KeywordSearch = ({
     <div
       ref={rootRef}
       id={"keyword-search-module"}
-      className={cx(styleWithTheme(defaultStyles(classNamePrefix)), className)}
+      className={cx(styleWithTheme(defaultStyles), className)}
     >
       {!isFocused && (
-        <div className={pfx("bar-container")}>
+        <div className={"bar-container"}>
           <Input
-            className={pfx("search-input")}
+            className={"search-input"}
             aria-label={"Search box"}
             hideError={true}
             value={searchTerm}
@@ -262,7 +249,7 @@ const KeywordSearch = ({
                   color={"var(--palette-primary-main)"}
                 />
               ) : searchResults.length > 0 ? (
-                <div className={pfx("results-adornment")}>
+                <div className={"results-adornment"}>
                   {searchResults.length} results
                 </div>
               ) : undefined
@@ -271,10 +258,10 @@ const KeywordSearch = ({
         </div>
       )}
       {isFocused && (
-        <Card ref={ref} className={pfx("panel-container")} elevation={3}>
-          <div className={pfx("search-controls")}>
+        <Card ref={ref} className={"panel-container"} elevation={3}>
+          <div className={"search-controls"}>
             <Select
-              className={pfx("entity-select")}
+              className={"entity-select"}
               label={t("keyword-search.node-type")}
               labelPlacement={"inner"}
               hideError={true}
@@ -284,7 +271,7 @@ const KeywordSearch = ({
               menuWidth={150}
             />
             <Select
-              className={pfx("entity-select")}
+              className={"entity-select"}
               label={t("keyword-search.node-attribute")}
               labelPlacement={"inner"}
               hideError={true}
@@ -294,7 +281,7 @@ const KeywordSearch = ({
               menuWidth={150}
             />
             <Select
-              className={pfx("entity-select")}
+              className={"entity-select"}
               label={t("keyword-search.node-exact-match")}
               labelPlacement={"inner"}
               hideError={true}
@@ -304,7 +291,7 @@ const KeywordSearch = ({
               menuWidth={150}
             />
             <Input
-              className={pfx("search-input")}
+              className={"search-input"}
               aria-label={"Search box"}
               hideError={true}
               autoFocus={true}
@@ -313,7 +300,7 @@ const KeywordSearch = ({
               placeholder={searchPlaceholder}
             />
             <IconButton
-              className={pfx("close-button")}
+              className={"close-button"}
               variant={"text"}
               tooltipText={"Close search"}
               tooltipPlacement={"bottom-center"}
@@ -321,10 +308,9 @@ const KeywordSearch = ({
               onPress={onInputFocusChange(false)}
             />
           </div>
-          <div className={pfx("search-results")}>
+          <div className={"search-results"}>
             {isFetching && (
               <PanelEmptyState
-                classNamePrefix={classNamePrefix}
                 title={"Searching..."}
                 subtitle={
                   <div>
@@ -356,17 +342,15 @@ const KeywordSearch = ({
             )}
             {noResultsAfterFetching && (
               <PanelEmptyState
-                classNamePrefix={classNamePrefix}
                 title={"No Results"}
                 subtitle={"Your criteria does not match with any record"}
                 icon={<SearchSadIcon />}
               />
             )}
             {withResultsAfterFetching && (
-              <div className={pfx("search-results-grid")}>
+              <div className={"search-results-grid"}>
                 <AdvancedList
-                  classNamePrefix={classNamePrefix}
-                  className={pfx("search-results-advanced-list")}
+                  className={"search-results-advanced-list"}
                   items={resultItems}
                   draggable={true}
                   defaultItemType={"graph-viewer__node"}
@@ -380,7 +364,7 @@ const KeywordSearch = ({
                   <Carousel
                     ref={carouselRef}
                     slidesToShow={1}
-                    className={pfx("carousel")}
+                    className={"carousel"}
                     pagination={{
                       el: `.swiper-pagination`,
                     }}
@@ -402,7 +386,7 @@ const KeywordSearch = ({
                 )}
                 {selection.state.size === 0 && (
                   <PanelEmptyState
-                    className={pfx("node-preview")}
+                    className={"node-preview"}
                     title="Select an item to preview"
                     icon={<GraphIcon />}
                   />
@@ -410,8 +394,8 @@ const KeywordSearch = ({
               </div>
             )}
           </div>
-          <div className={pfx("actions-footer")}>
-            <span className={pfx("footer-text")}>
+          <div className={"actions-footer"}>
+            <span className={"footer-text"}>
               Search returned {searchResults.length} results
               {currentTotal != null && " of "}
               {currentTotal != null && (
@@ -421,14 +405,14 @@ const KeywordSearch = ({
             <Button
               icon={<RemoveIcon />}
               onPress={() => selection.clear()}
-              className={pfx("refuse-shrink")}
+              className={"refuse-shrink"}
             >
               Clear Selection
             </Button>
             <Button
               icon={<AddCircleIcon />}
               onPress={handleAddEntities}
-              className={pfx("refuse-shrink")}
+              className={"refuse-shrink"}
             >
               {addSelectedNodesMessage()}
             </Button>

--- a/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
@@ -15,16 +15,12 @@ const COMMON_PREFIXES_ITEMS = Object.entries(commonPrefixes)
   })
   .sort((a, b) => a.title.localeCompare(b.title));
 
-export type CommonPrefixesProps = {
-  classNamePrefix?: string;
-};
-
-const CommonPrefixes = ({ classNamePrefix = "ft" }: CommonPrefixesProps) => {
+const CommonPrefixes = () => {
   const styleWithTheme = useWithTheme();
   const [search, setSearch] = useState("");
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
+    <div className={styleWithTheme(defaultStyles)}>
       <AdvancedList
         searchPlaceholder={"Search for Namespaces or URIs"}
         search={search}

--- a/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
@@ -3,13 +3,7 @@ import { AdvancedList, NamespaceIcon, PanelEmptyState } from "../../components";
 import { useConfiguration, useWithTheme } from "../../core";
 import defaultStyles from "./NsType.styles";
 
-export type GeneratedPrefixesProps = {
-  classNamePrefix?: string;
-};
-
-const GeneratedPrefixes = ({
-  classNamePrefix = "ft",
-}: GeneratedPrefixesProps) => {
+const GeneratedPrefixes = () => {
   const styleWithTheme = useWithTheme();
   const config = useConfiguration();
   const [search, setSearch] = useState("");
@@ -36,7 +30,7 @@ const GeneratedPrefixes = ({
   }, [config?.schema?.prefixes]);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
+    <div className={styleWithTheme(defaultStyles)}>
       {items.length === 0 && (
         <PanelEmptyState
           title={"No Namespaces"}

--- a/packages/graph-explorer/src/modules/Namespaces/NsType.styles.ts
+++ b/packages/graph-explorer/src/modules/Namespaces/NsType.styles.ts
@@ -1,27 +1,25 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    height: 100%;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .advanced-list {
+    background: ${theme.palette.background.default};
+    section > .content {
+      padding: 0 ${theme.spacing["4x"]};
+    }
+  }
+
+  .actions {
+    background: ${theme.palette.background.default};
     display: flex;
-    flex-direction: column;
-
-    .${pfx}-advanced-list {
-      background: ${theme.palette.background.default};
-      section > .${pfx}-content {
-        padding: 0 ${theme.spacing["4x"]};
-      }
-    }
-
-    .${pfx}-actions {
-      background: ${theme.palette.background.default};
-      display: flex;
-      justify-content: flex-end;
-      padding: ${theme.spacing["2x"]};
-      border-top: solid 1px ${theme.palette.divider};
-    }
-  `;
+    justify-content: flex-end;
+    padding: ${theme.spacing["2x"]};
+    border-top: solid 1px ${theme.palette.divider};
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/Namespaces/NsTypeModal.styles.ts
+++ b/packages/graph-explorer/src/modules/Namespaces/NsTypeModal.styles.ts
@@ -1,15 +1,13 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    .${pfx}-actions {
-      display: flex;
-      justify-content: flex-end;
-      padding-top: ${theme.spacing["2x"]};
-      border-top: solid 1px ${theme.palette.divider};
-    }
-  `;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: ${theme.spacing["2x"]};
+    border-top: solid 1px ${theme.palette.divider};
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
@@ -12,27 +12,18 @@ import {
   PanelEmptyState,
   SaveIcon,
 } from "../../components";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import { schemaAtom } from "../../core/StateProvider/schema";
 import defaultStyles from "./NsType.styles";
 import modalDefaultStyles from "./NsTypeModal.styles";
-
-export type UserPrefixesProps = {
-  classNamePrefix?: string;
-};
 
 type PrefixForm = {
   prefix: string;
   uri: string;
 };
 
-const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
+const UserPrefixes = () => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const config = useConfiguration();
   const [search, setSearch] = useState("");
   const [opened, setOpened] = useState(false);
@@ -142,7 +133,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
   }, [form.prefix, form.uri, onSave]);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
+    <div className={styleWithTheme(defaultStyles)}>
       {items.length === 0 && (
         <PanelEmptyState
           title={"No Namespaces"}
@@ -154,7 +145,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
       )}
       {items.length > 0 && (
         <AdvancedList
-          className={pfx("advanced-list")}
+          className={"advanced-list"}
           searchPlaceholder={"Search for Namespaces or URIs"}
           search={search}
           onSearch={setSearch}
@@ -165,7 +156,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
         />
       )}
       {items.length > 0 && (
-        <div className={pfx("actions")}>
+        <div className={"actions"}>
           <Button
             icon={<AddIcon />}
             variant={"filled"}
@@ -180,7 +171,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
         onClose={() => setOpened(false)}
         centered={true}
         title={"Create a new Namespace"}
-        className={styleWithTheme(modalDefaultStyles(classNamePrefix))}
+        className={styleWithTheme(modalDefaultStyles)}
       >
         <div>
           <Input
@@ -192,7 +183,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
             errorMessage={"Namespace is required"}
           />
           <Input
-            className={pfx("input-uri")}
+            className={"input-uri"}
             label={"URI"}
             value={form.uri}
             onChange={onFormChange("uri")}
@@ -201,7 +192,7 @@ const UserPrefixes = ({ classNamePrefix = "ft" }: UserPrefixesProps) => {
             errorMessage={"URI is required"}
           />
         </div>
-        <div className={pfx("actions")}>
+        <div className={"actions"}>
           <Button icon={<SaveIcon />} variant={"filled"} onPress={onSubmit}>
             Save
           </Button>

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.styles.ts
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.styles.ts
@@ -2,96 +2,94 @@ import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 import fade from "../../core/ThemeProvider/utils/fade";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    height: 100%;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: scroll;
+  background: ${theme.palette.background.default};
+
+  .empty-panel-state {
+    height: auto;
+    flex-grow: 1;
+  }
+  .h-divider {
+    height: 1px;
+    margin: ${theme.spacing["2x"]} 0;
+    background: ${theme.palette.divider};
+  }
+
+  .node-item {
+    display: flex;
+    justify-content: space-between;
+    margin-top: ${theme.spacing["2x"]};
+    gap: ${theme.spacing["2x"]};
+    .vertex-type {
+      display: flex;
+      align-items: center;
+      column-gap: ${theme.spacing["2x"]};
+
+      .icon {
+        color: ${theme.palette.primary.main};
+      }
+    }
+  }
+
+  .filters-section {
     display: flex;
     flex-direction: column;
-    overflow-y: scroll;
-    background: ${theme.palette.background.default};
+    gap: ${theme.spacing["2x"]};
+    padding: ${theme.spacing["4x"]};
+    flex-grow: 1;
+    overflow-y: auto;
+    min-height: 250px;
 
-    .${pfx}-empty-panel-state {
-      height: auto;
-      flex-grow: 1;
-    }
-    .${pfx}-h-divider {
-      height: 1px;
-      margin: ${theme.spacing["2x"]} 0;
-      background: ${theme.palette.divider};
-    }
-
-    .${pfx}-node-item {
+    .title {
       display: flex;
       justify-content: space-between;
-      margin-top: ${theme.spacing["2x"]};
-      gap: ${theme.spacing["2x"]};
-      .${pfx}-vertex-type {
-        display: flex;
-        align-items: center;
-        column-gap: ${theme.spacing["2x"]};
+      font-weight: bold;
+    }
 
-        .${pfx}-icon {
-          color: ${theme.palette.primary.main};
-        }
+    .content {
+      display: flex;
+      .chip {
+        padding: ${theme.spacing["2x"]};
+        background: ${fade(theme.palette.primary.main, 0.2)};
+        color: ${theme.palette.primary.main};
       }
     }
 
-    .${pfx}-filters-section {
+    .filters {
       display: flex;
       flex-direction: column;
-      gap: ${theme.spacing["2x"]};
-      padding: ${theme.spacing["4x"]};
-      flex-grow: 1;
-      overflow-y: auto;
-      min-height: 250px;
-
-      .${pfx}-title {
-        display: flex;
-        justify-content: space-between;
-        font-weight: bold;
-      }
-
-      .${pfx}-content {
-        display: flex;
-        .${pfx}-chip {
-          padding: ${theme.spacing["2x"]};
-          background: ${fade(theme.palette.primary.main, 0.2)};
-          color: ${theme.palette.primary.main};
-        }
-      }
-
-      .${pfx}-filters {
-        display: flex;
-        flex-direction: column;
-        gap: ${theme.spacing["4x"]};
-        margin-bottom: ${theme.spacing["4x"]};
-        .${pfx}-single-filter {
-          display: flex;
-          align-items: center;
-          gap: ${theme.spacing["2x"]};
-          .${pfx}-input {
-            flex-grow: 1;
-            width: 100%;
-          }
-        }
-      }
-
-      .${pfx}-limit {
+      gap: ${theme.spacing["4x"]};
+      margin-bottom: ${theme.spacing["4x"]};
+      .single-filter {
         display: flex;
         align-items: center;
         gap: ${theme.spacing["2x"]};
-        .${pfx}-input {
+        .input {
+          flex-grow: 1;
           width: 100%;
         }
       }
     }
 
-    .${pfx}-actions {
+    .limit {
       display: flex;
-      justify-content: flex-end;
-      padding: ${theme.spacing["4x"]};
+      align-items: center;
+      gap: ${theme.spacing["2x"]};
+      .input {
+        width: 100%;
+      }
     }
-  `;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: ${theme.spacing["4x"]};
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -6,7 +6,7 @@ import ExpandGraphIcon from "../../components/icons/ExpandGraphIcon";
 import GraphIcon from "../../components/icons/GraphIcon";
 import LoadingSpinner from "../../components/LoadingSpinner";
 import PanelEmptyState from "../../components/PanelEmptyState/PanelEmptyState";
-import { useWithTheme, withClassNamePrefix } from "../../core";
+import { useWithTheme } from "../../core";
 import { useExpandNode } from "../../hooks";
 import useNeighborsOptions from "../../hooks/useNeighborsOptions";
 import useTranslations from "../../hooks/useTranslations";
@@ -18,31 +18,21 @@ import { ExpandNodeRequest } from "../../hooks/useExpandNode";
 import { useUpdateNodeCountsQuery } from "../../hooks/useUpdateNodeCounts";
 
 export type NodeExpandContentProps = {
-  classNamePrefix?: string;
   vertex: Vertex;
 };
 
-export default function NodeExpandContent({
-  classNamePrefix = "ft",
-  vertex,
-}: NodeExpandContentProps) {
+export default function NodeExpandContent({ vertex }: NodeExpandContentProps) {
   const styleWithTheme = useWithTheme();
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
-      <VertexHeader vertex={vertex} classNamePrefix={classNamePrefix} />
-      <ExpandSidebarContent vertex={vertex} classNamePrefix={classNamePrefix} />
+    <div className={styleWithTheme(defaultStyles)}>
+      <VertexHeader vertex={vertex} />
+      <ExpandSidebarContent vertex={vertex} />
     </div>
   );
 }
 
-function ExpandSidebarContent({
-  classNamePrefix,
-  vertex,
-}: {
-  classNamePrefix?: string;
-  vertex: Vertex;
-}) {
+function ExpandSidebarContent({ vertex }: { vertex: Vertex }) {
   const t = useTranslations();
   const query = useUpdateNodeCountsQuery(vertex.data.id);
 
@@ -68,21 +58,14 @@ function ExpandSidebarContent({
 
   return (
     <>
-      <NeighborsList vertex={vertex} classNamePrefix={classNamePrefix} />
-      <ExpansionOptions classNamePrefix={classNamePrefix} vertex={vertex} />
+      <NeighborsList vertex={vertex} />
+      <ExpansionOptions vertex={vertex} />
     </>
   );
 }
 
-function ExpansionOptions({
-  vertex,
-  classNamePrefix,
-}: {
-  vertex: Vertex;
-  classNamePrefix?: string;
-}) {
+function ExpansionOptions({ vertex }: { vertex: Vertex }) {
   const t = useTranslations();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const neighborsOptions = useNeighborsOptions(vertex);
 
   const [selectedType, setSelectedType] = useState<string>(
@@ -101,7 +84,7 @@ function ExpansionOptions({
   if (!hasUnfetchedNeighbors) {
     return (
       <PanelEmptyState
-        className={pfx("empty-panel-state")}
+        className={"empty-panel-state"}
         icon={<GraphIcon />}
         title={t("node-expand.no-unfetched-title")}
         subtitle={t("node-expand.no-unfetched-subtitle")}
@@ -112,7 +95,6 @@ function ExpansionOptions({
   return (
     <>
       <NodeExpandFilters
-        classNamePrefix={classNamePrefix}
         neighborsOptions={neighborsOptions}
         selectedType={selectedType}
         onSelectedTypeChange={setSelectedType}

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -8,7 +8,7 @@ import {
   Input,
   Select,
 } from "../../components";
-import { useConfiguration, withClassNamePrefix } from "../../core";
+import { useConfiguration } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
 
@@ -17,7 +17,6 @@ export type NodeExpandFilter = {
   value: string;
 };
 export type NodeExpandFiltersProps = {
-  classNamePrefix?: string;
   neighborsOptions: Array<{ label: string; value: string }>;
   selectedType: string;
   onSelectedTypeChange(type: string): void;
@@ -28,7 +27,6 @@ export type NodeExpandFiltersProps = {
 };
 
 const NodeExpandFilters = ({
-  classNamePrefix = "ft",
   neighborsOptions,
   selectedType,
   onSelectedTypeChange,
@@ -40,7 +38,6 @@ const NodeExpandFilters = ({
   const config = useConfiguration();
   const t = useTranslations();
   const textTransform = useTextTransform();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const vtConfig = config?.getVertexTypeConfig(selectedType);
   const searchableAttributes =
@@ -79,8 +76,8 @@ const NodeExpandFilters = ({
   }, [onFiltersChange, selectedType]);
 
   return (
-    <div className={pfx("filters-section")}>
-      <div className={pfx("title")}>{t("node-expand.neighbors-of-type")}</div>
+    <div className={"filters-section"}>
+      <div className={"title"}>{t("node-expand.neighbors-of-type")}</div>
       <Select
         aria-label={"neighbor type"}
         value={selectedType}
@@ -90,7 +87,7 @@ const NodeExpandFilters = ({
         options={neighborsOptions}
       />
       {!!vtConfig?.attributes?.length && (
-        <div className={pfx("title")}>
+        <div className={"title"}>
           <div>Filter to narrow results</div>
           <IconButton
             icon={<AddIcon />}
@@ -101,9 +98,9 @@ const NodeExpandFilters = ({
         </div>
       )}
       {!!searchableAttributes?.length && (
-        <div className={pfx("filters")}>
+        <div className={"filters"}>
           {filters.map((filter, filterIndex) => (
-            <div key={filterIndex} className={pfx("single-filter")}>
+            <div key={filterIndex} className={"single-filter"}>
               <Select
                 aria-label={"Attribute"}
                 value={filter.name}
@@ -119,7 +116,7 @@ const NodeExpandFilters = ({
               />
               <Input
                 aria-label={"Filter"}
-                className={pfx("input")}
+                className={"input"}
                 value={filter.value}
                 onChange={value => {
                   onFilterChange(filterIndex, filter.name, value as string);
@@ -139,7 +136,7 @@ const NodeExpandFilters = ({
           ))}
         </div>
       )}
-      <div className={pfx("title")}>
+      <div className={"title"}>
         <div style={{ display: "flex", gap: 2, alignItems: "center" }}>
           Limit returned neighbors to
           <InfoTooltip>
@@ -155,10 +152,10 @@ const NodeExpandFilters = ({
         />
       </div>
       {limit !== null && (
-        <div className={pfx("limit")}>
+        <div className={"limit"}>
           <Input
             aria-label={"limit"}
-            className={pfx("input")}
+            className={"input"}
             type={"number"}
             min={1}
             step={1}

--- a/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.style.ts
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.style.ts
@@ -1,15 +1,13 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (): ThemeStyleFn =>
-  ({ theme }) => css`
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    background: ${theme.palette.background.default};
-    height: 100%;
-    overflow: auto;
-  `;
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: ${theme.palette.background.default};
+  height: 100%;
+  overflow: auto;
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
@@ -31,7 +31,7 @@ const NodesStyling = ({
         title={t("nodes-styling.title")}
         {...headerProps}
       />
-      <div className={styleWithTheme(defaultStyles())}>
+      <div className={styleWithTheme(defaultStyles)}>
         {config?.vertexTypes.map(vertexType => (
           <SingleNodeStyling
             key={vertexType}

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.style.ts
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.style.ts
@@ -1,41 +1,39 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  display: flex;
+  flex-direction: column;
+  background: ${theme.palette.background.default};
+  gap: ${theme.spacing["2x"]};
+  padding: ${theme.spacing["2x"]} ${theme.spacing["4x"]};
+  border-bottom: solid 1px ${theme.palette.divider};
+
+  &:last-of-type {
+    border-bottom: none;
+  }
+
+  .title {
     display: flex;
-    flex-direction: column;
-    background: ${theme.palette.background.default};
+    justify-content: space-between;
     gap: ${theme.spacing["2x"]};
-    padding: ${theme.spacing["2x"]} ${theme.spacing["4x"]};
-    border-bottom: solid 1px ${theme.palette.divider};
-
-    &:last-of-type {
-      border-bottom: none;
+    .vertex-name {
+      margin-bottom: ${theme.spacing.base};
+      max-width: 80%;
+      word-break: break-word;
     }
+  }
 
-    .${pfx}-title {
-      display: flex;
-      justify-content: space-between;
-      gap: ${theme.spacing["2x"]};
-      .${pfx}-vertex-name {
-        margin-bottom: ${theme.spacing.base};
-        max-width: 80%;
-        word-break: break-word;
-      }
+  .label-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: ${theme.spacing["2x"]};
+
+    .label-display {
+      width: 100%;
     }
-
-    .${pfx}-label-container {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: ${theme.spacing["2x"]};
-
-      .${pfx}-label-display {
-        width: 100%;
-      }
-    }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -14,11 +14,7 @@ import {
 } from "../../components";
 import ColorInput from "../../components/ColorInput/ColorInput";
 import { useNotification } from "../../components/NotificationProvider";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import {
   LineStyle,
   ShapeStyle,
@@ -34,7 +30,6 @@ import defaultStyles from "./SingleNodeStyling.style";
 import modalDefaultStyles from "./SingleNodeStylingModal.style";
 
 export type SingleNodeStylingProps = {
-  classNamePrefix?: string;
   vertexType: string;
   opened: boolean;
   onOpen(): void;
@@ -51,7 +46,6 @@ const file2Base64 = (file: File): Promise<string> => {
 };
 
 const SingleNodeStyling = ({
-  classNamePrefix = "ft",
   vertexType,
   opened,
   onOpen,
@@ -60,7 +54,6 @@ const SingleNodeStyling = ({
   const config = useConfiguration();
   const t = useTranslations();
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const userStyling = useRecoilValue(userStylingAtom);
   const textTransform = useTextTransform();
@@ -208,13 +201,13 @@ const SingleNodeStyling = ({
     (vtPrefs?.iconImageType || vtConfig?.iconImageType) === "image/svg+xml";
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
-      <div className={pfx("title")}>
-        <div className={pfx("vertex-name")}>{vertexType}</div>
+    <div className={styleWithTheme(defaultStyles)}>
+      <div className={"title"}>
+        <div className={"vertex-name"}>{vertexType}</div>
       </div>
-      <div className={pfx("label-container")}>
+      <div className={"label-container"}>
         <Input
-          className={pfx("label-display")}
+          className={"label-display"}
           label={"Display As"}
           labelPlacement={"inner"}
           value={displayAs}
@@ -240,15 +233,15 @@ const SingleNodeStyling = ({
             Customize <strong>{displayAs || vertexType}</strong>
           </div>
         }
-        className={styleWithTheme(modalDefaultStyles(classNamePrefix))}
+        className={styleWithTheme(modalDefaultStyles)}
         overlayProps={{
           backgroundOpacity: 0.1,
         }}
       >
-        <div className={pfx("container")}>
+        <div className={"container"}>
           <div>
             <p>Display Attributes</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <Select
                 label={"Display Name Attribute"}
                 labelPlacement={"inner"}
@@ -271,7 +264,7 @@ const SingleNodeStyling = ({
           </div>
           <div>
             <p>Shape and Icon</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <Select
                 label={"Style"}
                 labelPlacement={"inner"}
@@ -283,7 +276,7 @@ const SingleNodeStyling = ({
                 hideError={true}
                 noMargin={true}
               />
-              <div className={pfx("icon")}>
+              <div className={"icon"}>
                 <FileButton
                   accept={"image/*"}
                   onChange={file => {
@@ -294,11 +287,11 @@ const SingleNodeStyling = ({
                     <IconButton
                       icon={
                         <div>
-                          <div className={pfx("upload-icon")}>
+                          <div className={"upload-icon"}>
                             <UploadIcon />
                           </div>
                           <div
-                            className={pfx("vertex-icon")}
+                            className={"vertex-icon"}
                             style={{
                               background: fade(vtConfig?.color, 0.2),
                               color: vtConfig?.color,
@@ -332,7 +325,7 @@ const SingleNodeStyling = ({
           </div>
           <div>
             <p>Shape Styling</p>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <ColorInput
                 label={"Color"}
                 labelPlacement={"inner"}
@@ -356,7 +349,7 @@ const SingleNodeStyling = ({
             </div>
           </div>
           <div>
-            <div className={pfx("attrs-container")}>
+            <div className={"attrs-container"}>
               <ColorInput
                 label={"Border Color"}
                 labelPlacement={"inner"}
@@ -390,7 +383,7 @@ const SingleNodeStyling = ({
               />
             </div>
           </div>
-          <div className={pfx("actions")}>
+          <div className={"actions"}>
             <Button onPress={onUserPrefsReset}>Reset to Default</Button>
           </div>
         </div>

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStylingModal.style.ts
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStylingModal.style.ts
@@ -1,85 +1,83 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../core";
 
-const defaultStyles =
-  (pfx: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    div[role="presentation"] > div {
-      margin-top: auto;
-      margin-left: auto;
-      margin-bottom: 0;
-    }
-    .${pfx}-container {
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  div[role="presentation"] > div {
+    margin-top: auto;
+    margin-left: auto;
+    margin-bottom: 0;
+  }
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: ${theme.spacing["4x"]};
+
+    .attrs-container {
       display: flex;
-      flex-direction: column;
-      gap: ${theme.spacing["4x"]};
+      justify-content: space-between;
+      gap: ${theme.spacing["2x"]};
 
-      .${pfx}-attrs-container {
-        display: flex;
-        justify-content: space-between;
-        gap: ${theme.spacing["2x"]};
+      > * {
+        flex-grow: 1;
+        width: 100%;
+      }
+    }
 
-        > * {
-          flex-grow: 1;
-          width: 100%;
+    .icon {
+      width: 10%;
+      aspect-ratio: 1;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      button {
+        color: ${theme.palette.common.black};
+        box-shadow: none;
+        background: none;
+
+        .upload-icon {
+          display: none;
+        }
+
+        .vertex-icon {
+          border-radius: 50%;
+          padding: ${theme.spacing.base};
+          display: block;
+          width: 28px;
+          height: 28px;
+
+          > * {
+            width: 18px;
+            height: 18px;
+          }
         }
       }
 
-      .${pfx}-icon {
-        width: 10%;
-        aspect-ratio: 1;
-        display: flex;
-        justify-content: center;
-        align-items: center;
+      &:hover {
+        cursor: pointer;
 
         button {
-          color: ${theme.palette.common.black};
-          box-shadow: none;
-          background: none;
+          background: ${theme.palette.grey[200]};
+          border-radius: 50%;
 
-          .${pfx}-upload-icon {
+          .upload-icon {
+            display: block;
+          }
+
+          .vertex-icon {
             display: none;
           }
-
-          .${pfx}-vertex-icon {
-            border-radius: 50%;
-            padding: ${theme.spacing.base};
-            display: block;
-            width: 28px;
-            height: 28px;
-
-            > * {
-              width: 18px;
-              height: 18px;
-            }
-          }
         }
-
-        &:hover {
-          cursor: pointer;
-
-          button {
-            background: ${theme.palette.grey[200]};
-            border-radius: 50%;
-
-            .${pfx}-upload-icon {
-              display: block;
-            }
-
-            .${pfx}-vertex-icon {
-              display: none;
-            }
-          }
-        }
-      }
-
-      .${pfx}-actions {
-        display: flex;
-        justify-content: flex-end;
-        padding-top: ${theme.spacing["2x"]};
-        border-top: solid 1px ${theme.palette.divider};
       }
     }
-  `;
+
+    .actions {
+      display: flex;
+      justify-content: flex-end;
+      padding-top: ${theme.spacing["2x"]};
+      border-top: solid 1px ${theme.palette.divider};
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.styles.ts
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.styles.ts
@@ -1,50 +1,48 @@
 import { css } from "@emotion/css";
 import type { ThemeStyleFn } from "../../../core";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    &.${pfx}-section {
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  &.section {
+    display: flex;
+    flex-direction: column;
+    padding: ${theme.spacing["4x"]};
+    gap: ${theme.spacing["2x"]};
+    border-bottom: solid 1px ${theme.palette.divider};
+
+    .title {
+      font-weight: bold;
+    }
+
+    .node-item {
       display: flex;
-      flex-direction: column;
-      padding: ${theme.spacing["4x"]};
+      justify-content: space-between;
+      margin-top: ${theme.spacing["2x"]};
       gap: ${theme.spacing["2x"]};
-      border-bottom: solid 1px ${theme.palette.divider};
-
-      .${pfx}-title {
-        font-weight: bold;
+      .chip {
+        user-select: none;
+        min-width: 48px;
+        justify-content: center;
       }
-
-      .${pfx}-node-item {
+      .vertex-type {
         display: flex;
-        justify-content: space-between;
-        margin-top: ${theme.spacing["2x"]};
-        gap: ${theme.spacing["2x"]};
-        .${pfx}-chip {
-          user-select: none;
-          min-width: 48px;
-          justify-content: center;
-        }
-        .${pfx}-vertex-type {
-          display: flex;
-          align-items: center;
-          column-gap: ${theme.spacing["2x"]};
+        align-items: center;
+        column-gap: ${theme.spacing["2x"]};
 
-          .${pfx}-icon {
-            color: ${theme.palette.primary.main};
-          }
+        .icon {
+          color: ${theme.palette.primary.main};
         }
-        .${pfx}-vertex-totals {
-          display: flex;
-          align-items: flex-end;
-          column-gap: ${theme.spacing["2x"]};
+      }
+      .vertex-totals {
+        display: flex;
+        align-items: flex-end;
+        column-gap: ${theme.spacing["2x"]};
 
-          .${pfx}-icon {
-            color: ${theme.palette.primary.main};
-          }
+        .icon {
+          color: ${theme.palette.primary.main};
         }
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -7,7 +7,7 @@ import {
   VertexIcon,
   VisibleIcon,
 } from "../../../components";
-import { useWithTheme, withClassNamePrefix } from "../../../core";
+import { useWithTheme } from "../../../core";
 import useNeighborsOptions from "../../../hooks/useNeighborsOptions";
 import defaultStyles from "./NeighborsList.styles";
 import { useState } from "react";
@@ -15,31 +15,19 @@ import { useRecoilValue } from "recoil";
 import { activeConnectionSelector } from "../../../core/connector";
 
 export type NeighborsListProps = {
-  classNamePrefix?: string;
   vertex: Vertex;
 };
 
 const MAX_NEIGHBOR_TYPE_ROWS = 5;
 
-export default function NeighborsList({
-  classNamePrefix = "ft",
-  vertex,
-}: NeighborsListProps) {
+export default function NeighborsList({ vertex }: NeighborsListProps) {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const neighborsOptions = useNeighborsOptions(vertex);
   const [showMore, setShowMore] = useState(false);
 
   return (
-    <div
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("section")
-      )}
-    >
-      <div className={pfx("title")}>
-        Neighbors ({vertex.data.neighborsCount})
-      </div>
+    <div className={cx(styleWithTheme(defaultStyles), "section")}>
+      <div className={"title"}>Neighbors ({vertex.data.neighborsCount})</div>
       {neighborsOptions
         .slice(0, showMore ? undefined : MAX_NEIGHBOR_TYPE_ROWS)
         .map(op => {
@@ -47,8 +35,8 @@ export default function NeighborsList({
             vertex.data.neighborsCountByType[op.value] -
             (vertex.data.__unfetchedNeighborCounts?.[op.value] ?? 0);
           return (
-            <div key={op.value} className={pfx("node-item")}>
-              <div className={pfx("vertex-type")}>
+            <div key={op.value} className={"node-item"}>
+              <div className={"vertex-type"}>
                 <div
                   style={{
                     color: op.config?.color,
@@ -61,18 +49,15 @@ export default function NeighborsList({
                 </div>
                 {op.label}
               </div>
-              <div className={pfx("vertex-totals")}>
+              <div className={"vertex-totals"}>
                 <Tooltip
                   text={`${neighborsInView} ${op.label} in the Graph View`}
                 >
-                  <Chip
-                    className={pfx("chip")}
-                    startAdornment={<VisibleIcon />}
-                  >
+                  <Chip className={"chip"} startAdornment={<VisibleIcon />}>
                     {neighborsInView}
                   </Chip>
                 </Tooltip>
-                <Chip className={pfx("chip")}>
+                <Chip className={"chip"}>
                   {vertex.data.neighborsCountByType[op.value]}
                 </Chip>
               </div>

--- a/packages/graph-explorer/src/modules/common/VertexHeader.tsx
+++ b/packages/graph-explorer/src/modules/common/VertexHeader.tsx
@@ -1,59 +1,44 @@
 import { useMemo } from "react";
 import { Vertex } from "../../@types/entities";
 import { VertexIcon } from "../../components";
-import {
-  withClassNamePrefix,
-  useConfiguration,
-  fade,
-  ThemeStyleFn,
-  useWithTheme,
-} from "../../core";
+import { useConfiguration, fade, ThemeStyleFn, useWithTheme } from "../../core";
 import useDisplayNames from "../../hooks/useDisplayNames";
 import useTextTransform from "../../hooks/useTextTransform";
 import { css } from "@emotion/css";
 
-const defaultStyles =
-  (pfx?: string): ThemeStyleFn =>
-  ({ theme }) => css`
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: ${theme.palette.background.default};
+const defaultStyles: ThemeStyleFn = ({ theme }) => css`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: ${theme.palette.background.default};
+  display: flex;
+  padding: ${theme.spacing["4x"]};
+  align-items: center;
+  column-gap: ${theme.spacing["2x"]};
+  border-bottom: solid 1px ${theme.palette.border};
+  word-break: break-word;
+
+  .icon {
     display: flex;
-    padding: ${theme.spacing["4x"]};
+    justify-content: center;
     align-items: center;
-    column-gap: ${theme.spacing["2x"]};
-    border-bottom: solid 1px ${theme.palette.border};
-    word-break: break-word;
+    background: ${fade(theme.palette.primary.main, 0.2)};
+    color: ${theme.palette.primary.main};
+    font-size: 2em;
+    border-radius: 24px;
+    min-width: 36px;
+    min-height: 36px;
+  }
 
-    .${pfx}-icon {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      background: ${fade(theme.palette.primary.main, 0.2)};
-      color: ${theme.palette.primary.main};
-      font-size: 2em;
-      border-radius: 24px;
-      min-width: 36px;
-      min-height: 36px;
+  .content {
+    .title {
+      font-weight: bold;
+      word-break: break-word;
     }
+  }
+`;
 
-    .${pfx}-content {
-      .${pfx}-title {
-        font-weight: bold;
-        word-break: break-word;
-      }
-    }
-  `;
-
-export default function VertexHeader({
-  vertex,
-  classNamePrefix,
-}: {
-  vertex: Vertex;
-  classNamePrefix?: string;
-}) {
-  const pfx = withClassNamePrefix(classNamePrefix);
+export default function VertexHeader({ vertex }: { vertex: Vertex }) {
   const styleWithTheme = useWithTheme();
   const config = useConfiguration();
   const textTransform = useTextTransform();
@@ -72,10 +57,10 @@ export default function VertexHeader({
   const vtConfig = config?.getVertexTypeConfig(vertex.data.type);
 
   return (
-    <div className={styleWithTheme(defaultStyles(classNamePrefix))}>
+    <div className={styleWithTheme(defaultStyles)}>
       {vtConfig?.iconUrl && (
         <div
-          className={pfx("icon")}
+          className={"icon"}
           style={{
             background: fade(vtConfig?.color, 0.2),
             color: vtConfig.color,
@@ -87,8 +72,8 @@ export default function VertexHeader({
           />
         </div>
       )}
-      <div className={pfx("content")}>
-        <div className={pfx("title")}>{displayLabels || vertex.data.type}</div>
+      <div className={"content"}>
+        <div className={"title"}>{displayLabels || vertex.data.type}</div>
         <div>{name}</div>
       </div>
     </div>

--- a/packages/graph-explorer/src/workspaces/Connections/Connections.styles.ts
+++ b/packages/graph-explorer/src/workspaces/Connections/Connections.styles.ts
@@ -1,36 +1,34 @@
 import { css } from "@emotion/css";
 import { ActiveThemeType, ProcessedTheme } from "../../core";
 
-const defaultStyles =
-  (pfx: string) =>
-  ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
-    &.${pfx}-connections {
-      .${pfx}-button {
-        white-space: nowrap;
-      }
+const defaultStyles = ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
+  &.connections {
+    .button {
+      white-space: nowrap;
+    }
 
-      .${pfx}-advanced-list {
-        padding: ${theme.spacing["2x"]};
+    .advanced-list {
+      padding: ${theme.spacing["2x"]};
+      background: ${theme.palette.background.default};
+      .content {
         background: ${theme.palette.background.default};
-        .${pfx}-content {
-          background: ${theme.palette.background.default};
+        height: 100%;
+        .advanced-list-nogroup {
           height: 100%;
-          .${pfx}-advanced-list-nogroup {
-            height: 100%;
-            .${pfx}-advanced-list-item-subtitle {
-              display: flex;
-              gap: ${theme.spacing["4x"]};
-            }
-            .${pfx}-advanced-list-item {
+          .advanced-list-item-subtitle {
+            display: flex;
+            gap: ${theme.spacing["4x"]};
+          }
+          .advanced-list-item {
+            background: ${theme.palette.background.secondary};
+            .content {
               background: ${theme.palette.background.secondary};
-              .${pfx}-content {
-                background: ${theme.palette.background.secondary};
-              }
             }
           }
         }
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/workspaces/Connections/Connections.tsx
+++ b/packages/graph-explorer/src/workspaces/Connections/Connections.tsx
@@ -5,11 +5,7 @@ import { useRecoilValue } from "recoil";
 import Button from "../../components/Button";
 import { ExplorerIcon } from "../../components/icons";
 import Workspace from "../../components/Workspace/Workspace";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import {
   activeConfigurationAtom,
   configurationAtom,
@@ -20,13 +16,8 @@ import ConnectionDetail from "../../modules/ConnectionDetail";
 import TopBarWithLogo from "../common/TopBarWithLogo";
 import defaultStyles from "./Connections.styles";
 
-export type ConnectionsProps = {
-  classNamePrefix?: string;
-};
-
-const Connections = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
+const Connections = () => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
 
   const config = useConfiguration();
   const activeConfig = useRecoilValue(activeConfigurationAtom);
@@ -34,7 +25,7 @@ const Connections = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
   const [isModalOpen, setModal] = useState(configuration.size === 0);
   const [isSyncing, setSyncing] = useState(false);
 
-  // Everytime that the active connection changes,
+  // Every time that the active connection changes,
   // if it was not synchronized yet, try to sync it
   const updateSchema = useSchemaSync(setSyncing);
   useEffect(() => {
@@ -46,12 +37,7 @@ const Connections = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
   }, [activeConfig, config?.schema?.triedToSync, updateSchema]);
 
   return (
-    <Workspace
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("connections")
-      )}
-    >
+    <Workspace className={cx(styleWithTheme(defaultStyles), "connections")}>
       <TopBarWithLogo>
         <Workspace.TopBar.Title
           title="Connections Details"
@@ -67,7 +53,7 @@ const Connections = ({ classNamePrefix = "ft" }: ConnectionsProps) => {
           >
             <Button
               isDisabled={!activeConfig || !config?.schema?.lastUpdate}
-              className={pfx("button")}
+              className={"button"}
               icon={<ExplorerIcon />}
               variant={"filled"}
             >

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.styles.ts
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.styles.ts
@@ -1,133 +1,131 @@
 import { css } from "@emotion/css";
 import { ActiveThemeType, fade, ProcessedTheme } from "../../core";
 
-const defaultStyles =
-  (pfx: string) =>
-  ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
-    &.${pfx}-data-explorer {
-      .${pfx}-top-bar {
-        min-width: 500px;
-      }
+const defaultStyles = ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
+  &.data-explorer {
+    .top-bar {
+      min-width: 500px;
+    }
 
-      .${pfx}-button {
-        white-space: nowrap;
-      }
-      .${pfx}-v-divider {
-        height: 24px;
-        width: 2px;
-        margin: 0 ${theme.spacing["2x"]};
-        background: ${theme.palette.divider};
-      }
+    .button {
+      white-space: nowrap;
+    }
+    .v-divider {
+      height: 24px;
+      width: 2px;
+      margin: 0 ${theme.spacing["2x"]};
+      background: ${theme.palette.divider};
+    }
 
-      .${pfx}-vertex-count {
-        margin-left: ${theme.spacing.base};
-      }
+    .vertex-count {
+      margin-left: ${theme.spacing.base};
+    }
 
-      .${pfx}-banner {
+    .banner {
+      display: flex;
+      gap: ${theme.spacing["4x"]};
+
+      .kpi {
+        max-width: 300px;
         display: flex;
+        align-items: center;
+        flex-direction: row;
+        padding: ${theme.spacing["4x"]};
         gap: ${theme.spacing["4x"]};
 
-        .${pfx}-kpi {
-          max-width: 300px;
+        .icon {
           display: flex;
+          justify-content: center;
           align-items: center;
-          flex-direction: row;
-          padding: ${theme.spacing["4x"]};
-          gap: ${theme.spacing["4x"]};
+          width: 48px;
+          height: 48px;
+          border-radius: 24px;
+          font-size: 1.7rem;
+          color: ${theme.palette.primary.main};
+          background: ${fade(theme.palette.primary.main, 0.3)};
+        }
 
-          .${pfx}-icon {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 48px;
-            height: 48px;
-            border-radius: 24px;
-            font-size: 1.7rem;
-            color: ${theme.palette.primary.main};
-            background: ${fade(theme.palette.primary.main, 0.3)};
+        .kpi-content {
+          display: flex;
+          flex-direction: column;
+          gap: ${theme.spacing["2x"]};
+
+          .title {
+            font-size: ${theme.typography.sizes?.lg};
+            font-weight: ${theme.typography.weight?.bold};
           }
-
-          .${pfx}-kpi-content {
-            display: flex;
-            flex-direction: column;
-            gap: ${theme.spacing["2x"]};
-
-            .${pfx}-title {
-              font-size: ${theme.typography.sizes?.lg};
-              font-weight: ${theme.typography.weight?.bold};
-            }
-            .${pfx}-subtitle {
-              color: ${theme.palette.text.secondary};
-              font-size: ${theme.typography.sizes?.base};
-            }
+          .subtitle {
+            color: ${theme.palette.text.secondary};
+            font-size: ${theme.typography.sizes?.base};
           }
-        }
-      }
-
-      .${pfx}-advanced-list-item-title {
-        display: flex;
-        gap: ${theme.spacing["4x"]};
-
-        .${pfx}-node-title {
-          min-width: 200px;
-          font-weight: ${theme.typography.weight?.bold};
-        }
-        .${pfx}-nodes-count {
-          color: ${theme.palette.text.secondary};
-          font-weight: ${theme.typography.weight?.base};
-        }
-      }
-
-      .${pfx}-advanced-list {
-        background: ${theme.palette.background.secondary};
-        .${pfx}-content {
-          background: ${theme.palette.background.secondary};
-          .${pfx}-advanced-list-nogroup {
-            height: 100%;
-            .${pfx}-advanced-list-item {
-              background: ${theme.palette.background.default};
-              .${pfx}-content {
-                background: ${theme.palette.background.default};
-              }
-            }
-          }
-        }
-      }
-
-      .${pfx}-pagination-container {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        padding: 0 ${theme.spacing["2x"]};
-        min-height: 36px;
-        background: ${theme.palette.background.default};
-        border-top: solid 1px ${theme.palette.border};
-      }
-      .${pfx}-container-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: ${theme.spacing["2x"]};
-
-        .${pfx}-spinner {
-          width: 24px;
-          height: 24px;
-          > * {
-            color: ${theme.palette.primary.main};
-          }
-        }
-      }
-
-      .${pfx}-header-children {
-        display: flex;
-        justify-content: flex-end;
-        align-items: center;
-        gap: ${theme.spacing["2x"]};
-        .${pfx}-header-select {
-          width: 200px;
         }
       }
     }
-  `;
+
+    .advanced-list-item-title {
+      display: flex;
+      gap: ${theme.spacing["4x"]};
+
+      .node-title {
+        min-width: 200px;
+        font-weight: ${theme.typography.weight?.bold};
+      }
+      .nodes-count {
+        color: ${theme.palette.text.secondary};
+        font-weight: ${theme.typography.weight?.base};
+      }
+    }
+
+    .advanced-list {
+      background: ${theme.palette.background.secondary};
+      .content {
+        background: ${theme.palette.background.secondary};
+        .advanced-list-nogroup {
+          height: 100%;
+          .advanced-list-item {
+            background: ${theme.palette.background.default};
+            .content {
+              background: ${theme.palette.background.default};
+            }
+          }
+        }
+      }
+    }
+
+    .pagination-container {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      padding: 0 ${theme.spacing["2x"]};
+      min-height: 36px;
+      background: ${theme.palette.background.default};
+      border-top: solid 1px ${theme.palette.border};
+    }
+    .container-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: ${theme.spacing["2x"]};
+
+      .spinner {
+        width: 24px;
+        height: 24px;
+        > * {
+          color: ${theme.palette.primary.main};
+        }
+      }
+    }
+
+    .header-children {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: ${theme.spacing["2x"]};
+      .header-select {
+        width: 200px;
+      }
+    }
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -30,11 +30,7 @@ import ExternalPaginationControl from "../../components/Tabular/controls/Externa
 import Tabular from "../../components/Tabular/Tabular";
 import Workspace from "../../components/Workspace/Workspace";
 import type { KeywordSearchResponse } from "../../connector/useGEFetchTypes";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import { explorerSelector } from "../../core/connector";
 import {
   userStylingAtom,
@@ -51,7 +47,6 @@ import defaultStyles from "./DataExplorer.styles";
 
 export type ConnectionsProps = {
   vertexType: string;
-  classNamePrefix?: string;
 };
 
 const DEFAULT_COLUMN = {
@@ -69,12 +64,8 @@ export default function DataExplorer() {
   return <DataExplorerContent vertexType={vertexType} />;
 }
 
-function DataExplorerContent({
-  vertexType,
-  classNamePrefix = "ft",
-}: ConnectionsProps) {
+function DataExplorerContent({ vertexType }: ConnectionsProps) {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -262,12 +253,7 @@ function DataExplorerContent({
   );
 
   return (
-    <Workspace
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("data-explorer")
-      )}
-    >
+    <Workspace className={cx(styleWithTheme(defaultStyles), "data-explorer")}>
       <TopBarWithLogo>
         <Workspace.TopBar.Title
           title="Data Explorer"
@@ -276,7 +262,7 @@ function DataExplorerContent({
         <Workspace.TopBar.AdditionalControls>
           <Link to={"/graph-explorer"}>
             <Button
-              className={pfx("button")}
+              className={"button"}
               icon={<ExplorerIcon />}
               variant={"filled"}
             >
@@ -295,9 +281,9 @@ function DataExplorerContent({
           </Button>
         </Workspace.TopBar.Title>
         <Workspace.TopBar.AdditionalControls>
-          <div className={pfx("header-children")}>
+          <div className={"header-children"}>
             <Select
-              className={pfx("header-select")}
+              className={"header-select"}
               value={vertexConfig?.displayNameAttribute || ""}
               onChange={onDisplayNameChange("name")}
               options={selectOptions}
@@ -307,7 +293,7 @@ function DataExplorerContent({
               labelPlacement={"inner"}
             />
             <Select
-              className={pfx("header-select")}
+              className={"header-select"}
               value={vertexConfig?.longDisplayNameAttribute || ""}
               onChange={onDisplayNameChange("longName")}
               options={selectOptions}
@@ -323,11 +309,11 @@ function DataExplorerContent({
         <ModuleContainer>
           <ModuleContainerHeader
             title={
-              <div className={pfx("container-header")}>
+              <div className={"container-header"}>
                 <div>
                   {vertexConfig?.displayLabel || textTransform(vertexType)}
                 </div>
-                {isFetching && <LoadingSpinner className={pfx("spinner")} />}
+                {isFetching && <LoadingSpinner className={"spinner"} />}
               </div>
             }
           />

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.styles.ts
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.styles.ts
@@ -1,43 +1,41 @@
 import { css } from "@emotion/css";
 import { ActiveThemeType, ProcessedTheme } from "../../core";
 
-const defaultStyles =
-  (pfx: string) =>
-  ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
-    &.${pfx}-graph-explorer {
-      .${pfx}-v-divider {
-        height: 24px;
-        width: 1px;
-        margin: 0 ${theme.spacing["2x"]};
-        background: ${theme.palette.divider};
-      }
-      .${pfx}-button {
-        white-space: nowrap;
-      }
-      .${pfx}-space {
-        min-width: 4px;
-      }
+const defaultStyles = ({ theme }: ActiveThemeType<ProcessedTheme>) => css`
+  &.graph-explorer {
+    .v-divider {
+      height: 24px;
+      width: 1px;
+      margin: 0 ${theme.spacing["2x"]};
+      background: ${theme.palette.divider};
+    }
+    .button {
+      white-space: nowrap;
+    }
+    .space {
+      min-width: 4px;
+    }
 
-      .${pfx}-table-view-area {
-        position: relative;
-        width: 100% !important;
-        user-select: none;
-      }
+    .table-view-area {
+      position: relative;
+      width: 100% !important;
+      user-select: none;
+    }
 
-      .${pfx}-resizable-handle {
-        cursor: ns-resize;
-        width: 100%;
-        height: 4px;
-        position: absolute;
-        top: -6px;
-        z-index: 100000;
-        left: 0;
-        border-radius: ${theme.shape.borderRadius};
-        :hover {
-          background: ${theme.palette.grey["400"]};
-        }
+    .resizable-handle {
+      cursor: ns-resize;
+      width: 100%;
+      height: 4px;
+      position: absolute;
+      top: -6px;
+      z-index: 100000;
+      left: 0;
+      border-radius: ${theme.shape.borderRadius};
+      :hover {
+        background: ${theme.palette.grey["400"]};
       }
     }
-  `;
+  }
+`;
 
 export default defaultStyles;

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -21,11 +21,7 @@ import {
 } from "../../components/icons";
 import GridIcon from "../../components/icons/GridIcon";
 import Workspace from "../../components/Workspace";
-import {
-  useConfiguration,
-  useWithTheme,
-  withClassNamePrefix,
-} from "../../core";
+import { useConfiguration, useWithTheme } from "../../core";
 import { edgesSelectedIdsAtom } from "../../core/StateProvider/edges";
 import { nodesSelectedIdsAtom } from "../../core/StateProvider/nodes";
 import { totalFilteredCount } from "../../core/StateProvider/filterCount";
@@ -44,10 +40,6 @@ import NodesStyling from "../../modules/NodesStyling/NodesStyling";
 import TopBarWithLogo from "../common/TopBarWithLogo";
 import defaultStyles from "./GraphExplorer.styles";
 
-export type GraphViewProps = {
-  classNamePrefix?: string;
-};
-
 const RESIZE_ENABLE_TOP = {
   top: true,
   right: false,
@@ -59,9 +51,8 @@ const RESIZE_ENABLE_TOP = {
   topLeft: false,
 };
 
-const GraphExplorer = ({ classNamePrefix = "ft" }: GraphViewProps) => {
+const GraphExplorer = () => {
   const styleWithTheme = useWithTheme();
-  const pfx = withClassNamePrefix(classNamePrefix);
   const config = useConfiguration();
   const t = useTranslations();
   const hasNamespaces = config?.connection?.queryEngine === "sparql";
@@ -179,12 +170,7 @@ const GraphExplorer = ({ classNamePrefix = "ft" }: GraphViewProps) => {
   }, [debounceAutoOpenDetails, nodeOrEdgeSelected]);
 
   return (
-    <Workspace
-      className={cx(
-        styleWithTheme(defaultStyles(classNamePrefix)),
-        pfx("graph-explorer")
-      )}
-    >
+    <Workspace className={cx(styleWithTheme(defaultStyles), "graph-explorer")}>
       <TopBarWithLogo>
         <Workspace.TopBar.Title
           title="Graph Explorer"
@@ -214,10 +200,10 @@ const GraphExplorer = ({ classNamePrefix = "ft" }: GraphViewProps) => {
             icon={<GridIcon />}
             onPress={toggleView("table-view")}
           />
-          <div className={pfx("v-divider")} />
+          <div className={"v-divider"} />
           <Link to={"/connections"}>
             <Button
-              className={pfx("button")}
+              className={"button"}
               icon={<DatabaseIcon />}
               variant={"filled"}
             >

--- a/packages/graph-explorer/src/workspaces/common/TopBarWithLogo.tsx
+++ b/packages/graph-explorer/src/workspaces/common/TopBarWithLogo.tsx
@@ -9,7 +9,7 @@ const TopBarWithLogo = ({ children }: PropsWithChildren<any>) => {
       logoVisible={true}
       logo={<GraphExplorerIcon width={"2em"} height={"2em"} />}
       className={css`
-        .ft-navbar-logo-container {
+        .navbar-logo-container {
           background: linear-gradient(225deg, #4d72f2 12.15%, #3334b9 87.02%);
         }
       `}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This change removes all the logic dealing with dynamic class name prefixes in the app's CSS styling.

I can't find any reason for this logic to exist. It is a solution in search of a problem. And it amounts to a ton of noise in the code that makes creating new components a friction filled experience.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

After removing all the class name logic I tried testing out all the different controls in the UI. I even went searching for the parts of the app that I don't use very often, like the table views, export, style customization, legend, etc. Everything seems to work find and looks as it did before.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
