### PR TITLE
Remove Vite production server

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,9 @@
   [#548](https://github.com/aws/graph-explorer/pull/548))
 - **Improved** SageMaker Lifecycle script handling of CloudWatch log driver
   failures ([#550](https://github.com/aws/graph-explorer/pull/550))
+- **Removed** hosting production server using the client side Vite
+  configuration, requiring the use of the proxy server
+  ([#565](https://github.com/aws/graph-explorer/pull/565))
 - **Updated** multiple dependencies
   ([#555](https://github.com/aws/graph-explorer/pull/555))
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "check:types": "pnpm --stream -r check:types",
     "checks": "pnpm run '/^check:.*/'",
     "start": "pnpm --filter \"graph-explorer-proxy-server\" run start",
-    "start:client": "pnpm --filter \"graph-explorer\" run serve",
     "clean": "pnpm --stream -r run clean",
     "build": "pnpm --stream -r run build",
     "dev": "pnpm --stream -r run dev"

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -14,7 +14,6 @@
     "clean": "rimraf dist",
     "vite-build": "NODE_OPTIONS=--max_old_space_size=6144 vite build",
     "build": "pnpm vite-build -- --mode production",
-    "serve": "serve dist",
     "check:types": "tsc --noEmit"
   },
   "author": "amazon",

--- a/packages/graph-explorer/vite.config.ts
+++ b/packages/graph-explorer/vite.config.ts
@@ -1,8 +1,7 @@
 /// <reference types="vitest" />
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
-import * as fs from "fs";
-import { loadEnv, PluginOption, ServerOptions } from "vite";
+import { loadEnv, PluginOption } from "vite";
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig(({ mode }) => {
@@ -22,32 +21,10 @@ export default defineConfig(({ mode }) => {
     };
   };
 
-  const serverInfo = (): ServerOptions => {
-    if (
-      env.GRAPH_EXP_HTTPS_CONNECTION != "false" &&
-      fs.existsSync("../graph-explorer-proxy-server/cert-info/server.key") &&
-      fs.existsSync("../graph-explorer-proxy-server/cert-info/server.crt")
-    ) {
-      return {
-        host: true,
-        https: {
-          key: fs.readFileSync(
-            "../graph-explorer-proxy-server/cert-info/server.key"
-          ),
-          cert: fs.readFileSync(
-            "../graph-explorer-proxy-server/cert-info/server.crt"
-          ),
-        },
-      };
-    } else {
-      return {
-        host: true,
-      };
-    }
-  };
-
   return {
-    server: serverInfo(),
+    server: {
+      host: true,
+    },
     base: env.GRAPH_EXP_ENV_ROOT_FOLDER,
     envPrefix: "GRAPH_EXP",
     define: {


### PR DESCRIPTION
## Description

Vite is the tool we use for fast development on the React client side. It has a feature to run as a server, but it is discouraged to use in production.

We require running the client side through the proxy server. But there was an option in the code to run the client by itself without the proxy server.

This PR removes those options.

- Remove certificate handling in Vite config (still exists on the proxy server)
- Remove PNPM script to launch Vite server

## Validation

- Smoke test

## Related Issues

- None

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
