### PR TITLE
Add multiline log pattern

### DIFF
--- a/additionaldocs/sagemaker/install-graph-explorer-lc.sh
+++ b/additionaldocs/sagemaker/install-graph-explorer-lc.sh
@@ -152,6 +152,7 @@ start_graph_explorer_with_cw_logs() {
       --log-opt awslogs-region=${AWS_REGION} \
       --log-opt awslogs-group=/aws/sagemaker/NotebookInstances \
       --log-opt awslogs-stream=${GRAPH_NOTEBOOK_NAME}/graph-explorer.log \
+      --log-opt awslogs-multiline-pattern='^(INFO|DEBUG|ERROR|WARN|TRACE|FATAL)' \
       --env LOG_LEVEL=debug \
       --env HOST=127.0.0.1 \
       --env PUBLIC_OR_PROXY_ENDPOINT=${EXPLORER_URI} \


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Uses a parameter to the cloudwatch log driver to parse the logs for multiline entries.

One side effect is that anything that doesn't use the standard log format will be rolled up in to a single entry.

But I quite like this. The only occurrences should be some startup and shutdown messages that don't go through the logger. Rolling these up is convenient.

![CleanShot 2024-09-04 at 13 09 37@2x](https://github.com/user-attachments/assets/de83e61a-8e27-480b-9e68-571241d42ebc)


## Validation

SPARQL query rolled up

![CleanShot 2024-09-04 at 13 12 08@2x](https://github.com/user-attachments/assets/a50e6c6e-4060-4dea-8f3d-5acc00cad707)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- Resolves #583 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
