### PR TITLE
Remove order by in cypher search query

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,8 @@ a more pleasant experience, especially for users with larger databases.
   ([#477](https://github.com/aws/graph-explorer/pull/477))
 - **Improved** search using openCypher which will now execute a single request
   when searching across all labels
-  ([#493](https://github.com/aws/graph-explorer/pull/493))
+  ([#493](https://github.com/aws/graph-explorer/pull/493),
+  [#532](https://github.com/aws/graph-explorer/pull/532))
 - **Improved** error messages for node expansion
   ([#502](https://github.com/aws/graph-explorer/pull/502))
 - **Improved** Gremlin schema sync performance on larger databases, thanks to

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -11,7 +11,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
       normalize(`
         MATCH (v:\`airport\`) 
         RETURN v AS object 
-        ORDER BY id(v)
       `)
     );
   });
@@ -26,7 +25,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v) 
         WHERE (v:\`airport\` OR v:\`country\`) 
         RETURN v AS object 
-        ORDER BY id(v)
       `)
     );
   });
@@ -42,7 +40,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
       normalize(`
         MATCH (v:\`airport\`)
         RETURN v AS object
-        ORDER BY id(v)
         SKIP 10 LIMIT 20
       `)
     );
@@ -62,7 +59,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         WHERE (v:\`airport\` OR v:\`country\`) 
           AND (v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -80,7 +76,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v:\`airport\`)
         WHERE (v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -98,7 +93,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v:\`airport\`)
         WHERE (v.city = "JFK" OR v.code = "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -117,7 +111,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v:\`airport\`)
         WHERE (id(v) = "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -136,7 +129,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v:\`airport\`)
         WHERE (toString(id(v)) CONTAINS "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -154,7 +146,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         MATCH (v:\`airport\`)
         WHERE (toString(id(v)) CONTAINS "JFK" OR v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
         RETURN v AS object
-        ORDER BY id(v)
       `)
     );
   });
@@ -176,7 +167,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
         WHERE (v:\`airport\` OR v:\`country\`)
           AND (toString(id(v)) CONTAINS "JFK" OR v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
         RETURN v AS object
-        ORDER BY id(v)
         SKIP 25 LIMIT 50
       `)
     );

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -81,7 +81,6 @@ const keywordSearchTemplate = ({
     MATCH (${vertexMatchTemplate})
     ${whereTemplate}
     RETURN v AS object
-    ORDER BY id(v)
     ${limitTemplate}
   `;
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The order by clause was causing the default initial search query in openCypher to be extremely slow. Removing it makes the order less predictable, but is preferable to the slow query.

We will need to figure this out if we ever want to have paginated search results:

- #106 

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested in very large data set on Neptune

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #531 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
