### PR TITLE
Fix 404 issue on reload

### DIFF
--- a/packages/graph-explorer/index.html
+++ b/packages/graph-explorer/index.html
@@ -1,23 +1,40 @@
 <!doctype html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="%BASE_URL%/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Graph Explorer" />
-  <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%/apple-touch-icon.png" />
-  <link rel="icon" type="image/png" sizes="32x32" href="%BASE_URL%/favicon-32x32.png" />
-  <link rel="icon" type="image/png" sizes="16x16" href="%BASE_URL%/favicon-16x16.png" />
-  <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#FFFFFF" />
-  <meta name="theme-color" content="#ffffff" />
-  <!--
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%BASE_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Graph Explorer" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="%BASE_URL%/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="%BASE_URL%/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="%BASE_URL%/favicon-16x16.png"
+    />
+    <link
+      rel="mask-icon"
+      href="%PUBLIC_URL%/safari-pinned-tab.svg"
+      color="#FFFFFF"
+    />
+    <meta name="theme-color" content="#ffffff" />
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%BASE_URL%/manifest.json" />
-  <!--
+    <link rel="manifest" href="%BASE_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -26,12 +43,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>Graph Explorer</title>
-</head>
+    <title>Graph Explorer</title>
+  </head>
 
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/index.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
 </html>

--- a/packages/graph-explorer/index.html
+++ b/packages/graph-explorer/index.html
@@ -1,40 +1,23 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Graph Explorer" />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="%GRAPH_EXP_ENV_ROOT_FOLDER%/apple-touch-icon.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="%GRAPH_EXP_ENV_ROOT_FOLDER%/favicon-32x32.png"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="%GRAPH_EXP_ENV_ROOT_FOLDER%/favicon-16x16.png"
-    />
-    <link
-      rel="mask-icon"
-      href="%PUBLIC_URL%/safari-pinned-tab.svg"
-      color="#FFFFFF"
-    />
-    <meta name="theme-color" content="#ffffff" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%BASE_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Graph Explorer" />
+  <link rel="apple-touch-icon" sizes="180x180" href="%BASE_URL%/apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="%BASE_URL%/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="%BASE_URL%/favicon-16x16.png" />
+  <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#FFFFFF" />
+  <meta name="theme-color" content="#ffffff" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%GRAPH_EXP_ENV_ROOT_FOLDER%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%BASE_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -43,10 +26,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Graph Explorer</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/index.tsx"></script>
-  </body>
+  <title>Graph Explorer</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+
 </html>

--- a/packages/graph-explorer/src/core/AppErrorPage.tsx
+++ b/packages/graph-explorer/src/core/AppErrorPage.tsx
@@ -7,8 +7,7 @@ import {
   Paragraph,
   ResetIcon,
 } from "@/components";
-import { env } from "@/utils";
-import { APP_NAME } from "@/utils/constants";
+import { APP_NAME, RELOAD_URL } from "@/utils/constants";
 
 /** This is the app wide error page that will be shown when the app essentially crashes */
 export default function AppErrorPage(props: FallbackProps) {
@@ -24,7 +23,7 @@ export default function AppErrorPage(props: FallbackProps) {
         </div>
 
         {/* Force a full reload of the app in the browser */}
-        <a href={env.BASE_URL}>
+        <a href={RELOAD_URL}>
           <Button variant="filled" size="large" icon={<ResetIcon />}>
             Reload {APP_NAME}
           </Button>

--- a/packages/graph-explorer/src/utils/constants.ts
+++ b/packages/graph-explorer/src/utils/constants.ts
@@ -5,3 +5,9 @@ export const DEFAULT_CONCURRENT_REQUESTS_LIMIT = 10;
 
 /** The string "Graph Explorer". */
 export const APP_NAME = "Graph Explorer";
+
+/** The root URL for the app used for reloading fresh. */
+export const RELOAD_URL =
+  import.meta.env.BASE_URL.substring(-1) !== "/"
+    ? import.meta.env.BASE_URL + "/"
+    : import.meta.env.BASE_URL;

--- a/packages/graph-explorer/src/workspaces/Settings/LoadConfigButton.tsx
+++ b/packages/graph-explorer/src/workspaces/Settings/LoadConfigButton.tsx
@@ -19,8 +19,7 @@ import {
   type SerializedBackup,
 } from "@/core/StateProvider/localDb";
 import { useDebounceValue } from "@/hooks";
-import { env } from "@/utils";
-import { APP_NAME } from "@/utils/constants";
+import { APP_NAME, RELOAD_URL } from "@/utils/constants";
 
 export default function LoadConfigButton() {
   const [file, setFile] = useState<File | null>(null);
@@ -244,7 +243,7 @@ function SuccessModal({ success }: { success: boolean }) {
           </div>
 
           {/* Force a full reload of the app in the browser */}
-          <a href={env.BASE_URL} className="self-end">
+          <a href={RELOAD_URL} className="self-end">
             <Button variant="filled" size="large">
               Reload {APP_NAME}
             </Button>


### PR DESCRIPTION
## Description

The 404 happens because the `BASE_URL` environment value does not have a terminating `/`. So the URL was:

```
/proxy/9250/explorer
```

This leads to a redirect that leads to a 404.

The URL should be

```
/proxy/9250/explorer/
```

So I added a constant that is used for the two reload buttons. It checks whether the `BASE_URL` has an ending `/` before adding one.

I also updated updated the `index.html` to use `BASE_URL` hoping this would help with the CORS issue. It did not. But I'd like to keep the change since it removes a need for passing our custom `GRAPH_EXP_ENV_ROOT_FOLDER` environment value through the VITE config.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Tested in local environment
- Tested in Neptune Notebook environment

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- Resolves #579 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
