### PR TITLE
Refactor vertex type config hook

### DIFF
--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -197,8 +197,8 @@ export type ConfigurationContextProps = RawConfiguration & {
   vertexTypes: Array<string>;
   totalEdges: number;
   edgeTypes: Array<string>;
-  getVertexTypeConfig(vertexType: string): VertexTypeConfig | undefined;
+  getVertexTypeConfig(vertexType: string): VertexTypeConfig;
   getVertexTypeAttributes(vertexTypes: string[]): Array<AttributeConfig>;
   getVertexTypeSearchableAttributes(vertexType: string): Array<AttributeConfig>;
-  getEdgeTypeConfig(edgeType: string): EdgeTypeConfig | undefined;
+  getEdgeTypeConfig(edgeType: string): EdgeTypeConfig;
 };

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -118,6 +118,31 @@ export function useVertexTypeConfigs(vertexTypes?: string[]) {
   return useRecoilValue(vertexTypeConfigsSelector(types));
 }
 
+const edgeTypeConfigsSelector = selectorFamily({
+  key: "edge-type-configs",
+  get:
+    (edgeTypes: string[]) =>
+    ({ get }) =>
+      edgeTypes.map(
+        edgeType =>
+          get(assembledConfigSelector)?.getEdgeTypeConfig(edgeType) ??
+          getDefaultEdgeTypeConfig(edgeType)
+      ),
+});
+
+/** Gets the matching edge type config or a generated default value. */
+export function useEdgeTypeConfig(edgeType: string) {
+  return useRecoilValue(edgeTypeConfigsSelector([edgeType]))[0];
+}
+
+/** Gets the matching edge type configs or the generated default values. */
+export function useEdgeTypeConfigs(edgeTypes?: string[]) {
+  const config = useRecoilValue(assembledConfigSelector);
+  const types = edgeTypes ?? config?.edgeTypes ?? [];
+  return useRecoilValue(edgeTypeConfigsSelector(types));
+}
+
+/** Gets the fully merged and augmented configuration & schema */
 export default function useConfiguration() {
   return useRecoilValue(assembledConfigSelector);
 }

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -94,14 +94,29 @@ export const assembledConfigSelector = selector<
   },
 });
 
