### PR TITLE
Increase request body size limit for proxy server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 **Bug Fixes and Minor Changes**
 
+- Increase request body size limit for proxy server
+  (<https://github.com/aws/graph-explorer/pull/488>)
 - Development scripts updated to be more consistent with the industry
   (<https://github.com/aws/graph-explorer/pull/488>)
   - Run the dev environment `pnpm dev`

--- a/packages/graph-explorer-proxy-server/node-server.ts
+++ b/packages/graph-explorer-proxy-server/node-server.ts
@@ -182,8 +182,8 @@ async function fetchData(
 
 app.use(compression()); // Use compression middleware
 app.use(cors());
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: "50mb" }));
+app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 app.use(
   "/defaultConnection",
   express.static(path.join(clientRoot, "defaultConnection.json"))

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/aws4": "^1.11.6",
+    "@types/body-parser": "^1.19.5",
     "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       '@types/aws4':
         specifier: ^1.11.6
         version: 1.11.6
+      '@types/body-parser':
+        specifier: ^1.19.5
+        version: 1.19.5
       '@types/compression':
         specifier: ^1.7.5
         version: 1.7.5


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

- Add `body-parser` types package
- Increase body-parser limit to 50mb

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #484 
- Resolves #410

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
