### PR TITLE
Fix scenario where sync fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
-    "check:types": "tsc --build --force --verbose",
+    "check:types": "tsc --build --force",
     "checks": "pnpm run '/^check:.*/'",
     "start": "pnpm --filter \"graph-explorer-proxy-server\" run start",
     "clean": "pnpm --stream -r run clean",

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -42,7 +42,7 @@ export const activeSchemaSelector = selector({
       const updatedSchemaMap = new Map(prevSchemaMap);
 
       // Handle reset value
-      if (isDefaultValue(newValue) || !newValue) {
+      if (!newValue || isDefaultValue(newValue)) {
         updatedSchemaMap.delete(schemaId);
         return updatedSchemaMap;
       }

--- a/packages/graph-explorer/src/hooks/useUpdateSchema.test.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateSchema.test.ts
@@ -1,0 +1,134 @@
+import {
+  createRandomSchema,
+  createRandomSchemaResponse,
+  renderHookWithRecoilRoot,
+} from "@/utils/testing";
+import {
+  createRandomName,
+  createRandomDate,
+  createRandomInteger,
+} from "@shared/utils/testing";
+import useUpdateSchema from "./useUpdateSchema";
+import { act } from "@testing-library/react";
+import { useRecoilValue } from "recoil";
+import { schemaAtom, SchemaInference } from "@/core/StateProvider/schema";
+import { activeConfigurationAtom } from "@/core/StateProvider/configuration";
+
+describe("useUpdateSchema", () => {
+  describe("setSyncFailure", () => {
+    it("should do nothing if no schema exists", () => {
+      const { result } = renderHookWithRecoilRoot(render);
+      act(() => result.current.setSyncFailure());
+
+      expect(result.current.schemas).toHaveLength(0);
+    });
+
+    it("should update existing schema", () => {
+      const configId = createRandomName("ConfigId");
+      const existingSchema = createRandomSchema();
+      const { result } = renderHookWithRecoilRoot(render, snapshot => {
+        snapshot.set(activeConfigurationAtom, configId);
+        snapshot.set(schemaAtom, new Map([[configId, existingSchema]]));
+      });
+      act(() => result.current.setSyncFailure());
+
+      const schema = result.current.schemas.get(configId);
+      expect(schema).toEqual({
+        ...existingSchema,
+        lastSyncFail: true,
+      } satisfies SchemaInference);
+    });
+  });
+
+  describe("replaceSchema", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(createRandomDate());
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should set schema when none set", () => {
+      const configId = createRandomName("ConfigId");
+      const schemaResponse = createRandomSchemaResponse();
+
+      const { result } = renderHookWithRecoilRoot(render, snapshot => {
+        snapshot.set(activeConfigurationAtom, configId);
+      });
+
+      act(() => result.current.replaceSchema(schemaResponse));
+
+      const schema = result.current.schemas.get(configId);
+      expect(schema).toStrictEqual({
+        ...schemaResponse,
+        lastSyncFail: false,
+        lastUpdate: vi.getMockedSystemTime()!,
+        triedToSync: true,
+      } satisfies SchemaInference);
+    });
+
+    it("should update existing schema", () => {
+      const configId = createRandomName("ConfigId");
+      const existingSchema = createRandomSchema();
+      const schemaResponse = createRandomSchemaResponse();
+
+      const { result } = renderHookWithRecoilRoot(render, snapshot => {
+        snapshot.set(activeConfigurationAtom, configId);
+        snapshot.set(schemaAtom, new Map([[configId, existingSchema]]));
+      });
+      act(() => result.current.replaceSchema(schemaResponse));
+
+      expect(result.current.schemas.get(configId)).toEqual({
+        ...schemaResponse,
+        lastSyncFail: false,
+        lastUpdate: vi.getMockedSystemTime()!,
+        triedToSync: true,
+      } satisfies SchemaInference);
+    });
+  });
+
+  describe("updateVertexTotal", () => {
+    it("should do nothing if no schema exists", () => {
+      const configId = createRandomName("ConfigId");
+      const vertexType = createRandomName("VertexType");
+      const vertexTotal = createRandomInteger();
+
+      const { result } = renderHookWithRecoilRoot(render, snapshot => {
+        snapshot.set(activeConfigurationAtom, configId);
+      });
+
+      act(() => result.current.updateVertexTotal(vertexType, vertexTotal));
+
+      expect(result.current.schemas).toHaveLength(0);
+    });
+
+    it("should update total on given vertex type", () => {
+      const configId = createRandomName("ConfigId");
+      const vertexType = createRandomName("VertexType");
+      const vertexTotal = createRandomInteger();
+      const existingSchema = createRandomSchema();
+      existingSchema.vertices[0].type = vertexType;
+
+      const { result } = renderHookWithRecoilRoot(render, snapshot => {
+        snapshot.set(activeConfigurationAtom, configId);
+        snapshot.set(schemaAtom, new Map([[configId, existingSchema]]));
+      });
+
+      act(() => result.current.updateVertexTotal(vertexType, vertexTotal));
+
+      const schema = result.current.schemas.get(configId)!;
+      const vtConfig = schema.vertices.find(v => v.type === vertexType);
+      expect(vtConfig?.total).toEqual(vertexTotal);
+    });
+  });
+});
+
+function render() {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const actions = useUpdateSchema();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const schemas = useRecoilValue(schemaAtom);
+  return { schemas, ...actions };
+}

