### PR TITLE
OpenCypher singular search query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 ## Upcoming
 
+**Major Changes**
+
+- Search in openCypher will now execute a single request when searching across
+  all labels (<https://github.com/aws/graph-explorer/pull/493>)
+
 **Bug Fixes and Minor Changes**
 
 - Increase request body size limit for proxy server

--- a/packages/graph-explorer/src/connector/openCypher/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/openCypher/queries/keywordSearch.ts
@@ -22,25 +22,7 @@ const keywordSearch = async (
   openCypherFetch: OpenCypherFetch,
   req: KeywordSearchRequest
 ): Promise<KeywordSearchResponse> => {
-  const vertTypes = req.vertexTypes;
-
-  if (!vertTypes) {
-    return { vertices: [] };
-  }
-
-  // Create multiple requests, one per vertex
-  const modifiedRequests = vertTypes.map(vertex => ({
-    ...req,
-    vertexTypes: [vertex],
-  }));
-
-  // Execute all queries concurrently
-  const promises = modifiedRequests.map(modifiedRequest =>
-    vertexKeywordSearch(openCypherFetch, modifiedRequest)
-  );
-
-  // Wait for all results and flatten to a single array
-  const vertices = (await Promise.all(promises)).flat();
+  const vertices = await vertexKeywordSearch(openCypherFetch, req);
 
   return { vertices: vertices };
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The openCypher version of the keyword search query would execute multiple parallel requests if the user has chosen "All" for the "Node Type" field, which is the default option.

Instead, we use a single query that contains all the node labels in the WHERE clause. Here's an example from the Airports database.

```
MATCH (v)
WHERE (v:`airport` OR v:`continent` OR v:`country` OR v:`version`)
RETURN v AS object
ORDER BY id(v)
LIMIT 10
```

I've also updated the query generation to better handle any of the search parameters that can be passed.

- Add ability to handle multiple vertex types in a single request
- Fix limit and offset query handling
- Sort by ID for consistency
- Better formatting of query strings
- Improved testing

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->
- Test search with different parameters

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Partially addresses #481 
- Related to PR #489 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
