### PR TITLE
Fix inefficiencies with React data set choices

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- **Improved** UI responsiveness by using map instead of array for large data
+  sets [#658](https://github.com/aws/graph-explorer/pull/658)
 - **Improved** style for the sidebar buttons
   [#651](https://github.com/aws/graph-explorer/pull/651)
 - **Fixed** Docker image containing more files than necessary.

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -128,6 +128,7 @@
     "@vitest/coverage-v8": "^2.1.2",
     "autoprefixer": "^10.4.20",
     "buffer": "^6.0.3",
+    "core-js": "^3.39.0",
     "esbuild-loader": "^4.2.2",
     "happy-dom": "^15.7.4",
     "jsdom": "^25.0.1",

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchSchema.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchSchema.ts
@@ -84,13 +84,17 @@ const fetchPredicatesByClass = async (
           classPredicatesTemplate
         );
 
-      const attributes = predicatesResponse.results.bindings.map(item => ({
-        name: item.pred.value,
-        displayLabel: "",
-        searchable: true,
-        hidden: false,
-        dataType: TYPE_MAP[item.sample.datatype || ""] || "String",
-      }));
+      const attributes = new Map(
+        predicatesResponse.results.bindings
+          .map(item => ({
+            name: item.pred.value,
+            displayLabel: "",
+            searchable: true,
+            hidden: false,
+            dataType: TYPE_MAP[item.sample.datatype || ""] || "String",
+          }))
+          .map(a => [a.name, a])
+      );
 
       return {
         attributes,
@@ -104,12 +108,18 @@ const fetchPredicatesByClass = async (
     displayLabel: "",
     total: countsByClass[resourceClass],
     displayNameAttribute:
-      attributes.find(attr => displayNameCandidates.includes(attr.name))
-        ?.name || RESERVED_ID_PROPERTY,
+      displayNameCandidates
+        .values()
+        .map(c => attributes.get(c)?.name)
+        .filter(n => n != null)
+        .next().value ?? RESERVED_ID_PROPERTY,
     longDisplayNameAttribute:
-      attributes.find(attr => displayDescCandidates.includes(attr.name))
-        ?.name || "types",
-    attributes,
+      displayDescCandidates
+        .values()
+        .map(c => attributes.get(c)?.name)
+        .filter(n => n != null)
+        .next().value ?? "types",
+    attributes: attributes.values().toArray(),
   }));
 };
 

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -1,4 +1,3 @@
-import uniqBy from "lodash/uniqBy";
 import { selector, selectorFamily, useRecoilValue } from "recoil";
 import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 import { mergedConfigurationSelector } from "@/core/StateProvider/configuration";
@@ -37,40 +36,40 @@ export const assembledConfigSelector = selector<
       return;
     }
 
