### PR TITLE
Spacing fix and remove a couple `useEffect` uses

### DIFF
--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -373,11 +373,11 @@ function SearchResults({
         subtitle={
           currentTotal ? (
             <div>
-              Looking at
+              Looking at{" "}
               <HumanReadableNumberFormatter
                 value={currentTotal}
                 maxFractionDigits={0}
-              />
+              />{" "}
               records for matching results
             </div>
           ) : (

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { Vertex } from "../../@types/entities";
 import { ModuleContainerFooter, PanelError } from "../../components";
 import Button from "../../components/Button";
@@ -37,6 +37,7 @@ export default function NodeExpandContent({ vertex }: NodeExpandContentProps) {
 function ExpandSidebarContent({ vertex }: { vertex: Vertex }) {
   const t = useTranslations();
   const query = useUpdateNodeCountsQuery(vertex.data.id);
+  const neighborsOptions = useNeighborsOptions(vertex);
 
   if (query.isError) {
     return <PanelError error={query.error} onRetry={query.refetch} />;
@@ -61,26 +62,29 @@ function ExpandSidebarContent({ vertex }: { vertex: Vertex }) {
   return (
     <>
       <NeighborsList vertex={vertex} />
-      <ExpansionOptions vertex={vertex} />
+      <ExpansionOptions
+        vertex={vertex}
+        neighborsOptions={neighborsOptions}
+        key={neighborsOptions.map(o => o.value).join()}
+      />
     </>
   );
 }
 
-function ExpansionOptions({ vertex }: { vertex: Vertex }) {
+function ExpansionOptions({
+  vertex,
+  neighborsOptions,
+}: {
+  vertex: Vertex;
+  neighborsOptions: NeighborOption[];
+}) {
   const t = useTranslations();
-  const neighborsOptions = useNeighborsOptions(vertex);
 
   const [selectedType, setSelectedType] = useState<string>(
     firstNeighborAvailableForExpansion(neighborsOptions)?.value ?? ""
   );
   const [filters, setFilters] = useState<Array<NodeExpandFilter>>([]);
   const [limit, setLimit] = useState<number | null>(null);
-
-  useEffect(() => {
-    setSelectedType(
-      firstNeighborAvailableForExpansion(neighborsOptions)?.value ?? ""
-    );
-  }, [neighborsOptions]);
 
   const hasUnfetchedNeighbors = Boolean(vertex.data.__unfetchedNeighborCount);
   const hasSelectedType = Boolean(selectedType);

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -89,6 +89,13 @@ function ExpansionOptions({
   const hasUnfetchedNeighbors = Boolean(vertex.data.__unfetchedNeighborCount);
   const hasSelectedType = Boolean(selectedType);
 
+  // Reset filters when selected type changes
+  const [prevSelectedType, setPrevSelectedType] = useState(selectedType);
+  if (prevSelectedType !== selectedType) {
+    setPrevSelectedType(selectedType);
+    setFilters([]);
+  }
+
   if (!hasUnfetchedNeighbors) {
     return (
       <PanelEmptyState

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -1,5 +1,5 @@
 import { clone } from "lodash";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import {
   AddIcon,
   DeleteIcon,
@@ -71,10 +71,6 @@ const NodeExpandFilters = ({
     },
     [filters, onFiltersChange]
   );
-
-  useEffect(() => {
-    onFiltersChange([]);
-  }, [onFiltersChange, selectedType]);
 
   return (
     <div className={"filters-section"}>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I noticed a small bug in the search loading screen where the text was missing some spaces.

I also was reading about [how to avoid `useEffect()`](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes) and implemented two of those patterns in parts of code that reset state based on other state changes.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested search loading
- Tested node expansion side bar filters

### Missing spaces

![CleanShot 2024-07-25 at 09 28 24@2x](https://github.com/user-attachments/assets/c29b42a5-d00f-49c8-9561-ecd6f5e57962)


### Fixed

![CleanShot 2024-07-25 at 09 28 04@2x](https://github.com/user-attachments/assets/c8900cf4-57e5-4073-9fe5-e91fbf947474)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
