### PR TITLE
Fix expand selected type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 
 **Bug Fixes and Minor Changes**
 
+- Fix default selection of expand type to be the first available type for
+  expansion (<https://github.com/aws/graph-explorer/pull/501>)
 - Use `application/sparql-results+json` accept header for SPARQL requests
   (<https://github.com/aws/graph-explorer/pull/499>)
 - Fix text wrapping for labels in edge styling sidebar

--- a/packages/graph-explorer/src/hooks/useNeighborsOptions.ts
+++ b/packages/graph-explorer/src/hooks/useNeighborsOptions.ts
@@ -1,9 +1,17 @@
 import { useMemo } from "react";
 import { Vertex } from "../@types/entities";
-import { useConfiguration } from "../core/ConfigurationProvider";
+import {
+  useConfiguration,
+  VertexTypeConfig,
+} from "../core/ConfigurationProvider";
 import useTextTransform from "./useTextTransform";
+import { SelectOption } from "../components";
 
-const useNeighborsOptions = (vertex: Vertex) => {
+export type NeighborOption = SelectOption & {
+  config?: VertexTypeConfig;
+};
+
+export default function useNeighborsOptions(vertex: Vertex): NeighborOption[] {
   const config = useConfiguration();
   const textTransform = useTextTransform();
 
@@ -26,6 +34,4 @@ const useNeighborsOptions = (vertex: Vertex) => {
     vertex.data.neighborsCountByType,
     vertex.data.__unfetchedNeighborCounts,
   ]);
-};
-
-export default useNeighborsOptions;
+}

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -8,7 +8,9 @@ import LoadingSpinner from "../../components/LoadingSpinner";
 import PanelEmptyState from "../../components/PanelEmptyState/PanelEmptyState";
 import { useWithTheme } from "../../core";
 import { useExpandNode } from "../../hooks";
-import useNeighborsOptions from "../../hooks/useNeighborsOptions";
+import useNeighborsOptions, {
+  NeighborOption,
+} from "../../hooks/useNeighborsOptions";
 import useTranslations from "../../hooks/useTranslations";
 import NeighborsList from "../common/NeighborsList/NeighborsList";
 import defaultStyles from "./NodeExpandContent.styles";
@@ -69,13 +71,15 @@ function ExpansionOptions({ vertex }: { vertex: Vertex }) {
   const neighborsOptions = useNeighborsOptions(vertex);
 
   const [selectedType, setSelectedType] = useState<string>(
-    neighborsOptions[0]?.value
+    firstNeighborAvailableForExpansion(neighborsOptions)?.value ?? ""
   );
   const [filters, setFilters] = useState<Array<NodeExpandFilter>>([]);
   const [limit, setLimit] = useState<number | null>(null);
 
   useEffect(() => {
-    setSelectedType(neighborsOptions[0]?.value);
+    setSelectedType(
+      firstNeighborAvailableForExpansion(neighborsOptions)?.value ?? ""
+    );
   }, [neighborsOptions]);
 
   const hasUnfetchedNeighbors = Boolean(vertex.data.__unfetchedNeighborCount);
@@ -150,4 +154,10 @@ function ExpandButton({
       Expand
     </Button>
   );
+}
+
+function firstNeighborAvailableForExpansion(
+  neighborsOptions: NeighborOption[]
+) {
+  return neighborsOptions.find(x => !x.isDisabled) ?? neighborsOptions[0];
 }

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -7,6 +7,7 @@ import {
   InfoTooltip,
   Input,
   Select,
+  SelectOption,
 } from "../../components";
 import { useConfiguration } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
@@ -17,7 +18,7 @@ export type NodeExpandFilter = {
   value: string;
 };
 export type NodeExpandFiltersProps = {
-  neighborsOptions: Array<{ label: string; value: string }>;
+  neighborsOptions: SelectOption[];
   selectedType: string;
   onSelectedTypeChange(type: string): void;
   filters: Array<NodeExpandFilter>;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Before this change, Goal would be the selected neighbor type for expansion. But it is already fully expanded.

Now, we select Team instead because it is the first neighbor type with collapsed neighbors.

![CleanShot 2024-07-19 at 16 37 21@2x](https://github.com/user-attachments/assets/5b87cff6-9484-46ed-aea6-d8706e71febe)


## Validation


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
