### PR TITLE
Fix styling sidebar performance

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -1,4 +1,4 @@
-import { atom } from "recoil";
+import { atom, DefaultValue, selectorFamily } from "recoil";
 import localForageEffect from "./localForageEffect";
 
 export type ShapeStyle =
@@ -109,6 +109,84 @@ export const userStylingAtom = atom<UserPreferences["styling"]>({
   key: "user-styling",
   default: {},
   effects: [localForageEffect()],
+});
+
+export const userStylingNodeAtom = selectorFamily({
+  key: "user-styling-node",
+  get:
+    (nodeType: string) =>
+    ({ get }) => {
+      return get(userStylingAtom).vertices?.find(
+        node => node.type === nodeType
+      );
+    },
+  set:
+    (nodeType: string) =>
+    ({ set }, newValue) => {
+      set(userStylingAtom, prev => {
+        let newNodes = Array.from(prev.vertices ?? []);
+        const existingIndex = newNodes.findIndex(
+          node => node.type === nodeType
+        );
+
+        if (newValue instanceof DefaultValue || !newValue) {
+          // Remove the entry from user styles
+          newNodes = newNodes.filter(node => node.type !== nodeType);
+        } else if (existingIndex === -1) {
+          // Add it because it doesn't exist
+          newNodes.push(newValue);
+        } else {
+          // Replace the existing entry
+          newNodes[existingIndex] = {
+            ...newNodes[existingIndex],
+            ...newValue,
+          };
+        }
+
+        return {
+          ...prev,
+          vertices: newNodes,
+        };
+      });
+    },
+});
+
+export const userStylingEdgeAtom = selectorFamily({
+  key: "user-styling-edge",
+  get:
+    (edgeType: string) =>
+    ({ get }) => {
+      return get(userStylingAtom).edges?.find(edge => edge.type === edgeType);
+    },
+  set:
+    (edgeType: string) =>
+    ({ set }, newValue) => {
+      set(userStylingAtom, prev => {
+        let newEdges = Array.from(prev.edges ?? []);
+        const existingIndex = newEdges.findIndex(
+          edge => edge.type === edgeType
+        );
+
+        if (newValue instanceof DefaultValue || !newValue) {
+          // Remove the entry from user styles
+          newEdges = newEdges.filter(edge => edge.type !== edgeType);
+        } else if (existingIndex === -1) {
+          // Add it because it doesn't exist
+          newEdges.push(newValue);
+        } else {
+          // Replace the existing entry
+          newEdges[existingIndex] = {
+            ...newEdges[existingIndex],
+            ...newValue,
+          };
+        }
+
+        return {
+          ...prev,
+          edges: newEdges,
+        };
+      });
+    },
 });
 
 export const userLayoutAtom = atom<UserPreferences["layout"]>({

--- a/packages/graph-explorer/src/hooks/usePrevious.test.ts
+++ b/packages/graph-explorer/src/hooks/usePrevious.test.ts
@@ -2,9 +2,9 @@ import { renderHook } from "@testing-library/react";
 import usePrevious from "./usePrevious";
 
 describe("usePrevious", () => {
-  it("should return undefined for the first render", () => {
+  it("should return null for the first render", () => {
     const { result } = renderHook(() => usePrevious(10));
-    expect(result.current).toBeUndefined();
+    expect(result.current).toBeNull();
   });
 
   it("should return the previous value after a re-render", () => {
@@ -12,7 +12,7 @@ describe("usePrevious", () => {
       initialProps: { value: 10 },
     });
 
-    expect(result.current).toBeUndefined();
+    expect(result.current).toBeNull();
 
     rerender({ value: 20 });
     expect(result.current).toEqual(10);

--- a/packages/graph-explorer/src/hooks/usePrevious.ts
+++ b/packages/graph-explorer/src/hooks/usePrevious.ts
@@ -1,13 +1,13 @@
-import { useEffect, useRef } from "react";
+import React from "react";
 
-const usePrevious = <T>(value: T) => {
-  const ref = useRef<T>();
+export default function usePrevious<T>(value: T): T | null {
+  const [current, setCurrent] = React.useState(value);
+  const [previous, setPrevious] = React.useState<T | null>(null);
 
-  useEffect(() => {
-    ref.current = value;
-  }, [value]);
+  if (value !== current) {
+    setPrevious(current);
+    setCurrent(value);
+  }
 
-  return ref.current;
-};
-
-export default usePrevious;
+  return previous;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This fixes a gnarly performance issue when the number of node or edge types is large (roughly over 20). The browser would essentially lock up and be nearly unuseable.

The problem was that the effect that watch for the `Input` value change was being fired way too often, including the initial render, and the state update is very slow.

The fix was to properly debounce the value change and also compare to previous value. This led to another fix in the `usePrevious` hook where it didn't always have the correct value.

And finally, I did some cleanup in the `SingleEdgeStyling` and `SingleNodeStyling ` components to lean on Recoil selectors to simplify the logic.

### Changelog

I accidentally pushed the changelog update to `main` directly. Since it is a non-destructive change, I'm just going to leave it there rather than revert it and add it to this PR.

https://github.com/aws/graph-explorer/commit/fc0a0e5f2a814a8a8f14d8f45f32525a0274debb

## Validation

- Tested changing display name in Input in sidebar
- Tested changing preferences in customize popup
- Tested resetting styles in customize popup

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #541 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
