### PR TITLE
Server logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 
 **Bug Fixes and Minor Changes**
 
+- Provide better error messages when expanding a node fails
+  (<https://github.com/aws/graph-explorer/pull/502>)
 - Fix default selection of expand type to be the first available type for
   expansion (<https://github.com/aws/graph-explorer/pull/501>)
 - Use `application/sparql-results+json` accept header for SPARQL requests

--- a/packages/graph-explorer-proxy-server/node-server.ts
+++ b/packages/graph-explorer-proxy-server/node-server.ts
@@ -479,7 +479,7 @@ app.get("/rdf/statistics/summary", async (req, res, next) => {
   );
 });
 
-app.get("/logger", (req, res, next) => {
+app.post("/logger", (req, res, next) => {
   const headers = req.headers as LoggerIncomingHttpHeaders;
   let message;
   let level;

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -37,7 +37,7 @@ export default class LoggerConnector {
     }
 
     return fetch(this._baseUrl, {
-      method: "GET",
+      method: "POST",
       headers: {
         level,
         message: JSON.stringify(message),

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -2,7 +2,7 @@ import { logger } from "../utils";
 
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
-interface ILoggerConnector {
+export interface LoggerConnector {
   error(message: unknown): void;
   warn(message: unknown): void;
   info(message: unknown): void;
@@ -10,7 +10,8 @@ interface ILoggerConnector {
   trace(message: unknown): void;
 }
 
-export class LoggerConnector implements ILoggerConnector {
+/** Sends log messages to the server in the connection configuration. */
+export class ServerLoggerConnector implements LoggerConnector {
   private readonly _baseUrl: string;
 
   constructor(connectionUrl: string) {
@@ -49,7 +50,8 @@ export class LoggerConnector implements ILoggerConnector {
   }
 }
 
-export class ClientLoggerConnector implements ILoggerConnector {
+/** Sends logs to the browser's console. */
+export class ClientLoggerConnector implements LoggerConnector {
   error(message: unknown): void {
     logger.error(message);
   }

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -1,14 +1,11 @@
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
-type Options = { enable?: boolean };
 export default class LoggerConnector {
   private readonly _baseUrl: string;
-  private readonly _options: Options;
 
-  constructor(connectionUrl: string, options: Options = { enable: true }) {
+  constructor(connectionUrl: string) {
     const url = connectionUrl.replace(/\/$/, "");
     this._baseUrl = `${url}/logger`;
-    this._options = options;
   }
 
   public error(message: unknown) {
@@ -32,10 +29,6 @@ export default class LoggerConnector {
   }
 
   private _sendLog(level: LogLevel, message: unknown) {
-    if (!this._options.enable) {
-      return;
-    }
-
     return fetch(this._baseUrl, {
       method: "POST",
       headers: {

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -1,6 +1,16 @@
+import { logger } from "../utils";
+
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
-export default class LoggerConnector {
+interface ILoggerConnector {
+  error(message: unknown): void;
+  warn(message: unknown): void;
+  info(message: unknown): void;
+  debug(message: unknown): void;
+  trace(message: unknown): void;
+}
+
+export class LoggerConnector implements ILoggerConnector {
   private readonly _baseUrl: string;
 
   constructor(connectionUrl: string) {
@@ -36,5 +46,23 @@ export default class LoggerConnector {
         message: JSON.stringify(message),
       },
     });
+  }
+}
+
+export class ClientLoggerConnector implements ILoggerConnector {
+  error(message: unknown): void {
+    logger.error(message);
+  }
+  warn(message: unknown): void {
+    logger.warn(message);
+  }
+  info(message: unknown): void {
+    logger.log(message);
+  }
+  debug(message: unknown): void {
+    logger.debug(message);
+  }
+  trace(message: unknown): void {
+    logger.log(message);
   }
 }

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -1,5 +1,8 @@
 import { every, isEqual } from "lodash";
-import LoggerConnector from "../connector/LoggerConnector";
+import {
+  ClientLoggerConnector,
+  LoggerConnector,
+} from "../connector/LoggerConnector";
 import { createGremlinExplorer } from "../connector/gremlin/gremlinExplorer";
 import { createOpenCypherExplorer } from "../connector/openCypher/openCypherExplorer";
 import { createSparqlExplorer } from "../connector/sparql/sparqlExplorer";
@@ -81,7 +84,7 @@ export const loggerSelector = selector({
   get: ({ get }) => {
     const url = get(activeConnectionUrlSelector);
     if (!url) {
-      return null;
+      return new ClientLoggerConnector();
     }
 
     return new LoggerConnector(url);

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -2,6 +2,7 @@ import { every, isEqual } from "lodash";
 import {
   ClientLoggerConnector,
   LoggerConnector,
+  ServerLoggerConnector,
 } from "../connector/LoggerConnector";
 import { createGremlinExplorer } from "../connector/gremlin/gremlinExplorer";
 import { createOpenCypherExplorer } from "../connector/openCypher/openCypherExplorer";
@@ -67,7 +68,7 @@ export const explorerSelector = selector({
 /**
  * Logger based on the active connection proxy URL.
  */
-export const loggerSelector = selector({
+export const loggerSelector = selector<LoggerConnector>({
   key: "logger",
   get: ({ get }) => {
     const connection = get(activeConnectionSelector);
@@ -77,6 +78,6 @@ export const loggerSelector = selector({
       return new ClientLoggerConnector();
     }
 
-    return new LoggerConnector(connection.url);
+    return new ServerLoggerConnector(connection.url);
   },
 });

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -43,18 +43,6 @@ export const activeConnectionSelector = equalSelector({
 });
 
 /**
- * Active connection URL
- */
-const activeConnectionUrlSelector = equalSelector({
-  key: "activeConnectionUrl",
-  get: ({ get }) => {
-    const config = get(mergedConfigurationSelector);
-    return config?.connection?.url;
-  },
-  equals: (latest, prior) => latest === prior,
-});
-
-/**
  * Explorer based on the active connection.
  */
 export const explorerSelector = selector({
@@ -82,11 +70,13 @@ export const explorerSelector = selector({
 export const loggerSelector = selector({
   key: "logger",
   get: ({ get }) => {
-    const url = get(activeConnectionUrlSelector);
-    if (!url) {
+    const connection = get(activeConnectionSelector);
+
+    // Check for a url and that we are using the proxy server
+    if (!connection || !connection.url || connection.proxyConnection === true) {
       return new ClientLoggerConnector();
     }
 
-    return new LoggerConnector(url);
+    return new LoggerConnector(connection.url);
   },
 });

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -6,7 +6,6 @@ import { createSparqlExplorer } from "../connector/sparql/sparqlExplorer";
 import { mergedConfigurationSelector } from "./StateProvider/configuration";
 import { selector } from "recoil";
 import { equalSelector } from "../utils/recoilState";
-import { env } from "../utils";
 import { ConnectionConfig } from "./ConfigurationProvider";
 
 /**
@@ -85,8 +84,6 @@ export const loggerSelector = selector({
       return null;
     }
 
-    return new LoggerConnector(url, {
-      enable: env.PROD,
-    });
+    return new LoggerConnector(url);
   },
 });

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -10,13 +10,17 @@ import type {
   NeighborsRequest,
   NeighborsResponse,
 } from "../connector/useGEFetchTypes";
-import { activeConnectionSelector, explorerSelector } from "../core/connector";
+import {
+  activeConnectionSelector,
+  explorerSelector,
+  loggerSelector,
+} from "../core/connector";
 import useEntities from "./useEntities";
 import { useRecoilValue } from "recoil";
 import { useMutation } from "@tanstack/react-query";
-import useDisplayNames from "./useDisplayNames";
 import { Vertex } from "../@types/entities";
 import { useUpdateAllNodeCounts } from "./useUpdateNodeCounts";
+import { createDisplayError } from "../utils/createDisplayError";
 
 /*
 
@@ -52,7 +56,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
   const explorer = useRecoilValue(explorerSelector);
   const [_, setEntities] = useEntities();
   const { enqueueNotification, clearNotification } = useNotification();
-  const getDisplayNames = useDisplayNames();
+  const logger = useRecoilValue(loggerSelector);
 
   const mutation = useMutation({
     mutationFn: async (
@@ -84,12 +88,13 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
         edges: data.edges,
       });
     },
-    onError: (error, request) => {
-      const displayName = getDisplayNames(request.vertex);
+    onError: error => {
+      logger.error(`Failed to expand node: ${error.message}`);
+      const displayError = createDisplayError(error);
       // Notify the user of the error
       enqueueNotification({
         title: "Expanding Node Failed",
-        message: `Expanding the node ${displayName.name} failed with error "${error.message}"`,
+        message: displayError.message,
         type: "error",
       });
     },

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -42,13 +42,13 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
         stackable: true,
       });
       if (e.name === "AbortError") {
-        logger?.error(
+        logger.error(
           `[${
             config.displayLabel || config.id
           }] Fetch aborted, reached max time out ${config.connection?.fetchTimeoutMs} MS `
         );
       } else {
-        logger?.error(
+        logger.error(
           `[${
             config.displayLabel || config.id
           }] Error while fetching schema: ${e.message}`
@@ -68,7 +68,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
         type: "info",
         stackable: true,
       });
-      logger?.info(
+      logger.info(
         `[${
           config.displayLabel || config.id
         }] This connection has no data available: ${JSON.stringify(
@@ -87,7 +87,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
       type: "success",
       stackable: true,
     });
-    logger?.info(
+    logger.info(
       `[${
         config.displayLabel || config.id
       }] Connection successfully synchronized: ${JSON.stringify(

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -80,4 +80,13 @@ describe("createDisplayError", () => {
         "Increase the query timeout in the DB cluster parameter group, or retry the request.",
     });
   });
+
+  it("Should handle malformed query", () => {
+    const result = createDisplayError({ code: "MalformedQueryException" });
+    expect(result).toStrictEqual({
+      title: "Malformed Query",
+      message:
+        "The executed query was rejected by the database. It is possible the query structure is not supported by your database.",
+    });
+  });
 });

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -46,6 +46,18 @@ export function createDisplayError(error: any): DisplayError {
       };
     }
 
+    // Malformed query
+    if (
+      error?.code === "MalformedQueryException" ||
+      error?.cause?.code === "MalformedQueryException"
+    ) {
+      return {
+        title: "Malformed Query",
+        message:
+          "The executed query was rejected by the database. It is possible the query structure is not supported by your database.",
+      };
+    }
+
     // Fetch timeout
     if (error?.name === "AbortError") {
       return {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Modify the way logging is sent to the proxy server.

- Ensure we only send logs to the server when using the proxy server
- Use `ClientLoggerConnector` so we don't have to deal with null
- Change `/logger` endpoint to be a POST instead of GET
- Enable server logging for both DEV and PROD (in DEV it will just be logged to the terminal)
- Add check for `isNeptuneError()` that will use the message from the Neptune error in the `throw new Error()` message
- Add logging for errors in node expansion
- Add display error for malformed queries
- Use display error for node expansion error notification

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested by modifying the expand neighbor query template to fail

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
