### PR TITLE
Fix updating schema from expansion

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/edges.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.test.ts
@@ -1,0 +1,40 @@
+import {
+  createRandomEdge,
+  renderHookWithRecoilRoot,
+  createRandomVertex,
+} from "@/utils/testing";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { edgesAtom, edgesSelector } from "./edges";
+import { act } from "@testing-library/react";
+
+describe("edgeSelector", () => {
+  it("should return edges", () => {
+    const edge1 = createRandomEdge(createRandomVertex(), createRandomVertex());
+    const edge2 = createRandomEdge(createRandomVertex(), createRandomVertex());
+    const edge3 = createRandomEdge(createRandomVertex(), createRandomVertex());
+
+    const { result } = renderHookWithRecoilRoot(
+      () => useRecoilValue(edgesSelector),
+      snapshot => {
+        snapshot.set(edgesAtom, [edge1, edge2, edge3]);
+      }
+    );
+
+    expect(result.current).toContainEqual(edge1);
+    expect(result.current).toContainEqual(edge2);
+    expect(result.current).toContainEqual(edge3);
+  });
+
+  it("should add new edges", () => {
+    const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+
+    const { result } = renderHookWithRecoilRoot(() => {
+      const [value, set] = useRecoilState(edgesSelector);
+      return { value, set };
+    });
+
+    act(() => result.current.set([edge]));
+
+    expect(result.current.value).toContainEqual(edge);
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -1,9 +1,6 @@
 import { atom, selector } from "recoil";
 import type { Edge } from "@/types/entities";
-import { sanitizeText } from "@/utils";
-import { activeConfigurationAtom } from "./configuration";
 import isDefaultValue from "./isDefaultValue";
-import { schemaAtom } from "./schema";
 
 export type Edges = Array<Edge>;
 
@@ -41,62 +38,6 @@ export const edgesSelector = selector<Edges>({
     get(edgesOutOfFocusIdsAtom).size > 0 &&
       set(edgesOutOfFocusIdsAtom, cleanFn);
     get(edgesFilteredIdsAtom).size > 0 && set(edgesFilteredIdsAtom, cleanFn);
-
-    const activeConfig = get(activeConfigurationAtom);
-    if (!activeConfig) {
-      return;
-    }
-    const schemas = get(schemaAtom);
-    const activeSchema = schemas.get(activeConfig);
-
-    set(schemaAtom, prevSchemas => {
-      const updatedSchemas = new Map(prevSchemas);
-
-      const updatedEdges = newValue.reduce((schema, edge) => {
-        // Find the edge type definition in the schema
-        const schemaEdge = schema.find(s => s.type === edge.data.type);
-
-        // Add edge to schema if it is missing
-        if (!schemaEdge) {
-          schema.push({
-            type: edge.data.type,
-            displayLabel: "",
-            attributes: Object.keys(edge.data.attributes).map(attr => ({
-              name: attr,
-              displayLabel: sanitizeText(attr),
-              hidden: false,
-            })),
-          });
-
-          // Since the edge type is new we can go ahead and return
-          return schema;
-        }
-
-        // Ensure the edge attributes are updated in the schema
-        const schemaAttributes = schemaEdge.attributes.map(a => a.name);
-        const missingAttributeNames = Object.keys(edge.data.attributes).filter(
-          name => !schemaAttributes.includes(name)
-        );
-
-        for (const attributeName of missingAttributeNames) {
-          schemaEdge.attributes.push({
-            name: attributeName,
-            displayLabel: sanitizeText(attributeName),
-            hidden: false,
-          });
-        }
-
-        return schema;
-      }, activeSchema?.edges ?? []);
-
-      updatedSchemas.set(activeConfig, {
-        edges: updatedEdges,
-        vertices: activeSchema?.vertices || [],
-        ...(activeSchema || {}),
-      });
-
-      return updatedSchemas;
-    });
   },
 });
 

--- a/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
+++ b/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
@@ -12,6 +12,7 @@ import {
   nodesSelectedIdsAtom,
   nodesSelector,
 } from "./nodes";
+import { updateSchemaFromEntitiesAtom } from "./schema";
 
 export type Entities = {
   /**
@@ -232,6 +233,11 @@ const entitiesSelector = selector<Entities>({
     ) {
       set(edgesSelector, nonUnconnectedEdges);
     }
+
+    set(updateSchemaFromEntitiesAtom, {
+      nodes: nodesWithStats,
+      edges: nonUnconnectedEdges,
+    });
 
     // Select new entities preserving selected ones by default
     const selectedNodesIds =

--- a/packages/graph-explorer/src/core/StateProvider/nodes.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.test.ts
@@ -1,0 +1,36 @@
+import { createRandomVertex, renderHookWithRecoilRoot } from "@/utils/testing";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { nodesAtom, nodesSelector } from "./nodes";
+import { act } from "@testing-library/react";
+
+describe("nodeSelector", () => {
+  it("should return nodes", () => {
+    const node1 = createRandomVertex();
+    const node2 = createRandomVertex();
+    const node3 = createRandomVertex();
+
+    const { result } = renderHookWithRecoilRoot(
+      () => useRecoilValue(nodesSelector),
+      snapshot => {
+        snapshot.set(nodesAtom, [node1, node2, node3]);
+      }
+    );
+
+    expect(result.current).toContainEqual(node1);
+    expect(result.current).toContainEqual(node2);
+    expect(result.current).toContainEqual(node3);
+  });
+
+  it("should add new nodes", () => {
+    const node = createRandomVertex();
+
+    const { result } = renderHookWithRecoilRoot(() => {
+      const [value, set] = useRecoilState(nodesSelector);
+      return { value, set };
+    });
+
+    act(() => result.current.set([node]));
+
+    expect(result.current.value).toContainEqual(node);
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -1,9 +1,6 @@
 import { atom, selector } from "recoil";
 import type { Vertex } from "@/types/entities";
-import { sanitizeText } from "@/utils";
-import { activeConfigurationAtom } from "./configuration";
 import isDefaultValue from "./isDefaultValue";
-import { schemaAtom, SchemaInference } from "./schema";
 
 export const nodesAtom = atom<Array<Vertex>>({
   key: "nodes",
@@ -38,62 +35,6 @@ export const nodesSelector = selector<Array<Vertex>>({
     get(nodesOutOfFocusIdsAtom).size > 0 &&
       set(nodesOutOfFocusIdsAtom, cleanFn);
     get(nodesFilteredIdsAtom).size > 0 && set(nodesFilteredIdsAtom, cleanFn);
-
-    const activeConfig = get(activeConfigurationAtom);
-    if (!activeConfig) {
-      return;
-    }
-    const schemas = get(schemaAtom);
-    const activeSchema = schemas.get(activeConfig);
-
-    set(schemaAtom, prevSchemas => {
-      const updatedSchemas = new Map(prevSchemas);
-
-      updatedSchemas.set(activeConfig, {
-        ...(activeSchema || {}),
-        vertices: newValue.reduce(
-          (schema, node) => {
-            // Find the node type definition in the schema
-            const schemaNode = schema.find(s => s.type === node.data.type);
-
-            if (!schemaNode) {
-              schema.push({
-                type: node.data.type,
-                displayLabel: "",
-                attributes: Object.keys(node.data.attributes).map(attr => ({
-                  name: attr,
-                  displayLabel: sanitizeText(attr),
-                  hidden: false,
-                })),
-              });
-
-              // Since the node type is new we can go ahead and return
-              return schema;
-            }
-
-            // Ensure the node attributes are updated in the schema
-            const schemaAttributes = schemaNode.attributes.map(a => a.name);
-            const missingAttributeNames = Object.keys(
-              node.data.attributes
-            ).filter(name => !schemaAttributes.includes(name));
-
-            for (const attributeName of missingAttributeNames) {
-              schemaNode.attributes.push({
-                name: attributeName,
-                displayLabel: sanitizeText(attributeName),
-                hidden: false,
-              });
-            }
-
-            return schema;
-          },
-          activeSchema?.vertices as SchemaInference["vertices"]
-        ),
-        edges: activeSchema?.edges || [],
-      });
-
-      return updatedSchemas;
-    });
   },
 });
 

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -1,0 +1,105 @@
+import {
+  createRandomEdge,
+  createRandomSchema,
+  createRandomVertex,
+} from "@/utils/testing";
+import { extractConfigFromEntity, updateSchemaFromEntities } from "./schema";
+import { createArray } from "@shared/utils/testing";
+
+describe("schema", () => {
+  describe("extractConfigFromEntity", () => {
+    it("should work with vertex", () => {
+      const entity = createRandomVertex();
+      const result = extractConfigFromEntity(entity);
+      expect(result.type).toEqual(entity.data.type);
+      expect(result.hidden).toBeFalsy();
+      expect(result.attributes).toHaveLength(
+        Object.keys(entity.data.attributes).length
+      );
+    });
+    it("should work with edge", () => {
+      const entity = createRandomEdge(
+        createRandomVertex(),
+        createRandomVertex()
+      );
+      const result = extractConfigFromEntity(entity);
+      expect(result.type).toEqual(entity.data.type);
+      expect(result.hidden).toBeFalsy();
+      expect(result.attributes).toHaveLength(
+        Object.keys(entity.data.attributes).length
+      );
+    });
+  });
+
+  describe("updateSchemaFromEntities", () => {
+    it("should do nothing when no entities", () => {
+      const originalSchema = createRandomSchema();
+      const result = updateSchemaFromEntities({}, originalSchema);
+
+      expect(result).toEqual(originalSchema);
+    });
+
+    it("should add missing entities to schema", () => {
+      const originalSchema = createRandomSchema();
+      const newNodes = createArray(3, () => createRandomVertex());
+      const newEdges = createArray(3, () =>
+        createRandomEdge(createRandomVertex(), createRandomVertex())
+      );
+      const result = updateSchemaFromEntities(
+        {
+          nodes: newNodes,
+          edges: newEdges,
+        },
+        originalSchema
+      );
+
+      expect(result).toEqual({
+        ...originalSchema,
+        vertices: [
+          ...originalSchema.vertices,
+          ...newNodes.map(extractConfigFromEntity),
+        ],
+        edges: [
+          ...originalSchema.edges,
+          ...newEdges.map(extractConfigFromEntity),
+        ],
+      });
+    });
+
+    it("should add missing attributes to schema", () => {
+      const originalSchema = createRandomSchema();
+      const newNode = createRandomVertex();
+      const newEdge = createRandomEdge(
+        createRandomVertex(),
+        createRandomVertex()
+      );
+      newNode.data.type = originalSchema.vertices[0].type;
+      newEdge.data.type = originalSchema.edges[0].type;
+
+      const extractedNodeConfig = extractConfigFromEntity(newNode);
+      const extractedEdgeConfig = extractConfigFromEntity(newEdge);
+
+      const result = updateSchemaFromEntities(
+        {
+          nodes: [newNode],
+          edges: [newEdge],
+        },
+        originalSchema
+      );
+
+      expect(result.vertices.flatMap(v => v.attributes)).toEqual(
+        expect.arrayContaining([
+          ...originalSchema.vertices.flatMap(v => v.attributes),
+          ...extractedNodeConfig.attributes,
+        ])
+      );
+
+      expect(result.edges.flatMap(v => v.attributes)).toEqual(
+        expect.arrayContaining([
+          ...originalSchema.edges.flatMap(v => v.attributes),
+          ...extractedEdgeConfig.attributes,
+        ])
+      );
+    });
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -7,6 +7,8 @@ import {
 import localForageEffect from "./localForageEffect";
 import { activeConfigurationAtom } from "./configuration";
 import isDefaultValue from "./isDefaultValue";
+import { Edge, Vertex } from "@/@types/entities";
+import { sanitizeText } from "@/utils";
 
 export type SchemaInference = {
   vertices: VertexTypeConfig[];
@@ -42,7 +44,7 @@ export const activeSchemaSelector = selector({
       const updatedSchemaMap = new Map(prevSchemaMap);
 
       // Handle reset value
-      if (isDefaultValue(newValue) || !newValue) {
+      if (!newValue || isDefaultValue(newValue)) {
         updatedSchemaMap.delete(schemaId);
         return updatedSchemaMap;
       }
@@ -54,3 +56,82 @@ export const activeSchemaSelector = selector({
     });
   },
 });
+
+type Entities = { nodes?: Vertex[]; edges?: Edge[] };
+
+/** Write only atom that updates the schema based on the given nodes and edges. */
+export const updateSchemaFromEntitiesAtom = selector<Entities>({
+  key: "update-schema-from-entities",
+  get: () => ({}),
+  set({ set }, newValue) {
+    set(activeSchemaSelector, prev => {
+      if (!prev || isDefaultValue(newValue)) {
+        return prev;
+      }
+      return updateSchemaFromEntities(newValue, prev);
+    });
+  },
+});
+
+/** Updates the schema based on the given nodes and edges. */
+export function updateSchemaFromEntities(
+  entities: Entities,
+  schema: SchemaInference
+) {
+  const newVertexConfigs = (entities.nodes ?? []).map(extractConfigFromEntity);
+  const newEdgeConfigs = (entities.edges ?? []).map(extractConfigFromEntity);
+
+  return {
+    ...schema,
+    vertices: merge(schema.vertices, newVertexConfigs),
+    edges: merge(schema.edges, newEdgeConfigs),
+  } satisfies SchemaInference;
+}
+
+/** Merges new node or edge configs in to a set of existing node or edge configs. */
+function merge<T extends VertexTypeConfig | EdgeTypeConfig>(
+  existing: T[],
+  newConfigs: T[]
+): T[] {
+  // Update existing nodes with new attributes
+  const updated = existing.map(config => {
+    const newConfig = newConfigs.find(vt => vt.type === config.type);
+
+    // No attributes to update
+    if (!newConfig) {
+      return config;
+    }
+
+    // Find missing attributes
+    const missingAttributes = newConfig.attributes.filter(
+      newAttr => !config.attributes.find(attr => attr.name === newAttr.name)
+    );
+
+    return {
+      ...config,
+      attributes: [...config.attributes, ...missingAttributes],
+    };
+  });
+
+  // Find missing vertex type configs
+  const existingTypes = new Set(updated.map(vt => vt.type));
+  const missing = newConfigs.filter(vt => !existingTypes.has(vt.type));
+
+  // Combine all together
+  return [...updated, ...missing];
+}
+
+/** Creates a type config from a given node or edge. */
+export function extractConfigFromEntity<Entity extends Vertex | Edge>(
+  entity: Entity
+): Entity extends Vertex ? VertexTypeConfig : EdgeTypeConfig {
+  return {
+    type: entity.data.type,
+    displayLabel: "",
+    attributes: Object.keys(entity.data.attributes).map(attr => ({
+      name: attr,
+      displayLabel: sanitizeText(attr),
+      hidden: false,
+    })),
+  };
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The process that updates the schema when new nodes and edges are added to the graph had an issue. The schema would be updated from the `nodeSelector` then the `edgeSelector` from within the `entitySelector`. But that state doesn't merge the two updates properly.

To solve this I pulled the logic out of the node and edge selectors and placed it in the entity selector. This will only update the schema once during the `setEntities()` call.

I also rewrote the schema merging logic and added a bunch of tests around it.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Added tests
- Verified using Airports DB where the `contains` edge is not present after a schema sync, and is added when expanding an Airport to its connected country.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #568 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
