### PR TITLE
Fix clashing node ID property

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 - **Fixed** Docker image containing more files than necessary.
   ([#613](https://github.com/aws/graph-explorer/pull/613))
+- **Fixed** conflict when a node has a property named "id" that prevented
+  changing the display attribute.
+  ([#626](https://github.com/aws/graph-explorer/pull/626))
 - **Improved** Docker image size, reducing it by 196 MB
   ([#619](https://github.com/aws/graph-explorer/pull/619))
 - **Improved** query when searching across all node types

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchSchema.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchSchema.ts
@@ -1,5 +1,8 @@
 import { batchPromisesSerially } from "@/utils";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
+import {
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+  RESERVED_ID_PROPERTY,
+} from "@/utils/constants";
 import type { SchemaResponse } from "@/connector/useGEFetchTypes";
 import classesWithCountsTemplates from "../templates/classesWithCountsTemplates";
 import predicatesByClassTemplate from "../templates/predicatesByClassTemplate";
@@ -102,7 +105,7 @@ const fetchPredicatesByClass = async (
     total: countsByClass[resourceClass],
     displayNameAttribute:
       attributes.find(attr => displayNameCandidates.includes(attr.name))
-        ?.name || "id",
+        ?.name || RESERVED_ID_PROPERTY,
     longDisplayNameAttribute:
       attributes.find(attr => displayDescCandidates.includes(attr.name))
         ?.name || "types",

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -10,12 +10,13 @@ import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 import { SchemaInference } from "./schema";
 import { UserStyling } from "./userPreferences";
 import { sanitizeText } from "@/utils";
+import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 const defaultVertexStyle = {
   color: "#128EE5",
   iconUrl: DEFAULT_ICON_URL,
   iconImageType: "image/svg+xml",
-  displayNameAttribute: "id",
+  displayNameAttribute: RESERVED_ID_PROPERTY,
   longDisplayNameAttribute: "types",
 };
 

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -17,6 +17,7 @@ import {
   VertexPreferences,
 } from "./userPreferences";
 import isDefaultValue from "./isDefaultValue";
+import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 export const isStoreLoadedAtom = atom<boolean>({
   key: "store-loaded",
@@ -178,7 +179,7 @@ const mergeVertex = (
     color: "#128EE5",
     iconUrl: DEFAULT_ICON_URL,
     iconImageType: "image/svg+xml",
-    displayNameAttribute: "id",
+    displayNameAttribute: RESERVED_ID_PROPERTY,
     longDisplayNameAttribute: "types",
     // Automatic schema override
     ...(schemaVertex || {}),

--- a/packages/graph-explorer/src/hooks/useDisplayNames.ts
+++ b/packages/graph-explorer/src/hooks/useDisplayNames.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Edge, Vertex } from "@/types/entities";
 import { useConfiguration } from "@/core";
 import useTextTransform from "./useTextTransform";
+import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 const isVertex = (vOrE: any): vOrE is Vertex => {
   return vOrE.data.neighborsCount != null;
@@ -35,7 +36,7 @@ const useDisplayNames = () => {
           longDisplayNameAttribute: __longName,
         } = vtConfig;
 
-        if (__name === "id") {
+        if (__name === RESERVED_ID_PROPERTY) {
           name = vertex.data.id;
         } else if (__name === "types") {
           name = (vertex.data.types ?? [vertex.data.type])
@@ -45,7 +46,7 @@ const useDisplayNames = () => {
           name = attrs[__name] ? String(attrs[__name]) : "---";
         }
 
-        if (__longName === "id") {
+        if (__longName === RESERVED_ID_PROPERTY) {
           longName = vertex.data.id;
         } else if (__longName === "types") {
           longName = (vertex.data.types ?? [vertex.data.type])

--- a/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/NodeDetail.tsx
@@ -10,6 +10,7 @@ import EntityAttribute from "./EntityAttribute";
 import defaultStyles from "./EntityDetail.styles";
 import VertexHeader from "@/modules/common/VertexHeader";
 import { useVertexTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
+import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 export type VertexDetailProps = {
   hideNeighbors?: boolean;
@@ -67,7 +68,7 @@ export default function NodeDetail({
                 : node.data.id
             }
             attribute={{
-              name: "id",
+              name: RESERVED_ID_PROPERTY,
               displayLabel: node.data.__isBlank
                 ? "Blank node ID"
                 : t("node-detail.node-id"),

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -30,6 +30,7 @@ import modalDefaultStyles from "./SingleNodeStylingModal.style";
 import { useVertexTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { cn } from "@/utils";
+import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 export type SingleNodeStylingProps = {
   vertexType: string;
@@ -78,7 +79,10 @@ export default function SingleNodeStyling({
       label: t("nodes-styling.node-type"),
       value: "types",
     });
-    options.unshift({ label: t("nodes-styling.node-id"), value: "id" });
+    options.unshift({
+      label: t("nodes-styling.node-id"),
+      value: RESERVED_ID_PROPERTY,
+    });
 
     return options;
   }, [t, textTransform, vtConfig.attributes]);

--- a/packages/graph-explorer/src/utils/constants.ts
+++ b/packages/graph-explorer/src/utils/constants.ts
@@ -3,6 +3,9 @@ export const DEFAULT_FETCH_TIMEOUT = 240000;
 export const DEFAULT_NODE_EXPAND_LIMIT = 500;
 export const DEFAULT_CONCURRENT_REQUESTS_LIMIT = 10;
 
+/** The name of the special property representing the node ID */
+export const RESERVED_ID_PROPERTY = "~id";
+
 /** The string "Graph Explorer". */
 export const APP_NAME = "Graph Explorer";
 

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -48,7 +48,7 @@ import useUpdateVertexTypeCounts from "@/hooks/useUpdateVertexTypeCounts";
 import defaultStyles from "./DataExplorer.styles";
 import { searchQuery } from "@/connector/queries";
 import { useVertexTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
-import { APP_NAME } from "@/utils/constants";
+import { APP_NAME, RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 export type ConnectionsProps = {
   vertexType: string;
@@ -193,7 +193,10 @@ function DisplayNameAndDescriptionOptions({
       label: t("data-explorer.node-type"),
       value: "types",
     });
-    options.unshift({ label: t("data-explorer.node-id"), value: "id" });
+    options.unshift({
+      label: t("data-explorer.node-id"),
+      value: RESERVED_ID_PROPERTY,
+    });
 
     return options;
   }, [t, textTransform, vertexConfig?.attributes]);


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

If a node has a property named `id` then Graph Explorer would not allow switching the display name and description for the node style. This is because the actual node ID used the key `id` which conflicts with the user property `id`.

To fix it I switched the id key to use `~id`, which is the standard in other AWS tooling.

## Validation

- Tested schema sync
- Tested node styling by changing display name and display description

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #618

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