-export const vertexTypeConfigSelector = selectorFamily({
-  key: "vertex-type-config",
+const vertexTypeConfigsSelector = selectorFamily({
+  key: "vertex-type-configs",
   get:
-    (vertexType: string) =>
-    ({ get }) => {
-      return get(assembledConfigSelector)?.getVertexTypeConfig(vertexType);
-    },
+    (vertexTypes: string[]) =>
+    ({ get }) =>
+      vertexTypes.map(
+        vertexType =>
+          get(assembledConfigSelector)?.getVertexTypeConfig(vertexType) ??
+          getDefaultVertexTypeConfig(vertexType)
+      ),
 });
+
+/** Gets the matching vertex type config or a generated default value. */
+export function useVertexTypeConfig(vertexType: string) {
+  return useRecoilValue(vertexTypeConfigsSelector([vertexType]))[0];
+}
+
+/** Gets the matching vertex type configs or the generated default values. */
+export function useVertexTypeConfigs(vertexTypes?: string[]) {
+  const config = useRecoilValue(assembledConfigSelector);
+  const types = vertexTypes ?? config?.vertexTypes ?? [];
+  return useRecoilValue(vertexTypeConfigsSelector(types));
+}
 
 export default function useConfiguration() {
   return useRecoilValue(assembledConfigSelector);

--- a/packages/graph-explorer/src/hooks/useEntitiesCounts.test.ts
+++ b/packages/graph-explorer/src/hooks/useEntitiesCounts.test.ts
@@ -1,68 +1,122 @@
-import { renderHook } from "@testing-library/react";
 import useEntitiesCounts from "./useEntitiesCounts";
-import { useConfiguration } from "../core";
-import { Mock, vi } from "vitest";
+import { RawConfiguration, Schema } from "../core";
+import { vi } from "vitest";
+import {
+  createRandomEdgeTypeConfig,
+  createRandomInteger,
+  createRandomRawConfiguration,
+  createRandomSchema,
+  createRandomVertexTypeConfig,
+  renderHookWithRecoilRoot,
+} from "../utils/testing";
+import {
+  activeConfigurationAtom,
+  configurationAtom,
+} from "../core/StateProvider/configuration";
+import { schemaAtom } from "../core/StateProvider/schema";
 
-vi.mock("../core", () => ({
-  __esModule: true,
-  useConfiguration: vi.fn(),
-}));
+function renderUseEntitiesHook(config: RawConfiguration, schema: Schema) {
+  return renderHookWithRecoilRoot(
+    () => useEntitiesCounts(),
+    snapshot => {
+      snapshot.set(schemaAtom, new Map([[config.id, schema]]));
+      snapshot.set(configurationAtom, new Map([[config.id, config]]));
+      snapshot.set(activeConfigurationAtom, config.id);
+    }
+  );
+}
 
 describe("useEntitiesCounts", () => {
+  let config: RawConfiguration;
+  let schema: Schema;
+
   beforeEach(() => {
+    config = createRandomRawConfiguration();
+    schema = createRandomSchema();
     vi.resetAllMocks();
   });
 
-  it("should return total vertices when totalVertices is defined", () => {
-    (useConfiguration as Mock).mockReturnValue({
-      id: "some-id",
-      totalVertices: 10,
-      vertexTypes: ["type1", "type2"],
-      edgeTypes: ["edgeType1"],
-      getEdgeTypeConfig: vi.fn(() => ({ total: 5 })),
-    });
+  it("should return null when schema has not been synced", () => {
+    schema.lastUpdate = undefined;
+    schema.triedToSync = false;
+    schema.lastSyncFail = false;
 
-    const { result } = renderHook(() => useEntitiesCounts());
+    const { result } = renderUseEntitiesHook(config, schema);
 
-    expect(result.current.totalNodes).toEqual(10);
+    expect(result.current.totalNodes).toBeNull();
+    expect(result.current.totalEdges).toBeNull();
   });
 
-  it("should return 0 for totalNodes when vertexTypes array is empty", () => {
-    (useConfiguration as Mock).mockReturnValue({
-      id: "some-id-two",
-      totalVertices: 0,
-      totalEdges: 0,
-      vertexTypes: [],
-      edgeTypes: ["edgeType1"],
-    });
+  it("should return null when schema has tried to sync", () => {
+    schema.lastUpdate = undefined;
+    schema.triedToSync = true;
+    schema.lastSyncFail = true;
 
-    const { result } = renderHook(() => useEntitiesCounts());
+    const { result } = renderUseEntitiesHook(config, schema);
+
+    expect(result.current.totalNodes).toBeNull();
+    expect(result.current.totalEdges).toBeNull();
+  });
+
+  it("should return total vertices when totalVertices is defined", () => {
+    const preCalculatedTotal = createRandomInteger();
+    schema.totalVertices = preCalculatedTotal;
+    schema.totalEdges = preCalculatedTotal;
+
+    const { result } = renderUseEntitiesHook(config, schema);
+
+    expect(result.current.totalNodes).toEqual(preCalculatedTotal);
+    expect(result.current.totalEdges).toEqual(preCalculatedTotal);
+  });
+
+  it("should return 0 when schema has no entity type configs", () => {
+    schema.totalVertices = 0;
+    schema.vertices = [];
+    schema.totalEdges = 0;
+    schema.edges = [];
+
+    const { result } = renderUseEntitiesHook(config, schema);
 
     expect(result.current.totalNodes).toBe(0);
+    expect(result.current.totalEdges).toBe(0);
   });
 
-  it("should return calculated total nodes when vertexTypes array is not empty and each type has a total", () => {
-    (useConfiguration as Mock).mockReturnValue({
-      vertexTypes: ["type1", "type2"],
-      edgeTypes: ["edgeType1", "edgeType2"],
-      getVertexTypeConfig: vi.fn(() => ({ total: 5 })),
-      getEdgeTypeConfig: vi.fn(() => ({ total: 5 })),
-    });
-    const { result } = renderHook(() => useEntitiesCounts());
+  it("should calculate total when when all entity type configs have a total", () => {
+    schema.totalVertices = 0;
+    schema.vertices = [
+      createRandomVertexTypeConfig(),
+      createRandomVertexTypeConfig(),
+    ].map(vtConfig => ({ ...vtConfig, total: 5 }));
+    schema.totalEdges = 0;
+    schema.edges = [
+      createRandomEdgeTypeConfig(),
+      createRandomEdgeTypeConfig(),
+    ].map(etConfig => ({ ...etConfig, total: 5 }));
+
+    const { result } = renderUseEntitiesHook(config, schema);
 
     expect(result.current.totalNodes).toEqual(10);
+    expect(result.current.totalEdges).toEqual(10);
   });
 
-  it("should return totalNodes when vertexTypes array is not empty and at least one type does not have a total", () => {
-    (useConfiguration as Mock).mockReturnValue({
-      vertexTypes: ["type1", "type2"],
-      edgeTypes: ["edgeType1", "edgeType2"],
-      getVertexTypeConfig: vi.fn(() => ({ total: 5 })),
-      getEdgeTypeConfig: vi.fn(() => ({ total: null })),
-    });
+  it("should return null when some entity type configs are missing a total", () => {
+    schema.totalVertices = 0;
+    schema.vertices = [
+      createRandomVertexTypeConfig(),
+      createRandomVertexTypeConfig(),
+    ].map(vtConfig => ({ ...vtConfig, total: undefined }));
+    schema.vertices[0].total = 10;
 
-    const { result } = renderHook(() => useEntitiesCounts());
+    schema.totalEdges = 0;
+    schema.edges = [
+      createRandomEdgeTypeConfig(),
+      createRandomEdgeTypeConfig(),
+    ].map(etConfig => ({ ...etConfig, total: undefined }));
+    schema.edges[0].total = 10;
 
-    expect(result.current.totalNodes).toBe(10);
+    const { result } = renderUseEntitiesHook(config, schema);
+
+    expect(result.current.totalNodes).toBeNull();
+    expect(result.current.totalEdges).toBeNull();
   });
 });

--- a/packages/graph-explorer/src/hooks/useEntitiesCounts.ts
+++ b/packages/graph-explorer/src/hooks/useEntitiesCounts.ts
@@ -1,22 +1,24 @@
 import { useMemo } from "react";
 import { useConfiguration } from "../core";
+import { useVertexTypeConfigs } from "../core/ConfigurationProvider/useConfiguration";
 
 const useEntitiesCounts = () => {
   const config = useConfiguration();
+  const vtConfigs = useVertexTypeConfigs();
 
   const totalNodes = useMemo(() => {
     if (config?.totalVertices != null) {
-      return config?.totalVertices;
+      return config.totalVertices;
     }
 
-    if (!config?.vertexTypes.length) {
+    if (!vtConfigs.length) {
       return null;
     }
 
     let total = 0;
 
-    for (const vt of config.vertexTypes) {
-      const currTotal = config?.getVertexTypeConfig(vt)?.total;
+    for (const vtConfig of vtConfigs) {
+      const currTotal = vtConfig.total;
       if (currTotal == null) {
         return null;
       }
@@ -25,7 +27,7 @@ const useEntitiesCounts = () => {
     }
 
     return total;
-  }, [config]);
+  }, [config?.totalVertices, vtConfigs]);
 
   const totalEdges = useMemo(() => {
     if (config?.totalEdges != null) {

--- a/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
+++ b/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
@@ -6,8 +6,10 @@ import {
 } from "../core/StateProvider/configuration";
 import {
   createRandomRawConfiguration,
+  createRandomSchema,
   renderHookWithRecoilRoot,
 } from "../utils/testing";
+import { schemaAtom } from "../core/StateProvider/schema";
 
 describe("useNeighborsOptions", () => {
   const vertex = {
@@ -22,7 +24,8 @@ describe("useNeighborsOptions", () => {
       () => useNeighborsOptions(vertex),
       snapshot => {
         const config = createRandomRawConfiguration();
-        config.schema!.vertices = [
+        const schema = createRandomSchema();
+        schema.vertices = [
           {
             type: "nodeType1",
             displayLabel: "Label nodeType1",
@@ -35,6 +38,7 @@ describe("useNeighborsOptions", () => {
           },
         ];
         snapshot.set(configurationAtom, new Map([[config.id, config]]));
+        snapshot.set(schemaAtom, new Map([[config.id, schema]]));
         snapshot.set(activeConfigurationAtom, config.id);
       }
     );

--- a/packages/graph-explorer/src/hooks/useTextTransform.test.ts
+++ b/packages/graph-explorer/src/hooks/useTextTransform.test.ts
@@ -5,22 +5,26 @@ import {
 } from "../core/StateProvider/configuration";
 import {
   createRandomRawConfiguration,
+  createRandomSchema,
   renderHookWithRecoilRoot,
 } from "../utils/testing";
 import useTextTransform from "./useTextTransform";
 import { vi } from "vitest";
+import { schemaAtom } from "../core/StateProvider/schema";
 
 function initializeConfigWithPrefix(snapshot: MutableSnapshot) {
   // Create config and setup schema
   const config = createRandomRawConfiguration();
+  const schema = createRandomSchema();
   config.connection!.queryEngine = "sparql";
-  config.schema!.prefixes = [
+  schema.prefixes = [
     {
       prefix: "rdf",
       uri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     },
   ];
   snapshot.set(configurationAtom, new Map([[config.id, config]]));
+  snapshot.set(schemaAtom, new Map([[config.id, schema]]));
 
   // Make config active
   snapshot.set(activeConfigurationAtom, config.id);

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -18,9 +18,11 @@ import useEntitiesCounts from "../../hooks/useEntitiesCounts";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
 import defaultStyles from "./ConnectionDetail.styles";
+import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
 
 const ConnectionData = () => {
   const config = useConfiguration();
+  const vtConfigs = useVertexTypeConfigs();
   const navigate = useNavigate();
   const styleWithTheme = useWithTheme();
   const { totalNodes, totalEdges } = useEntitiesCounts();
@@ -29,9 +31,9 @@ const ConnectionData = () => {
 
   const verticesByTypeItems = useMemo(() => {
     const items: AdvancedListItemType<any>[] = [];
-    (config?.vertexTypes || []).forEach(vt => {
-      const vtConfig = config?.getVertexTypeConfig(vt);
-      const displayLabel = vtConfig?.displayLabel || vt;
+    vtConfigs.forEach(vtConfig => {
+      const vt = vtConfig.type;
+      const displayLabel = vtConfig.displayLabel || vt;
 
       items.push({
         id: vt,
@@ -44,19 +46,19 @@ const ConnectionData = () => {
         icon: (
           <div
             style={{
-              color: vtConfig?.color,
+              color: vtConfig.color,
             }}
           >
             <VertexIcon
-              iconUrl={vtConfig?.iconUrl}
-              iconImageType={vtConfig?.iconImageType}
+              iconUrl={vtConfig.iconUrl}
+              iconImageType={vtConfig.iconImageType}
             />
           </div>
         ),
         className: css`
           .start-adornment {
-            color: ${vtConfig?.color}!important;
-            background: ${fade(vtConfig?.color, 0.3)}!important;
+            color: ${vtConfig.color}!important;
+            background: ${fade(vtConfig.color, 0.3)}!important;
           }
         `,
         endAdornment: (
@@ -72,7 +74,7 @@ const ConnectionData = () => {
     });
 
     return items;
-  }, [config, textTransform, navigate]);
+  }, [vtConfigs, textTransform, navigate]);
 
   const [search, setSearch] = useState("");
 

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRecoilCallback, useRecoilValue } from "recoil";
 import { Button, Input, Select, StylingIcon } from "../../components";
 import ColorInput from "../../components/ColorInput/ColorInput";
-import { useConfiguration, useWithTheme } from "../../core";
+import { useWithTheme } from "../../core";
 import {
   ArrowStyle,
   EdgePreferences,
@@ -21,6 +21,7 @@ import {
 import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import defaultStyles from "./SingleEdgeStyling.style";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
+import { useEdgeTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type SingleEdgeStylingProps = {
   edgeType: string;
@@ -35,13 +36,12 @@ const SingleEdgeStyling = ({
   onOpen,
   onClose,
 }: SingleEdgeStylingProps) => {
-  const config = useConfiguration();
   const t = useTranslations();
   const styleWithTheme = useWithTheme();
 
   const userStyling = useRecoilValue(userStylingAtom);
   const textTransform = useTextTransform();
-  const etConfig = config?.getEdgeTypeConfig(edgeType);
+  const etConfig = useEdgeTypeConfig(edgeType);
   const etPrefs = userStyling.edges?.find(e => e.type === edgeType);
 
   const [displayAs, setDisplayAs] = useState(

--- a/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.tsx
@@ -12,6 +12,7 @@ import {
   vertexTypesSelector,
 } from "../../core/StateProvider/configuration";
 import { CheckboxListItemProps } from "../../components";
+import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
 
 const selectedVerticesSelector = selector({
   key: "filters-selected-vertices",
@@ -40,6 +41,7 @@ const useFiltersConfig = () => {
   const textTransform = useTextTransform();
 
   const vertexTypes = useRecoilValue(vertexTypesSelector);
+  const vtConfigs = useVertexTypeConfigs();
   const edgeTypes = useRecoilValue(edgeTypesSelector);
   const setNodesTypesFiltered = useSetRecoilState(nodesTypesFilteredAtom);
   const setEdgesTypesFiltered = useSetRecoilState(edgesTypesFilteredAtom);
@@ -104,7 +106,7 @@ const useFiltersConfig = () => {
     [vertexTypes, setNodesTypesFiltered]
   );
 
-  const { getVertexTypeConfig, getEdgeTypeConfig } = config || {};
+  const { getEdgeTypeConfig } = config || {};
 
   const onChangeConnectionTypes = useCallback(
     (connectionId: string, isSelected: boolean): void => {
@@ -122,8 +124,8 @@ const useFiltersConfig = () => {
 
   const vertexTypesCheckboxes = useMemo(() => {
     return sortBy(
-      vertexTypes?.map(vt => {
-        const vertexConfig = getVertexTypeConfig?.(vt);
+      vtConfigs.map(vertexConfig => {
+        const vt = vertexConfig.type;
 
         return {
           id: vt,
@@ -144,7 +146,7 @@ const useFiltersConfig = () => {
       }),
       type => type.text
     );
-  }, [vertexTypes, getVertexTypeConfig, textTransform]);
+  }, [vtConfigs, textTransform]);
 
   const connectionTypesCheckboxes = useMemo(() => {
     return sortBy(

--- a/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/useFiltersConfig.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo } from "react";
 import { selector, useRecoilValue, useSetRecoilState } from "recoil";
 import { EdgeIcon } from "../../components/icons";
 import VertexIcon from "../../components/VertexIcon";
-import { useConfiguration } from "../../core";
 import { edgesTypesFilteredAtom } from "../../core/StateProvider/edges";
 import { nodesTypesFilteredAtom } from "../../core/StateProvider/nodes";
 import useTextTransform from "../../hooks/useTextTransform";
@@ -12,7 +11,10 @@ import {
   vertexTypesSelector,
 } from "../../core/StateProvider/configuration";
 import { CheckboxListItemProps } from "../../components";
-import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
+import {
+  useEdgeTypeConfigs,
+  useVertexTypeConfigs,
+} from "../../core/ConfigurationProvider/useConfiguration";
 
 const selectedVerticesSelector = selector({
   key: "filters-selected-vertices",
@@ -37,12 +39,12 @@ const selectedEdgesSelector = selector({
 });
 
 const useFiltersConfig = () => {
-  const config = useConfiguration();
   const textTransform = useTextTransform();
 
   const vertexTypes = useRecoilValue(vertexTypesSelector);
   const vtConfigs = useVertexTypeConfigs();
   const edgeTypes = useRecoilValue(edgeTypesSelector);
+  const etConfigs = useEdgeTypeConfigs();
   const setNodesTypesFiltered = useSetRecoilState(nodesTypesFilteredAtom);
   const setEdgesTypesFiltered = useSetRecoilState(edgesTypesFilteredAtom);
   const selectedVertexTypes = useRecoilValue(selectedVerticesSelector);
@@ -106,8 +108,6 @@ const useFiltersConfig = () => {
     [vertexTypes, setNodesTypesFiltered]
   );
 
-  const { getEdgeTypeConfig } = config || {};
-
   const onChangeConnectionTypes = useCallback(
     (connectionId: string, isSelected: boolean): void => {
       isSelected ? deleteConnection(connectionId) : addConnection(connectionId);
@@ -150,17 +150,16 @@ const useFiltersConfig = () => {
 
   const connectionTypesCheckboxes = useMemo(() => {
     return sortBy(
-      edgeTypes?.map(et => {
-        const edgeConfig = getEdgeTypeConfig?.(et);
+      etConfigs.map(edgeConfig => {
         return {
-          id: et,
-          text: edgeConfig?.displayLabel || textTransform(et),
+          id: edgeConfig.type,
+          text: edgeConfig?.displayLabel || textTransform(edgeConfig.type),
           endAdornment: <EdgeIcon />,
         } as CheckboxListItemProps;
       }),
       type => type.text
     );
-  }, [edgeTypes, getEdgeTypeConfig, textTransform]);
+  }, [etConfigs, textTransform]);
 
   return {
     selectedVertexTypes,

--- a/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
@@ -24,6 +24,7 @@ import useDisplayNames from "../../hooks/useDisplayNames";
 import useTextTransform from "../../hooks/useTextTransform";
 import { formatDate } from "../../utils";
 import defaultStyles from "./EntityDetail.styles";
+import { useEdgeTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type EdgeDetailProps = {
   edge: Edge;
@@ -35,9 +36,7 @@ const EdgeDetail = ({ edge, sourceVertex, targetVertex }: EdgeDetailProps) => {
   const config = useConfiguration();
   const styleWithTheme = useWithTheme();
 
-  const edgeConfig = useMemo(() => {
-    return config?.getEdgeTypeConfig(edge.data.type);
-  }, [config, edge.data.type]);
+  const edgeConfig = useEdgeTypeConfig(edge.data.type);
 
   const sourceVertexConfig = useMemo(() => {
     if (!sourceVertex) {

--- a/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
@@ -9,6 +9,7 @@ import NeighborsList from "../common/NeighborsList/NeighborsList";
 import EntityAttribute from "./EntityAttribute";
 import defaultStyles from "./EntityDetail.styles";
 import VertexHeader from "../common/VertexHeader";
+import { useVertexTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type VertexDetailProps = {
   hideNeighbors?: boolean;
@@ -24,9 +25,7 @@ export default function NodeDetail({
   const styleWithTheme = useWithTheme();
   const textTransform = useTextTransform();
 
-  const vertexConfig = useMemo(() => {
-    return config?.getVertexTypeConfig(node.data.type);
-  }, [config, node.data.type]);
+  const vertexConfig = useVertexTypeConfig(node.data.type);
 
   const sortedAttributes = useMemo(() => {
     const attributes =
@@ -76,7 +75,7 @@ export default function NodeDetail({
           />
           <EntityAttribute
             value={
-              vertexConfig?.displayLabel ||
+              vertexConfig.displayLabel ||
               (node.data.types ?? [node.data.type])
                 .map(textTransform)
                 .join(", ")

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -22,7 +22,6 @@ import ScreenshotIcon from "../../components/icons/ScreenshotIcon";
 import ListItem from "../../components/ListItem";
 import RemoteSvgIcon from "../../components/RemoteSvgIcon";
 import Select from "../../components/Select";
-import { useConfiguration } from "../../core/ConfigurationProvider";
 import {
   edgesHiddenIdsAtom,
   edgesOutOfFocusIdsAtom,
@@ -44,6 +43,7 @@ import useGraphGlobalActions from "./useGraphGlobalActions";
 import useGraphStyles from "./useGraphStyles";
 import useNodeBadges from "./useNodeBadges";
 import useNodeDrop from "./useNodeDrop";
+import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type GraphViewerProps = Omit<
   ModuleContainerHeaderProps,
@@ -326,8 +326,8 @@ export default function GraphViewer({
 }
 
 function Legend({ onClose }: { onClose: () => void }) {
-  const config = useConfiguration();
   const textTransform = useTextTransform();
+  const vtConfigs = useVertexTypeConfigs();
 
   return (
     <Card className={"legend-container"}>
@@ -344,19 +344,18 @@ function Legend({ onClose }: { onClose: () => void }) {
       >
         Legend
       </ListItem>
-      {config?.vertexTypes.map(vertexType => {
-        const vtConfig = config?.getVertexTypeConfig(vertexType);
+      {vtConfigs.map(vtConfig => {
         return (
           <ListItem
-            key={vertexType}
+            key={vtConfig.type}
             className={"legend-item"}
             startAdornment={
-              vtConfig?.iconUrl && (
+              vtConfig.iconUrl && (
                 <div
                   className={"icon"}
                   style={{
-                    background: fade(vtConfig?.color, 0.2),
-                    color: vtConfig?.color,
+                    background: fade(vtConfig.color, 0.2),
+                    color: vtConfig.color,
                   }}
                 >
                   <RemoteSvgIcon src={vtConfig.iconUrl} />
@@ -364,7 +363,7 @@ function Legend({ onClose }: { onClose: () => void }) {
               )
             }
           >
-            {vtConfig?.displayLabel || textTransform(vertexType)}
+            {vtConfig.displayLabel || textTransform(vtConfig.type)}
           </ListItem>
         );
       })}

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -2,10 +2,12 @@ import Color from "color";
 import { useEffect, useState } from "react";
 import { EdgeData } from "../../@types/entities";
 import type { GraphProps } from "../../components";
-import { useConfiguration } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
 import { renderNode } from "./renderNode";
-import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
+import {
+  useEdgeTypeConfigs,
+  useVertexTypeConfigs,
+} from "../../core/ConfigurationProvider/useConfiguration";
 
 const LINE_PATTERN = {
   solid: undefined,
@@ -14,8 +16,8 @@ const LINE_PATTERN = {
 };
 
 const useGraphStyles = () => {
-  const config = useConfiguration();
   const vtConfigs = useVertexTypeConfigs();
+  const etConfigs = useEdgeTypeConfigs();
   const textTransform = useTextTransform();
   const [styles, setStyles] = useState<GraphProps["styles"]>({});
 
@@ -43,7 +45,9 @@ const useGraphStyles = () => {
         };
       }
 
-      for (const et of config?.edgeTypes || []) {
+      for (const etConfig of etConfigs) {
+        const et = etConfig?.type;
+
         let label = textTransform(et);
         if (label.length > 20) {
           label = label.substring(0, 17) + "...";
@@ -54,11 +58,6 @@ const useGraphStyles = () => {
           "source-distance-from-node": 0,
           "target-distance-from-node": 0,
         };
-
-        const etConfig = config?.getEdgeTypeConfig(et);
-        if (!etConfig) {
-          continue;
-        }
 
         styles[`edge[type="${et}"]`] = {
           label: (el: cytoscape.EdgeSingular) => {
@@ -99,7 +98,7 @@ const useGraphStyles = () => {
 
       setStyles(styles);
     })();
-  }, [config, textTransform, vtConfigs]);
+  }, [etConfigs, textTransform, vtConfigs]);
 
   return styles;
 };

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -5,6 +5,7 @@ import type { GraphProps } from "../../components";
 import { useConfiguration } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
 import { renderNode } from "./renderNode";
+import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
 
 const LINE_PATTERN = {
   solid: undefined,
@@ -14,6 +15,7 @@ const LINE_PATTERN = {
 
 const useGraphStyles = () => {
   const config = useConfiguration();
+  const vtConfigs = useVertexTypeConfigs();
   const textTransform = useTextTransform();
   const [styles, setStyles] = useState<GraphProps["styles"]>({});
 
@@ -21,11 +23,8 @@ const useGraphStyles = () => {
     (async () => {
       const styles: GraphProps["styles"] = {};
 
-      for (const vt of config?.vertexTypes || []) {
-        const vtConfig = config?.getVertexTypeConfig(vt);
-        if (!vtConfig) {
-          continue;
-        }
+      for (const vtConfig of vtConfigs) {
+        const vt = vtConfig.type;
 
         // Process the image data or SVG
         const backgroundImage = await renderNode(vtConfig);
@@ -100,7 +99,7 @@ const useGraphStyles = () => {
 
       setStyles(styles);
     })();
-  }, [config, textTransform]);
+  }, [config, textTransform, vtConfigs]);
 
   return styles;
 };

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.test.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.test.ts
@@ -1,6 +1,9 @@
 import useKeywordSearch from "./useKeywordSearch";
 import { ConnectionConfig } from "../../core";
-import { renderHookWithRecoilRoot } from "../../utils/testing";
+import {
+  createRandomSchema,
+  renderHookWithRecoilRoot,
+} from "../../utils/testing";
 import { createRandomRawConfiguration } from "../../utils/testing";
 import {
   activeConfigurationAtom,
@@ -8,6 +11,7 @@ import {
 } from "../../core/StateProvider/configuration";
 import { MutableSnapshot } from "recoil";
 import { vi } from "vitest";
+import { schemaAtom } from "../../core/StateProvider/schema";
 
 vi.mock("./useKeywordSearchQuery", () => ({
   useKeywordSearchQuery: vi.fn().mockReturnValue({
@@ -118,8 +122,9 @@ describe("useKeywordSearch", () => {
     function initializeConfigWithRdfLabel(snapshot: MutableSnapshot) {
       // Create config and setup schema
       const config = createRandomRawConfiguration();
+      const schema = createRandomSchema();
       config.connection!.queryEngine = "sparql";
-      config.schema?.vertices[0].attributes.push({
+      schema.vertices[0].attributes.push({
         name: "rdfs:label",
         displayLabel: "rdfs:label",
         searchable: true,
@@ -127,6 +132,7 @@ describe("useKeywordSearch", () => {
       });
 
       snapshot.set(configurationAtom, new Map([[config.id, config]]));
+      snapshot.set(schemaAtom, new Map([[config.id, schema]]));
 
       // Make config active
       snapshot.set(activeConfigurationAtom, config.id);

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -5,6 +5,7 @@ import { useConfiguration } from "../../core";
 import useDebounceValue from "../../hooks/useDebounceValue";
 import useTextTransform from "../../hooks/useTextTransform";
 import { useKeywordSearchQuery } from "./useKeywordSearchQuery";
+import { useVertexTypeConfigs } from "../../core/ConfigurationProvider/useConfiguration";
 
 export interface PromiseWithCancel<T> extends Promise<T> {
   cancel?: () => void;
@@ -32,20 +33,20 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
   // Sparql uses rdfs:label, not ID
   const allowsIdSearch = config?.connection?.queryEngine !== "sparql";
 
+  const vtConfigs = useVertexTypeConfigs();
   const vertexOptions = useMemo(() => {
     const vertexOps =
-      config?.vertexTypes
-        .map(vt => {
-          const vtConfig = config?.getVertexTypeConfig(vt);
+      vtConfigs
+        .map(vtConfig => {
           return {
-            label: textTransform(vtConfig?.displayLabel || vt),
-            value: vt,
+            label: textTransform(vtConfig?.displayLabel || vtConfig.type),
+            value: vtConfig.type,
           };
         })
         .sort((a, b) => a.label.localeCompare(b.label)) || [];
 
     return [{ label: "All", value: allVerticesValue }, ...vertexOps];
-  }, [config, textTransform]);
+  }, [textTransform, vtConfigs]);
 
   const onSearchTermChange = useCallback((value: string) => {
     setSearchTerm(value);

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -12,6 +12,7 @@ import {
 import { useConfiguration } from "../../core";
 import useTextTransform from "../../hooks/useTextTransform";
 import useTranslations from "../../hooks/useTranslations";
+import { useVertexTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type NodeExpandFilter = {
   name: string;
@@ -40,7 +41,7 @@ const NodeExpandFilters = ({
   const t = useTranslations();
   const textTransform = useTextTransform();
 
-  const vtConfig = config?.getVertexTypeConfig(selectedType);
+  const vtConfig = useVertexTypeConfig(selectedType);
   const searchableAttributes =
     config?.getVertexTypeSearchableAttributes(selectedType);
 
@@ -48,11 +49,11 @@ const NodeExpandFilters = ({
     onFiltersChange([
       ...filters,
       {
-        name: vtConfig?.attributes?.[0].name || "",
+        name: vtConfig.attributes[0]?.name || "",
         value: "",
       },
     ]);
-  }, [filters, onFiltersChange, vtConfig?.attributes]);
+  }, [filters, onFiltersChange, vtConfig.attributes]);
 
   const onFilterDelete = useCallback(
     (filterIndex: number) => {
@@ -83,7 +84,7 @@ const NodeExpandFilters = ({
         }}
         options={neighborsOptions}
       />
-      {!!vtConfig?.attributes?.length && (
+      {!!vtConfig.attributes.length && (
         <div className={"title"}>
           <div>Filter to narrow results</div>
           <IconButton

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../components";
 import ColorInput from "../../components/ColorInput/ColorInput";
 import { useNotification } from "../../components/NotificationProvider";
-import { useConfiguration, useWithTheme } from "../../core";
+import { useWithTheme } from "../../core";
 import {
   LineStyle,
   ShapeStyle,
@@ -28,6 +28,7 @@ import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import { NODE_SHAPE } from "./nodeShape";
 import defaultStyles from "./SingleNodeStyling.style";
 import modalDefaultStyles from "./SingleNodeStylingModal.style";
+import { useVertexTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type SingleNodeStylingProps = {
   vertexType: string;
@@ -51,25 +52,23 @@ const SingleNodeStyling = ({
   onOpen,
   onClose,
 }: SingleNodeStylingProps) => {
-  const config = useConfiguration();
   const t = useTranslations();
   const styleWithTheme = useWithTheme();
 
   const userStyling = useRecoilValue(userStylingAtom);
   const textTransform = useTextTransform();
-  const vtConfig = config?.getVertexTypeConfig(vertexType);
+  const vtConfig = useVertexTypeConfig(vertexType);
   const vtPrefs = userStyling.vertices?.find(v => v.type === vertexType);
 
   const [displayAs, setDisplayAs] = useState(
-    vtConfig?.displayLabel || textTransform(vertexType)
+    vtConfig.displayLabel || textTransform(vertexType)
   );
 
   const selectOptions = useMemo(() => {
-    const options =
-      vtConfig?.attributes.map(attr => ({
-        value: attr.name,
-        label: attr.displayLabel || textTransform(attr.name),
-      })) || [];
+    const options = vtConfig.attributes.map(attr => ({
+      value: attr.name,
+      label: attr.displayLabel || textTransform(attr.name),
+    }));
 
     options.unshift({
       label: t("nodes-styling.node-type"),
@@ -78,7 +77,7 @@ const SingleNodeStyling = ({
     options.unshift({ label: t("nodes-styling.node-id"), value: "id" });
 
     return options;
-  }, [t, textTransform, vtConfig?.attributes]);
+  }, [t, textTransform, vtConfig.attributes]);
 
   const onUserPrefsChange = useRecoilCallback(
     ({ set }) =>
@@ -198,7 +197,7 @@ const SingleNodeStyling = ({
   }, [displayAs, debouncedChange]);
 
   const isSvg =
-    (vtPrefs?.iconImageType || vtConfig?.iconImageType) === "image/svg+xml";
+    (vtPrefs?.iconImageType || vtConfig.iconImageType) === "image/svg+xml";
 
   return (
     <div className={styleWithTheme(defaultStyles)}>
@@ -245,7 +244,7 @@ const SingleNodeStyling = ({
               <Select
                 label={"Display Name Attribute"}
                 labelPlacement={"inner"}
-                value={vtConfig?.displayNameAttribute || ""}
+                value={vtConfig.displayNameAttribute || ""}
                 onChange={onDisplayNameChange("name")}
                 options={selectOptions}
                 hideError={true}
@@ -254,7 +253,7 @@ const SingleNodeStyling = ({
               <Select
                 label={"Display Description Attribute"}
                 labelPlacement={"inner"}
-                value={vtConfig?.longDisplayNameAttribute || ""}
+                value={vtConfig.longDisplayNameAttribute || ""}
                 onChange={onDisplayNameChange("longName")}
                 options={selectOptions}
                 hideError={true}
@@ -293,22 +292,20 @@ const SingleNodeStyling = ({
                           <div
                             className={"vertex-icon"}
                             style={{
-                              background: fade(vtConfig?.color, 0.2),
-                              color: vtConfig?.color,
+                              background: fade(vtConfig.color, 0.2),
+                              color: vtConfig.color,
                             }}
                           >
                             {isSvg && (
                               <RemoteSvgIcon
-                                src={
-                                  vtPrefs?.iconUrl || vtConfig?.iconUrl || ""
-                                }
+                                src={vtPrefs?.iconUrl || vtConfig.iconUrl || ""}
                               />
                             )}
                             {!isSvg && (
                               <img
                                 width={24}
                                 height={24}
-                                src={vtPrefs?.iconUrl || vtConfig?.iconUrl}
+                                src={vtPrefs?.iconUrl || vtConfig.iconUrl}
                               />
                             )}
                           </div>

--- a/packages/graph-explorer/src/modules/common/VertexHeader.tsx
+++ b/packages/graph-explorer/src/modules/common/VertexHeader.tsx
@@ -1,10 +1,13 @@
-import { useMemo } from "react";
 import { Vertex } from "../../@types/entities";
 import { VertexIcon } from "../../components";
-import { useConfiguration, fade, ThemeStyleFn, useWithTheme } from "../../core";
+import { fade, ThemeStyleFn, useWithTheme } from "../../core";
 import useDisplayNames from "../../hooks/useDisplayNames";
 import useTextTransform from "../../hooks/useTextTransform";
 import { css } from "@emotion/css";
+import {
+  useVertexTypeConfig,
+  useVertexTypeConfigs,
+} from "../../core/ConfigurationProvider/useConfiguration";
 
 const defaultStyles: ThemeStyleFn = ({ theme }) => css`
   position: sticky;
@@ -40,35 +43,30 @@ const defaultStyles: ThemeStyleFn = ({ theme }) => css`
 
 export default function VertexHeader({ vertex }: { vertex: Vertex }) {
   const styleWithTheme = useWithTheme();
-  const config = useConfiguration();
   const textTransform = useTextTransform();
-  const displayLabels = useMemo(() => {
-    return (vertex.data.types ?? [vertex.data.type])
-      .map(type => {
-        return (
-          config?.getVertexTypeConfig(type)?.displayLabel || textTransform(type)
-        );
-      })
-      .filter(Boolean)
-      .join(", ");
-  }, [config, textTransform, vertex.data.type, vertex.data.types]);
+  const vertexTypeConfigs = useVertexTypeConfigs(
+    vertex.data.types ?? [vertex.data.type]
+  );
+  const displayLabels = vertexTypeConfigs
+    .map(vtConfig => vtConfig.displayLabel || textTransform(vtConfig.type))
+    .join(", ");
   const getDisplayNames = useDisplayNames();
   const { name } = getDisplayNames(vertex);
-  const vtConfig = config?.getVertexTypeConfig(vertex.data.type);
+  const vtConfig = useVertexTypeConfig(vertex.data.type);
 
   return (
     <div className={styleWithTheme(defaultStyles)}>
-      {vtConfig?.iconUrl && (
+      {vtConfig.iconUrl && (
         <div
           className={"icon"}
           style={{
-            background: fade(vtConfig?.color, 0.2),
+            background: fade(vtConfig.color, 0.2),
             color: vtConfig.color,
           }}
         >
           <VertexIcon
-            iconUrl={vtConfig?.iconUrl}
-            iconImageType={vtConfig?.iconImageType}
+            iconUrl={vtConfig.iconUrl}
+            iconImageType={vtConfig.iconImageType}
           />
         </div>
       )}

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -118,6 +118,7 @@ export function createRandomEdgeTypeConfig(): EdgeTypeConfig {
     attributes: createArray(6, createRandomAttributeConfig),
     displayLabel: randomlyUndefined(createRandomName("displayLabel")),
     hidden: randomlyUndefined(createRandomBoolean()),
+    total: createRandomInteger(),
   };
 }
 
@@ -131,6 +132,7 @@ export function createRandomVertexTypeConfig(): VertexTypeConfig {
     attributes: createArray(6, createRandomAttributeConfig),
     displayLabel: randomlyUndefined(createRandomName("displayLabel")),
     hidden: randomlyUndefined(createRandomBoolean()),
+    total: createRandomInteger(),
   };
 }
 
@@ -144,8 +146,15 @@ export function createRandomSchema(): Schema {
   const schema: Schema = {
     edges,
     vertices,
-    totalEdges: edges.length,
-    totalVertices: vertices.length,
+    totalEdges: edges
+      .map(e => e.total ?? 0)
+      .reduce((prev, current) => current + prev, 0),
+    totalVertices: vertices
+      .map(v => v.total ?? 0)
+      .reduce((prev, current) => current + prev, 0),
+    lastSyncFail: false,
+    lastUpdate: new Date(),
+    triedToSync: true,
   };
   return schema;
 }

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -236,6 +236,5 @@ export function createRandomRawConfiguration(): RawConfiguration {
       url: createRandomName("url"),
       queryEngine: pickRandomElement(["gremlin", "openCypher", "sparql"]),
     },
-    schema: createRandomSchema(),
   };
 }

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -48,7 +48,7 @@ import useUpdateVertexTypeCounts from "../../hooks/useUpdateVertexTypeCounts";
 import TopBarWithLogo from "../common/TopBarWithLogo";
 import defaultStyles from "./DataExplorer.styles";
 import { searchQuery } from "../../connector/queries";
-import { vertexTypeConfigSelector } from "../../core/ConfigurationProvider/useConfiguration";
+import { useVertexTypeConfig } from "../../core/ConfigurationProvider/useConfiguration";
 
 export type ConnectionsProps = {
   vertexType: string;
@@ -78,7 +78,7 @@ function DataExplorerContent({ vertexType }: ConnectionsProps) {
   // Automatically updates counts if needed
   useUpdateVertexTypeCounts(vertexType);
 
-  const vertexConfig = useRecoilValue(vertexTypeConfigSelector(vertexType));
+  const vertexConfig = useVertexTypeConfig(vertexType);
   const { pageIndex, pageSize, onPageIndexChange, onPageSizeChange } =
     usePagingOptions();
 
@@ -178,7 +178,7 @@ function DisplayNameAndDescriptionOptions({
 }) {
   const textTransform = useTextTransform();
   const t = useTranslations();
-  const vertexConfig = useRecoilValue(vertexTypeConfigSelector(vertexType));
+  const vertexConfig = useVertexTypeConfig(vertexType);
   const selectOptions = useMemo(() => {
     const options =
       vertexConfig?.attributes.map(attr => ({
@@ -280,7 +280,7 @@ function AddToExplorerButton({ vertex }: { vertex: Vertex }) {
 function useColumnDefinitions(vertexType: string) {
   const textTransform = useTextTransform();
   const t = useTranslations();
-  const vertexConfig = useRecoilValue(vertexTypeConfigSelector(vertexType));
+  const vertexConfig = useVertexTypeConfig(vertexType);
   const columns: ColumnDefinition<Vertex>[] = useMemo(() => {
     const vtColumns: ColumnDefinition<Vertex>[] =
       vertexConfig?.attributes


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a clean hook around getting the vertex type config for a given vertex, array of vertices, or all vertices.

This is step one in cleaning up the config/schema access code and make it more "React" like.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Smoke test

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
