### PR TITLE
Fix prefix updater

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 - **Improved** performance of styling sidebar panels when many node & edge types
   exist ([#542](https://github.com/aws/graph-explorer/pull/542))
+- **Fixed** issue with upper case characters in RDF URIs
+  ([#544](https://github.com/aws/graph-explorer/pull/544))
 
 ## Release 1.9.0
 

--- a/packages/graph-explorer/src/hooks/usePrefixesUpdater.ts
+++ b/packages/graph-explorer/src/hooks/usePrefixesUpdater.ts
@@ -10,25 +10,29 @@ const usePrefixesUpdater = () => {
   const setSchema = useSetRecoilState(schemaAtom);
   const { enqueueNotification } = useNotification();
 
+  const supportsPrefixes = config?.connection?.queryEngine === "sparql"
+  const existingPrefixes = config?.schema?.prefixes
+  const activeConfigId = config?.id;
+
   return useCallback(
     (ids: Array<string>) => {
-      if (config?.connection?.queryEngine !== "sparql" || ids.length === 0) {
+      if (supportsPrefixes || ids.length === 0) {
         return;
       }
 
-      const genPrefixes = generatePrefixes(ids, config?.schema?.prefixes);
+      const genPrefixes = generatePrefixes(ids, existingPrefixes);
       if (!genPrefixes?.length) {
         return;
       }
 
       setSchema(prevSchemaMap => {
-        if (!config?.id) {
+        if (!activeConfigId) {
           return prevSchemaMap;
         }
 
         const updatedSchema = new Map(prevSchemaMap);
-        const schema = updatedSchema.get(config.id);
-        updatedSchema.set(config.id, {
+        const schema = updatedSchema.get(activeConfigId);
+        updatedSchema.set(activeConfigId, {
           // Update prefixes does not affect to sync last update date
           lastUpdate: schema?.lastUpdate,
           vertices: schema?.vertices || [],
@@ -40,11 +44,11 @@ const usePrefixesUpdater = () => {
         return updatedSchema;
       });
 
-      const oldPrefixesSize = config?.schema?.prefixes?.length || 0;
-      const newPrefixesSize = genPrefixes.length || 0;
+      const oldPrefixesSize = existingPrefixes?.length ?? 0;
+      const newPrefixesSize = genPrefixes.length;
       if (
         genPrefixes.length &&
-        config?.schema?.prefixes?.length !== genPrefixes.length
+        existingPrefixes?.length !== genPrefixes.length
       ) {
         const addedCount = newPrefixesSize - oldPrefixesSize;
         enqueueNotification({
@@ -58,13 +62,7 @@ const usePrefixesUpdater = () => {
         });
       }
     },
-    [
-      config?.id,
-      config?.connection?.queryEngine,
-      config?.schema?.prefixes,
-      enqueueNotification,
-      setSchema,
-    ]
+    [supportsPrefixes, existingPrefixes, setSchema,  activeConfigId, enqueueNotification]
   );
 };
 

--- a/packages/graph-explorer/src/hooks/usePrefixesUpdater.ts
+++ b/packages/graph-explorer/src/hooks/usePrefixesUpdater.ts
@@ -10,8 +10,8 @@ const usePrefixesUpdater = () => {
   const setSchema = useSetRecoilState(schemaAtom);
   const { enqueueNotification } = useNotification();
 
-  const supportsPrefixes = config?.connection?.queryEngine === "sparql"
-  const existingPrefixes = config?.schema?.prefixes
+  const supportsPrefixes = config?.connection?.queryEngine === "sparql";
+  const existingPrefixes = config?.schema?.prefixes;
   const activeConfigId = config?.id;
 
   return useCallback(
@@ -62,7 +62,13 @@ const usePrefixesUpdater = () => {
         });
       }
     },
-    [supportsPrefixes, existingPrefixes, setSchema,  activeConfigId, enqueueNotification]
+    [
+      supportsPrefixes,
+      existingPrefixes,
+      setSchema,
+      activeConfigId,
+      enqueueNotification,
+    ]
   );
 };
 

--- a/packages/graph-explorer/src/utils/generatePrefixes.test.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.test.ts
@@ -87,6 +87,15 @@ describe("generatePrefixes", () => {
       [
         { prefix: "owl", uri: "https://www.w3.org/2002/07/owl#" },
         { prefix: "dbr", uri: "https://dbpedia.org/resource/" },
+        {
+          __inferred: true,
+          prefix: "loc-r",
+          uri: "http://www.example.com/location/resource#",
+          __matches: new Set([
+            "http://www.example.com/location/resource#London",
+            "http://www.example.com/location/resource#Manchester",
+          ]),
+        },
       ]
     );
 
@@ -103,24 +112,59 @@ describe("generatePrefixes", () => {
     });
     expect(updatedPrefixes?.[2]).toEqual({
       __inferred: true,
-      uri: "http://www.example.com/soccer/ontology/",
-      prefix: "soc",
-      __matches: new Set(["http://www.example.com/soccer/ontology/League"]),
-    });
-    expect(updatedPrefixes?.[3]).toEqual({
-      __inferred: true,
-      uri: "http://www.example.com/soccer/resource#",
-      prefix: "soc-r",
-      __matches: new Set(["http://www.example.com/soccer/resource#EPL"]),
-    });
-    expect(updatedPrefixes?.[4]).toEqual({
-      __inferred: true,
       uri: "http://www.example.com/location/resource#",
       prefix: "loc-r",
       __matches: new Set([
         "http://www.example.com/location/resource#London",
         "http://www.example.com/location/resource#Manchester",
       ]),
+    });
+    expect(updatedPrefixes?.[3]).toEqual({
+      __inferred: true,
+      uri: "http://www.example.com/soccer/ontology/",
+      prefix: "soc",
+      __matches: new Set(["http://www.example.com/soccer/ontology/League"]),
+    });
+    expect(updatedPrefixes?.[4]).toEqual({
+      __inferred: true,
+      uri: "http://www.example.com/soccer/resource#",
+      prefix: "soc-r",
+      __matches: new Set(["http://www.example.com/soccer/resource#EPL"]),
+    });
+  });
+
+  it("Should update existing prefixes when casing doesn't match", () => {
+    const updatedPrefixes = generatePrefixes(
+      [
+        "http://SecretSpyOrg/entity/quantity",
+        "http://SecretSpyOrg/entity/other",
+        "http://SecretSpyOrg/data/hasText",
+      ],
+      [
+        {
+          __inferred: true,
+          prefix: "ent",
+          uri: "http://secretspyorg/entity/",
+          __matches: new Set(["http://SecretSpyOrg/entity/quantity"]),
+        },
+      ]
+    );
+
+    expect(updatedPrefixes).toHaveLength(2);
+    expect(updatedPrefixes?.[0]).toEqual({
+      __inferred: true,
+      uri: "http://secretspyorg/entity/",
+      prefix: "ent",
+      __matches: new Set([
+        "http://SecretSpyOrg/entity/quantity",
+        "http://SecretSpyOrg/entity/other",
+      ]),
+    });
+    expect(updatedPrefixes?.[1]).toEqual({
+      __inferred: true,
+      uri: "http://secretspyorg/data/",
+      prefix: "dat",
+      __matches: new Set(["http://SecretSpyOrg/data/hasText"]),
     });
   });
 });

--- a/packages/graph-explorer/src/utils/generatePrefixes.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.ts
@@ -95,17 +95,18 @@ const generatePrefixes = (
   const updatedPrefixes: PrefixTypeConfig[] = cloneDeep(currentPrefixes);
   uris.forEach(uri => {
     const existInCommon = cPrefixes.some(prefixConfig => {
-      return !!uri.match(new RegExp(`^${prefixConfig.uri}`));
+      return !!uri.match(new RegExp(`^${prefixConfig.uri}`, "i"));
     });
     if (existInCommon) {
       return;
     }
 
     const existPrefixIndex = updatedPrefixes.findIndex(prefixConfig => {
-      return !!uri.match(new RegExp(`^${prefixConfig.uri}`));
+      return !!uri.match(new RegExp(`^${prefixConfig.uri}`, "i"));
     });
 
     if (existPrefixIndex === -1) {
+      // Create a new prefix entry
       try {
         const url = new URL(uri);
         let newPrefix: PrefixTypeConfig;
@@ -120,6 +121,7 @@ const generatePrefixes = (
         // Catching wrong URLs and skip them
       }
     } else {
+      // Update existing prefix entry
       if (!updatedPrefixes[existPrefixIndex].__matches) {
         updatedPrefixes[existPrefixIndex].__matches = new Set();
       }

--- a/packages/graph-explorer/src/utils/logger.ts
+++ b/packages/graph-explorer/src/utils/logger.ts
@@ -20,7 +20,7 @@ export default {
       return;
     }
     optionalParams.length > 0
-      ? console.debug(message, optionalParams)
+      ? console.debug(message, ...optionalParams)
       : console.debug(message);
   },
   /** Calls `console.log` if the app is running in DEV mode. */
@@ -29,19 +29,19 @@ export default {
       return;
     }
     optionalParams.length > 0
-      ? console.log(message, optionalParams)
+      ? console.log(message, ...optionalParams)
       : console.log(message);
   },
   /** Calls `console.warn`. */
   warn(message?: any, ...optionalParams: any[]) {
     optionalParams.length > 0
-      ? console.warn(message, optionalParams)
+      ? console.warn(message, ...optionalParams)
       : console.warn(message);
   },
   /** Calls `console.error`. */
   error(message?: any, ...optionalParams: any[]) {
     optionalParams.length > 0
-      ? console.error(message, optionalParams)
+      ? console.error(message, ...optionalParams)
       : console.error(message);
   },
 };


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This fixes an issue with RDF data sets that contain upper case characters in the URI. For example:

```
http://www.ExampleData.com/Entity
```

These uppercase characters would cause the prefix generator to miss the existing entry in the prefixes array, causing a new entry to be created. That new entry would be converted to lower case. On the next pass the same thing would happen looped to infinity.

This infinite loop would cause Graph Explorer to crash.

To fix, I made the search for an existing entry be case insensitive.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested with dataset that produces the crash
- Added unit tests for case sensitivity

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #545

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
