### PR TITLE
Remove searchById

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
@@ -44,7 +44,6 @@ describe("Gremlin > keywordSearch", () => {
       searchTerm: "SFA",
       vertexTypes: ["airport"],
       searchByAttributes: ["code"],
-      searchById: false,
     });
 
     expect(keywordResponse).toMatchObject({

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -59,7 +59,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       exactMatch: true,
       searchByAttributes: ["__id"],
     });
@@ -73,7 +72,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       exactMatch: false,
       searchByAttributes: ["__id"],
     });
@@ -88,7 +86,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
   it("Should return a template for searched attributes matching with the search terms, and the ID token attribute", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
-      searchById: true,
       searchByAttributes: ["city", "code", "__all"],
     });
 
@@ -121,7 +118,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
       searchByAttributes: ["code"],
-      searchById: false,
       offset: 2,
       limit: 10,
     });
@@ -136,7 +132,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
       searchTerm: "JFK",
       vertexTypes: ["airport"],
       searchByAttributes: ["code"],
-      searchById: false,
       limit: 25,
       offset: 1,
     });

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -6,7 +6,6 @@ import { escapeString } from "@/utils";
  * @example
  * searchTerm = "JFK"
  * vertexTypes = ["airport"]
- * searchById = false
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
@@ -23,7 +22,6 @@ import { escapeString } from "@/utils";
 export default function keywordSearchTemplate({
   searchTerm,
   vertexTypes = [],
-  searchById = true,
   searchByAttributes = [],
   limit = 10,
   offset = 0,
@@ -39,11 +37,11 @@ export default function keywordSearchTemplate({
     template += `.hasLabel(${hasLabelContent})`;
   }
 
-  if (Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById)) {
+  if (searchTerm) {
     const escapedSearchTerm = escapeString(searchTerm);
 
     const orContent = uniq(
-      searchById && searchByAttributes.includes("__all")
+      searchByAttributes.includes("__all")
         ? ["__id", ...searchByAttributes]
         : searchByAttributes
     )

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -101,7 +101,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       exactMatch: true,
       searchByAttributes: ["__id"],
     });
@@ -119,7 +118,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       exactMatch: false,
       searchByAttributes: ["__id"],
     });
@@ -137,7 +135,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchById: true,
       searchByAttributes: ["city", "code", "__all"],
     });
 
@@ -154,7 +151,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport", "country"],
       searchTerm: "JFK",
-      searchById: true,
       exactMatch: false,
       searchByAttributes: ["city", "code", "__all"],
       limit: 50,

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -7,7 +7,6 @@ import dedent from "dedent";
  * @example
  * searchTerm = "JFK"
  * vertexTypes = ["airport"]
- * searchById = false
  * searchByAttributes = ["city", "code"]
  * limit = 100
  * offset = 0
@@ -22,7 +21,6 @@ import dedent from "dedent";
 const keywordSearchTemplate = ({
   searchTerm,
   vertexTypes = [],
-  searchById,
   searchByAttributes = [],
   limit,
   offset,
@@ -37,12 +35,11 @@ const keywordSearchTemplate = ({
     vertexTypes.map(type => `v:\`${type}\``).join(" OR ");
 
   // If we have a search term we need to build the search term where clause
-  const hasSearchTerm =
-    Boolean(searchTerm) && (searchByAttributes.length !== 0 || searchById);
+  const hasSearchTerm = Boolean(searchTerm);
   const searchTermWhereClause =
     hasSearchTerm &&
     uniq(
-      searchById && searchByAttributes.includes("__all")
+      searchByAttributes.includes("__all")
         ? ["__id", ...searchByAttributes]
         : searchByAttributes
     )

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -167,10 +167,6 @@ export type KeywordSearchRequest = {
    */
   searchTerm?: string;
   /**
-   * Include the Node ID in the attributes
-   */
-  searchById?: boolean;
-  /**
    * Filter by attribute names.
    */
   searchByAttributes?: Array<string>;

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearchQuery.ts
@@ -28,7 +28,6 @@ export function useKeywordSearchQuery({
     ? {
         searchTerm: debouncedSearchTerm,
         vertexTypes,
-        searchById: true,
         limit: 10,
         // Only set these when there is a search term to reduce queries
         searchByAttributes: debouncedSearchTerm


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The search query parameter `searchById` may have done something in the past, but ever since we added the ability to search specifically by the ID field it has served no purpose. But I've been too cautious to remove it before because I wasn't confident enough in how the search algorithm worked.

Now I am confident enough to remove it. It does not affect the logic whatsoever. There are two places where the search query is executed:

- In keyword search, where the value is always set to `true`
- In data explorer, where a search term is never passed

So, in reality, the value is always `true` or it is irrelevant. Removing it simplifies the search logic and clarifies intent in the algorithm.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Ran through search permutations using all forms of search parameters with and without search terms in all three query languages
- Verified data explorer still works as before

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
