### PR TITLE
Fix context menu styles

### DIFF
--- a/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.styles.ts
@@ -8,7 +8,7 @@ const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
     margin: 0;
     border-radius: ${theme.shape.borderRadius};
 
-    .list-item {
+    .collapsed-action-list-item {
       border-radius: ${theme.shape.borderRadius};
       font-size: ${theme.typography.sizes.xs};
       padding-right: ${theme.spacing["2x"]};

--- a/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/CollapsedActions.tsx
@@ -49,7 +49,7 @@ const CollapsedActions = ({
             >
               <UseLayerTrigger>
                 <ListItem
-                  className={cx("list-item", {
+                  className={cx("collapsed-action-list-item", {
                     ["submenu-is-open"]: open === actionIndex,
                     ["submenu-is-disabled"]: action.isDisabled,
                   })}
@@ -77,7 +77,7 @@ const CollapsedActions = ({
           <ListItem
             key={action.value}
             ref={action.ref}
-            className="list-item"
+            className="collapsed-action-list-item"
             clickable={!action.isDisabled}
             onClick={() => {
               onActionClick(action.value);

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.styles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.styles.ts
@@ -19,7 +19,7 @@ const defaultStyles: ThemeStyleFn = ({ theme }) => css`
       padding: ${theme.spacing.base} ${theme.spacing["4x"]};
     }
 
-    .list-item {
+    .context-menu-list-item {
       &.list-item-header {
         .primary {
           font-weight: ${theme.typography.weight?.bold};

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -181,14 +181,14 @@ const ContextMenu = ({
       >
         <Card className={"card-root"}>
           <ListItem
-            className={cx("list-item", "list-item-header")}
+            className={cx("context-menu-list-item", "list-item-header")}
             startAdornment={<GraphIcon />}
           >
             {getDisplayNames(affectedNode)?.name}
           </ListItem>
           <div className={"divider"} />
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -196,7 +196,7 @@ const ContextMenu = ({
             Details Panel
           </ListItem>
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={openSidebarPanel("expand")}
             startAdornment={<ExpandGraphIcon />}
@@ -204,7 +204,7 @@ const ContextMenu = ({
             Expand Panel
           </ListItem>
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={openSidebarPanel("nodes-styling", {
               nodeType: affectedNode.data.type,
@@ -215,7 +215,7 @@ const ContextMenu = ({
           </ListItem>
           <div className={"divider"} />
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={handleRemoveFromCanvas([affectedNode.data.id], [])}
             startAdornment={<RemoveFromCanvasIcon color={"red"} />}
@@ -234,14 +234,14 @@ const ContextMenu = ({
       >
         <Card className={"card-root"}>
           <ListItem
-            className={cx("list-item", "list-item-header")}
+            className={cx("context-menu-list-item", "list-item-header")}
             startAdornment={<EdgeIcon />}
           >
             {getDisplayNames(affectedEdge)?.name}
           </ListItem>
           <div className={"divider"} />
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -249,7 +249,7 @@ const ContextMenu = ({
             Details Panel
           </ListItem>
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={openSidebarPanel("edges-styling", {
               edgeType: affectedEdge.data.type,
@@ -260,7 +260,7 @@ const ContextMenu = ({
           </ListItem>
           <div className={"divider"} />
           <ListItem
-            className={"list-item"}
+            className={"context-menu-list-item"}
             clickable={true}
             onClick={handleRemoveFromCanvas([], [affectedEdge.data.id])}
             startAdornment={<RemoveFromCanvasIcon color={"red"} />}
@@ -278,7 +278,7 @@ const ContextMenu = ({
     >
       <Card className={"card-root"}>
         <ListItem
-          className={"list-item"}
+          className={"context-menu-list-item"}
           clickable={true}
           onClick={handleFitToFrame}
           startAdornment={<FitToFrameIcon />}
@@ -286,7 +286,7 @@ const ContextMenu = ({
           {nonEmptySelection ? "Fit Selection to Frame" : "Fit to Frame"}
         </ListItem>
         <ListItem
-          className={"list-item"}
+          className={"context-menu-list-item"}
           clickable={true}
           onClick={handleCenter}
           startAdornment={<CenterGraphIcon />}
@@ -294,7 +294,7 @@ const ContextMenu = ({
           {nonEmptySelection ? "Center Selection" : "Center"}
         </ListItem>
         <ListItem
-          className={"list-item"}
+          className={"context-menu-list-item"}
           clickable={true}
           onClick={handleDownloadScreenshot}
           startAdornment={<ScreenshotIcon />}
@@ -303,7 +303,7 @@ const ContextMenu = ({
         </ListItem>
         <div className={"divider"} />
         <ListItem
-          className={"list-item"}
+          className={"context-menu-list-item"}
           clickable={true}
           onClick={handleZoomIn}
           startAdornment={<ZoomInIcon />}
@@ -311,7 +311,7 @@ const ContextMenu = ({
           Zoom in
         </ListItem>
         <ListItem
-          className={"list-item"}
+          className={"context-menu-list-item"}
           clickable={true}
           onClick={handleZoomOut}
           startAdornment={<ZoomOutIcon />}
@@ -322,7 +322,7 @@ const ContextMenu = ({
           <>
             <div className={"divider"} />
             <ListItem
-              className={"list-item"}
+              className={"context-menu-list-item"}
               clickable={true}
               onClick={handleRemoveFromCanvas(
                 Array.from(nodesSelectedIds),
@@ -338,7 +338,7 @@ const ContextMenu = ({
           <>
             <div className={"divider"} />
             <ListItem
-              className={"list-item"}
+              className={"context-menu-list-item"}
               clickable={true}
               onClick={handleRemoveAllFromCanvas}
               startAdornment={<RemoveFromCanvasIcon color={"red"} />}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The context menu was broken because the style name `list-item` collides with a Tailwind class called `list-item`. I renamed the existing `list-item` classes to avoid the collision.

## Validation

![CleanShot 2024-09-09 at 12 10 34@2x](https://github.com/user-attachments/assets/f16039b2-41c8-4baa-80e4-e9750b46dc43)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #590

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
