### PR TITLE
Use strong types for VertexId and EdgeId

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -1,10 +1,15 @@
+import { Branded } from "@/utils";
+
+export type EdgeId = Branded<string, "EdgeId">;
+export type VertexId = Branded<string, "VertexId">;
+
 export interface VertexData {
   /**
    * Unique identifier for the vertex.
    * - For PG, the node id
    * - For RDF, the resource URI
    */
-  id: string;
+  id: VertexId;
   /**
    * Data type for the node id.
    * - For Gremlin, could be string or number
@@ -85,7 +90,7 @@ export interface EdgeData {
    * - For RDF, predicates do not have ids like PG graphs.
    *   So, a synthetic id is created using <source URI>-[predicate]-><target URI>
    */
-  id: string;
+  id: EdgeId;
   /**
    * Edge type.
    * - For PG, the label which identifies the relation type
@@ -95,7 +100,7 @@ export interface EdgeData {
   /**
    * Source vertex id
    */
-  source: string;
+  source: VertexId;
   /**
    * Source vertex type
    */
@@ -103,7 +108,7 @@ export interface EdgeData {
   /**
    * Target vertex id
    */
-  target: string;
+  target: VertexId;
   /**
    * Target vertex type
    */

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
@@ -1,4 +1,4 @@
-import type { Edge } from "@/@types/entities";
+import type { Edge, EdgeId, VertexId } from "@/@types/entities";
 import type { GEdge } from "../types";
 import parseEdgePropertiesValues from "./parseEdgePropertiesValues";
 import toStringId from "./toStringId";
@@ -6,11 +6,11 @@ import toStringId from "./toStringId";
 const mapApiEdge = (apiEdge: GEdge): Edge => {
   return {
     data: {
-      id: toStringId(apiEdge["@value"].id),
+      id: toStringId(apiEdge["@value"].id) as EdgeId,
       type: apiEdge["@value"].label,
-      source: toStringId(apiEdge["@value"].outV),
+      source: toStringId(apiEdge["@value"].outV) as VertexId,
       sourceType: apiEdge["@value"].outVLabel,
-      target: toStringId(apiEdge["@value"].inV),
+      target: toStringId(apiEdge["@value"].inV) as VertexId,
       targetType: apiEdge["@value"].inVLabel,
       attributes: parseEdgePropertiesValues(apiEdge["@value"].properties || {}),
     },

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -1,4 +1,4 @@
-import type { Vertex } from "@/@types/entities";
+import type { Vertex, VertexId } from "@/@types/entities";
 import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import type { GVertex } from "../types";
 import { detectIdType } from "./detectIdType";
@@ -14,7 +14,7 @@ const mapApiVertex = (
 
   return {
     data: {
-      id: toStringId(apiVertex["@value"].id),
+      id: toStringId(apiVertex["@value"].id) as VertexId,
       idType: detectIdType(apiVertex["@value"].id),
       type: vt,
       types: labels,

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
@@ -1,4 +1,4 @@
-import type { Edge } from "@/@types/entities";
+import type { Edge, EdgeId, VertexId } from "@/@types/entities";
 import type { OCEdge } from "../types";
 
 const mapApiEdge = (
@@ -8,11 +8,11 @@ const mapApiEdge = (
 ): Edge => {
   return {
     data: {
-      id: apiEdge["~id"],
+      id: apiEdge["~id"] as EdgeId,
       type: apiEdge["~type"],
-      source: apiEdge["~start"],
+      source: apiEdge["~start"] as VertexId,
       sourceType: sourceType,
-      target: apiEdge["~end"],
+      target: apiEdge["~end"] as VertexId,
       targetType: targetType,
       attributes: apiEdge["~properties"] || {},
     },

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -1,4 +1,4 @@
-import type { Vertex } from "@/@types/entities";
+import type { Vertex, VertexId } from "@/@types/entities";
 import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import type { OCVertex } from "../types";
 
@@ -11,7 +11,7 @@ export default function mapApiVertex(
 
   return {
     data: {
-      id: apiVertex["~id"],
+      id: apiVertex["~id"] as VertexId,
       idType: "string",
       type: vt,
       types: labels,

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -6,9 +6,9 @@ import {
   KeywordSearchResponse,
   NeighborsRequest,
   NeighborsResponse,
-  VertexId,
-  typeofVertexId,
+  VertexIdType,
 } from "./useGEFetchTypes";
+import { VertexId } from "@/@types/entities";
 
 /**
  * Performs a search with the provided parameters.
@@ -68,16 +68,17 @@ export type NeighborCountsQueryResponse = {
  */
 export const neighborsCountQuery = (
   id: VertexId,
+  idType: VertexIdType,
   limit: number | undefined,
   explorer: Explorer | null
 ) =>
   queryOptions({
-    queryKey: ["neighborsCount", id, limit, explorer],
+    queryKey: ["neighborsCount", id, idType, limit, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
       const result = await explorer?.fetchNeighborsCount({
         vertexId: id.toString(),
-        idType: typeofVertexId(id),
+        idType: idType,
         limit,
       });
 

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
@@ -1,4 +1,4 @@
-import { Edge } from "@/@types/entities";
+import { Edge, EdgeId, VertexId } from "@/@types/entities";
 import { RawValue } from "../types";
 
 export type IncomingPredicate = {
@@ -14,11 +14,11 @@ const mapIncomingToEdge = (
 ): Edge => {
   return {
     data: {
-      id: `${result.subject.value}-[${result.predFromSubject.value}]->${resourceURI}`,
+      id: `${result.subject.value}-[${result.predFromSubject.value}]->${resourceURI}` as EdgeId,
       type: result.predFromSubject.value,
-      source: result.subject.value,
+      source: result.subject.value as VertexId,
       sourceType: result.subjectClass.value,
-      target: resourceURI,
+      target: resourceURI as VertexId,
       targetType: resourceClass,
       attributes: {},
     },

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
@@ -1,4 +1,4 @@
-import { Edge } from "@/@types/entities";
+import { Edge, EdgeId, VertexId } from "@/@types/entities";
 import { RawValue } from "../types";
 
 export type OutgoingPredicate = {
@@ -14,11 +14,11 @@ const mapOutgoingToEdge = (
 ): Edge => {
   return {
     data: {
-      id: `${resourceURI}-[${result.predToSubject.value}]->${result.subject.value}`,
+      id: `${resourceURI}-[${result.predToSubject.value}]->${result.subject.value}` as EdgeId,
       type: result.predToSubject.value,
-      source: resourceURI,
+      source: resourceURI as VertexId,
       sourceType: resourceClass,
-      target: result.subject.value,
+      target: result.subject.value as VertexId,
       targetType: result.subjectClass.value,
       attributes: {},
     },

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -1,4 +1,4 @@
-import { Vertex } from "@/@types/entities";
+import { Vertex, VertexId } from "@/@types/entities";
 import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import { RawResult } from "../types";
 
@@ -8,7 +8,7 @@ const mapRawResultToVertex = (
 ): Vertex => {
   return {
     data: {
-      id: rawResult.uri,
+      id: rawResult.uri as VertexId,
       idType: "string",
       type: rawResult.class,
       neighborsCount: neighborsCount?.totalCount || 0,

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -14,14 +14,6 @@ export type QueryOptions = RequestInit & {
  * The type of the vertex ID.
  */
 export type VertexIdType = "string" | "number";
-export type VertexId = string | number;
-
-export function typeofVertexId(id: VertexId): VertexIdType {
-  if (typeof id === "number") {
-    return "number";
-  }
-  return "string";
-}
 
 export type VertexSchemaResponse = Pick<
   VertexTypeConfig,

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -39,7 +39,7 @@ export default function NodeExpandContent({ vertex }: NodeExpandContentProps) {
 
 function ExpandSidebarContent({ vertex }: { vertex: Vertex }) {
   const t = useTranslations();
-  const query = useUpdateNodeCountsQuery(vertex.data.id);
+  const query = useUpdateNodeCountsQuery(vertex.data.id, vertex.data.idType);
   const neighborsOptions = useNeighborsOptions(vertex);
 
   if (query.isError) {

--- a/packages/graph-explorer/src/utils/branded.ts
+++ b/packages/graph-explorer/src/utils/branded.ts
@@ -1,0 +1,4 @@
+/* https://egghead.io/blog/using-branded-types-in-typescript */
+declare const __brand: unique symbol;
+type Brand<B> = { [__brand]: B };
+export type Branded<T, B> = T & Brand<B>;

--- a/packages/graph-explorer/src/utils/index.ts
+++ b/packages/graph-explorer/src/utils/index.ts
@@ -9,6 +9,7 @@ export { DEFAULT_SERVICE_TYPE } from "./constants";
 export { default as escapeString } from "./escapeString";
 export { default as batchPromisesSerially } from "./batchPromisesSerially";
 export { default as logger } from "./logger";
+export * from "./branded";
 export * from "./sanitizeQuery";
 export * from "./cn";
 export * from "./set";

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -6,7 +6,7 @@ import {
   Schema,
   VertexTypeConfig,
 } from "@/core";
-import { Edge, Vertex } from "@/types/entities";
+import { Edge, EdgeId, Vertex, VertexId } from "@/types/entities";
 import { Entities } from "@/core/StateProvider/entitiesSelector";
 import {
   createArray,
@@ -136,7 +136,7 @@ export function createRandomEntities(): Entities {
 export function createRandomVertex(): Vertex {
   return {
     data: {
-      id: createRandomName("VertexId"),
+      id: createRandomName("VertexId") as VertexId,
       idType: "string",
       type: createRandomName("VertexType"),
       attributes: createRecord(3, createRandomEntityAttribute),
@@ -153,7 +153,7 @@ export function createRandomVertex(): Vertex {
 export function createRandomEdge(source: Vertex, target: Vertex): Edge {
   return {
     data: {
-      id: createRandomName("EdgeId"),
+      id: createRandomName("EdgeId") as EdgeId,
       type: createRandomName("EdgeType"),
       attributes: createRecord(3, createRandomEntityAttribute),
       source: source.data.id,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Using a [branded type](https://egghead.io/blog/using-branded-types-in-typescript) for the `VertexId` and `EdgeId` values allows me to enforce that a specific ID type is being passed in to the functions.

Also, fixes a bug where the ID type was not being passed to the neighbor count query. This only affects a small optimization in the query when the ID type is a number instead of a string. So the bug did not result in any kind of error.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified no change to behavior

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
