### PR TITLE
Use focus-visible instead of focus

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
   ([#607](https://github.com/aws/graph-explorer/pull/607))
 - **Improved** query generation by removing empty lines
   ([#608](https://github.com/aws/graph-explorer/pull/608))
+- **Fixed** style issue where buttons have a halo around them after being
+  clicked ([#650](https://github.com/aws/graph-explorer/pull/650))
 - **Fixed** security vulnerabilities in the Docker image from dev dependencies
   remaining in the image
   ([#616](https://github.com/aws/graph-explorer/pull/616))

--- a/packages/graph-explorer/src/components/Button/Button.styles.ts
+++ b/packages/graph-explorer/src/components/Button/Button.styles.ts
@@ -127,7 +127,7 @@ export const defaultStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary?.main}`};
@@ -175,7 +175,7 @@ export const defaultStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary?.main}`};
@@ -219,7 +219,7 @@ export const defaultStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary?.main}`};
@@ -264,7 +264,7 @@ export const defaultStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || error?.main}`};

--- a/packages/graph-explorer/src/components/IconButton/IconButton.styles.ts
+++ b/packages/graph-explorer/src/components/IconButton/IconButton.styles.ts
@@ -89,7 +89,7 @@ export const defaultIconButtonStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary.main}`};
@@ -161,7 +161,7 @@ export const defaultIconButtonStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary.main}`};
@@ -223,7 +223,7 @@ export const defaultIconButtonStyles =
             ${themeByVariant?.active?.border?.color || "transparent"};
         }
 
-        &:focus {
+        &:focus-visible {
           box-shadow: ${isDarkTheme
             ? "none"
             : `0 0 3px ${themeByVariant?.hover?.background || primary.main}`};
@@ -305,7 +305,7 @@ export const defaultToggleButtonStyles =
           background-color: ${themeByVariant?.hover?.background ||
           fade(theme.palette.primary.main, 0.5)};
           color: ${themeByVariant?.hover?.color || primary.dark};
-          &:focus {
+          &:focus-visible {
             box-shadow: none !important;
             border: 1px solid
               ${themeByVariant?.hover?.background ||

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.tsx
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeader.tsx
@@ -190,7 +190,7 @@ const ModuleContainerHeader = (
                   badge={action.badge}
                   badgeVariant={action.badgeVariant}
                   badgePlacement="bottom-right"
-                  className="hover:text-primary-main focus:text-primary-main focus:bg-primary-main/20"
+                  className="hover:text-primary-main focus-visible:text-primary-main focus-visible:bg-primary-main/20"
                 />
               </div>
             );

--- a/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.styles.ts
+++ b/packages/graph-explorer/src/components/ModuleContainer/components/ModuleContainerHeaderActions.styles.ts
@@ -22,7 +22,7 @@ const defaultStyles: ThemeStyleFn = ({ theme, isDarkTheme }) => css`
     color: ${theme.palette.primary.main};
   }
 
-  &.module-container-header-actions button:focus {
+  &.module-container-header-actions button:focus-visible {
     color: ${theme.palette.primary.main};
     background-color: ${fade(theme.palette.primary.main, 0.2)};
   }

--- a/packages/graph-explorer/src/components/TextArea/TextArea.styles.ts
+++ b/packages/graph-explorer/src/components/TextArea/TextArea.styles.ts
@@ -301,6 +301,8 @@ export const textAreaContainerStyles =
         &:focus {
           background-color: ${themeWithDefault?.focus?.background};
           color: ${themeWithDefault?.focus?.color};
+        }
+        &:focus-visible {
           outline: none;
           box-shadow: ${themeWithDefault?.focus?.outlineColor};
         }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix issue with style where the focus shadow would remain on buttons after clicking. Using `focus-visible` instead of `focus` will only apply the style when the user is using the keyboard or other accessibility tool to navigate the website. When the user uses a mouse/trackpad, the `focus-visible` styles will not be applied.

## Validation

- Verified `Select` and `Input` still show correct focus styles
- Verified tab to focus shows focus shadow
- Verified `Button` and `IconButton` no longer leave the focus shadow on click

## Related Issues

- Fixes #273

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
