### PR TITLE
Add SageMaker script fallback for CloudWatch logging driver failure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@
 - **Improved** app styles
   ([#543](https://github.com/aws/graph-explorer/pull/543),
   [#548](https://github.com/aws/graph-explorer/pull/548))
+- **Improved** SageMaker Lifecycle script handling of CloudWatch log driver failures
+  ([#543](https://github.com/aws/graph-explorer/pull/550))
 
 ## Release 1.9.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@
   ([#543](https://github.com/aws/graph-explorer/pull/543),
   [#548](https://github.com/aws/graph-explorer/pull/548))
 - **Improved** SageMaker Lifecycle script handling of CloudWatch log driver failures
-  ([#543](https://github.com/aws/graph-explorer/pull/550))
+  ([#550](https://github.com/aws/graph-explorer/pull/550))
 
 ## Release 1.9.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,8 +14,8 @@
 - **Improved** app styles
   ([#543](https://github.com/aws/graph-explorer/pull/543),
   [#548](https://github.com/aws/graph-explorer/pull/548))
-- **Improved** SageMaker Lifecycle script handling of CloudWatch log driver failures
-  ([#550](https://github.com/aws/graph-explorer/pull/550))
+- **Improved** SageMaker Lifecycle script handling of CloudWatch log driver
+  failures ([#550](https://github.com/aws/graph-explorer/pull/550))
 
 ## Release 1.9.0
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description
- Added handling and fallback for possible failure of `awslogs` driver on Docker container startup, in the absence of required IAM permissions for CloudWatch logging.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- [x] Tested in Neptune SageMaker Notebook instance

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
