### PR TITLE
Setting to enable or disable DB query logging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,8 +10,10 @@
   exist ([#542](https://github.com/aws/graph-explorer/pull/542))
 - **Added** global error page if the React app crashes
   ([#547](https://github.com/aws/graph-explorer/pull/547))
-- **Added** server logging of database queries when using the proxy server
-  ([#574](https://github.com/aws/graph-explorer/pull/574))
+- **Added** optional server logging of database queries when using the proxy
+  server which can be enabled within settings
+  ([#574](https://github.com/aws/graph-explorer/pull/574),
+  [#575](https://github.com/aws/graph-explorer/pull/575))
 - **Improved** handling of server errors with more consistent logging
   ([#557](https://github.com/aws/graph-explorer/pull/557))
 - **Transition** to Tailwind instead of EmotionCSS for styles, which should make

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -4,7 +4,7 @@ import { clientRoot } from "./paths.js";
 import { z } from "zod";
 
 /** Coerces a string to a boolean value in a case insensitive way. */
-const BooleanStringSchema = z
+export const BooleanStringSchema = z
   .string()
   .refine(s => s.toLowerCase() === "true" || s.toLowerCase() === "false")
   .transform(s => s.toLowerCase() === "true");

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -73,6 +73,12 @@ export function requestLoggingMiddleware() {
       return;
     }
 
+    // Ignore CORS options requests
+    if (req.method === "OPTIONS") {
+      next();
+      return;
+    }
+
     // Wait for the request to complete.
     req.on("end", () => {
       logRequestAndResponse(req, res);

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -10,9 +10,11 @@ import { v4 } from "uuid";
 import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
+import { FeatureFlags } from "@/core";
 
 function _gremlinFetch(
   connection: ConnectionConfig,
+  featureFlags: FeatureFlags,
   options?: ExplorerRequestOptions
 ) {
   return async (queryTemplate: string) => {
@@ -26,22 +28,29 @@ function _gremlinFetch(
       headers.queryId = options.queryId;
     }
 
-    return fetchDatabaseRequest(connection, `${connection.url}/gremlin`, {
-      method: "POST",
-      headers,
-      body,
-      ...options,
-    });
+    return fetchDatabaseRequest(
+      connection,
+      featureFlags,
+      `${connection.url}/gremlin`,
+      {
+        method: "POST",
+        headers,
+        body,
+        ...options,
+      }
+    );
   };
 }
 
 async function fetchSummary(
   connection: ConnectionConfig,
-  options: RequestInit
+  featureFlags: FeatureFlags,
+  options?: RequestInit
 ) {
   try {
     const response = await fetchDatabaseRequest(
       connection,
+      featureFlags,
       `${connection.url}/pg/statistics/summary?mode=detailed`,
       {
         method: "GET",
@@ -57,33 +66,51 @@ async function fetchSummary(
   }
 }
 
-export function createGremlinExplorer(connection: ConnectionConfig): Explorer {
+export function createGremlinExplorer(
+  connection: ConnectionConfig,
+  featureFlags: FeatureFlags
+): Explorer {
   const remoteLogger = createLoggerFromConnection(connection);
   return {
     connection: connection,
     async fetchSchema(options) {
       remoteLogger.info("[Gremlin Explorer] Fetching schema...");
-      const summary = await fetchSummary(connection, options);
-      return fetchSchema(_gremlinFetch(connection, options), summary);
+      const summary = await fetchSummary(connection, featureFlags, options);
+      return fetchSchema(
+        _gremlinFetch(connection, featureFlags, options),
+        summary
+      );
     },
     async fetchVertexCountsByType(req, options) {
       remoteLogger.info("[Gremlin Explorer] Fetching vertex counts by type...");
-      return fetchVertexTypeCounts(_gremlinFetch(connection, options), req);
+      return fetchVertexTypeCounts(
+        _gremlinFetch(connection, featureFlags, options),
+        req
+      );
     },
     async fetchNeighbors(req, options) {
       remoteLogger.info("[Gremlin Explorer] Fetching neighbors...");
-      return fetchNeighbors(_gremlinFetch(connection, options), req);
+      return fetchNeighbors(
+        _gremlinFetch(connection, featureFlags, options),
+        req
+      );
     },
     async fetchNeighborsCount(req, options) {
       remoteLogger.info("[Gremlin Explorer] Fetching neighbors count...");
-      return fetchNeighborsCount(_gremlinFetch(connection, options), req);
+      return fetchNeighborsCount(
+        _gremlinFetch(connection, featureFlags, options),
+        req
+      );
     },
     async keywordSearch(req, options) {
       options ??= {};
       options.queryId = v4();
 
       remoteLogger.info("[Gremlin Explorer] Fetching keyword search...");
-      return keywordSearch(_gremlinFetch(connection, options), req);
+      return keywordSearch(
+        _gremlinFetch(connection, featureFlags, options),
+        req
+      );
     },
   } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -7,11 +7,14 @@ import keywordSearch from "./queries/keywordSearch";
 import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
 import { GraphSummary } from "./types";
 import { v4 } from "uuid";
-import { Explorer } from "../useGEFetchTypes";
+import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
 
-function _gremlinFetch(connection: ConnectionConfig, options: any) {
+function _gremlinFetch(
+  connection: ConnectionConfig,
+  options?: ExplorerRequestOptions
+) {
   return async (queryTemplate: string) => {
     logger.debug(queryTemplate);
     const body = JSON.stringify({ query: queryTemplate });
@@ -82,5 +85,5 @@ export function createGremlinExplorer(connection: ConnectionConfig): Explorer {
       remoteLogger.info("[Gremlin Explorer] Fetching keyword search...");
       return keywordSearch(_gremlinFetch(connection, options), req);
     },
-  };
+  } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -7,11 +7,14 @@ import { GraphSummary } from "./types";
 import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
 import { ConnectionConfig } from "@shared/types";
 import { DEFAULT_SERVICE_TYPE } from "@/utils/constants";
-import { Explorer } from "../useGEFetchTypes";
+import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { env, logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
 
-function _openCypherFetch(connection: ConnectionConfig, options: any) {
+function _openCypherFetch(
+  connection: ConnectionConfig,
+  options?: ExplorerRequestOptions
+) {
   return async (queryTemplate: string) => {
     logger.debug(queryTemplate);
     return fetchDatabaseRequest(connection, `${connection.url}/openCypher`, {
@@ -55,13 +58,13 @@ export function createOpenCypherExplorer(
       remoteLogger.info("[openCypher Explorer] Fetching keyword search...");
       return keywordSearch(_openCypherFetch(connection, options), req);
     },
-  };
+  } satisfies Explorer;
 }
 
 async function fetchSummary(
   serviceType: string,
   connection: ConnectionConfig,
-  options: RequestInit
+  options?: RequestInit
 ) {
   try {
     const endpoint =

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -1,6 +1,7 @@
 import type {
   Criterion,
   Explorer,
+  ExplorerRequestOptions,
   KeywordSearchRequest,
   KeywordSearchResponse,
   NeighborsResponse,
@@ -133,16 +134,20 @@ const storedBlankNodeNeighborsRequest = (
   });
 };
 
-function _sparqlFetch(connection: ConnectionConfig, options?: any) {
+function _sparqlFetch(
+  connection: ConnectionConfig,
+  options?: ExplorerRequestOptions
+) {
   return async (queryTemplate: string) => {
     logger.debug(queryTemplate);
     const body = `query=${encodeURIComponent(queryTemplate)}`;
-    const headers =
-      options?.queryId && connection.proxyConnection === true
+    const queryId = options?.queryId;
+    const headers: Record<string, string> =
+      queryId && connection.proxyConnection === true
         ? {
             accept: "application/sparql-results+json",
             "Content-Type": "application/x-www-form-urlencoded",
-            queryId: options.queryId,
+            queryId: queryId,
           }
         : {
             accept: "application/sparql-results+json",
@@ -297,5 +302,5 @@ export function createSparqlExplorer(
 
       return { vertices };
     },
-  };
+  } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -211,27 +211,31 @@ export type ConfigurationWithConnection = Omit<
 > &
   Required<Pick<ConfigurationContextProps, "connection">>;
 
+export type ExplorerRequestOptions = RequestInit & {
+  queryId?: string;
+};
+
 /**
  * Abstracted interface to the common database queries used by
  * Graph Explorer.
  */
 export type Explorer = {
   connection: ConnectionConfig;
-  fetchSchema: (options?: any) => Promise<SchemaResponse>;
+  fetchSchema: (options?: ExplorerRequestOptions) => Promise<SchemaResponse>;
   fetchVertexCountsByType: (
     req: CountsByTypeRequest,
-    options?: any
+    options?: ExplorerRequestOptions
   ) => Promise<CountsByTypeResponse>;
   fetchNeighbors: (
     req: NeighborsRequest,
-    options?: any
+    options?: ExplorerRequestOptions
   ) => Promise<NeighborsResponse>;
   fetchNeighborsCount: (
     req: NeighborsCountRequest,
-    options?: any
+    options?: ExplorerRequestOptions
   ) => Promise<NeighborsCountResponse>;
   keywordSearch: (
     req: KeywordSearchRequest,
-    options?: any
+    options?: ExplorerRequestOptions
   ) => Promise<KeywordSearchResponse>;
 };

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -1,0 +1,159 @@
+import {
+  createRandomEdgePreferences,
+  createRandomRawConfiguration,
+  createRandomSchema,
+  createRandomVertexPreferences,
+} from "@/utils/testing";
+import { mergeConfiguration } from "./configuration";
+import { RawConfiguration, VertexTypeConfig } from "../ConfigurationProvider";
+import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
+import { SchemaInference } from "./schema";
+import { UserStyling } from "./userPreferences";
+import { sanitizeText } from "@/utils";
+
+const defaultVertexStyle = {
+  color: "#128EE5",
+  iconUrl: DEFAULT_ICON_URL,
+  iconImageType: "image/svg+xml",
+  displayNameAttribute: "id",
+  longDisplayNameAttribute: "types",
+};
+
+const defaultEdgeStyle = {
+  type: "unknown",
+  displayLabel: "Unknown",
+};
+
+describe("mergedConfiguration", () => {
+  it("should produce empty defaults when empty object is passed", () => {
+    const config = {} as RawConfiguration;
+    const result = mergeConfiguration(null, config, {});
+
+    expect(result).toEqual({
+      connection: {
+        graphDbUrl: "",
+        queryEngine: "gremlin",
+        url: "",
+      },
+      schema: {
+        edges: [],
+        vertices: [],
+        totalEdges: 0,
+        totalVertices: 0,
+      },
+    });
+  });
+
+  it("should produce empty schema when no schema provided", () => {
+    const config = createRandomRawConfiguration();
+    const result = mergeConfiguration(null, config, {});
+
+    expect(result).toEqual({
+      ...config,
+      connection: {
+        url: "",
+        graphDbUrl: "",
+        ...config.connection,
+      },
+      schema: {
+        edges: [],
+        vertices: [],
+        totalEdges: 0,
+        totalVertices: 0,
+      },
+    } satisfies RawConfiguration);
+  });
+
+  it("should use schema when provided", () => {
+    const config = createRandomRawConfiguration();
+    const schema = createRandomSchema();
+    const result = mergeConfiguration(schema, config, {});
+
+    const expectedSchema = {
+      ...schema,
+      vertices: schema.vertices
+        .map(v => ({
+          ...defaultVertexStyle,
+          displayLabel: sanitizeText(v.type),
+          ...v,
+        }))
+        .sort(byType),
+      edges: schema.edges.map(e => {
+        return {
+          ...defaultEdgeStyle,
+          ...e,
+        };
+      }),
+    } satisfies SchemaInference;
+
+    expect(result.schema?.vertices).toEqual(expectedSchema.vertices);
+    expect(result.schema?.edges).toEqual(expectedSchema.edges);
+    expect(result.schema).toEqual(expectedSchema);
+    expect(result).toEqual({
+      ...config,
+      connection: {
+        ...config.connection,
+        url: config.connection?.url ?? "",
+        graphDbUrl: config.connection?.graphDbUrl ?? "",
+      },
+      schema: expectedSchema,
+    } satisfies RawConfiguration);
+  });
+
+  it("should use styling when provided", () => {
+    const config = createRandomRawConfiguration();
+    const schema = createRandomSchema();
+    const styling: UserStyling = {
+      vertices: schema.vertices.map(v => ({
+        ...createRandomVertexPreferences(),
+        type: v.type,
+      })),
+      edges: schema.edges.map(v => ({
+        ...createRandomEdgePreferences(),
+        type: v.type,
+      })),
+    };
+    const result = mergeConfiguration(schema, config, styling);
+
+    const expectedSchema = {
+      ...schema,
+      vertices: schema.vertices
+        .map(v => {
+          const style = styling.vertices?.find(s => s.type === v.type) ?? {};
+          return {
+            ...defaultVertexStyle,
+            displayLabel: sanitizeText(v.type),
+            ...v,
+            ...style,
+          };
+        })
+        .sort(byType),
+      edges: schema.edges.map(e => {
+        const style = styling.edges?.find(s => s.type === e.type) ?? {};
+        return {
+          ...defaultEdgeStyle,
+          ...e,
+          ...style,
+        };
+      }),
+    } satisfies SchemaInference;
+
+    expect(result.schema?.vertices).toEqual(expectedSchema.vertices);
+    expect(result.schema?.edges).toEqual(expectedSchema.edges);
+    expect(result.schema).toEqual(expectedSchema);
+    expect(result).toEqual({
+      ...config,
+      connection: {
+        ...config.connection,
+        url: config.connection?.url ?? "",
+        graphDbUrl: config.connection?.graphDbUrl ?? "",
+      },
+      schema: expectedSchema,
+    });
+  });
+});
+
+/** Sorts the configs by type name */
+function byType(a: VertexTypeConfig, b: VertexTypeConfig) {
+  return a.type.localeCompare(b.type);
+}

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -38,7 +38,7 @@ export const mergedConfigurationSelector = selector<RawConfiguration | null>({
   get: ({ get }) => {
     const activeConfig = get(activeConfigurationAtom);
     const config = get(configurationAtom);
-    const currentConfig = activeConfig && config.get(activeConfig);
+    const currentConfig = activeConfig ? config.get(activeConfig) : null;
     if (!currentConfig) {
       return null;
     }

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -90,6 +90,11 @@ export type EdgePreferences = {
   targetArrowStyle?: ArrowStyle;
 };
 
+export type UserStyling = {
+  vertices?: Array<VertexPreferences>;
+  edges?: Array<EdgePreferences>;
+};
+
 export type UserPreferences = {
   layout: {
     activeToggles: Set<string>;
@@ -99,13 +104,10 @@ export type UserPreferences = {
     };
     detailsAutoOpenOnSelection?: boolean;
   };
-  styling: {
-    vertices?: Array<VertexPreferences>;
-    edges?: Array<EdgePreferences>;
-  };
+  styling: UserStyling;
 };
 
-export const userStylingAtom = atom<UserPreferences["styling"]>({
+export const userStylingAtom = atom<UserStyling>({
   key: "user-styling",
   default: {},
   effects: [localForageEffect()],

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -12,6 +12,7 @@ import { selector } from "recoil";
 import { equalSelector } from "@/utils/recoilState";
 import { ConnectionConfig } from "@shared/types";
 import { logger } from "@/utils";
+import { featureFlagsSelector } from "./featureFlags";
 
 /**
  * Active connection where the value will only change when one of the
@@ -51,17 +52,18 @@ export const explorerSelector = selector({
   key: "explorer",
   get: ({ get }) => {
     const connection = get(activeConnectionSelector);
+    const featureFlags = get(featureFlagsSelector);
 
     if (!connection) {
       return null;
     }
     switch (connection.queryEngine) {
       case "openCypher":
-        return createOpenCypherExplorer(connection);
+        return createOpenCypherExplorer(connection, featureFlags);
       case "sparql":
-        return createSparqlExplorer(connection, new Map());
+        return createSparqlExplorer(connection, featureFlags, new Map());
       default:
-        return createGremlinExplorer(connection);
+        return createGremlinExplorer(connection, featureFlags);
     }
   },
 });

--- a/packages/graph-explorer/src/core/featureFlags.ts
+++ b/packages/graph-explorer/src/core/featureFlags.ts
@@ -14,3 +14,10 @@ export const showDebugActionsAtom = atom({
   default: false,
   effects: [asyncLocalForageEffect("showDebugActions")],
 });
+
+/** Shows debug actions in various places around the app. */
+export const allowLoggingDbQueryAtom = atom({
+  key: "feature-flag-db-query-logging",
+  default: false,
+  effects: [asyncLocalForageEffect("allowLoggingDbQuery")],
+});

--- a/packages/graph-explorer/src/core/featureFlags.ts
+++ b/packages/graph-explorer/src/core/featureFlags.ts
@@ -1,4 +1,4 @@
-import { atom } from "recoil";
+import { atom, selector } from "recoil";
 import { asyncLocalForageEffect } from "./StateProvider/localForageEffect";
 
 /** Shows Recoil diff logs in the browser console. */
@@ -20,4 +20,21 @@ export const allowLoggingDbQueryAtom = atom({
   key: "feature-flag-db-query-logging",
   default: false,
   effects: [asyncLocalForageEffect("allowLoggingDbQuery")],
+});
+
+export type FeatureFlags = {
+  showRecoilStateLogging: boolean;
+  showDebugActions: boolean;
+  allowLoggingDbQuery: boolean;
+};
+
+export const featureFlagsSelector = selector<FeatureFlags>({
+  key: "feature-flags",
+  get: ({ get }) => {
+    return {
+      showRecoilStateLogging: get(showRecoilStateLoggingAtom),
+      showDebugActions: get(showDebugActionsAtom),
+      allowLoggingDbQuery: get(allowLoggingDbQueryAtom),
+    } satisfies FeatureFlags;
+  },
 });

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -1,6 +1,7 @@
 import {
   AttributeConfig,
   EdgeTypeConfig,
+  FeatureFlags,
   RawConfiguration,
   Schema,
   VertexTypeConfig,
@@ -260,5 +261,13 @@ export function createRandomUserStyling(): UserStyling {
   return {
     vertices: createArray(3, createRandomVertexPreferences),
     edges: createArray(3, createRandomEdgePreferences),
+  };
+}
+
+export function createRandomFeatureFlags(): FeatureFlags {
+  return {
+    showRecoilStateLogging: createRandomBoolean(),
+    showDebugActions: createRandomBoolean(),
+    allowLoggingDbQuery: createRandomBoolean(),
   };
 }

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -10,12 +10,18 @@ import { Entities } from "@/core/StateProvider/entitiesSelector";
 import {
   createArray,
   createRandomBoolean,
+  createRandomColor,
   createRandomInteger,
   createRandomName,
   createRandomUrlString,
   createRecord,
   randomlyUndefined,
 } from "@shared/utils/testing";
+import {
+  EdgePreferences,
+  UserStyling,
+  VertexPreferences,
+} from "@/core/StateProvider/userPreferences";
 
 /*
 
@@ -36,12 +42,15 @@ affected by those values, regardless of what they are.
  * @returns A random AttributeConfig object.
  */
 export function createRandomAttributeConfig(): AttributeConfig {
+  const dataType = randomlyUndefined(createRandomName("dataType"));
+  const hidden = randomlyUndefined(createRandomBoolean());
+  const searchable = randomlyUndefined(createRandomBoolean());
   return {
     name: createRandomName("name"),
     displayLabel: createRandomName("displayLabel"),
-    dataType: randomlyUndefined(createRandomName("dataType")),
-    hidden: randomlyUndefined(createRandomBoolean()),
-    searchable: randomlyUndefined(createRandomBoolean()),
+    ...(dataType && { dataType }),
+    ...(hidden && { hidden }),
+    ...(searchable && { searchable }),
   };
 }
 
@@ -50,11 +59,13 @@ export function createRandomAttributeConfig(): AttributeConfig {
  * @returns A random EdgeTypeConfig object.
  */
 export function createRandomEdgeTypeConfig(): EdgeTypeConfig {
+  const displayLabel = randomlyUndefined(createRandomName("displayLabel"));
+  const hidden = randomlyUndefined(createRandomBoolean());
   return {
     type: createRandomName("type"),
     attributes: createArray(6, createRandomAttributeConfig),
-    displayLabel: randomlyUndefined(createRandomName("displayLabel")),
-    hidden: randomlyUndefined(createRandomBoolean()),
+    ...(displayLabel && { displayLabel }),
+    ...(hidden && { hidden }),
     total: createRandomInteger(),
   };
 }
@@ -64,11 +75,13 @@ export function createRandomEdgeTypeConfig(): EdgeTypeConfig {
  * @returns A random VertexTypeConfig object.
  */
 export function createRandomVertexTypeConfig(): VertexTypeConfig {
+  const displayLabel = randomlyUndefined(createRandomName("displayLabel"));
+  const hidden = randomlyUndefined(createRandomBoolean());
   return {
     type: createRandomName("type"),
     attributes: createArray(6, createRandomAttributeConfig),
-    displayLabel: randomlyUndefined(createRandomName("displayLabel")),
-    hidden: randomlyUndefined(createRandomBoolean()),
+    ...(displayLabel && { displayLabel }),
+    ...(hidden && { hidden }),
     total: createRandomInteger(),
   };
 }
@@ -177,25 +190,75 @@ function pickRandomElement<T>(array: T[]): T {
 export function createRandomRawConfiguration(): RawConfiguration {
   const isProxyConnection = createRandomBoolean();
   const isIamEnabled = createRandomBoolean();
+  const fetchTimeoutMs = randomlyUndefined(createRandomInteger());
+  const nodeExpansionLimit = randomlyUndefined(createRandomInteger());
+  const serviceType = randomlyUndefined(
+    pickRandomElement(["neptune-db", "neptune-graph"] as const)
+  );
   return {
     id: createRandomName("id"),
     displayLabel: createRandomName("displayLabel"),
     connection: {
       url: createRandomUrlString(),
-      graphDbUrl: isProxyConnection ? createRandomUrlString() : undefined,
+      ...(isProxyConnection && { graphDbUrl: createRandomUrlString() }),
       queryEngine: pickRandomElement(["gremlin", "openCypher", "sparql"]),
       proxyConnection: isProxyConnection,
-      awsAuthEnabled: isIamEnabled ? createRandomBoolean() : undefined,
-      awsRegion: isIamEnabled
-        ? pickRandomElement(["us-west-1", "us-west-2", "us-east-1"])
-        : undefined,
-      fetchTimeoutMs: randomlyUndefined(createRandomInteger()),
-      nodeExpansionLimit: randomlyUndefined(createRandomInteger()),
-      serviceType: pickRandomElement([
-        "neptune-db",
-        "neptune-graph",
-        undefined,
-      ]),
+      ...(isIamEnabled && { awsAuthEnabled: createRandomBoolean() }),
+      ...(isIamEnabled && {
+        awsRegion: pickRandomElement(["us-west-1", "us-west-2", "us-east-1"]),
+      }),
+      ...(fetchTimeoutMs && { fetchTimeoutMs }),
+      ...(nodeExpansionLimit && { nodeExpansionLimit }),
+      ...(serviceType && { serviceType }),
     },
+  };
+}
+
+export function createRandomVertexPreferences(): VertexPreferences {
+  const color = randomlyUndefined(createRandomColor());
+  const borderColor = randomlyUndefined(createRandomColor());
+  const iconUrl = randomlyUndefined(createRandomUrlString());
+  const longDisplayNameAttribute = randomlyUndefined(
+    createRandomName("LongDisplayNameAttribute")
+  );
+  const displayNameAttribute = randomlyUndefined(
+    createRandomName("DisplayNameAttribute")
+  );
+  const displayLabel = randomlyUndefined(createRandomName("DisplayLabel"));
+  return {
+    type: createRandomName("VertexType"),
+    ...(displayLabel && { displayLabel }),
+    ...(displayNameAttribute && { displayNameAttribute }),
+    ...(longDisplayNameAttribute && { longDisplayNameAttribute }),
+    ...(color && { color }),
+    ...(borderColor && { borderColor }),
+    ...(iconUrl && { iconUrl }),
+  };
+}
+
+export function createRandomEdgePreferences(): EdgePreferences {
+  const displayLabel = randomlyUndefined(createRandomName("DisplayLabel"));
+  const displayNameAttribute = randomlyUndefined(
+    createRandomName("DisplayNameAttribute")
+  );
+  const lineColor = randomlyUndefined(createRandomColor());
+  const labelColor = randomlyUndefined(createRandomColor());
+  const labelBorderColor = randomlyUndefined(createRandomColor());
+  const lineThickness = randomlyUndefined(createRandomInteger(25));
+  return {
+    type: createRandomName("EdgeType"),
+    ...(displayLabel && { displayLabel }),
+    ...(displayNameAttribute && { displayNameAttribute }),
+    ...(lineColor && { lineColor }),
+    ...(labelColor && { labelColor }),
+    ...(labelBorderColor && { labelBorderColor }),
+    ...(lineThickness && { lineThickness }),
+  };
+}
+
+export function createRandomUserStyling(): UserStyling {
+  return {
+    vertices: createArray(3, createRandomVertexPreferences),
+    edges: createArray(3, createRandomEdgePreferences),
   };
 }

--- a/packages/graph-explorer/src/workspaces/Settings/SettingsGeneral.tsx
+++ b/packages/graph-explorer/src/workspaces/Settings/SettingsGeneral.tsx
@@ -1,5 +1,9 @@
 import { useRecoilState } from "recoil";
-import { showDebugActionsAtom, showRecoilStateLoggingAtom } from "@/core";
+import {
+  allowLoggingDbQueryAtom,
+  showDebugActionsAtom,
+  showRecoilStateLoggingAtom,
+} from "@/core";
 import {
   Button,
   Checkbox,
@@ -23,11 +27,37 @@ export default function SettingsGeneral() {
   const [isDebugOptionsEnabled, setIsDebugOptionsEnabled] =
     useRecoilState(showDebugActionsAtom);
 
+  const [allowLoggingDbQuery, setAllowLoggingDbQuery] = useRecoilState(
+    allowLoggingDbQueryAtom
+  );
+
   return (
     <>
       <PageHeading>General Settings</PageHeading>
 
       <SettingsSectionContainer>
+        <SettingsSection className="items-start">
+          <SectionTitle>Logging</SectionTitle>
+          <Paragraph className="max-w-paragraph">
+            If you have encountered an issue it may be helpful to enable server
+            side logging of the database queries used by Graph Explorer.
+          </Paragraph>
+          <ImportantBlock className="max-w-paragraph mb-4">
+            This <b>will not</b> log any data returned by the database queries.
+            However, the node & edge labels, ID values, and any value filters
+            will be present in the queries.
+          </ImportantBlock>
+          <Checkbox
+            value="isLoggingDbQueryEnabled"
+            isSelected={allowLoggingDbQuery}
+            onChange={isSelected => {
+              setAllowLoggingDbQuery(isSelected);
+            }}
+          >
+            Enable database query logging on proxy server
+          </Checkbox>
+        </SettingsSection>
+
         <SettingsSection className="items-start">
           <SectionTitle>Save Configuration Data</SectionTitle>
           <Paragraph className="max-w-paragraph">
@@ -41,6 +71,7 @@ export default function SettingsGeneral() {
             Save Configuration
           </Button>
         </SettingsSection>
+
         <SettingsSection className="items-start">
           <SectionTitle>Load Configuration Data</SectionTitle>
           <Paragraph className="max-w-paragraph">


### PR DESCRIPTION
## Description

Adds a new setting for enabling or disabling logging of the database queries for Graph Explorer operations.

- Default value is disabled
- Applies to all queries across all connections that use the proxy server
- Setting is communicated to the server through a new HTTP header `db-query-logging-enabled`
- If the setting is missing it is assumed disabled

### Other changes

I went down some alternative paths that contained some cleanup of existing code. I'm including those here, but can break them out to a separate PR if desired.

- Don't log requests for CORS `OPTIONS` method to reduce logger noise
- Updated random data functions for tests so that when generating `undefined` values the properties won't be on the resulting object
  - In JavaScript `prop: undefined` is treated differently than an "undefined" prop (a prop that doesn't exist on an object)
- Move configuration merging logic to a separate function (no logic changed)
  - Added some tests around the configuration merging logic
  - Added type for user styling
  - Added `activeConfigSelector` to get the config that is active out of the `Map` (similar to `activeSchemaSelector`)
- Added concrete type for the `options` param to `Explorer` functions (was `any` before)

## Validation

![CleanShot 2024-08-30 at 16 42 10@2x](https://github.com/user-attachments/assets/12f9fb4b-2b7d-4e6b-8c00-925431bf3f69)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #540 
- Resolves #556 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