--- a/packages/graph-explorer/src/hooks/useUpdateSchema.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateSchema.ts
@@ -1,56 +1,53 @@
-import { useRecoilCallback } from "recoil";
+import { useSetRecoilState } from "recoil";
 import type { SchemaResponse } from "@/connector/useGEFetchTypes";
-import { schemaAtom } from "@/core/StateProvider/schema";
+import { activeSchemaSelector } from "@/core/StateProvider/schema";
+import { useCallback } from "react";
 
-const useUpdateSchema = () => {
-  return useRecoilCallback(
-    ({ set }) =>
-      (
-        id: string,
-        schema?:
-          | Partial<SchemaResponse>
-          | ((prevSchema?: SchemaResponse) => Partial<SchemaResponse>)
-      ) => {
-        set(schemaAtom, prevSchemaMap => {
-          const updatedSchema = new Map(prevSchemaMap);
-          const prevSchema = prevSchemaMap.get(id);
+export default function useUpdateSchema() {
+  const setSchema = useSetRecoilState(activeSchemaSelector);
 
-          const currentSchema =
-            typeof schema === "function" ? schema(prevSchema) : schema;
+  // Keeps previous data, but sets the status to sync failure
+  const setSyncFailure = useCallback(() => {
+    setSchema(prev => ({
+      ...prev,
+      vertices: prev?.vertices ?? [],
+      edges: prev?.edges ?? [],
+      triedToSync: true,
+      lastSyncFail: true,
+    }));
+  }, [setSchema]);
 
-          // Vertices counts
-          const vertices = (currentSchema?.vertices || []).map(vertex => {
-            return {
-              ...vertex,
-              total: vertex.total,
-            };
-          });
-
-          // Edges counts
-          const edges = (currentSchema?.edges || prevSchema?.edges || []).map(
-            edge => {
-              return {
-                ...edge,
-                total: edge.total,
-              };
-            }
-          );
-
-          updatedSchema.set(id, {
-            totalVertices: currentSchema?.totalVertices || 0,
-            vertices,
-            totalEdges: currentSchema?.totalEdges || 0,
-            edges,
-            prefixes: prevSchema?.prefixes || [],
-            lastUpdate: !currentSchema ? prevSchema?.lastUpdate : new Date(),
-            triedToSync: true,
-            lastSyncFail: !currentSchema && !!prevSchema,
-          });
-          return updatedSchema;
-        });
-      },
-    []
+  // Updates the stored schema with the given schema
+  const replaceSchema = useCallback(
+    (schema: SchemaResponse) => {
+      setSchema({
+        ...schema,
+        triedToSync: true,
+        lastUpdate: new Date(),
+        lastSyncFail: false,
+      });
+    },
+    [setSchema]
   );
-};
 
-export default useUpdateSchema;
+  // Update the vertex totals (used by Data Explorer)
+  const updateVertexTotal = useCallback(
+    (vertexType: string, newTotal: number) => {
+      setSchema(prev => {
+        if (!prev) {
+          return prev;
+        }
+
+        return {
+          ...prev,
+          vertices: prev.vertices.map(vertex =>
+            vertex.type === vertexType ? { ...vertex, total: newTotal } : vertex
+          ),
+        };
+      });
+    },
+    [setSchema]
+  );
+
+  return { setSyncFailure, replaceSchema, updateVertexTotal };
+}

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -1,43 +1,23 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useConfiguration } from "@/core";
 import { explorerSelector } from "@/core/connector";
 import useUpdateSchema from "./useUpdateSchema";
 import { useRecoilValue } from "recoil";
 import { nodeCountByNodeTypeQuery } from "@/connector/queries";
 
 export default function useUpdateVertexTypeCounts(vertexType: string) {
-  const config = useConfiguration();
-  const configId = config?.id;
   const explorer = useRecoilValue(explorerSelector);
 
   const query = useQuery(nodeCountByNodeTypeQuery(vertexType, explorer));
 
   // Sync the result over to the schema in Recoil state
-  const updateSchemaState = useUpdateSchema();
+  const { updateVertexTotal } = useUpdateSchema();
   useEffect(() => {
-    if (!configId || !query.data) {
+    if (!query.data) {
       return;
     }
     const vertexTotal = query.data.total;
 
-    updateSchemaState(configId, prevSchema => {
-      const vertexSchema = prevSchema?.vertices.find(
-        vertex => vertex.type === vertexType
-      );
-      if (!vertexSchema) {
-        return { ...(prevSchema || {}) };
-      }
-      vertexSchema.total = vertexTotal;
-      return {
-        ...prevSchema,
-        vertices: [
-          ...(prevSchema?.vertices.filter(
-            vertex => vertex.type !== vertexType
-          ) || []),
-          vertexSchema,
-        ],
-      };
-    });
-  }, [query.data, configId, updateSchemaState, vertexType]);
+    updateVertexTotal(vertexType, vertexTotal);
+  }, [query.data, vertexType, updateVertexTotal]);
 }

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -39,8 +39,8 @@ const ConnectionData = () => {
         id: vt,
         title: displayLabel,
         titleComponent: (
-          <div className={"advanced-list-item-title"}>
-            <div className={"node-title"}>{textTransform(displayLabel)}</div>
+          <div className="advanced-list-item-title">
+            <div className="node-title">{textTransform(displayLabel)}</div>
           </div>
         ),
         icon: (
@@ -65,8 +65,8 @@ const ConnectionData = () => {
           <IconButton
             tooltipText={`Explore ${textTransform(displayLabel)}`}
             icon={<ChevronRightIcon />}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             onPress={() => navigate(`/data-explorer/${encodeURIComponent(vt)}`)}
           />
         ),
@@ -84,11 +84,11 @@ const ConnectionData = () => {
 
   return (
     <div className={cx(styleWithTheme(defaultStyles), "h-full")}>
-      <div className={"info-bar"}>
-        <div className={"item"}>
-          <div className={"tag"}>{t("connection-detail.nodes")}</div>
-          <div className={"value"}>
-            <Chip className={"value-chip"}>
+      <div className="info-bar">
+        <div className="item">
+          <div className="tag">{t("connection-detail.nodes")}</div>
+          <div className="value">
+            <Chip className="value-chip">
               <GraphIcon />
               {totalNodes != null && (
                 <HumanReadableNumberFormatter value={totalNodes} />
@@ -97,10 +97,10 @@ const ConnectionData = () => {
             </Chip>
           </div>
         </div>
-        <div className={"item"}>
-          <div className={"tag"}>{t("connection-detail.edges")}</div>
-          <div className={"value"}>
-            <Chip className={"value-chip"}>
+        <div className="item">
+          <div className="tag">{t("connection-detail.edges")}</div>
+          <div className="value">
+            <Chip className="value-chip">
               <EdgeIcon />
               {totalEdges != null && (
                 <HumanReadableNumberFormatter value={totalEdges} />
@@ -114,7 +114,7 @@ const ConnectionData = () => {
         searchPlaceholder={t("connection-detail.search-placeholder")}
         search={search}
         onSearch={setSearch}
-        className={"advanced-list"}
+        className="advanced-list"
         items={verticesByTypeItems}
         emptyState={{
           noSearchResultsTitle: t("connection-detail.no-search-title"),

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -268,6 +268,28 @@ function DebugActions() {
       };
     });
   };
+  const resetAllTotals = () => {
+    logger.log("Setting vertex totals to undefined");
+    setActiveSchema(prev => {
+      if (!prev) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        vertices: prev.vertices.map(vertex => ({
+          ...vertex,
+          total: undefined,
+        })),
+        edges: prev.edges.map(edge => ({
+          ...edge,
+          total: undefined,
+        })),
+        totalEdges: undefined,
+        totalVertices: undefined,
+      };
+    });
+  };
 
   return (
     <div className="item">
@@ -279,6 +301,7 @@ function DebugActions() {
         </Button>
         <Button onPress={() => setSchemaSyncFailed()}>Last Sync Failed</Button>
         <Button onPress={() => resetVertexTotals()}>Reset Vertex Totals</Button>
+        <Button onPress={() => resetAllTotals()}>Reset All Totals</Button>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -1,6 +1,10 @@
 import { Modal } from "@mantine/core";
 import { useCallback, useState } from "react";
-import { useRecoilCallback, useSetRecoilState } from "recoil";
+import {
+  useRecoilCallback,
+  useResetRecoilState,
+  useSetRecoilState,
+} from "recoil";
 import {
   ActionItem,
   Button,
@@ -223,10 +227,11 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
 
 function DebugActions() {
   const setActiveSchema = useSetRecoilState(activeSchemaSelector);
+  const resetActiveSchema = useResetRecoilState(activeSchemaSelector);
 
   const deleteSchema = () => {
     logger.log("Deleting schema");
-    setActiveSchema(null);
+    resetActiveSchema();
   };
   const resetSchemaLastUpdated = () => {
     logger.log("Resetting schema last updated");

--- a/packages/graph-explorer/src/utils/testing/index.ts
+++ b/packages/graph-explorer/src/utils/testing/index.ts
@@ -1,4 +1,5 @@
 export * from "./normalize";
 export * from "./randomData";
+export * from "./randomSchemaResponse";
 export { default as renderHookWithRecoilRoot } from "./renderHookWithRecoilRoot";
 export * from "./waitForValueToChange";

--- a/packages/graph-explorer/src/utils/testing/randomSchemaResponse.ts
+++ b/packages/graph-explorer/src/utils/testing/randomSchemaResponse.ts
@@ -1,0 +1,50 @@
+import {
+  EdgeSchemaResponse,
+  SchemaResponse,
+  VertexSchemaResponse,
+} from "@/connector/useGEFetchTypes";
+import { createRandomAttributeConfig } from "./randomData";
+import {
+  createArray,
+  createRandomName,
+  randomlyUndefined,
+  createRandomInteger,
+} from "@shared/utils/testing";
+
+/**
+ * Creates a random schema response object.
+ * @returns A random Schema object.
+ */
+export function createRandomSchemaResponse(): SchemaResponse {
+  const edges = createArray(3, createRandomEdgeTypeConfig);
+  const vertices = createArray(3, createRandomVertexTypeConfig);
+  const schema: SchemaResponse = {
+    edges,
+    vertices,
+    totalEdges: edges
+      .map(e => e.total ?? 0)
+      .reduce((prev, current) => current + prev, 0),
+    totalVertices: vertices
+      .map(v => v.total ?? 0)
+      .reduce((prev, current) => current + prev, 0),
+  };
+  return schema;
+}
+
+function createRandomEdgeTypeConfig(): EdgeSchemaResponse {
+  return {
+    type: createRandomName("type"),
+    attributes: createArray(6, createRandomAttributeConfig),
+    displayLabel: randomlyUndefined(createRandomName("displayLabel")),
+    total: createRandomInteger(),
+  };
+}
+
+function createRandomVertexTypeConfig(): VertexSchemaResponse {
+  return {
+    type: createRandomName("type"),
+    attributes: createArray(6, createRandomAttributeConfig),
+    displayLabel: randomlyUndefined(createRandomName("displayLabel")),
+    total: createRandomInteger(),
+  };
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This fixes the issue where a schema sync failure would break a previous good schema sync.

- Fix issue checking for null vs default value in recoil setter
- Make each schema update scenario a separate function
- Add tests for each scenario

### Other changes

- Add new debug action to reset all schema counts
- Use reset for debug action to delete existing schema
- Remove `--verbose` on `pnpm check:types` because it was too much noise
- Remove some unnecessary curly braces around string props

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified using Neptune connection with and without SSH tunnel to provoke schema sync failure
- Verified using debug actions to manipulate schema data

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #569 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
