### PR TITLE
Remove need for extendable type definition for Vertex and Edge

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -68,13 +68,7 @@ export interface VertexData {
   __fetchedOutEdgeCount?: number;
 }
 
-/**
- * Sometimes is needed to add some extra properties to a Vertex
- * which cannot be mixed or overwritten with the original data
- * of a vertex.
- * For example, NodesTabular add __is_visible property to hide/show a node.
- */
-export type Vertex<T = Record<string, unknown>> = T & {
+export type Vertex = {
   data: VertexData;
 };
 
@@ -115,12 +109,6 @@ export interface EdgeData {
   attributes: Record<string, string | number>;
 }
 
-/**
- * Sometimes is needed to add some extra properties to an Edge
- * which cannot be mixed or overwritten with the original data
- * of en edge.
- * For example, EdgesTabular add __is_visible property to hide/show an edge.
- */
-export interface Edge<T = Record<string, unknown>> {
-  data: EdgeData & T;
+export interface Edge {
+  data: EdgeData;
 }

--- a/packages/graph-explorer/src/@types/react-table-config.d.ts
+++ b/packages/graph-explorer/src/@types/react-table-config.d.ts
@@ -57,7 +57,7 @@ export type UseDiffState = {
 declare module "react-table" {
   // take this file as-is, or comment out the sections that don't apply to your plugin configuration
 
-  export interface TableOptions<D extends Record<string, unknown>>
+  export interface TableOptions<D>
     extends UseExpandedOptions<D>,
       UseFiltersOptions<D>,
       UseGlobalFiltersOptions<D>,

--- a/packages/graph-explorer/src/components/Tabular/Tabular.tsx
+++ b/packages/graph-explorer/src/components/Tabular/Tabular.tsx
@@ -53,7 +53,7 @@ export interface TabularProps<T extends object> extends TabularOptions<T> {
   globalSearch?: string;
 }
 
-export const Tabular = <T extends Record<string, unknown>>(
+export const Tabular = <T extends object>(
   {
     children,
     className,
@@ -126,7 +126,7 @@ export const Tabular = <T extends Record<string, unknown>>(
   );
 };
 
-const TabularContent = <T extends Record<string, unknown>>({
+const TabularContent = <T extends object>({
   children,
   className,
   tableInstance,
@@ -266,7 +266,7 @@ const TabularContent = <T extends Record<string, unknown>>({
   );
 };
 
-export default forwardRef(Tabular) as <T extends Record<string, unknown>>(
+export default forwardRef(Tabular) as <T extends object>(
   props: PropsWithChildren<TabularProps<T>> & {
     ref?: ForwardedRef<TabularInstance<T>>;
   }

--- a/packages/graph-explorer/src/components/Tabular/TabularControlsProvider.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularControlsProvider.tsx
@@ -10,7 +10,7 @@ import {
 
 import type { TabularInstance } from "./helpers/tableInstanceToTabularInstance";
 
-type TabularContextValue<T extends Record<string, unknown>> = {
+type TabularContextValue<T extends object> = {
   tableRef: RefObject<HTMLDivElement>;
   instance: TabularInstance<T>;
   headerControlsRef: RefObject<HTMLDivElement>;
@@ -19,7 +19,7 @@ type TabularContextValue<T extends Record<string, unknown>> = {
   disablePagination?: boolean;
 };
 
-const createTabularContext = <T extends Record<string, unknown> = any>(
+const createTabularContext = <T extends object = any>(
   defaultValue: TabularContextValue<T>
 ) => {
   return createContext<TabularContextValue<T>>(defaultValue);
@@ -27,7 +27,7 @@ const createTabularContext = <T extends Record<string, unknown> = any>(
 
 const TabularContext = createTabularContext(undefined!);
 
-const TabularControlsProvider = <T extends Record<string, unknown>>({
+const TabularControlsProvider = <T extends object>({
   tabularInstance,
   children,
 }: PropsWithChildren<{ tabularInstance: TabularInstance<T> }>) => {

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
@@ -4,13 +4,13 @@ import Switch from "@/components/Switch";
 import type { TabularInstance } from "@/components/Tabular/helpers/tableInstanceToTabularInstance";
 import { useTabularControl } from "@/components/Tabular/TabularControlsProvider";
 
-type ColumnItemProps<T extends Record<string, unknown>> = {
+type ColumnItemProps<T extends object> = {
   columnId: string;
   column: TabularInstance<T>["columns"][number];
   index: number;
 };
 
-const ColumnItem = <T extends Record<string, unknown>>({
+const ColumnItem = <T extends object>({
   columnId,
   column,
   index,

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/getNestedObjectValue.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/getNestedObjectValue.ts
@@ -1,13 +1,10 @@
-const getNestedObjectValue = (
-  nestedObj: Record<string, unknown>,
+function getNestedObjectValue<T extends object>(
+  nestedObj: T,
   path: string[]
-): string | number => {
+): string | number {
   return path.reduce((obj, key) => {
-    return (obj?.[key] !== undefined ? obj[key] : undefined) as Record<
-      string,
-      unknown
-    >;
-  }, nestedObj) as unknown as string | number;
-};
+    return obj && key in obj ? obj[key] : undefined;
+  }, nestedObj as any) as string | number;
+}
 
 export default getNestedObjectValue;

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transfomerToCsv.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transfomerToCsv.ts
@@ -3,7 +3,7 @@ import type { Row } from "react-table";
 import type { TabularColumnInstance } from "@/components/Tabular/helpers/tableInstanceToTabularInstance";
 import getNestedObjectValue from "./getNestedObjectValue";
 
-export default function transformToCsv<T extends Record<string, unknown>>(
+export default function transformToCsv<T extends object>(
   currentDataSource: readonly T[] | Row<T>[],
   selectedColumns: Record<string, boolean>,
   columns: TabularColumnInstance<T>[]

--- a/packages/graph-explorer/src/components/Tabular/helpers/tableInstanceToTabularInstance.ts
+++ b/packages/graph-explorer/src/components/Tabular/helpers/tableInstanceToTabularInstance.ts
@@ -22,12 +22,12 @@ import {
 import type { TabularProps } from "../Tabular";
 import type { ColumnDefinition } from "../useTabular";
 
-export type TabularColumnInstance<T extends Record<string, unknown>> = {
+export type TabularColumnInstance<T extends object> = {
   instance: ColumnInstance<T>;
   definition?: ColumnDefinition<T>;
 };
 
-export type TabularInstance<T extends Record<string, unknown>> = {
+export type TabularInstance<T extends object> = {
   /**
    * Original data
    */
@@ -142,7 +142,7 @@ export type TabularInstance<T extends Record<string, unknown>> = {
   initialHiddenColumns: Array<IdType<T>>;
 };
 
-const tableInstanceToTabularInstance = <T extends Record<string, unknown>>(
+const tableInstanceToTabularInstance = <T extends object>(
   tableInstance: TableInstance<T>,
   tableProps: TabularProps<T>
 ): TabularInstance<T> => {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The `Vertex` and `Edge` types have a type definition that allowed adding additional properties at runtime. Since TypeScript does not actually do any typing at runtime, this is unnecessary.

This extra type information was used by the abstraction around React Table. This essentially undoes a part of a change I made months ago to fix the table export.

- #297

## Validation

- Verified table still works as it did before
- Verified table export still works as it did before (including trying all the export options)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
