### PR TITLE
Only send queryId when using proxy server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -45,6 +45,9 @@ a more pleasant experience, especially for users with larger databases.
 - **Fixed** some SPARQL endpoints by using `application/sparql-results+json`
   accept header for SPARQL requests
   ([#499](https://github.com/aws/graph-explorer/pull/499))
+- **Fixed** CORS issue for some SPARQL and Gremlin endpoints due to `queryId` in
+  the request headers ([#529](https://github.com/aws/graph-explorer/pull/529))
+  ([#499](https://github.com/aws/graph-explorer/pull/499))
 - **Fixed** text wrapping for labels in edge styling sidebar
   ([#499](https://github.com/aws/graph-explorer/pull/499))
 - **Fixed** potential error when the request body is very large by increasing

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -18,7 +18,7 @@ function _gremlinFetch(connection: ConnectionConfig, options: any) {
       "Content-Type": "application/json",
       Accept: "application/vnd.gremlin-v3.0+json",
     };
-    if (options?.queryId && connection?.proxyConnection === true) {
+    if (options?.queryId && connection.proxyConnection === true) {
       headers.queryId = options.queryId;
     }
 

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -136,16 +136,17 @@ function _sparqlFetch(connection: ConnectionConfig, options?: any) {
   return async (queryTemplate: string) => {
     logger.debug(queryTemplate);
     const body = `query=${encodeURIComponent(queryTemplate)}`;
-    const headers = options?.queryId
-      ? {
-          accept: "application/sparql-results+json",
-          "Content-Type": "application/x-www-form-urlencoded",
-          queryId: options.queryId,
-        }
-      : {
-          accept: "application/sparql-results+json",
-          "Content-Type": "application/x-www-form-urlencoded",
-        };
+    const headers =
+      options?.queryId && connection.proxyConnection === true
+        ? {
+            accept: "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            queryId: options.queryId,
+          }
+        : {
+            accept: "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+          };
     return fetchDatabaseRequest(connection, `${connection.url}/sparql`, {
       method: "POST",
       headers,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

We put the `queryId` in the headers for Gremlin and SPARQL requests so they can be cancelled by the proxy server. But some database endpoints will report CORS issues if the header contains unexpected values.

If we are not using the proxy server then there is no reason to have the `queryId` in the headers.

## Validation

- Tested against Neptune
- Tested against `https://id.nlm.nih.gov/mesh` (SPARQL)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #530 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