+    const vertexTypesMap = new Map(
+      configuration.schema?.vertices.map(v => [v.type, v])
+    );
+
+    const edgeTypesMap = new Map(
+      configuration.schema?.edges.map(e => [e.type, e])
+    );
+
     return {
       ...configuration,
       totalVertices: configuration.schema?.totalVertices ?? 0,
-      vertexTypes: configuration.schema?.vertices?.map(vt => vt.type) || [],
+      vertexTypes: vertexTypesMap.keys().toArray(),
       totalEdges: configuration.schema?.totalEdges ?? 0,
-      edgeTypes: configuration.schema?.edges?.map(et => et.type) || [],
+      edgeTypes: edgeTypesMap.keys().toArray(),
       getVertexTypeConfig(vertexType) {
-        const vtConfig = configuration?.schema?.vertices?.find(
-          v => v.type === vertexType
+        return (
+          vertexTypesMap.get(vertexType) ??
+          getDefaultVertexTypeConfig(vertexType)
         );
-        if (!vtConfig) {
-          return getDefaultVertexTypeConfig(vertexType);
-        }
-
-        return vtConfig;
       },
       getVertexTypeAttributes(vertexTypes) {
-        const vtConfig = configuration?.schema?.vertices?.filter(v =>
-          vertexTypes.includes(v.type)
+        const attributesByNameMap = new Map(
+          vertexTypes
+            .values()
+            .map(vertexTypesMap.get)
+            .filter(vt => vt != null)
+            .flatMap(vt => vt.attributes)
+            .map(attr => [attr.name, attr])
         );
 
-        if (!vtConfig?.length) {
-          return [];
-        }
-
-        return uniqBy(
-          vtConfig.flatMap(v => v.attributes),
-          v => v.name
-        );
+        return attributesByNameMap.values().toArray();
       },
       getVertexTypeSearchableAttributes(vertexType) {
-        const vtConfig = configuration?.schema?.vertices?.find(
-          v => v.type === vertexType
-        );
+        const vtConfig = vertexTypesMap.get(vertexType);
         if (!vtConfig) {
           return [];
         }
@@ -81,14 +80,7 @@ export const assembledConfigSelector = selector<
         );
       },
       getEdgeTypeConfig(edgeType) {
-        const etConfig = configuration?.schema?.edges?.find(
-          e => e.type === edgeType
-        );
-        if (!etConfig) {
-          return getDefaultEdgeTypeConfig(edgeType);
-        }
-
-        return etConfig;
+        return edgeTypesMap.get(edgeType) ?? getDefaultEdgeTypeConfig(edgeType);
       },
     };
   },

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -60,7 +60,7 @@ export const assembledConfigSelector = selector<
         const attributesByNameMap = new Map(
           vertexTypes
             .values()
-            .map(vertexTypesMap.get)
+            .map(vt => vertexTypesMap.get(vt))
             .filter(vt => vt != null)
             .flatMap(vt => vt.attributes)
             .map(attr => [attr.name, attr])

--- a/packages/graph-explorer/src/core/StateProvider/edges.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.test.ts
@@ -4,7 +4,7 @@ import {
   createRandomVertex,
 } from "@/utils/testing";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { edgesAtom, edgesSelector } from "./edges";
+import { edgesAtom, edgesSelector, toEdgeMap } from "./edges";
 import { act } from "@testing-library/react";
 
 describe("edgeSelector", () => {
@@ -16,13 +16,13 @@ describe("edgeSelector", () => {
     const { result } = renderHookWithRecoilRoot(
       () => useRecoilValue(edgesSelector),
       snapshot => {
-        snapshot.set(edgesAtom, [edge1, edge2, edge3]);
+        snapshot.set(edgesAtom, toEdgeMap([edge1, edge2, edge3]));
       }
     );
 
-    expect(result.current).toContainEqual(edge1);
-    expect(result.current).toContainEqual(edge2);
-    expect(result.current).toContainEqual(edge3);
+    expect(result.current.get(edge1.id)).toEqual(edge1);
+    expect(result.current.get(edge2.id)).toEqual(edge2);
+    expect(result.current.get(edge3.id)).toEqual(edge3);
   });
 
   it("should add new edges", () => {
@@ -33,8 +33,8 @@ describe("edgeSelector", () => {
       return { value, set };
     });
 
-    act(() => result.current.set([edge]));
+    act(() => result.current.set(toEdgeMap([edge])));
 
-    expect(result.current.value).toContainEqual(edge);
+    expect(result.current.value.get(edge.id)).toEqual(edge);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -1,5 +1,5 @@
 import { atom, selector } from "recoil";
-import type { Edge } from "@/types/entities";
+import type { Edge, EdgeId } from "@/types/entities";
 import isDefaultValue from "./isDefaultValue";
 
 export type Edges = Array<Edge>;
@@ -22,8 +22,8 @@ export const edgesSelector = selector<Edges>({
 
     set(edgesAtom, newValue);
 
-    const cleanFn = (curr: Set<string>) => {
-      const existingEdgesIds = new Set<string>();
+    const cleanFn = (curr: Set<EdgeId>) => {
+      const existingEdgesIds = new Set<EdgeId>();
       curr.forEach(eId => {
         const exist = newValue.find(n => n.id === eId);
         if (exist) {
@@ -41,22 +41,22 @@ export const edgesSelector = selector<Edges>({
   },
 });
 
-export const edgesSelectedIdsAtom = atom<Set<string>>({
+export const edgesSelectedIdsAtom = atom<Set<EdgeId>>({
   key: "edges-selected-ids",
   default: new Set(),
 });
 
-export const edgesHiddenIdsAtom = atom<Set<string>>({
+export const edgesHiddenIdsAtom = atom<Set<EdgeId>>({
   key: "edges-hidden-ids",
   default: new Set(),
 });
 
-export const edgesOutOfFocusIdsAtom = atom<Set<string>>({
+export const edgesOutOfFocusIdsAtom = atom<Set<EdgeId>>({
   key: "edges-out-of-focus-ids",
   default: new Set(),
 });
 
-export const edgesFilteredIdsAtom = atom<Set<string>>({
+export const edgesFilteredIdsAtom = atom<Set<EdgeId>>({
   key: "edges-filtered-ids",
   default: new Set(),
 });

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -2,11 +2,15 @@ import { atom, selector } from "recoil";
 import type { Edge, EdgeId } from "@/types/entities";
 import isDefaultValue from "./isDefaultValue";
 
-export type Edges = Array<Edge>;
+export type Edges = Map<EdgeId, Edge>;
+
+export function toEdgeMap(edges: Edge[]): Edges {
+  return new Map(edges.map(e => [e.id, e]));
+}
 
 export const edgesAtom = atom<Edges>({
   key: "edges",
-  default: [],
+  default: new Map(),
 });
 
 export const edgesSelector = selector<Edges>({
@@ -25,7 +29,7 @@ export const edgesSelector = selector<Edges>({
     const cleanFn = (curr: Set<EdgeId>) => {
       const existingEdgesIds = new Set<EdgeId>();
       curr.forEach(eId => {
-        const exist = newValue.find(n => n.id === eId);
+        const exist = newValue.has(eId);
         if (exist) {
           existingEdgesIds.add(eId);
         }

--- a/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
+++ b/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
@@ -4,7 +4,7 @@ import isEqualWith from "lodash/isEqualWith";
 import uniqBy from "lodash/uniqBy";
 import type { GetRecoilValue, RecoilState, SetRecoilState } from "recoil";
 import { selector } from "recoil";
-import type { Edge, Vertex } from "@/types/entities";
+import type { Edge, EdgeId, Vertex, VertexId } from "@/types/entities";
 import { edgesAtom, edgesSelectedIdsAtom, edgesSelector } from "./edges";
 import {
   nodesAtom,
@@ -28,7 +28,7 @@ const isEntities = (value: any): value is Entities => {
   return !!value.nodes;
 };
 
-const removeFromSetIfDeleted = (
+function removeFromSetIfDeleted<T>(
   {
     get,
     set,
@@ -36,9 +36,9 @@ const removeFromSetIfDeleted = (
     get: GetRecoilValue;
     set: SetRecoilState;
   },
-  deletedIds: Set<string>,
-  selector: RecoilState<Set<string>>
-) => {
+  deletedIds: Set<T>,
+  selector: RecoilState<Set<T>>
+) {
   const selectorIds = get(selector);
   const copiedSelectorIds = new Set(selectorIds);
   deletedIds.forEach(id => {
@@ -46,7 +46,7 @@ const removeFromSetIfDeleted = (
   });
   set(selector, copiedSelectorIds);
   return copiedSelectorIds;
-};
+}
 
 // This selector is the safer way to add entities to the graph
 // It computes stats (counts) every time that some entity is added
@@ -185,7 +185,7 @@ const entitiesSelector = selector<Entities>({
               })
               .map(edge => edge.id)
           )
-        : new Set<string>();
+        : new Set<EdgeId>();
 
     // When a node is removed, we should remove its involved edge id from other edges-state sets
     if (affectedEdgesIds.size > 0) {
@@ -237,11 +237,11 @@ const entitiesSelector = selector<Entities>({
     // Select new entities preserving selected ones by default
     const selectedNodesIds =
       newEntities.preserveSelection === false
-        ? new Set<string>()
+        ? new Set<VertexId>()
         : new Set(get(nodesSelectedIdsAtom));
     const selectedEdgesIds =
       newEntities.preserveSelection === false
-        ? new Set<string>()
+        ? new Set<EdgeId>()
         : new Set(get(edgesSelectedIdsAtom));
 
     if (

--- a/packages/graph-explorer/src/core/StateProvider/nodes.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.test.ts
@@ -1,6 +1,6 @@
 import { createRandomVertex, renderHookWithRecoilRoot } from "@/utils/testing";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { nodesAtom, nodesSelector } from "./nodes";
+import { nodesAtom, nodesSelector, toNodeMap } from "./nodes";
 import { act } from "@testing-library/react";
 
 describe("nodeSelector", () => {
@@ -12,13 +12,13 @@ describe("nodeSelector", () => {
     const { result } = renderHookWithRecoilRoot(
       () => useRecoilValue(nodesSelector),
       snapshot => {
-        snapshot.set(nodesAtom, [node1, node2, node3]);
+        snapshot.set(nodesAtom, toNodeMap([node1, node2, node3]));
       }
     );
 
-    expect(result.current).toContainEqual(node1);
-    expect(result.current).toContainEqual(node2);
-    expect(result.current).toContainEqual(node3);
+    expect(result.current.get(node1.id)).toEqual(node1);
+    expect(result.current.get(node2.id)).toEqual(node2);
+    expect(result.current.get(node3.id)).toEqual(node3);
   });
 
   it("should add new nodes", () => {
@@ -29,8 +29,8 @@ describe("nodeSelector", () => {
       return { value, set };
     });
 
-    act(() => result.current.set([node]));
+    act(() => result.current.set(toNodeMap([node])));
 
-    expect(result.current.value).toContainEqual(node);
+    expect(result.current.value.get(node.id)).toEqual(node);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -1,5 +1,5 @@
 import { atom, selector } from "recoil";
-import type { Vertex } from "@/types/entities";
+import type { Vertex, VertexId } from "@/types/entities";
 import isDefaultValue from "./isDefaultValue";
 
 export const nodesAtom = atom<Array<Vertex>>({
@@ -19,8 +19,8 @@ export const nodesSelector = selector<Array<Vertex>>({
     }
 
     set(nodesAtom, newValue);
-    const cleanFn = (curr: Set<string>) => {
-      const existingNodesIds = new Set<string>();
+    const cleanFn = (curr: Set<VertexId>) => {
+      const existingNodesIds = new Set<VertexId>();
       curr.forEach(nId => {
         const exist = newValue.find(n => n.id === nId);
         if (exist) {
@@ -38,22 +38,22 @@ export const nodesSelector = selector<Array<Vertex>>({
   },
 });
 
-export const nodesSelectedIdsAtom = atom<Set<string>>({
+export const nodesSelectedIdsAtom = atom<Set<VertexId>>({
   key: "nodes-selected-ids",
   default: new Set(),
 });
 
-export const nodesHiddenIdsAtom = atom<Set<string>>({
+export const nodesHiddenIdsAtom = atom<Set<VertexId>>({
   key: "nodes-hidden-ids",
   default: new Set(),
 });
 
-export const nodesOutOfFocusIdsAtom = atom<Set<string>>({
+export const nodesOutOfFocusIdsAtom = atom<Set<VertexId>>({
   key: "nodes-out-of-focus-ids",
   default: new Set(),
 });
 
-export const nodesFilteredIdsAtom = atom<Set<string>>({
+export const nodesFilteredIdsAtom = atom<Set<VertexId>>({
   key: "nodes-filtered-ids",
   default: new Set(),
 });

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -2,12 +2,16 @@ import { atom, selector } from "recoil";
 import type { Vertex, VertexId } from "@/types/entities";
 import isDefaultValue from "./isDefaultValue";
 
-export const nodesAtom = atom<Array<Vertex>>({
+export function toNodeMap(nodes: Vertex[]): Map<VertexId, Vertex> {
+  return new Map(nodes.map(n => [n.id, n]));
+}
+
+export const nodesAtom = atom<Map<VertexId, Vertex>>({
   key: "nodes",
-  default: [],
+  default: new Map(),
 });
 
-export const nodesSelector = selector<Array<Vertex>>({
+export const nodesSelector = selector<Map<VertexId, Vertex>>({
   key: "nodes-selector",
   get: ({ get }) => {
     return get(nodesAtom);
@@ -22,7 +26,7 @@ export const nodesSelector = selector<Array<Vertex>>({
     const cleanFn = (curr: Set<VertexId>) => {
       const existingNodesIds = new Set<VertexId>();
       curr.forEach(nId => {
-        const exist = newValue.find(n => n.id === nId);
+        const exist = newValue.get(nId);
         if (exist) {
           existingNodesIds.add(nId);
         }

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@/utils/testing";
 import { extractConfigFromEntity, updateSchemaFromEntities } from "./schema";
 import { createArray } from "@shared/utils/testing";
+import { toNodeMap } from "./nodes";
 
 describe("schema", () => {
   describe("extractConfigFromEntity", () => {
@@ -34,7 +35,10 @@ describe("schema", () => {
   describe("updateSchemaFromEntities", () => {
     it("should do nothing when no entities", () => {
       const originalSchema = createRandomSchema();
-      const result = updateSchemaFromEntities({}, originalSchema);
+      const result = updateSchemaFromEntities(
+        { nodes: new Map(), edges: [] },
+        originalSchema
+      );
 
       expect(result).toEqual(originalSchema);
     });
@@ -47,7 +51,7 @@ describe("schema", () => {
       );
       const result = updateSchemaFromEntities(
         {
-          nodes: newNodes,
+          nodes: toNodeMap(newNodes),
           edges: newEdges,
         },
         originalSchema
@@ -81,7 +85,7 @@ describe("schema", () => {
 
       const result = updateSchemaFromEntities(
         {
-          nodes: [newNode],
+          nodes: toNodeMap([newNode]),
           edges: [newEdge],
         },
         originalSchema

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -6,6 +6,7 @@ import {
 import { extractConfigFromEntity, updateSchemaFromEntities } from "./schema";
 import { createArray } from "@shared/utils/testing";
 import { toNodeMap } from "./nodes";
+import { toEdgeMap } from "./edges";
 
 describe("schema", () => {
   describe("extractConfigFromEntity", () => {
@@ -36,7 +37,7 @@ describe("schema", () => {
     it("should do nothing when no entities", () => {
       const originalSchema = createRandomSchema();
       const result = updateSchemaFromEntities(
-        { nodes: new Map(), edges: [] },
+        { nodes: new Map(), edges: new Map() },
         originalSchema
       );
 
@@ -52,7 +53,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         {
           nodes: toNodeMap(newNodes),
-          edges: newEdges,
+          edges: toEdgeMap(newEdges),
         },
         originalSchema
       );
@@ -86,7 +87,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         {
           nodes: toNodeMap([newNode]),
-          edges: [newEdge],
+          edges: toEdgeMap([newEdge]),
         },
         originalSchema
       );

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -63,7 +63,7 @@ type SchemaEntities = Pick<Entities, "nodes" | "edges">;
 /** Write only atom that updates the schema based on the given nodes and edges. */
 export const updateSchemaFromEntitiesAtom = selector<SchemaEntities>({
   key: "update-schema-from-entities",
-  get: () => ({ nodes: new Map(), edges: [] }),
+  get: () => ({ nodes: new Map(), edges: new Map() }),
   set({ set }, newValue) {
     set(activeSchemaSelector, prev => {
       if (!prev || isDefaultValue(newValue)) {
@@ -83,7 +83,10 @@ export function updateSchemaFromEntities(
     .values()
     .map(extractConfigFromEntity)
     .toArray();
-  const newEdgeConfigs = entities.edges.map(extractConfigFromEntity);
+  const newEdgeConfigs = entities.edges
+    .values()
+    .map(extractConfigFromEntity)
+    .toArray();
 
   return {
     ...schema,

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -9,6 +9,7 @@ import { activeConfigurationAtom } from "./configuration";
 import isDefaultValue from "./isDefaultValue";
 import { Edge, Vertex } from "@/@types/entities";
 import { sanitizeText } from "@/utils";
+import { Entities } from "./entitiesSelector";
 
 export type SchemaInference = {
   vertices: VertexTypeConfig[];
@@ -57,12 +58,12 @@ export const activeSchemaSelector = selector({
   },
 });
 
-type Entities = { nodes?: Vertex[]; edges?: Edge[] };
+type SchemaEntities = Pick<Entities, "nodes" | "edges">;
 
 /** Write only atom that updates the schema based on the given nodes and edges. */
-export const updateSchemaFromEntitiesAtom = selector<Entities>({
+export const updateSchemaFromEntitiesAtom = selector<SchemaEntities>({
   key: "update-schema-from-entities",
-  get: () => ({}),
+  get: () => ({ nodes: new Map(), edges: [] }),
   set({ set }, newValue) {
     set(activeSchemaSelector, prev => {
       if (!prev || isDefaultValue(newValue)) {
@@ -75,11 +76,14 @@ export const updateSchemaFromEntitiesAtom = selector<Entities>({
 
 /** Updates the schema based on the given nodes and edges. */
 export function updateSchemaFromEntities(
-  entities: Entities,
+  entities: SchemaEntities,
   schema: SchemaInference
 ) {
-  const newVertexConfigs = (entities.nodes ?? []).map(extractConfigFromEntity);
-  const newEdgeConfigs = (entities.edges ?? []).map(extractConfigFromEntity);
+  const newVertexConfigs = entities.nodes
+    .values()
+    .map(extractConfigFromEntity)
+    .toArray();
+  const newEdgeConfigs = entities.edges.map(extractConfigFromEntity);
 
   return {
     ...schema,

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -15,6 +15,7 @@ import { renderHookWithRecoilRoot } from "@/utils/testing";
 import { waitForValueToChange } from "@/utils/testing/waitForValueToChange";
 import { vi } from "vitest";
 import { createRandomInteger, createRandomName } from "@shared/utils/testing";
+import { toNodeMap } from "@/core/StateProvider/nodes";
 
 describe("useEntities", () => {
   beforeEach(() => {
@@ -28,10 +29,8 @@ describe("useEntities", () => {
       neighborsCount: Math.floor(Math.random() * 100),
       neighborsCountByType: {},
     } as Vertex;
-    const expectedRandomNodes = {
-      id: randomNode.id,
-      type: randomNode.type,
-      neighborsCount: randomNode.neighborsCount,
+    const expectedRandomNodes: Vertex = {
+      ...randomNode,
       neighborsCountByType: {},
       __unfetchedNeighborCounts: {},
       __fetchedOutEdgeCount: 0,
@@ -44,53 +43,56 @@ describe("useEntities", () => {
       return { entities, setEntities };
     });
 
-    result.current.setEntities({ nodes: [randomNode], edges: [] });
+    result.current.setEntities({ nodes: toNodeMap([randomNode]), edges: [] });
 
     await waitForValueToChange(() => result.current.entities);
 
     expect(result.current.entities).toEqual({
-      nodes: [expectedRandomNodes],
+      nodes: toNodeMap([expectedRandomNodes]),
       edges: [],
     });
-    expect(result.current.entities.nodes[0].id).toEqual(randomNode.id);
-    expect(result.current.entities.nodes[0].type).toEqual(randomNode.type);
-    expect(result.current.entities.nodes[0].neighborsCount).toEqual(
-      randomNode.neighborsCount
-    );
-    expect(result.current.entities.nodes[0].neighborsCountByType).toEqual({});
-    expect(result.current.entities.nodes[0].__unfetchedNeighborCounts).toEqual(
-      {}
-    );
-    expect(result.current.entities.nodes[0].__fetchedOutEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[0].__fetchedInEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[0].__unfetchedNeighborCount).toEqual(
-      0
-    );
+    const actualNode = result.current.entities.nodes.get(randomNode.id);
+    expect(actualNode?.id).toEqual(randomNode.id);
+    expect(actualNode?.type).toEqual(randomNode.type);
+    expect(actualNode?.neighborsCount).toEqual(randomNode.neighborsCount);
+    expect(actualNode?.neighborsCountByType).toEqual({});
+    expect(actualNode?.__unfetchedNeighborCounts).toEqual({});
+    expect(actualNode?.__fetchedOutEdgeCount).toEqual(0);
+    expect(actualNode?.__fetchedInEdgeCount).toEqual(0);
+    expect(actualNode?.__unfetchedNeighborCount).toEqual(0);
   });
 
   it("should handle multiple nodes correctly", async () => {
-    const node1 = {
-      id: "1",
+    const node1: Vertex = {
+      id: "1" as VertexId,
+      idType: "string",
       type: "type1",
+      attributes: {},
       neighborsCount: 1,
       neighborsCountByType: {},
-    } as Vertex;
-    const node2 = {
-      id: "2",
+    };
+    const node2: Vertex = {
+      id: "2" as VertexId,
+      idType: "string",
       type: "type2",
+      attributes: {},
       neighborsCount: 2,
       neighborsCountByType: {},
-    } as Vertex;
-    const node3 = {
-      id: "3",
+    };
+    const node3: Vertex = {
+      id: "3" as VertexId,
+      idType: "string",
       type: "type3",
+      attributes: {},
       neighborsCount: 3,
       neighborsCountByType: {},
-    } as Vertex;
-    const expectedNodes = [
+    };
+    const expectedNodes = toNodeMap([
       {
         id: node1.id,
+        idType: "string",
         type: node1.type,
+        attributes: {},
         neighborsCount: node1.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
@@ -100,7 +102,9 @@ describe("useEntities", () => {
       },
       {
         id: node2.id,
+        idType: "string",
         type: node2.type,
+        attributes: {},
         neighborsCount: node2.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
@@ -110,7 +114,9 @@ describe("useEntities", () => {
       },
       {
         id: node3.id,
+        idType: "string",
         type: node3.type,
+        attributes: {},
         neighborsCount: node3.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
@@ -118,14 +124,17 @@ describe("useEntities", () => {
         __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
-    ];
+    ]);
 
     const { result } = renderHookWithRecoilRoot(() => {
       const [entities, setEntities] = useEntities({ disableFilters: true });
       return { entities, setEntities };
     });
 
-    result.current.setEntities({ nodes: [node1, node2, node3], edges: [] });
+    result.current.setEntities({
+      nodes: toNodeMap([node1, node2, node3]),
+      edges: [],
+    });
 
     await waitForValueToChange(() => result.current.entities);
 
@@ -133,50 +142,38 @@ describe("useEntities", () => {
       nodes: expectedNodes,
       edges: [],
     });
-    expect(result.current.entities.nodes[0].id).toEqual(node1.id);
-    expect(result.current.entities.nodes[0].type).toEqual(node1.type);
-    expect(result.current.entities.nodes[0].neighborsCount).toEqual(
-      node1.neighborsCount
-    );
-    expect(result.current.entities.nodes[0].neighborsCountByType).toEqual({});
-    expect(result.current.entities.nodes[0].__unfetchedNeighborCounts).toEqual(
-      {}
-    );
-    expect(result.current.entities.nodes[0].__fetchedOutEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[0].__fetchedInEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[0].__unfetchedNeighborCount).toEqual(
-      0
-    );
+    const actualNode1 = result.current.entities.nodes.get(node1.id);
+    expect(actualNode1).not.toBeUndefined();
+    expect(actualNode1?.id).toEqual(node1.id);
+    expect(actualNode1?.type).toEqual(node1.type);
+    expect(actualNode1?.neighborsCount).toEqual(node1.neighborsCount);
+    expect(actualNode1?.neighborsCountByType).toEqual({});
+    expect(actualNode1?.__unfetchedNeighborCounts).toEqual({});
+    expect(actualNode1?.__fetchedOutEdgeCount).toEqual(0);
+    expect(actualNode1?.__fetchedInEdgeCount).toEqual(0);
+    expect(actualNode1?.__unfetchedNeighborCount).toEqual(0);
 
-    expect(result.current.entities.nodes[1].id).toEqual(node2.id);
-    expect(result.current.entities.nodes[1].type).toEqual(node2.type);
-    expect(result.current.entities.nodes[1].neighborsCount).toEqual(
-      node2.neighborsCount
-    );
-    expect(result.current.entities.nodes[1].neighborsCountByType).toEqual({});
-    expect(result.current.entities.nodes[1].__unfetchedNeighborCounts).toEqual(
-      {}
-    );
-    expect(result.current.entities.nodes[1].__fetchedOutEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[1].__fetchedInEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[1].__unfetchedNeighborCount).toEqual(
-      0
-    );
+    const actualNode2 = result.current.entities.nodes.get(node2.id);
+    expect(actualNode2).not.toBeUndefined();
+    expect(actualNode2?.id).toEqual(node2.id);
+    expect(actualNode2?.type).toEqual(node2.type);
+    expect(actualNode2?.neighborsCount).toEqual(node2.neighborsCount);
+    expect(actualNode2?.neighborsCountByType).toEqual({});
+    expect(actualNode2?.__unfetchedNeighborCounts).toEqual({});
+    expect(actualNode2?.__fetchedOutEdgeCount).toEqual(0);
+    expect(actualNode2?.__fetchedInEdgeCount).toEqual(0);
+    expect(actualNode2?.__unfetchedNeighborCount).toEqual(0);
 
-    expect(result.current.entities.nodes[2].id).toEqual(node3.id);
-    expect(result.current.entities.nodes[2].type).toEqual(node3.type);
-    expect(result.current.entities.nodes[2].neighborsCount).toEqual(
-      node3.neighborsCount
-    );
-    expect(result.current.entities.nodes[2].neighborsCountByType).toEqual({});
-    expect(result.current.entities.nodes[2].__unfetchedNeighborCounts).toEqual(
-      {}
-    );
-    expect(result.current.entities.nodes[2].__fetchedOutEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[2].__fetchedInEdgeCount).toEqual(0);
-    expect(result.current.entities.nodes[2].__unfetchedNeighborCount).toEqual(
-      0
-    );
+    const actualNode3 = result.current.entities.nodes.get(node3.id);
+    expect(actualNode3).not.toBeUndefined();
+    expect(actualNode3?.id).toEqual(node3.id);
+    expect(actualNode3?.type).toEqual(node3.type);
+    expect(actualNode3?.neighborsCount).toEqual(node3.neighborsCount);
+    expect(actualNode3?.neighborsCountByType).toEqual({});
+    expect(actualNode3?.__unfetchedNeighborCounts).toEqual({});
+    expect(actualNode3?.__fetchedOutEdgeCount).toEqual(0);
+    expect(actualNode3?.__fetchedInEdgeCount).toEqual(0);
+    expect(actualNode3?.__unfetchedNeighborCount).toEqual(0);
   });
 
   it("should calculate stats after adding new nodes and edges", async () => {
@@ -192,13 +189,14 @@ describe("useEntities", () => {
       return { entities, setEntities };
     });
 
-    result.current.setEntities({ nodes: [node1, node2], edges: [edge1to2] });
+    result.current.setEntities({
+      nodes: toNodeMap([node1, node2]),
+      edges: [edge1to2],
+    });
 
     await waitForValueToChange(() => result.current.entities);
 
-    const actualNode1 = result.current.entities.nodes.find(
-      n => n.id === node1.id
-    )!;
+    const actualNode1 = result.current.entities.nodes.get(node1.id)!;
     expect(actualNode1.__unfetchedNeighborCount).toEqual(
       randomNeighborCount - 1
     );
@@ -258,7 +256,10 @@ describe("useEntities", () => {
 
     // Ensure new node types are added to the schema
     const schemaNodeLabels = schema.vertices.map(v => v.type);
-    const entityNodeLabels = originalEntities.nodes.map(n => n.type);
+    const entityNodeLabels = originalEntities.nodes
+      .values()
+      .map(n => n.type)
+      .toArray();
     expect(schemaNodeLabels).toEqual(expect.arrayContaining(entityNodeLabels));
   });
 
@@ -283,7 +284,8 @@ describe("useEntities", () => {
 
     // Add a node that matches a node type in the schema
     const nodeTypeWithAdditionalAttributes = originalSchema.vertices[0].type;
-    originalEntities.nodes[0].type = nodeTypeWithAdditionalAttributes;
+    originalEntities.nodes.values().next().value!.type =
+      nodeTypeWithAdditionalAttributes;
 
     const { schema, entities } = await setupAndPerformSetEntities(
       originalSchema,
@@ -294,7 +296,7 @@ describe("useEntities", () => {
     const schemaNode = schema.vertices.find(
       v => v.type === nodeTypeWithAdditionalAttributes
     )!;
-    const entityNode = entities.nodes[0];
+    const entityNode = entities.nodes.values().next().value!;
     const schemaNodeAttributeNames = schemaNode.attributes.map(a => a.name);
     const entityNodeAttributeNames = Object.keys(entityNode.attributes);
     expect(schemaNodeAttributeNames).toEqual(

--- a/packages/graph-explorer/src/hooks/useEntities.ts
+++ b/packages/graph-explorer/src/hooks/useEntities.ts
@@ -49,9 +49,7 @@ const useEntities = ({ disableFilters }: { disableFilters?: boolean } = {}): [
         // Filter nodes that are defined and not hidden
         const filteredNodes = new Map(
           nextEntities.nodes.entries().filter(([_id, node]) => {
-            return !config?.schema?.vertices.find(
-              vertex => vertex.type === node.type
-            )?.hidden;
+            return !config?.getVertexTypeConfig(node.type)?.hidden;
           })
         );
 
@@ -62,11 +60,7 @@ const useEntities = ({ disableFilters }: { disableFilters?: boolean } = {}): [
               node.neighborsCountByType
             ).reduce(
               (totalNeighborsCounts, [type, count]) => {
-                if (
-                  !config?.schema?.vertices.find(
-                    vertex => vertex.type === node.type
-                  )?.hidden
-                ) {
+                if (!config?.getVertexTypeConfig(node.type)?.hidden) {
                   totalNeighborsCounts[1][type] = count;
                 } else {
                   totalNeighborsCounts[0] -= count;
@@ -94,8 +88,7 @@ const useEntities = ({ disableFilters }: { disableFilters?: boolean } = {}): [
         // Filter edges that are defined and not hidden
         const filteredEdges = new Map(
           nextEntities.edges.entries().filter(([_id, edge]) => {
-            return !config?.schema?.edges.find(e => e.type === edge.type)
-              ?.hidden;
+            return !config?.getEdgeTypeConfig(edge.type)?.hidden;
           })
         );
 

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -21,6 +21,7 @@ import { useMutation } from "@tanstack/react-query";
 import { Vertex } from "@/types/entities";
 import { useUpdateAllNodeCounts } from "./useUpdateNodeCounts";
 import { createDisplayError } from "@/utils/createDisplayError";
+import { toNodeMap } from "@/core/StateProvider/nodes";
 
 /*
 
@@ -84,7 +85,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
       }
       // Update nodes and edges in the graph
       setEntities({
-        nodes: data.vertices,
+        nodes: toNodeMap(data.vertices),
         edges: data.edges,
       });
     },

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -22,6 +22,7 @@ import { Vertex } from "@/types/entities";
 import { useUpdateAllNodeCounts } from "./useUpdateNodeCounts";
 import { createDisplayError } from "@/utils/createDisplayError";
 import { toNodeMap } from "@/core/StateProvider/nodes";
+import { toEdgeMap } from "@/core/StateProvider/edges";
 
 /*
 
@@ -86,7 +87,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
       // Update nodes and edges in the graph
       setEntities({
         nodes: toNodeMap(data.vertices),
-        edges: data.edges,
+        edges: toEdgeMap(data.edges),
       });
     },
     onError: error => {

--- a/packages/graph-explorer/src/hooks/useFetchNode.ts
+++ b/packages/graph-explorer/src/hooks/useFetchNode.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { Vertex } from "@/types/entities";
 import useEntities from "./useEntities";
+import { toNodeMap } from "@/core/StateProvider/nodes";
 
 /** Returns a callback that adds a node or array of nodes to the graph. */
 export default function useFetchNode() {
@@ -17,7 +18,7 @@ export default function useFetchNode() {
       }
 
       setEntities({
-        nodes: validResults,
+        nodes: toNodeMap(validResults),
         edges: [],
         selectNewEntities: "nodes",
       });

--- a/packages/graph-explorer/src/hooks/useFetchNode.ts
+++ b/packages/graph-explorer/src/hooks/useFetchNode.ts
@@ -19,7 +19,7 @@ export default function useFetchNode() {
 
       setEntities({
         nodes: toNodeMap(validResults),
-        edges: [],
+        edges: new Map(),
         selectNewEntities: "nodes",
       });
     },

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -35,16 +35,18 @@ export function useUpdateAllNodeCounts() {
   const explorer = useRecoilValue(explorerSelector);
   const { enqueueNotification, clearNotification } = useNotification();
 
-  // Unique ID & ID type combos
-  const nodeIdAndTypes = entities.nodes
-    .entries()
-    .map(([id, node]) => [id, node.idType] as const)
-    .toArray();
-
   const query = useQueries({
-    queries: nodeIdAndTypes.map(([id, idType]) =>
-      neighborsCountQuery(id, idType, connection?.nodeExpansionLimit, explorer)
-    ),
+    queries: entities.nodes
+      .values()
+      .map(node =>
+        neighborsCountQuery(
+          node.id,
+          node.idType,
+          connection?.nodeExpansionLimit,
+          explorer
+        )
+      )
+      .toArray(),
     combine: results => {
       // Combines data with existing node data and filters out undefined
       const data = results

--- a/packages/graph-explorer/src/index.tsx
+++ b/packages/graph-explorer/src/index.tsx
@@ -8,6 +8,7 @@ import ConnectedProvider from "./core/ConnectedProvider";
 import "./index.css";
 import "@mantine/core/styles.css";
 import { DEFAULT_SERVICE_TYPE } from "./utils/constants";
+import "core-js/full/iterator";
 
 const grabConfig = async (): Promise<RawConfiguration | undefined> => {
   const defaultConnectionPath = `${location.origin}/defaultConnection`;

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/EdgesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/EdgesTabular.tsx
@@ -94,10 +94,13 @@ const EdgesTabular = forwardRef<TabularInstance<ToggleEdge>, any>(
     }, [t, onToggleVisibility, textTransform]);
 
     const data: ToggleEdge[] = useDeepMemo(() => {
-      return edges.map(edge => ({
-        ...edge,
-        __is_visible: !hiddenEdgesIds.has(edge.id),
-      }));
+      return edges
+        .values()
+        .map(edge => ({
+          ...edge,
+          __is_visible: !hiddenEdgesIds.has(edge.id),
+        }))
+        .toArray();
     }, [edges, hiddenEdgesIds]);
 
     const onSelectRows = useCallback(
@@ -130,7 +133,7 @@ const EdgesTabular = forwardRef<TabularInstance<ToggleEdge>, any>(
         data={data}
         columns={columns as any[]}
         onDataFilteredChange={rows => {
-          const edgesIds = edges.map(e => e.id);
+          const edgesIds = edges.keys().toArray();
           const ids = rows.map(row => row.original.id);
           setEdgesOut(new Set(difference(edgesIds, ids)));
         }}

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
@@ -123,10 +123,13 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
     }, [config, getDisplayNames, t, onToggleVisibility, textTransform]);
 
     const data: ToggleVertex[] = useDeepMemo(() => {
-      return nodes.map(node => ({
-        ...node,
-        __is_visible: !hiddenNodesIds.has(node.id),
-      }));
+      return nodes
+        .values()
+        .map(node => ({
+          ...node,
+          __is_visible: !hiddenNodesIds.has(node.id),
+        }))
+        .toArray();
     }, [nodes, hiddenNodesIds]);
 
     const onSelectRows = useCallback(
@@ -159,7 +162,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
         data={data}
         columns={columns}
         onDataFilteredChange={rows => {
-          const nodesIds = nodes.map(n => n.id);
+          const nodesIds = nodes.keys().toArray();
           const ids = rows.map(row => row.original.id);
           setNodesOut(new Set(difference(nodesIds, ids)));
         }}

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
@@ -37,7 +37,11 @@ const EntityDetails = ({
   const [userLayout, setUserLayout] = useRecoilState(userLayoutAtom);
 
   const selectedNode = useMemo(() => {
-    return nodes.find(node => selectedNodesIds.has(node.id));
+    return selectedNodesIds
+      .keys()
+      .map(id => nodes.get(id))
+      .filter(n => n != null)
+      .next().value;
   }, [nodes, selectedNodesIds]);
 
   const selectedEdge = useMemo(() => {
@@ -49,10 +53,7 @@ const EntityDetails = ({
       return [undefined, undefined];
     }
 
-    return [
-      nodes.find(node => node.id === selectedEdge.source),
-      nodes.find(node => node.id === selectedEdge.target),
-    ];
+    return [nodes.get(selectedEdge.source), nodes.get(selectedEdge.target)];
   }, [selectedEdgesIds, selectedEdge, nodes]);
 
   const isEmptySelection = selectedNodesIds.size + selectedEdgesIds.size === 0;

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
@@ -45,7 +45,11 @@ const EntityDetails = ({
   }, [nodes, selectedNodesIds]);
 
   const selectedEdge = useMemo(() => {
-    return edges.find(edge => selectedEdgesIds.has(edge.id));
+    return selectedEdgesIds
+      .keys()
+      .map(id => edges.get(id))
+      .filter(n => n != null)
+      .next().value;
   }, [edges, selectedEdgesIds]);
 
   const [sourceNode, targetNode] = useMemo(() => {

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -201,7 +201,7 @@ export default function GraphViewer({
   const onClearCanvas = useCallback(() => {
     setEntities({
       nodes: new Map(),
-      edges: [],
+      edges: new Map(),
       forceSet: true,
     });
   }, [setEntities]);
@@ -233,7 +233,11 @@ export default function GraphViewer({
     [entities]
   );
   const edges = useMemo(
-    () => entities.edges.map(e => ({ data: e })),
+    () =>
+      entities.edges
+        .values()
+        .map(e => ({ data: e }))
+        .toArray(),
     [entities]
   );
 

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/utils";
 import { MouseEvent, useCallback, useMemo, useRef, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { Vertex } from "@/types/entities";
+import { EdgeId, Vertex, VertexId } from "@/types/entities";
 import type { ActionItem, ModuleContainerHeaderProps } from "@/components";
 import {
   ModuleContainer,
@@ -150,14 +150,14 @@ export default function GraphViewer({
   const edgesOutIds = useRecoilValue(edgesOutOfFocusIdsAtom);
 
   const onSelectedNodesIdsChange = useCallback(
-    (selectedIds: string[] | Set<string>) => {
+    (selectedIds: VertexId[] | Set<VertexId>) => {
       setNodesSelectedIds(new Set(selectedIds));
     },
     [setNodesSelectedIds]
   );
 
   const onSelectedEdgesIdsChange = useCallback(
-    (selectedIds: string[] | Set<string>) => {
+    (selectedIds: EdgeId[] | Set<EdgeId>) => {
       setEdgesSelectedIds(new Set(selectedIds));
     },
     [setEdgesSelectedIds]

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -200,7 +200,7 @@ export default function GraphViewer({
   const [layout, setLayout] = useState("F_COSE");
   const onClearCanvas = useCallback(() => {
     setEntities({
-      nodes: [],
+      nodes: new Map(),
       edges: [],
       forceSet: true,
     });
@@ -225,7 +225,11 @@ export default function GraphViewer({
   );
 
   const nodes = useMemo(
-    () => entities.nodes.map(n => ({ data: n })),
+    () =>
+      entities.nodes
+        .values()
+        .map(n => ({ data: n }))
+        .toArray(),
     [entities]
   );
   const edges = useMemo(

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -22,11 +22,12 @@ import useEntities from "@/hooks/useEntities";
 import useTranslations from "@/hooks/useTranslations";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import defaultStyles from "./ContextMenu.styles";
+import { EdgeId, VertexId } from "@/@types/entities";
 
 export type ContextMenuProps = {
   className?: string;
-  affectedNodesIds?: string[];
-  affectedEdgesIds?: string[];
+  affectedNodesIds?: VertexId[];
+  affectedEdgesIds?: EdgeId[];
   graphRef: RefObject<GraphRef | null>;
   onClose?(): void;
   onNodeCustomize(nodeType?: string): void;
@@ -126,7 +127,7 @@ const ContextMenu = ({
   }, [onClose, onZoomOut]);
 
   const handleRemoveFromCanvas = useCallback(
-    (nodesIds: string[], edgesIds: string[]) => () => {
+    (nodesIds: VertexId[], edgesIds: EdgeId[]) => () => {
       setEntities(prev => ({
         nodes: prev.nodes.filter(n => !nodesIds.includes(n.id)),
         edges: prev.edges.filter(e => !edgesIds.includes(e.id)),

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -14,7 +14,7 @@ import {
   ZoomOutIcon,
 } from "@/components/icons";
 import { useWithTheme } from "@/core";
-import { edgesSelectedIdsAtom } from "@/core/StateProvider/edges";
+import { edgesSelectedIdsAtom, toEdgeMap } from "@/core/StateProvider/edges";
 import { nodesSelectedIdsAtom, toNodeMap } from "@/core/StateProvider/nodes";
 import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
 import useDisplayNames from "@/hooks/useDisplayNames";
@@ -139,7 +139,12 @@ const ContextMenu = ({
               .filter(n => !nodesIds.includes(n.id))
               .toArray()
           ),
-          edges: prev.edges.filter(e => !edgesIds.includes(e.id)),
+          edges: toEdgeMap(
+            prev.edges
+              .values()
+              .filter(e => !edgesIds.includes(e.id))
+              .toArray()
+          ),
           forceSet: true,
         };
       });
@@ -151,7 +156,7 @@ const ContextMenu = ({
   const handleRemoveAllFromCanvas = useCallback(() => {
     setEntities({
       nodes: new Map(),
-      edges: [],
+      edges: new Map(),
       forceSet: true,
     });
     onClose?.();
@@ -182,7 +187,7 @@ const ContextMenu = ({
       return;
     }
 
-    return entities.edges.find(e => e.id === affectedEdgesIds[0]);
+    return entities.edges.get(affectedEdgesIds[0]);
   }, [affectedEdgesIds, entities.edges]);
 
   if (affectedNode) {

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/icons";
 import { useWithTheme } from "@/core";
 import { edgesSelectedIdsAtom } from "@/core/StateProvider/edges";
-import { nodesSelectedIdsAtom } from "@/core/StateProvider/nodes";
+import { nodesSelectedIdsAtom, toNodeMap } from "@/core/StateProvider/nodes";
 import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
 import useDisplayNames from "@/hooks/useDisplayNames";
 import useEntities from "@/hooks/useEntities";
@@ -128,11 +128,21 @@ const ContextMenu = ({
 
   const handleRemoveFromCanvas = useCallback(
     (nodesIds: VertexId[], edgesIds: EdgeId[]) => () => {
-      setEntities(prev => ({
-        nodes: prev.nodes.filter(n => !nodesIds.includes(n.id)),
-        edges: prev.edges.filter(e => !edgesIds.includes(e.id)),
-        forceSet: true,
-      }));
+      setEntities(prev => {
+        // const newNodes = new Map(prev.nodes);
+        // nodesIds.forEach(id => newNodes.delete(id));
+        return {
+          // nodes: newNodes,
+          nodes: toNodeMap(
+            prev.nodes
+              .values()
+              .filter(n => !nodesIds.includes(n.id))
+              .toArray()
+          ),
+          edges: prev.edges.filter(e => !edgesIds.includes(e.id)),
+          forceSet: true,
+        };
+      });
       onClose?.();
     },
     [onClose, setEntities]
@@ -140,7 +150,7 @@ const ContextMenu = ({
 
   const handleRemoveAllFromCanvas = useCallback(() => {
     setEntities({
-      nodes: [],
+      nodes: new Map(),
       edges: [],
       forceSet: true,
     });
@@ -164,7 +174,7 @@ const ContextMenu = ({
       return;
     }
 
-    return entities.nodes.find(n => n.id === affectedNodesIds[0]);
+    return entities.nodes.get(affectedNodesIds[0]);
   }, [affectedNodesIds, entities.nodes]);
 
   const affectedEdge = useMemo(() => {

--- a/packages/graph-explorer/src/modules/GraphViewer/useContextMenu.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useContextMenu.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { useLayer, useMousePositionAsTrigger } from "react-laag";
-import type { Edge, Vertex } from "@/types/entities";
+import type { Edge, EdgeId, Vertex, VertexId } from "@/types/entities";
 import type {
   ElementEventCallback,
   GraphEventCallback,
@@ -11,8 +11,8 @@ const useContextMenu = () => {
   // Bounding container used to position the layer correctly
   const parentRef = useRef<HTMLDivElement>(null);
 
-  const [contextNodeId, setContextNodeId] = useState<string | null>(null);
-  const [contextEdgeId, setContextEdgeId] = useState<string | null>(null);
+  const [contextNodeId, setContextNodeId] = useState<VertexId | null>(null);
+  const [contextEdgeId, setContextEdgeId] = useState<EdgeId | null>(null);
   const [contextPosition, setContextPosition] = useState<{
     top: number;
     left: number;

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
@@ -14,17 +14,13 @@ const useNodeBadges = () => {
   const nodes = useRecoilValue(nodesAtom);
 
   const nodesCurrentNames = useMemo(() => {
-    return nodes.reduce(
-      (names, node) => {
+    return new Map(
+      nodes.entries().map(([id, node]) => {
         const vtConfig = config?.getVertexTypeConfig(node.type);
+        const title = vtConfig?.displayLabel || textTransform(node.type);
         const { name } = getDisplayNames(node);
-        names[node.id] = {
-          name,
-          title: vtConfig?.displayLabel || textTransform(node.type),
-        };
-        return names;
-      },
-      {} as Record<string, { name: string; title: string }>
+        return [id, { name, title }];
+      })
     );
   }, [config, getDisplayNames, nodes, textTransform]);
 
@@ -32,8 +28,8 @@ const useNodeBadges = () => {
     (outOfFocusIds: Set<VertexId>): BadgeRenderer =>
       (nodeData, boundingBox, { zoomLevel }) => {
         // Ensure we have the node name and title
-        const name = nodesCurrentNames[nodeData.id]?.name ?? "";
-        const title = nodesCurrentNames[nodeData.id]?.title ?? "";
+        const name = nodesCurrentNames.get(nodeData.id)?.name ?? "";
+        const title = nodesCurrentNames.get(nodeData.id)?.title ?? "";
 
         return [
           {

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
@@ -5,6 +5,7 @@ import { useConfiguration } from "@/core";
 import { nodesAtom } from "@/core/StateProvider/nodes";
 import useDisplayNames from "@/hooks/useDisplayNames";
 import useTextTransform from "@/hooks/useTextTransform";
+import { VertexId } from "@/@types/entities";
 
 const useNodeBadges = () => {
   const config = useConfiguration();
@@ -28,7 +29,7 @@ const useNodeBadges = () => {
   }, [config, getDisplayNames, nodes, textTransform]);
 
   return useCallback(
-    (outOfFocusIds: Set<string>): BadgeRenderer =>
+    (outOfFocusIds: Set<VertexId>): BadgeRenderer =>
       (nodeData, boundingBox, { zoomLevel }) => {
         // Ensure we have the node name and title
         const name = nodesCurrentNames[nodeData.id]?.name ?? "";

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/css";
 import { cn } from "@/utils";
 import { useClickOutside, useHotkeys } from "@mantine/hooks";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Vertex } from "@/types/entities";
+import { Vertex, VertexId } from "@/types/entities";
 
 import {
   AddCircleIcon,
@@ -53,7 +53,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [isFocused, setInputFocused] = useState(false);
-  const selection = useSet<string>(new Set());
+  const selection = useSet<VertexId>(new Set());
 
   const {
     query,
@@ -279,7 +279,7 @@ function SearchResults({
 }: {
   query: UseQueryResult<KeywordSearchResponse | null, Error>;
   currentTotal: number | null | undefined;
-  selection: SetResult<string>;
+  selection: SetResult<VertexId>;
   close: () => void;
 }) {
   const config = useConfiguration();
@@ -412,7 +412,7 @@ function SearchResults({
         draggable={true}
         defaultItemType="graph-viewer__node"
         onItemClick={(_event, item) => {
-          selection.toggle(item.id);
+          selection.toggle(item.id as VertexId);
         }}
         selectedItemsIds={Array.from(selection.state)}
         hideFooter

--- a/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
+++ b/packages/graph-explorer/src/modules/KeywordSearch/KeywordSearch.tsx
@@ -84,12 +84,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
 
   const searchResults = useMemo(() => query.data?.vertices ?? [], [query.data]);
 
-  const isTheNodeAdded = (nodeId: string): boolean => {
-    const possibleNode = entities.nodes.find(
-      addedNode => addedNode.id === nodeId
-    );
-    return possibleNode !== undefined;
-  };
+  const isTheNodeAdded = (nodeId: VertexId) => entities.nodes.has(nodeId);
 
   const getNodeIdsToAdd = () => {
     const selectedNodeIds = Array.from(selection.state);
@@ -114,9 +109,7 @@ export default function KeywordSearch({ className }: KeywordSearchProps) {
 
   const handleAddEntities = () => {
     const nodeIdsToAdd = getNodeIdsToAdd();
-    const nodes = nodeIdsToAdd
-      .map(getNodeSearchedById)
-      .filter(Boolean) as Vertex[];
+    const nodes = nodeIdsToAdd.map(getNodeSearchedById).filter(n => n != null);
     fetchNode(nodes);
     handleOnClose();
   };
@@ -317,7 +310,7 @@ function SearchResults({
               iconImageType={vtConfig?.iconImageType}
             />
           ),
-          endAdornment: entities.nodes.find(n => n.id === vertex.id) ? (
+          endAdornment: entities.nodes.has(vertex.id) ? (
             <IconButton
               tooltipText="Remove from canvas"
               icon={<RemoveFromCanvasIcon className="graph-remove-icon" />}
@@ -327,7 +320,11 @@ function SearchResults({
                 setEntities(prev => {
                   return {
                     ...prev,
-                    nodes: prev.nodes.filter(n => n.id !== vertex.id),
+                    nodes: new Map(
+                      prev.nodes
+                        .entries()
+                        .filter(([id, _node]) => id !== vertex.id)
+                    ),
                     forceSet: true,
                   };
                 });

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpand.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpand.tsx
@@ -27,7 +27,12 @@ const NodeExpand = ({ title = "Expand", ...headerProps }: NodeExpandProps) => {
   const edgesSelectedIds = useRecoilValue(edgesSelectedIdsAtom);
 
   const selectedNode = useMemo(() => {
-    return nodes.find(node => nodesSelectedIds.has(node.id));
+    return nodesSelectedIds
+      .keys()
+      .map(id => nodes.get(id))
+      .filter(v => v != null)
+      .next().value;
+    // return nodes.find(node => nodesSelectedIds.has(node.id));
   }, [nodes, nodesSelectedIds]);
 
   return (

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -5,6 +5,7 @@
 import { expect, afterEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import "core-js/full/iterator";
 
 expect.extend(matchers);
 

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -23,6 +23,7 @@ import {
   UserStyling,
   VertexPreferences,
 } from "@/core/StateProvider/userPreferences";
+import { toNodeMap } from "@/core/StateProvider/nodes";
 
 /*
 
@@ -126,7 +127,7 @@ export function createRandomEntities(): Entities {
     createRandomEdge(nodes[2], nodes[0]),
     createRandomEdge(nodes[2], nodes[1]),
   ];
-  return { nodes, edges };
+  return { nodes: toNodeMap(nodes), edges };
 }
 
 /**

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -24,6 +24,7 @@ import {
   VertexPreferences,
 } from "@/core/StateProvider/userPreferences";
 import { toNodeMap } from "@/core/StateProvider/nodes";
+import { toEdgeMap } from "@/core/StateProvider/edges";
 
 /*
 
@@ -127,7 +128,7 @@ export function createRandomEntities(): Entities {
     createRandomEdge(nodes[2], nodes[0]),
     createRandomEdge(nodes[2], nodes[1]),
   ];
-  return { nodes: toNodeMap(nodes), edges };
+  return { nodes: toNodeMap(nodes), edges: toEdgeMap(edges) };
 }
 
 /**

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -261,7 +261,7 @@ function DisplayNameAndDescriptionOptions({
 function AddToExplorerButton({ vertex }: { vertex: Vertex }) {
   const fetchNode = useFetchNode();
   const [entities] = useEntities({ disableFilters: true });
-  const isInExplorer = !!entities.nodes.find(node => node.id === vertex.id);
+  const isInExplorer = entities.nodes.has(vertex.id);
 
   return (
     <div style={{ display: "inline-block" }}>

--- a/packages/graph-explorer/tsconfig.app.json
+++ b/packages/graph-explorer/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "extends": ["../../tsconfig.base.json"],
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      core-js:
+        specifier: ^3.39.0
+        version: 3.39.0
       esbuild-loader:
         specifier: ^4.2.2
         version: 4.2.2(webpack@5.95.0)
@@ -3213,6 +3216,9 @@ packages:
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+
+  core-js@3.39.0:
+    resolution: {integrity: sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -9466,6 +9472,8 @@ snapshots:
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.24.0
+
+  core-js@3.39.0: {}
 
   cors@2.8.5:
     dependencies:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The data used to power the React graph UI was written using arrays. But arrays are not very efficient when looking for specific data using `.find(x => x.foo == "bar")`. It is much more efficient to use `Map` or `Set` for those situations.

So, I transitioned a few core data sets that are utilized in many places throughout the app to use `Map` instead. I also lean in to `Iterator` helper functions that don't recreate the array on each `.filter()` or `.map()` call.

This resulted in a decent improvement to the UI responsiveness. This means the UI doesn't freeze or drop frames nearly as much as before. But it's a hard thing to measure.

- Adds `core-js` for polyfill of iterator helper methods (not available in Safari)
- Use `Map` for vertices and edges added to the graph
- Use `Map` for type configs in the merged config
- Use `Map` for display name lookup
- Use `VertexId` and `EdgeId` in more places

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Verified by adding many nodes to the graph

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- None (tech debt)

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
