### PR TITLE
Fix swiper error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 
 - Reduce search queries when no search term provided by ignoring attribute and
   exact match changes (<https://github.com/aws/graph-explorer/pull/473>)
+- Fix issue when selecting an item in search results that resulted in errors in
+  the browser console (<https://github.com/aws/graph-explorer/pull/474>)
 - Update PNPM version (<https://github.com/aws/graph-explorer/pull/475>)
 
 ## Release 1.8.0


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In the search modal when the user selects a search result you would see a error in the browser's console.

This was caused by the use of `setTimeout()` within a `useEffect()`. This is almost never a good idea.

I have replaced it with `useTransition()`, which is the React supported way of delaying a task until the next render.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified no more error
- Verified multiple selection still works
- Verified swiping still works
- Verified prev/next buttons work

**The original error**

![CleanShot 2024-07-03 at 18 27 27@2x](https://github.com/aws/graph-explorer/assets/212862/a47eb7dc-1c4a-4050-ab99-28aa76a62a68)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Fixes #435 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
