### PR TITLE
Remove development and documentation related files from Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,15 @@
 # Avoid copying node_modules to fix issue with esbuild working on a macOS computer with an ARM processor 
 # More info: https://esbuild.github.io/getting-started/#simultaneous-platforms
 node_modules
+
+# Ignore development related files
+.git
+.github
+.husky
+.vscode
+coverage
+
+# Ignore documentation related files
+additionaldocs
+images
+*.md

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # graph-explorer Change Log
 
+## Upcoming
+
+- **Fixed** Docker image containing more files than necessary.
+  ([#613](https://github.com/aws/graph-explorer/pull/613))
+
 ## Release 1.10.1
 
 - **Improved** support for databases with thousands of node & edge types


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

- Removes `package` write permissions from Docker image workflow
- Updates `.dockerignore` file to exclude development files and documentation

## Validation

- [x] Built and loaded Docker container to ensure `.git` folder and other dev and doc files were not present
- [x] Verify docker image still runs Graph Explorer fine

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
