### PR TITLE
Remove filter for all vertex types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
   ([#613](https://github.com/aws/graph-explorer/pull/613))
 - **Improved** Docker image size, reducing it by 196 MB
   ([#619](https://github.com/aws/graph-explorer/pull/619))
+- **Improved** query when searching across all node types
+  ([#607](https://github.com/aws/graph-explorer/pull/607))
 - **Improved** query generation by removing empty lines
   ([#608](https://github.com/aws/graph-explorer/pull/608))
 - **Fixed** security vulnerabilities in the Docker image from dev dependencies

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -2,7 +2,7 @@ import keywordSearchTemplate from "./keywordSearchTemplate";
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 
 describe("Gremlin > keywordSearchTemplate", () => {
-  it("Should return a template only with default range", () => {
+  it("Should return a template for an empty request", () => {
     const template = keywordSearchTemplate({});
 
     expect(normalize(template)).toBe(normalize("g.V().range(0,10)"));

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
@@ -1,0 +1,101 @@
+import { createRandomInteger, createRandomName } from "@shared/utils/testing";
+import mapApiVertex from "./mapApiVertex";
+
+test("maps empty vertex", () => {
+  const input = {
+    "~labels": [],
+    "~entityType": "node",
+    "~id": "",
+    "~properties": {},
+  };
+  const result = mapApiVertex(input);
+
+  expect(result).toEqual({
+    data: {
+      id: "",
+      idType: "string",
+      type: "",
+      types: [],
+      attributes: {},
+      neighborsCount: 0,
+      neighborsCountByType: {},
+    },
+  });
+});
+
+test("applies the given counts", () => {
+  const input = {
+    "~labels": [],
+    "~entityType": "node",
+    "~id": "",
+    "~properties": {},
+  };
+  const counts = {
+    totalCount: createRandomInteger(),
+    counts: {
+      [`${createRandomName("label")}`]: createRandomInteger(),
+    },
+  };
+  const result = mapApiVertex(input, counts);
+
+  expect(result).toEqual({
+    data: {
+      id: "",
+      idType: "string",
+      type: "",
+      types: [],
+      attributes: {},
+      neighborsCount: counts.totalCount,
+      neighborsCountByType: counts.counts,
+    },
+  });
+});
+
+test("maps airport node", () => {
+  const input = {
+    "~id": "1",
+    "~entityType": "node",
+    "~labels": ["airport"],
+    "~properties": {
+      code: "ATL",
+      type: "airport",
+      desc: "Hartsfield - Jackson Atlanta International Airport",
+      country: "US",
+      longest: 12390,
+      city: "Atlanta",
+      lon: -84.4281005859375,
+      elev: 1026,
+      icao: "KATL",
+      region: "US-GA",
+      runways: 5,
+      lat: 33.6366996765137,
+    },
+  };
+
+  const result = mapApiVertex(input);
+
+  expect(result).toEqual({
+    data: {
+      id: "1",
+      idType: "string",
+      type: "airport",
+      types: ["airport"],
+      attributes: {
+        city: "Atlanta",
+        code: "ATL",
+        country: "US",
+        desc: "Hartsfield - Jackson Atlanta International Airport",
+        elev: 1026,
+        icao: "KATL",
+        lat: 33.6366996765137,
+        lon: -84.4281005859375,
+        longest: 12390,
+        region: "US-GA",
+        runways: 5,
+        type: "airport",
+      },
+      neighborsCount: 0,
+      neighborsCountByType: {},
+    },
+  });
+});

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -2,12 +2,12 @@ import type { Vertex } from "@/@types/entities";
 import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import type { OCVertex } from "../types";
 
-const mapApiVertex = (
+export default function mapApiVertex(
   apiVertex: OCVertex,
   neighborsCount: NeighborsCountResponse = { totalCount: 0, counts: {} }
-): Vertex => {
+): Vertex {
   const labels = apiVertex["~labels"];
-  const vt = labels[0];
+  const vt = labels[0] ?? "";
 
   return {
     data: {
@@ -20,6 +20,4 @@ const mapApiVertex = (
       attributes: apiVertex["~properties"],
     },
   };
-};
-
-export default mapApiVertex;
+}

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -8,7 +8,6 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v)
-        WHERE (size(labels(v)) > 0) 
         RETURN v AS object 
       `)
     );

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -2,6 +2,18 @@ import { normalize } from "@/utils/testing";
 import keywordSearchTemplate from "./keywordSearchTemplate";
 
 describe("OpenCypher > keywordSearchTemplate", () => {
+  it("Should return a template for empty request", () => {
+    const template = keywordSearchTemplate({});
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v)
+        WHERE (size(labels(v)) > 0) 
+        RETURN v AS object 
+      `)
+    );
+  });
+
   it("Should return a template only for vertex type", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -30,10 +30,8 @@ const keywordSearchTemplate = ({
     vertexTypes.length === 1 ? `v:\`${vertexTypes[0]}\`` : "v";
   // For multiple vertex types we use the where clause
   const vertexTypeWhereClause =
-    vertexTypes.length == 0
-      ? `size(labels(v)) > 0`
-      : vertexTypes.length > 1 &&
-        vertexTypes.map(type => `v:\`${type}\``).join(" OR ");
+    vertexTypes.length > 1 &&
+    vertexTypes.map(type => `v:\`${type}\``).join(" OR ");
 
   // If we have a search term we need to build the search term where clause
   const hasSearchTerm = Boolean(searchTerm);

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.ts
@@ -30,8 +30,10 @@ const keywordSearchTemplate = ({
     vertexTypes.length === 1 ? `v:\`${vertexTypes[0]}\`` : "v";
   // For multiple vertex types we use the where clause
   const vertexTypeWhereClause =
-    vertexTypes.length > 1 &&
-    vertexTypes.map(type => `v:\`${type}\``).join(" OR ");
+    vertexTypes.length == 0
+      ? `size(labels(v)) > 0`
+      : vertexTypes.length > 1 &&
+        vertexTypes.map(type => `v:\`${type}\``).join(" OR ");
 
   // If we have a search term we need to build the search term where clause
   const hasSearchTerm = Boolean(searchTerm);

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
@@ -2,6 +2,24 @@ import { normalize } from "@/utils/testing";
 import keywordSearchTemplate from "./keywordSearchTemplate";
 
 describe("SPARQL > keywordSearchTemplate", () => {
+  it("Should return a template for an empty request", () => {
+    const template = keywordSearchTemplate({});
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT ?subject ?pred ?value ?class { 
+          ?subject ?pred ?value { 
+            SELECT DISTINCT ?subject ?class { 
+              ?subject a ?class ; ?predicate ?value . 
+            } 
+            LIMIT 10 OFFSET 0 
+          } 
+          FILTER(isLiteral(?value)) 
+        }
+      `)
+    );
+  });
+
   it("Should return a template only for vertex type", () => {
     const template = keywordSearchTemplate({
       subjectClasses: ["air:airport"],

--- a/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
+++ b/packages/graph-explorer/src/modules/KeywordSearch/useKeywordSearch.ts
@@ -170,9 +170,7 @@ const useKeywordSearch = ({ isOpen }: { isOpen: boolean }) => {
   }, [config?.connection?.queryEngine, allowsIdSearch, attributesOptions]);
 
   const vertexTypes =
-    selectedVertexType === allVerticesValue
-      ? config?.vertexTypes
-      : [selectedVertexType];
+    selectedVertexType === allVerticesValue ? [] : [selectedVertexType];
   const searchByAttributes =
     selectedAttribute === allAttributesValue
       ? uniq(


### PR DESCRIPTION
## Description

When searching across all vertex types, the query that is generated will include a list of all the known vertex types. This filter is unnecessary and can lead to slower query performance.

Once the filter is removed we must consider a result from the query that include nodes which have no type or label.

- Gremlin does not support vertices without labels, so is not a concern
- OpenCypher supports empty labels, but Neptune doesn't support them
  - Originally, I added a filter to ensure at least one label exists, but this was noticeably slow so I removed it
  - If the label array is empty we'll use an empty string for the label to ensure the rest of the app continues to function properly
- SPARQL allows resources without classes, but the query already filters down to only the resources with a class defined

## Validation

- Verified in all query languages

## Related Issues

- Resolves #594 
- Resolves #595 
- Resolves #596
- Resolves #533

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.