### PR TITLE
Update Gremlin query to avoid order by vertex

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 
 **Bug Fixes and Minor Changes**
 
+- Fix expanding a node on old versions of Gremlin
+  (<https://github.com/aws/graph-explorer/pull/503>)
 - Provide better error messages when expanding a node fails
   (<https://github.com/aws/graph-explorer/pull/502>)
 - Fix default selection of expand type to be the first available type for

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
@@ -11,7 +11,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().dedup().order().as("v")
+          .both().dedup().order().by(id()).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -32,7 +32,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V(12L)
-          .both().dedup().order().as("v")
+          .both().dedup().order().by(id()).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -55,7 +55,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().dedup().order().range(5, 10).as("v")
+          .both().dedup().order().by(id()).range(5, 10).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -79,7 +79,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().hasLabel("country").dedup().order().range(5, 15).as("v")
+          .both().hasLabel("country").dedup().order().by(id()).range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -103,7 +103,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().hasLabel("country", "airport", "continent").dedup().order().range(5, 15).as("v")
+          .both().hasLabel("country", "airport", "continent").dedup().order().by(id()).range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -133,7 +133,7 @@ describe("Gremlin > oneHopTemplate", () => {
         g.V("12")
           .both().hasLabel("country")
             .and(has("longest",gte(10000)),has("country",containing("ES")))
-            .dedup().order().range(5, 15).as("v")
+            .dedup().order().by(id()).range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
@@ -160,7 +160,7 @@ export default function oneHopTemplate({
 
   return dedent`
     g.V(${idTemplate})
-      .both()${nodeFiltersTemplate}.dedup().order()${range}.as("v")
+      .both()${nodeFiltersTemplate}.dedup().order().by(id())${range}.as("v")
       .project("vertex", "edges")
         .by()
         .by(

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -9,9 +9,9 @@ const RESPONSES_FILES_MAP: Record<string, string> = {
   "7062d2e": `${GREMLIN}/edges-labels-and-counts.json`,
   "35be2501": `${GREMLIN}/should-return-1-random-node.json`,
   "54fa1494": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
-  "749bfe6f": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
+  "1559ced5": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
   "37e14b1": `${GREMLIN}/should-return-all-neighbors-from-node-2018-counts.json`,
-  "3332c010": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
+  "7afef36": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
   "40a4690b": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018-counts.json`,
   "59bc2d43": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Order by vertex was added in Gremlin v3.6.0. In order to at least partially support older versions I've updated the query to use `.order().by(id())` instead.

## Validation

- Tested with Neptune v1.2.0.1
- Tested with Neptune v1.3.2.1

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
