### PR TITLE
Fix keyword search close button alignment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
   ([#600](https://github.com/aws/graph-explorer/pull/600))
 - **Improved** support for databases with thousands of node & edge types
   ([#599](https://github.com/aws/graph-explorer/pull/599))
+- **Fixed** alignment of close button in search panel
+  ([#603](https://github.com/aws/graph-explorer/pull/603))
 
 ## Release 1.10.0
 

--- a/packages/graph-explorer/src/components/IconButton/IconButton.tsx
+++ b/packages/graph-explorer/src/components/IconButton/IconButton.tsx
@@ -93,7 +93,7 @@ export const IconButton = (
   if (tooltipText) {
     return (
       <Tooltip text={tooltipText} placement={tooltipPlacement} delayEnter={400}>
-        <span>{component}</span>
+        {component}
       </Tooltip>
     );
   }

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.styles.ts
@@ -48,24 +48,6 @@ const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
     width: 100vw;
     z-index: ${theme.zIndex.popover};
 
-    .search-controls {
-      display: flex;
-      flex-direction: row;
-      height: 42px;
-      column-gap: ${theme.spacing["2x"]};
-
-      .search-input {
-        flex-grow: 5;
-        width: unset;
-      }
-
-      .entity-select {
-        flex-grow: 1;
-        min-width: 100px;
-        width: 100px;
-      }
-    }
-
     .node-preview {
       width: 50%;
     }

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -184,9 +184,9 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
       )}
       {isFocused && (
         <Card ref={ref} className="panel-container" elevation={3}>
-          <div className="search-controls">
+          <div className="flex h-[42px] flex-row gap-2">
             <Select
-              className="entity-select"
+              className="w-[100px] min-w-[100px] grow"
               label={t("keyword-search.node-type")}
               labelPlacement="inner"
               hideError={true}
@@ -196,7 +196,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
               menuWidth={150}
             />
             <Select
-              className="entity-select"
+              className="w-[100px] min-w-[100px] grow"
               label={t("keyword-search.node-attribute")}
               labelPlacement="inner"
               hideError={true}
@@ -206,7 +206,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
               menuWidth={150}
             />
             <Select
-              className="entity-select"
+              className="w-[100px] min-w-[100px] grow"
               label={t("keyword-search.node-exact-match")}
               labelPlacement="inner"
               hideError={true}
@@ -216,7 +216,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
               menuWidth={150}
             />
             <Input
-              className="search-input"
+              className="grow-[5]"
               aria-label="Search box"
               hideError={true}
               autoFocus={true}
@@ -225,7 +225,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
               placeholder={searchPlaceholder}
             />
             <IconButton
-              className="close-button"
+              className="close-button self-center"
               variant="text"
               tooltipText="Close search"
               tooltipPlacement="bottom-center"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes the alignment of the close button in the search panel to be centered in the row of inputs.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

### Old
![CleanShot 2024-09-10 at 18 19 56@2x](https://github.com/user-attachments/assets/75f54fed-00cb-4308-83be-557ddf06b2d8)

### New
![CleanShot 2024-09-10 at 18 23 30@2x](https://github.com/user-attachments/assets/d5737482-860b-443f-9d06-d34c72d1b21b)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
