### PR TITLE
Remove limit defaults for search query

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -5,7 +5,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
   it("Should return a template for an empty request", () => {
     const template = keywordSearchTemplate({});
 
-    expect(normalize(template)).toBe(normalize("g.V().range(0,10)"));
+    expect(normalize(template)).toBe(normalize("g.V()"));
   });
 
   it("Should return a template only for vertex type", () => {
@@ -13,9 +13,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
       vertexTypes: ["airport"],
     });
 
-    expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport").range(0,10)')
-    );
+    expect(normalize(template)).toBe(normalize('g.V().hasLabel("airport")'));
   });
 
   it("Should return a template for searched attributes containing the search term", () => {
@@ -26,7 +24,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(
-        'g.V().or(has("city",containing("JFK")),has("code",containing("JFK"))).range(0,10)'
+        'g.V().or(has("city",containing("JFK")),has("code",containing("JFK")))'
       )
     );
   });
@@ -39,7 +37,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("city","JFK"),has("code","JFK")).range(0,10)')
+      normalize('g.V().or(has("city","JFK"),has("code","JFK"))')
     );
   });
 
@@ -51,7 +49,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("code","\\"JFK\\"")).range(0,10)')
+      normalize('g.V().or(has("code","\\"JFK\\""))')
     );
   });
 
@@ -64,7 +62,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport").or(has(id,"JFK")).range(0,10)')
+      normalize('g.V().hasLabel("airport").or(has(id,"JFK"))')
     );
   });
 
@@ -77,9 +75,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize(
-        'g.V().hasLabel("airport").or(has(id,containing("JFK"))).range(0,10)'
-      )
+      normalize('g.V().hasLabel("airport").or(has(id,containing("JFK")))')
     );
   });
 
