### PR TITLE
Entity mapping

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -56,6 +56,11 @@ export type Vertex = {
 
   // The following properties are computed on run-time
   /**
+   * Sometimes the vertex response does not include the properties, so this flag
+   * indicates that another query must be executed to get the properties.
+   */
+  __isFragment?: boolean;
+  /**
    * Internal flag to mark the resource as blank node in RDF.
    */
   __isBlank?: boolean;
@@ -116,4 +121,10 @@ export type Edge = {
    * For RDF, predicates do not have more properties than the predicate itself.
    */
   attributes: Record<string, string | number>;
+
+  /**
+   * Sometimes the edge response does not include the properties, so this flag
+   * indicates that another query must be executed to get the properties.
+   */
+  __isFragment?: boolean;
 };

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -5,6 +5,10 @@ export type VertexId = Branded<string, "VertexId">;
 
 export type Vertex = {
   /**
+   * Indicates the type in order to discriminate from the `Edge` type in unions.
+   */
+  entityType: "vertex";
+  /**
    * Unique identifier for the vertex.
    * - For PG, the node id
    * - For RDF, the resource URI
@@ -74,6 +78,10 @@ export type Vertex = {
 };
 
 export type Edge = {
+  /**
+   * Indicates the type in order to discriminate from the `Vertex` type in unions.
+   */
+  entityType: "edge";
   /**
    * Unique identifier for the edge.
    * - For PG, the edge id

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -5,7 +5,7 @@ import fetchSchema from "./queries/fetchSchema";
 import fetchVertexTypeCounts from "./queries/fetchVertexTypeCounts";
 import keywordSearch from "./queries/keywordSearch";
 import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
-import { GraphSummary } from "./types";
+import { GraphSummary, GremlinFetch } from "./types";
 import { v4 } from "uuid";
 import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { logger } from "@/utils";
@@ -16,7 +16,7 @@ function _gremlinFetch(
   connection: ConnectionConfig,
   featureFlags: FeatureFlags,
   options?: ExplorerRequestOptions
-) {
+): GremlinFetch {
   return async (queryTemplate: string) => {
     logger.debug(queryTemplate);
     const body = JSON.stringify({ query: queryTemplate });

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
@@ -5,6 +5,7 @@ import toStringId from "./toStringId";
 
 const mapApiEdge = (apiEdge: GEdge): Edge => {
   return {
+    entityType: "edge",
     id: toStringId(apiEdge["@value"].id) as EdgeId,
     type: apiEdge["@value"].label,
     source: toStringId(apiEdge["@value"].outV) as VertexId,

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
@@ -4,6 +4,7 @@ import parseEdgePropertiesValues from "./parseEdgePropertiesValues";
 import toStringId from "./toStringId";
 
 const mapApiEdge = (apiEdge: GEdge): Edge => {
+  const isFragment = apiEdge["@value"].properties == null;
   return {
     entityType: "edge",
     id: toStringId(apiEdge["@value"].id) as EdgeId,
@@ -13,6 +14,7 @@ const mapApiEdge = (apiEdge: GEdge): Edge => {
     target: toStringId(apiEdge["@value"].inV) as VertexId,
     targetType: apiEdge["@value"].inVLabel,
     attributes: parseEdgePropertiesValues(apiEdge["@value"].properties || {}),
+    __isFragment: isFragment,
   };
 };
 

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -11,6 +11,7 @@ const mapApiVertex = (
 ): Vertex => {
   const labels = apiVertex["@value"].label.split("::");
   const vt = labels[0];
+  const isFragment = apiVertex["@value"].properties == null;
 
   return {
     entityType: "vertex",
@@ -20,7 +21,8 @@ const mapApiVertex = (
     types: labels,
     neighborsCount: neighborsCount?.totalCount || 0,
     neighborsCountByType: neighborsCount?.counts || {},
-    attributes: parsePropertiesValues(apiVertex["@value"].properties),
+    attributes: parsePropertiesValues(apiVertex["@value"].properties ?? {}),
+    __isFragment: isFragment,
   };
 };
 

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -13,6 +13,7 @@ const mapApiVertex = (
   const vt = labels[0];
 
   return {
+    entityType: "vertex",
     id: toStringId(apiVertex["@value"].id) as VertexId,
     idType: detectIdType(apiVertex["@value"].id),
     type: vt,

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -1,0 +1,53 @@
+import { Vertex, Edge } from "@/@types/entities";
+import { GAnyValue } from "../types";
+import mapApiEdge from "./mapApiEdge";
+import mapApiVertex from "./mapApiVertex";
+
+export type ScalarValue = number | string | Date;
+
+export type MappedQueryResults = {
+  vertices: Vertex[];
+  edges: Edge[];
+  scalars: ScalarValue[];
+};
+
+export function mapResults(data: GAnyValue) {
+  const values = mapAnyValue(data);
+
+  const result: MappedQueryResults = {
+    vertices: values.filter(e => "vertex" in e).map(e => e.vertex),
+    edges: values.filter(e => "edge" in e).map(e => e.edge),
+    scalars: values.filter(s => "scalar" in s).map(s => s.scalar),
+  };
+
+  return result;
+}
+
+function mapAnyValue(
+  data: GAnyValue
+): Array<{ vertex: Vertex } | { edge: Edge } | { scalar: string | number }> {
+  if (typeof data === "string") {
+    return [{ scalar: data }];
+  } else if (
+    data["@type"] === "g:Int32" ||
+    data["@type"] === "g:Int64" ||
+    data["@type"] === "g:Double"
+  ) {
+    return [{ scalar: data["@value"] }];
+  } else if (data["@type"] === "g:Edge") {
+    return [{ edge: mapApiEdge(data) }];
+  } else if (data["@type"] === "g:Vertex") {
+    return [{ vertex: mapApiVertex(data) }];
+  } else if (data["@type"] === "g:Path") {
+    return mapAnyValue(data["@value"].objects);
+  } else if (
+    data["@type"] === "g:List" ||
+    data["@type"] === "g:Map" ||
+    data["@type"] === "g:Set"
+  ) {
+    return data["@value"].flatMap((item: GAnyValue) => mapAnyValue(item));
+  }
+
+  // Unsupported type
+  return [];
+}

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.ts
@@ -42,6 +42,7 @@ const fetchNeighbors = async (
   return {
     vertices,
     edges,
+    scalars: [],
   };
 };
 

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchSchema.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchSchema.ts
@@ -144,7 +144,7 @@ const fetchVerticesAttributes = async (
     for (let i = 0; i < verticesSchemas.length; i += 2) {
       const label = verticesSchemas[i] as string;
       const vertex = verticesSchemas[i + 1] as GVertex;
-      const properties = vertex["@value"].properties;
+      const properties = vertex["@value"].properties ?? {};
       vertices.push({
         type: label,
         displayLabel: sanitizeText(label),

--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.ts
@@ -37,7 +37,7 @@ const keywordSearch = async (
     return mapApiVertex(value);
   });
 
-  return { vertices };
+  return { vertices, edges: [], scalars: [] };
 };
 
 export default keywordSearch;

--- a/packages/graph-explorer/src/connector/gremlin/types.ts
+++ b/packages/graph-explorer/src/connector/gremlin/types.ts
@@ -18,6 +18,8 @@ export type GDate = {
   "@value": number;
 };
 
+export type GScalar = GInt32 | GInt64 | GDouble | GDate | string;
+
 export type JanusID = {
   "@type": "janusgraph:RelationIdentifier";
   "@value": {
@@ -30,7 +32,7 @@ export type GVertexProperty = {
   "@value": {
     id: GInt32;
     label: string;
-    value: string | GInt32 | GDouble | GDate;
+    value: GScalar;
   };
 };
 
@@ -39,7 +41,7 @@ export type GProperty = {
   "@value": {
     id: GInt32;
     key: string;
-    value: string | GInt32 | GDouble | GDate;
+    value: GScalar;
   };
 };
 
@@ -48,7 +50,7 @@ export type GVertex = {
   "@value": {
     id: string | GInt64;
     label: string;
-    properties: Record<string, Array<GVertexProperty>>;
+    properties?: Record<string, Array<GVertexProperty>>;
   };
 };
 
@@ -74,6 +76,36 @@ export type GEdgeList = {
   "@type": "g:List";
   "@value": Array<GEdge>;
 };
+
+export type GPath = {
+  "@type": "g:Path";
+  "@value": {
+    labels: GList;
+    objects: GList;
+  };
+};
+
+export type GList = {
+  "@type": "g:List";
+  "@value": Array<GAnyValue>;
+};
+
+export type GMap = {
+  "@type": "g:Map";
+  "@value": Array<GAnyValue>;
+};
+
+export type GSet = {
+  "@type": "g:Set";
+  "@value": Array<GAnyValue>;
+};
+
+export type GEntityList = {
+  "@type": "g:List";
+  "@value": Array<GVertex | GEdge>;
+};
+
+export type GAnyValue = GList | GMap | GSet | GPath | GVertex | GEdge | GScalar;
 
 export type GremlinFetch = <TResult = any>(
   queryTemplate: string

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
@@ -7,6 +7,7 @@ const mapApiEdge = (
   targetType: string
 ): Edge => {
   return {
+    entityType: "edge",
     id: apiEdge["~id"] as EdgeId,
     type: apiEdge["~type"],
     source: apiEdge["~start"] as VertexId,

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
@@ -1,5 +1,6 @@
 import { createRandomInteger, createRandomName } from "@shared/utils/testing";
 import mapApiVertex from "./mapApiVertex";
+import { Vertex, VertexId } from "@/@types/entities";
 
 test("maps empty vertex", () => {
   const input = {
@@ -11,14 +12,15 @@ test("maps empty vertex", () => {
   const result = mapApiVertex(input);
 
   expect(result).toEqual({
-    id: "",
+    entityType: "vertex",
+    id: "" as VertexId,
     idType: "string",
     type: "",
     types: [],
     attributes: {},
     neighborsCount: 0,
     neighborsCountByType: {},
-  });
+  } satisfies Vertex);
 });
 
 test("applies the given counts", () => {
@@ -37,14 +39,15 @@ test("applies the given counts", () => {
   const result = mapApiVertex(input, counts);
 
   expect(result).toEqual({
-    id: "",
+    entityType: "vertex",
+    id: "" as VertexId,
     idType: "string",
     type: "",
     types: [],
     attributes: {},
     neighborsCount: counts.totalCount,
     neighborsCountByType: counts.counts,
-  });
+  } satisfies Vertex);
 });
 
 test("maps airport node", () => {
@@ -71,7 +74,8 @@ test("maps airport node", () => {
   const result = mapApiVertex(input);
 
   expect(result).toEqual({
-    id: "1",
+    entityType: "vertex",
+    id: "1" as VertexId,
     idType: "string",
     type: "airport",
     types: ["airport"],
@@ -91,5 +95,5 @@ test("maps airport node", () => {
     },
     neighborsCount: 0,
     neighborsCountByType: {},
-  });
+  } satisfies Vertex);
 });

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -10,6 +10,7 @@ export default function mapApiVertex(
   const vt = labels[0] ?? "";
 
   return {
+    entityType: "vertex",
     id: apiVertex["~id"] as VertexId,
     idType: "string",
     type: vt,

--- a/packages/graph-explorer/src/connector/openCypher/queries/fetchNeighbors.ts
+++ b/packages/graph-explorer/src/connector/openCypher/queries/fetchNeighbors.ts
@@ -41,6 +41,7 @@ const fetchNeighbors = async (
   return {
     vertices,
     edges,
+    scalars: [],
   };
 };
 

--- a/packages/graph-explorer/src/connector/openCypher/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/openCypher/queries/keywordSearch.ts
@@ -24,7 +24,7 @@ const keywordSearch = async (
 ): Promise<KeywordSearchResponse> => {
   const vertices = await vertexKeywordSearch(openCypherFetch, req);
 
-  return { vertices: vertices };
+  return { vertices: vertices, edges: [], scalars: [] };
 };
 
 const vertexKeywordSearch = async (

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -25,7 +25,7 @@ export function searchQuery(
     enabled: Boolean(explorer) && Boolean(request),
     queryFn: async ({ signal }): Promise<KeywordSearchResponse | null> => {
       if (!explorer || !request) {
-        return { vertices: [] };
+        return { vertices: [], edges: [], scalars: [] };
       }
       return await explorer.keywordSearch(request, { signal });
     },

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
@@ -13,6 +13,7 @@ const mapIncomingToEdge = (
   result: IncomingPredicate
 ): Edge => {
   return {
+    entityType: "edge",
     id: `${result.subject.value}-[${result.predFromSubject.value}]->${resourceURI}` as EdgeId,
     type: result.predFromSubject.value,
     source: result.subject.value as VertexId,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
@@ -13,6 +13,7 @@ const mapOutgoingToEdge = (
   result: OutgoingPredicate
 ): Edge => {
   return {
+    entityType: "edge",
     id: `${resourceURI}-[${result.predToSubject.value}]->${result.subject.value}` as EdgeId,
     type: result.predToSubject.value,
     source: resourceURI as VertexId,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -7,6 +7,7 @@ const mapRawResultToVertex = (
   neighborsCount?: NeighborsCountResponse
 ): Vertex => {
   return {
+    entityType: "vertex",
     id: rawResult.uri as VertexId,
     idType: "string",
     type: rawResult.class,

--- a/packages/graph-explorer/src/connector/sparql/queries/fetchNeighbors.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/fetchNeighbors.ts
@@ -160,6 +160,7 @@ const fetchNeighbors = async (
   return {
     vertices,
     edges: [...edges, ...bNodesEdges],
+    scalars: [],
   };
 };
 

--- a/packages/graph-explorer/src/connector/sparql/queries/keywordSearch.ts
+++ b/packages/graph-explorer/src/connector/sparql/queries/keywordSearch.ts
@@ -67,6 +67,8 @@ const keywordSearch = async (
 
   return {
     vertices,
+    edges: [],
+    scalars: [],
   };
 };
 

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -93,6 +93,7 @@ const storedBlankNodeNeighborsRequest = (
       resolve({
         vertices: [],
         edges: [],
+        scalars: [],
       });
       return;
     }
@@ -129,6 +130,7 @@ const storedBlankNodeNeighborsRequest = (
         req.limit ? req.limit + (req.offset ?? 0) : undefined
       ),
       edges: bNode.neighbors.edges,
+      scalars: [],
     });
   });
 };
@@ -243,7 +245,7 @@ export function createSparqlExplorer(
         request,
         response
       );
-      return { vertices, edges: response.edges };
+      return { vertices, edges: response.edges, scalars: [] };
     },
     async fetchNeighborsCount(req, options) {
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors count...");
@@ -315,7 +317,7 @@ export function createSparqlExplorer(
         response
       );
 
-      return { vertices };
+      return { vertices, edges: [], scalars: [] };
     },
   } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -1,10 +1,10 @@
-import { Edge, Vertex } from "@/types/entities";
 import {
   ConfigurationContextProps,
   EdgeTypeConfig,
   VertexTypeConfig,
 } from "@/core";
 import { ConnectionConfig } from "@shared/types";
+import { MappedQueryResults } from "./gremlin/mappers/mapResults";
 
 export type QueryOptions = RequestInit & {
   queryId?: string;
@@ -115,16 +115,7 @@ export type NeighborsRequest = {
   offset?: number;
 };
 
-export type NeighborsResponse = {
-  /**
-   * List of vertices.
-   */
-  vertices: Array<Vertex>;
-  /**
-   * List of edges.
-   */
-  edges: Array<Edge>;
-};
+export type NeighborsResponse = MappedQueryResults;
 
 export type NeighborsCountRequest = {
   /**
@@ -181,12 +172,7 @@ export type KeywordSearchRequest = {
   exactMatch?: boolean;
 };
 
-export type KeywordSearchResponse = {
-  /**
-   * List of vertices.
-   */
-  vertices: Array<Vertex>;
-};
+export type KeywordSearchResponse = MappedQueryResults;
 
 export type ErrorResponse = {
   code: string;

--- a/packages/graph-explorer/src/hooks/useDisplayNames.ts
+++ b/packages/graph-explorer/src/hooks/useDisplayNames.ts
@@ -5,7 +5,7 @@ import useTextTransform from "./useTextTransform";
 import { RESERVED_ID_PROPERTY } from "@/utils/constants";
 
 const isVertex = (vOrE: Vertex | Edge): vOrE is Vertex => {
-  return "neighborsCount" in vOrE && vOrE.neighborsCount != null;
+  return vOrE.entityType === "vertex";
 };
 
 const useDisplayNames = () => {

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -68,6 +68,7 @@ describe("useEntities", () => {
 
   it("should handle multiple nodes correctly", async () => {
     const node1: Vertex = {
+      entityType: "vertex",
       id: "1" as VertexId,
       idType: "string",
       type: "type1",
@@ -76,6 +77,7 @@ describe("useEntities", () => {
       neighborsCountByType: {},
     };
     const node2: Vertex = {
+      entityType: "vertex",
       id: "2" as VertexId,
       idType: "string",
       type: "type2",
@@ -84,6 +86,7 @@ describe("useEntities", () => {
       neighborsCountByType: {},
     };
     const node3: Vertex = {
+      entityType: "vertex",
       id: "3" as VertexId,
       idType: "string",
       type: "type3",
@@ -93,6 +96,7 @@ describe("useEntities", () => {
     };
     const expectedNodes = toNodeMap([
       {
+        entityType: "vertex",
         id: node1.id,
         idType: "string",
         type: node1.type,
@@ -105,6 +109,7 @@ describe("useEntities", () => {
         __unfetchedNeighborCount: 0,
       },
       {
+        entityType: "vertex",
         id: node2.id,
         idType: "string",
         type: node2.type,
@@ -117,6 +122,7 @@ describe("useEntities", () => {
         __unfetchedNeighborCount: 0,
       },
       {
+        entityType: "vertex",
         id: node3.id,
         idType: "string",
         type: node3.type,

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -137,6 +137,7 @@ export function createRandomEntities(): Entities {
  */
 export function createRandomVertex(): Vertex {
   return {
+    entityType: "vertex",
     id: createRandomName("VertexId") as VertexId,
     idType: "string",
     type: createRandomName("VertexType"),
@@ -152,6 +153,7 @@ export function createRandomVertex(): Vertex {
  */
 export function createRandomEdge(source: Vertex, target: Vertex): Edge {
   return {
+    entityType: "edge",
     id: createRandomName("EdgeId") as EdgeId,
     type: createRandomName("EdgeType"),
     attributes: createRecord(3, createRandomEntityAttribute),


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This logic is from my prototype work with the raw query editor. I had to support many more types of Gremlin responses, so I expanded the mapping logic.

- Added `entityType: 'vertex' | 'edge'` to both Vertex and Edge types to aid in discriminated unions
- Added `__isFragment` to Vertex and Edge to flag when a query returns a vertex or edge without any properties (this will allow us query for the details later)
- Added recursive mapping logic for Gremlin results that will properly map nearly any data type within the query result

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

- Validated all three query languages

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- None (code improvement)

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
