### PR TITLE
Replace existing defaultConnection file on startup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,8 @@
 
 **Bug Fixes and Minor Changes**
 
+- Fix issue with default connections when Neptune Notebook instance is restarted
+  (<https://github.com/aws/graph-explorer/pull/508>)
 - Fix expanding a node on old versions of Gremlin
   (<https://github.com/aws/graph-explorer/pull/503>)
 - Provide better error messages when expanding a node fails

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -41,6 +41,9 @@ fi
 
 # Update the default connection file with the configuration values
 if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
+    # Overwrite existing file with an empty string
+    echo "" > ./packages/graph-explorer/defaultConnection.json
+    
     echo -e "{\n\"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT\":\"${PUBLIC_OR_PROXY_ENDPOINT}\"," >> ./packages/graph-explorer/defaultConnection.json
 
     if [ -n "$SERVICE_TYPE" ]; then


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I noticed that when running Graph Explorer in Neptune Notebook it would sometimes fail to get the default connections. I determined it is because every time the Notebook is rebooted another entry is added to the `defaultConnection.json` file. But it is missing a comma between them so it is invalid JSON and can't be parsed by the JavaScript code.

So instead, each startup will replace the existing `defaultConnection.json` file with the current environment values. This will ensure that only one connection is present in the file.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested in local docker environment with Neptune Notebook like settings

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