@@ -97,7 +93,6 @@ describe("Gremlin > keywordSearchTemplate", () => {
             has("city", containing("JFK")), 
             has("code", containing("JFK"))
           )
-          .range(0,10)
       `)
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.test.ts
@@ -122,6 +122,30 @@ describe("Gremlin > keywordSearchTemplate", () => {
     );
   });
 
+  it("Should return a template with just a limit", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchByAttributes: ["code"],
+      limit: 10,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().or(has("code",containing("JFK"))).range(0,10)')
+    );
+  });
+
+  it("Should return a template without a range when limit is zero", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchByAttributes: ["code"],
+      limit: 0,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().or(has("code",containing("JFK")))')
+    );
+  });
+
   it("Should return a template for a specific vertex type", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",

--- a/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/keywordSearchTemplate.ts
@@ -23,7 +23,7 @@ export default function keywordSearchTemplate({
   searchTerm,
   vertexTypes = [],
   searchByAttributes = [],
-  limit = 10,
+  limit,
   offset = 0,
   exactMatch = false,
 }: KeywordSearchRequest): string {
@@ -63,6 +63,8 @@ export default function keywordSearchTemplate({
     template += `.or(${orContent})`;
   }
 
-  template += `.range(${offset},${offset + limit})`;
+  if (limit) {
+    template += `.range(${offset},${offset + limit})`;
+  }
   return template;
 }

--- a/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/keywordSearchTemplate.test.ts
@@ -56,6 +56,35 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     );
   });
 
+  it("Should return a template with just a limit", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      limit: 20,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v:\`airport\`)
+        RETURN v AS object
+        LIMIT 20
+      `)
+    );
+  });
+
+  it("Should return a template where a limit of zero is not limited", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport"],
+      limit: 0,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v:\`airport\`)
+        RETURN v AS object
+      `)
+    );
+  });
+
   it("Should return a template with multiple vertex types and for searched attributes containing the search term", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport", "country"],

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
@@ -16,7 +16,7 @@ export default function keywordSearchBlankNodesIdsTemplate({
   searchTerm,
   subjectClasses = [],
   predicates = [],
-  limit = 10,
+  limit,
   offset = 0,
   exactMatch = true,
 }: SPARQLKeywordSearchRequest): string {
@@ -31,7 +31,7 @@ export default function keywordSearchBlankNodesIdsTemplate({
             ${getSubjectClasses(subjectClasses)}
             ${getFilterObject(exactMatch, searchTerm)}
         }
-        ${limit > 0 ? `LIMIT ${limit} OFFSET ${offset}` : ""}
+        ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""}
       }
       FILTER(isLiteral(?value))
       FILTER(isBlank(?bNode))

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
@@ -12,6 +12,25 @@ describe("SPARQL > keywordSearchTemplate", () => {
             SELECT DISTINCT ?subject ?class { 
               ?subject a ?class ; ?predicate ?value . 
             } 
+          } 
+          FILTER(isLiteral(?value)) 
+        }
+      `)
+    );
+  });
+
+  it("Should return a template with paging", () => {
+    const template = keywordSearchTemplate({
+      limit: 10,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT ?subject ?pred ?value ?class { 
+          ?subject ?pred ?value { 
+            SELECT DISTINCT ?subject ?class { 
+              ?subject a ?class ; ?predicate ?value . 
+            } 
             LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
@@ -33,7 +52,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               ?subject a ?class ; ?predicate ?value . 
               FILTER (?class IN (<air:airport>))
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }
@@ -59,7 +77,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               FILTER (?class IN (<air:airport>))
               FILTER (regex(str(?value), "JFK", "i"))
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }
@@ -85,7 +102,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               FILTER (?class IN (<air:airport>))
               FILTER (?value = "JFK")
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }
@@ -111,7 +127,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               FILTER (?class IN (<air:airport>))
               FILTER (?value = "JFK")
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }
@@ -137,7 +152,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               FILTER (?class IN (<air:airport>))
               FILTER (?value = "JFK")
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }
@@ -163,7 +177,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
               FILTER (?class IN (<air:airport>))
               FILTER (regex(str(?value), "JFK", "i"))
             } 
-            LIMIT 10 OFFSET 0 
           } 
           FILTER(isLiteral(?value)) 
         }

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.test.ts
@@ -22,6 +22,27 @@ describe("SPARQL > keywordSearchTemplate", () => {
   it("Should return a template with paging", () => {
     const template = keywordSearchTemplate({
       limit: 10,
+      offset: 20,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT ?subject ?pred ?value ?class { 
+          ?subject ?pred ?value { 
+            SELECT DISTINCT ?subject ?class { 
+              ?subject a ?class ; ?predicate ?value . 
+            } 
+            LIMIT 10 OFFSET 20 
+          } 
+          FILTER(isLiteral(?value)) 
+        }
+      `)
+    );
+  });
+
+  it("Should return a template with just a limit", () => {
+    const template = keywordSearchTemplate({
+      limit: 10,
     });
 
     expect(normalize(template)).toBe(
@@ -32,6 +53,25 @@ describe("SPARQL > keywordSearchTemplate", () => {
               ?subject a ?class ; ?predicate ?value . 
             } 
             LIMIT 10 OFFSET 0 
+          } 
+          FILTER(isLiteral(?value)) 
+        }
+      `)
+    );
+  });
+
+  it("Should return a template where a limit of zero is not limited", () => {
+    const template = keywordSearchTemplate({
+      limit: 0,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT ?subject ?pred ?value ?class { 
+          ?subject ?pred ?value { 
+            SELECT DISTINCT ?subject ?class { 
+              ?subject a ?class ; ?predicate ?value . 
+            } 
           } 
           FILTER(isLiteral(?value)) 
         }

--- a/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/templates/keywordSearch/keywordSearchTemplate.ts
@@ -42,7 +42,7 @@ export default function keywordSearchTemplate({
   searchTerm,
   subjectClasses = [],
   predicates = [],
-  limit = 10,
+  limit,
   offset = 0,
   exactMatch = false,
 }: SPARQLKeywordSearchRequest): string {
@@ -57,7 +57,7 @@ export default function keywordSearchTemplate({
             ${getSubjectClasses(subjectClasses)}
             ${getFilterObject(exactMatch, searchTerm)}
         }
-        ${limit > 0 ? `LIMIT ${limit} OFFSET ${offset}` : ""}
+        ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""}
       }
       FILTER(isLiteral(?value))
     }

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -8,7 +8,7 @@ const RESPONSES_FILES_MAP: Record<string, string> = {
   "2c38e2dd": `${GREMLIN}/edges-schema.json`,
   "7062d2e": `${GREMLIN}/edges-labels-and-counts.json`,
   "35be2501": `${GREMLIN}/should-return-1-random-node.json`,
-  "54fa1494": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
+  "4b332677": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
   "1559ced5": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
   "37e14b1": `${GREMLIN}/should-return-all-neighbors-from-node-2018-counts.json`,
   "7afef36": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The keyword search query template functions had a default value for the limit. Since the two places it is called already pass the limit (search and data explorer) I have removed the parameter default to allow for an unbounded request if desired.

## Validation

- Tested with all query languages

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #622 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
