### PR TITLE
Log DB query & environment values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
   exist ([#542](https://github.com/aws/graph-explorer/pull/542))
 - **Added** global error page if the React app crashes
   ([#547](https://github.com/aws/graph-explorer/pull/547))
+- **Added** server logging of database queries when using the proxy server
+  ([#574](https://github.com/aws/graph-explorer/pull/574))
 - **Improved** handling of server errors with more consistent logging
   ([#557](https://github.com/aws/graph-explorer/pull/557))
 - **Transition** to Tailwind instead of EmotionCSS for styles, which should make
@@ -22,6 +24,9 @@
   [#548](https://github.com/aws/graph-explorer/pull/548))
 - **Improved** SageMaker Lifecycle script handling of CloudWatch log driver
   failures ([#550](https://github.com/aws/graph-explorer/pull/550))
+- **Improved** parsing of environment values in proxy server resulting in an
+  error when the values are invalid
+  ([#574](https://github.com/aws/graph-explorer/pull/574))
 - **Changed** Node to run in production mode
   ([#558](https://github.com/aws/graph-explorer/pull/558))
 - **Removed** hosting production server using the client side Vite

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -1,0 +1,45 @@
+import dotenv from "dotenv";
+import path from "path";
+import { clientRoot } from "./paths.js";
+import { z } from "zod";
+
+/** Coerces a string to a boolean value in a case insensitive way. */
+const BooleanStringSchema = z
+  .string()
+  .refine(s => s.toLowerCase() === "true" || s.toLowerCase() === "false")
+  .transform(s => s.toLowerCase() === "true");
+
+// Define a required schema for the values we expect along with their defaults
+const EnvironmentValuesSchema = z.object({
+  HOST: z.string().default("localhost"),
+  PROXY_SERVER_HTTPS_CONNECTION: BooleanStringSchema.default("false"),
+  PROXY_SERVER_HTTPS_PORT: z.coerce.number().default(443),
+  PROXY_SERVER_HTTP_PORT: z.coerce.number().default(80),
+  LOG_LEVEL: z
+    .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
+    .default("debug"),
+  LOG_STYLE: z.enum(["cloudwatch", "default"]).default("default"),
+});
+
+// Load environment variables from .env file.
+dotenv.config({
+  path: [path.join(clientRoot, ".env.local"), path.join(clientRoot, ".env")],
+});
+
+// Parse the environment values from the process
+const parsedEnvironmentValues = EnvironmentValuesSchema.safeParse(process.env);
+
+if (!parsedEnvironmentValues.success) {
+  console.error("Failed to parse environment values");
+  const flattenedErrors = parsedEnvironmentValues.error.flatten();
+  console.error(flattenedErrors.fieldErrors);
+  process.exit(1);
+}
+
+// eslint-disable-next-line no-console
+console.log("Parsed environment values:", parsedEnvironmentValues.data);
+
+// Adds all environment values to local object
+export const env = {
+  ...parsedEnvironmentValues.data,
+};

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -67,6 +67,12 @@ export function logRequestAndResponse(req: Request, res: Response) {
 /** Creates the pino-http middleware with the given logger and appropriate options. */
 export function requestLoggingMiddleware() {
   return (req: Request, res: Response, next: NextFunction) => {
+    // Ignore requests to logger endpoint
+    if (req.path.includes("/logger")) {
+      next();
+      return;
+    }
+
     // Wait for the request to complete.
     req.on("end", () => {
       logRequestAndResponse(req, res);

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -1,37 +1,16 @@
 import { NextFunction, Request, Response } from "express";
 import { pino } from "pino";
 import { PrettyOptions } from "pino-pretty";
-import { z } from "zod";
+import { env } from "./env.js";
 
 export type LogLevel = pino.LevelWithSilent;
 
-const LogLevelSchema = z.enum([
-  "fatal",
-  "error",
-  "warn",
-  "info",
-  "debug",
-  "trace",
-  "silent",
-]);
-
 export const logger = createLogger();
-
-/** Parses the log level from a given string. If the value is unrecognized or undefined, the default is "info". */
-function toLogLevel(value: string | undefined): LogLevel {
-  const parsed = LogLevelSchema.safeParse(value);
-
-  if (!parsed.success) {
-    return "info";
-  }
-
-  return parsed.data;
-}
 
 /** Create a logger instance with pino. */
 function createLogger() {
   // Check whether we are configured with CloudWatch style
-  const loggingInCloudWatch = process.env.LOG_STYLE === "cloudwatch";
+  const loggingInCloudWatch = env.LOG_STYLE === "cloudwatch";
   const options: PrettyOptions = loggingInCloudWatch
     ? {
         // Avoid colors
@@ -43,7 +22,7 @@ function createLogger() {
         colorize: true,
         translateTime: true,
       };
-  const level = toLogLevel(process.env.LOG_LEVEL);
+  const level = env.LOG_LEVEL;
 
   return pino({
     level,

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -1,7 +1,6 @@
 import express, { NextFunction, Response } from "express";
 import cors from "cors";
 import compression from "compression";
-import dotenv from "dotenv";
 import fetch, { RequestInit } from "node-fetch";
 import https from "https";
 import bodyParser from "body-parser";
@@ -13,13 +12,9 @@ import { IncomingHttpHeaders } from "http";
 import { logger as proxyLogger, requestLoggingMiddleware } from "./logging.js";
 import { clientRoot, proxyServerRoot } from "./paths.js";
 import { errorHandlingMiddleware, handleError } from "./error-handler.js";
+import { env } from "./env.js";
 
 const app = express();
-
-// Load environment variables from .env file.
-dotenv.config({
-  path: [path.join(clientRoot, ".env.local"), path.join(clientRoot, ".env")],
-});
 
 const DEFAULT_SERVICE_TYPE = "neptune-db";
 
@@ -498,11 +493,11 @@ const certificateKeyFilePath = path.join(
 const certificateFilePath = path.join(proxyServerRoot, "cert-info/server.crt");
 
 // Get the port numbers to listen on
-const host = process.env.HOST || "localhost";
-const httpPort = process.env.PROXY_SERVER_HTTP_PORT || 80;
-const httpsPort = process.env.PROXY_SERVER_HTTPS_PORT || 443;
+const host = env.HOST;
+const httpPort = env.PROXY_SERVER_HTTP_PORT;
+const httpsPort = env.PROXY_SERVER_HTTPS_PORT;
 const useHttps =
-  process.env.PROXY_SERVER_HTTPS_CONNECTION === "true" &&
+  env.PROXY_SERVER_HTTPS_CONNECTION &&
   fs.existsSync(certificateKeyFilePath) &&
   fs.existsSync(certificateFilePath);
 

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -224,11 +224,13 @@ app.post("/sparql", (req, res, next) => {
   });
 
   // Validate the input before making any external calls.
-  if (!req.body.query) {
+  const queryString = req.body.query;
+  if (!queryString) {
     return res.status(400).send({ error: "[Proxy]SPARQL: Query not provided" });
   }
+  proxyLogger.debug("[SPARQL] Received database query:\n%s", queryString);
   const rawUrl = `${graphDbConnectionUrl}/sparql`;
-  let body = `query=${encodeURIComponent(req.body.query)}`;
+  let body = `query=${encodeURIComponent(queryString)}`;
   if (queryId) {
     body += `&queryId=${encodeURIComponent(queryId)}`;
   }
@@ -265,11 +267,14 @@ app.post("/gremlin", (req, res, next) => {
     : "";
 
   // Validate the input before making any external calls.
-  if (!req.body.query) {
+  const queryString = req.body.query;
+  if (!queryString) {
     return res
       .status(400)
       .send({ error: "[Proxy]Gremlin: query not provided" });
   }
+
+  proxyLogger.debug("[Gremlin] Received database query:\n%s", queryString);
 
   /// Function to cancel long running queries if the client disappears before completion
   async function cancelQuery() {
@@ -307,7 +312,7 @@ app.post("/gremlin", (req, res, next) => {
     await cancelQuery();
   });
 
-  const body = { gremlin: req.body.query, queryId };
+  const body = { gremlin: queryString, queryId };
   const rawUrl = `${graphDbConnectionUrl}/gremlin`;
   const requestOptions = {
     method: "POST",
@@ -331,12 +336,15 @@ app.post("/gremlin", (req, res, next) => {
 
 // POST endpoint for openCypher queries.
 app.post("/openCypher", (req, res, next) => {
+  const queryString = req.body.query;
   // Validate the input before making any external calls.
-  if (!req.body.query) {
+  if (!queryString) {
     return res
       .status(400)
       .send({ error: "[Proxy]OpenCypher: query not provided" });
   }
+
+  proxyLogger.debug("[openCypher] Received database query:\n%s", queryString);
 
   const headers = req.headers as DbQueryIncomingHttpHeaders;
   const rawUrl = `${headers["graph-db-connection-url"]}/openCypher`;
@@ -346,7 +354,7 @@ app.post("/openCypher", (req, res, next) => {
       "Content-Type": "application/x-www-form-urlencoded",
       Accept: "application/json",
     },
-    body: `query=${encodeURIComponent(req.body.query)}`,
+    body: `query=${encodeURIComponent(queryString)}`,
   };
 
   const isIamEnabled = !!headers["aws-neptune-region"];

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -13,29 +13,36 @@ export interface LoggerConnector {
 /** Sends log messages to the server in the connection configuration. */
 export class ServerLoggerConnector implements LoggerConnector {
   private readonly _baseUrl: string;
+  private readonly _clientLogger: ClientLoggerConnector;
 
   constructor(connectionUrl: string) {
     const url = connectionUrl.replace(/\/$/, "");
     this._baseUrl = `${url}/logger`;
+    this._clientLogger = new ClientLoggerConnector();
   }
 
   public error(message: unknown) {
+    this._clientLogger.error(message);
     return this._sendLog("error", message);
   }
 
   public warn(message: unknown) {
+    this._clientLogger.warn(message);
     return this._sendLog("warn", message);
   }
 
   public info(message: unknown) {
+    this._clientLogger.info(message);
     return this._sendLog("info", message);
   }
 
   public debug(message: unknown) {
+    this._clientLogger.info(message);
     return this._sendLog("debug", message);
   }
 
   public trace(message: unknown) {
+    this._clientLogger.trace(message);
     return this._sendLog("trace", message);
   }
 

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -9,6 +9,7 @@ import { GraphSummary } from "./types";
 import { v4 } from "uuid";
 import { Explorer } from "../useGEFetchTypes";
 import { logger } from "@/utils";
+import { createLoggerFromConnection } from "@/core/connector";
 
 function _gremlinFetch(connection: ConnectionConfig, options: any) {
   return async (queryTemplate: string) => {
@@ -54,30 +55,31 @@ async function fetchSummary(
 }
 
 export function createGremlinExplorer(connection: ConnectionConfig): Explorer {
+  const remoteLogger = createLoggerFromConnection(connection);
   return {
     connection: connection,
     async fetchSchema(options) {
-      logger.log("[Gremlin Explorer] Fetching schema...");
+      remoteLogger.info("[Gremlin Explorer] Fetching schema...");
       const summary = await fetchSummary(connection, options);
       return fetchSchema(_gremlinFetch(connection, options), summary);
     },
     async fetchVertexCountsByType(req, options) {
-      logger.log("[Gremlin Explorer] Fetching vertex counts by type...");
+      remoteLogger.info("[Gremlin Explorer] Fetching vertex counts by type...");
       return fetchVertexTypeCounts(_gremlinFetch(connection, options), req);
     },
     async fetchNeighbors(req, options) {
-      logger.log("[Gremlin Explorer] Fetching neighbors...");
+      remoteLogger.info("[Gremlin Explorer] Fetching neighbors...");
       return fetchNeighbors(_gremlinFetch(connection, options), req);
     },
     async fetchNeighborsCount(req, options) {
-      logger.log("[Gremlin Explorer] Fetching neighbors count...");
+      remoteLogger.info("[Gremlin Explorer] Fetching neighbors count...");
       return fetchNeighborsCount(_gremlinFetch(connection, options), req);
     },
     async keywordSearch(req, options) {
       options ??= {};
       options.queryId = v4();
 
-      logger.log("[Gremlin Explorer] Fetching keyword search...");
+      remoteLogger.info("[Gremlin Explorer] Fetching keyword search...");
       return keywordSearch(_gremlinFetch(connection, options), req);
     },
   };

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -9,6 +9,7 @@ import { ConnectionConfig } from "@shared/types";
 import { DEFAULT_SERVICE_TYPE } from "@/utils/constants";
 import { Explorer } from "../useGEFetchTypes";
 import { env, logger } from "@/utils";
+import { createLoggerFromConnection } from "@/core/connector";
 
 function _openCypherFetch(connection: ConnectionConfig, options: any) {
   return async (queryTemplate: string) => {
@@ -27,23 +28,31 @@ function _openCypherFetch(connection: ConnectionConfig, options: any) {
 export function createOpenCypherExplorer(
   connection: ConnectionConfig
 ): Explorer {
+  const remoteLogger = createLoggerFromConnection(connection);
   const serviceType = connection.serviceType || DEFAULT_SERVICE_TYPE;
   return {
     connection: connection,
     async fetchSchema(options) {
+      remoteLogger.info("[openCypher Explorer] Fetching schema...");
       const summary = await fetchSummary(serviceType, connection, options);
       return fetchSchema(_openCypherFetch(connection, options), summary);
     },
     async fetchVertexCountsByType(req, options) {
+      remoteLogger.info(
+        "[openCypher Explorer] Fetching vertex counts by type..."
+      );
       return fetchVertexTypeCounts(_openCypherFetch(connection, options), req);
     },
     async fetchNeighbors(req, options) {
+      remoteLogger.info("[openCypher Explorer] Fetching neighbors...");
       return fetchNeighbors(_openCypherFetch(connection, options), req);
     },
     async fetchNeighborsCount(req, options) {
+      remoteLogger.info("[openCypher Explorer] Fetching neighbors count...");
       return fetchNeighborsCount(_openCypherFetch(connection, options), req);
     },
     async keywordSearch(req, options) {
+      remoteLogger.info("[openCypher Explorer] Fetching keyword search...");
       return keywordSearch(_openCypherFetch(connection, options), req);
     },
   };

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -23,6 +23,7 @@ import {
 import { ConnectionConfig } from "@shared/types";
 import { v4 } from "uuid";
 import { env, logger } from "@/utils";
+import { createLoggerFromConnection } from "@/core/connector";
 
 const replaceBlankNodeFromSearch = (
   blankNodes: BlankNodesMap,
@@ -182,16 +183,20 @@ export function createSparqlExplorer(
   connection: ConnectionConfig,
   blankNodes: BlankNodesMap
 ): Explorer {
+  const remoteLogger = createLoggerFromConnection(connection);
   return {
     connection: connection,
     async fetchSchema(options) {
+      remoteLogger.info("[SPARQL Explorer] Fetching schema...");
       const summary = await fetchSummary(connection, options);
       return fetchSchema(_sparqlFetch(connection, options), summary);
     },
     async fetchVertexCountsByType(req, options) {
+      remoteLogger.info("[SPARQL Explorer] Fetching vertex counts by type...");
       return fetchClassCounts(_sparqlFetch(connection, options), req);
     },
     async fetchNeighbors(req, options) {
+      remoteLogger.info("[SPARQL Explorer] Fetching neighbors...");
       const request: SPARQLNeighborsRequest = {
         resourceURI: req.vertexId,
         resourceClass: req.vertexType,
@@ -221,6 +226,7 @@ export function createSparqlExplorer(
       return { vertices, edges: response.edges };
     },
     async fetchNeighborsCount(req, options) {
+      remoteLogger.info("[SPARQL Explorer] Fetching neighbors count...");
       const bNode = blankNodes.get(req.vertexId);
 
       if (bNode?.neighbors) {
@@ -267,6 +273,8 @@ export function createSparqlExplorer(
     async keywordSearch(req, options) {
       options ??= {};
       options.queryId = v4();
+
+      remoteLogger.info("[SPARQL Explorer] Fetching keyword search...");
 
       const reqParams: SPARQLKeywordSearchRequest = {
         searchTerm: req.searchTerm,

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -56,7 +56,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
   const explorer = useRecoilValue(explorerSelector);
   const [_, setEntities] = useEntities();
   const { enqueueNotification, clearNotification } = useNotification();
-  const logger = useRecoilValue(loggerSelector);
+  const remoteLogger = useRecoilValue(loggerSelector);
 
   const mutation = useMutation({
     mutationFn: async (
@@ -89,7 +89,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
       });
     },
     onError: error => {
-      logger.error(`Failed to expand node: ${error.message}`);
+      remoteLogger.error(`Failed to expand node: ${error.message}`);
       const displayError = createDisplayError(error);
       // Notify the user of the error
       enqueueNotification({

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -10,7 +10,7 @@ import { useRecoilValue } from "recoil";
 const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
   const config = useConfiguration();
   const explorer = useRecoilValue(explorerSelector);
-  const logger = useRecoilValue(loggerSelector);
+  const remoteLogger = useRecoilValue(loggerSelector);
 
   const updatePrefixes = usePrefixesUpdater();
   const { enqueueNotification, clearNotification } = useNotification();
@@ -40,7 +40,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
           type: "info",
           stackable: true,
         });
-        logger.info(
+        remoteLogger.info(
           `[${
             config.displayLabel || config.id
           }] This connection has no data available: ${JSON.stringify(
@@ -59,7 +59,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
         type: "success",
         stackable: true,
       });
-      logger.info(
+      remoteLogger.info(
         `[${
           config.displayLabel || config.id
         }] Connection successfully synchronized: ${JSON.stringify(
@@ -82,13 +82,13 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
         stackable: true,
       });
       if (e instanceof Error && e.name === "AbortError") {
-        logger.error(
+        remoteLogger.error(
           `[${
             config.displayLabel || config.id
           }] Fetch aborted, reached max time out ${config.connection?.fetchTimeoutMs} MS`
         );
       } else {
-        logger.error(
+        remoteLogger.error(
           `[${
             config.displayLabel || config.id
           }] Error while fetching schema: ${e instanceof Error ? e.message : "Unexpected error"}`
@@ -104,7 +104,7 @@ const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
     enqueueNotification,
     replaceSchema,
     clearNotification,
-    logger,
+    remoteLogger,
     updatePrefixes,
     setSyncFailure,
   ]);


### PR DESCRIPTION
## Description

Sends DB query to server to log. Also sends broad context at the explorer request level to the server.

### Logging

- Add DB query string logging to proxy server at `debug` level
- Logs client side explorer requests to server at `info` level
- Adds explorer request logs to all client side explorers (openCypher and SPARQL)
- Fix bug in remote logger creation, where the remote logger would never be created
- Send logs to both client and server when using remote logger
- Rename `logger` to `remoteLogger` to be more clear when it is being used
- Don't log in the request middleware for path `/logger` to reduce noise

### Environment Values

Reworked how environment values are parsed. 

- Move access to `process.env` to a single place in `env.ts`
- Add Zod schema for environment values the server cares about
  - Default values are used if the key is missing or undefined
- Parse `process.env` and print out any errors
  - Any errors will terminate the server

## Validation

### Logging in app

![CleanShot 2024-08-29 at 14 44 34@2x](https://github.com/user-attachments/assets/6356cc55-b817-4a4c-b5ef-e6af28b91430)

### Logging on server

![CleanShot 2024-08-29 at 14 45 39@2x](https://github.com/user-attachments/assets/c54b5244-9cb7-4c5f-8236-341b308b3196)

### Parsing environment values successful

![CleanShot 2024-08-29 at 14 22 27@2x](https://github.com/user-attachments/assets/7a998830-fde7-41cd-9426-11606b4d515f)

### Parsing environment values error

![CleanShot 2024-08-29 at 14 17 57@2x](https://github.com/user-attachments/assets/2282d5de-f932-4727-97fb-e4c704bf16c5)

## Related Issues

- Resolves #514 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
