### PR TITLE
Open search by default

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -204,7 +204,7 @@ export const userLayoutAtom = atom<UserPreferences["layout"]>({
   key: "user-layout",
   default: {
     activeToggles: new Set(["graph-viewer", "table-view"]),
-    activeSidebarItem: null,
+    activeSidebarItem: "search",
     detailsAutoOpenOnSelection: true,
     tableView: {
       height: 300,

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -98,7 +98,15 @@ export type UserStyling = {
 export type UserPreferences = {
   layout: {
     activeToggles: Set<string>;
-    activeSidebarItem: string | null;
+    activeSidebarItem:
+      | "search"
+      | "details"
+      | "filters"
+      | "expand"
+      | "nodes-styling"
+      | "edges-styling"
+      | "namespaces"
+      | null;
     tableView?: {
       height: number;
     };
@@ -106,6 +114,7 @@ export type UserPreferences = {
   };
   styling: UserStyling;
 };
+export type SidebarItems = UserPreferences["layout"]["activeSidebarItem"];
 
 export const userStylingAtom = atom<UserStyling>({
   key: "user-styling",

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -195,6 +195,7 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
             actionLabel="Start synchronization"
             onAction={onConfigSync}
             actionVariant="text"
+            className="p-6"
           />
         )}
         {isSync && (
@@ -203,6 +204,7 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
             icon={<SyncIcon className="animate-spin" />}
             title="Synchronizing..."
             subtitle="The connection is being synchronized."
+            className="p-6"
           />
         )}
         <Modal

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -16,7 +16,10 @@ import {
 import { useWithTheme } from "@/core";
 import { edgesSelectedIdsAtom, toEdgeMap } from "@/core/StateProvider/edges";
 import { nodesSelectedIdsAtom, toNodeMap } from "@/core/StateProvider/nodes";
-import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
+import {
+  SidebarItems,
+  userLayoutAtom,
+} from "@/core/StateProvider/userPreferences";
 import { useDisplayNames, useEntities, useTranslations } from "@/hooks";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import defaultStyles from "./ContextMenu.styles";
@@ -63,7 +66,10 @@ const ContextMenu = ({
     nodesSelectedIds.size >= 1 || edgesSelectedIds.size >= 1;
 
   const openSidebarPanel = useCallback(
-    (panelName: string, props?: { nodeType?: string; edgeType?: string }) =>
+    (
+      panelName: SidebarItems,
+      props?: { nodeType?: string; edgeType?: string }
+    ) =>
       () => {
         setUserLayout(prev => ({
           ...prev,

--- a/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
@@ -1,5 +1,5 @@
 import { Vertex } from "@/@types/entities";
-import { Button, VertexSymbol } from "@/components";
+import { Button, Tooltip, VertexSymbol } from "@/components";
 import { useVertexTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
 import {
   useAddToGraph,
@@ -9,7 +9,11 @@ import {
   useTextTransform,
 } from "@/hooks";
 import { cn } from "@/utils";
-import { ChevronRightIcon, PlusCircleIcon, Trash2Icon } from "lucide-react";
+import {
+  ChevronRightIcon,
+  MinusCircleIcon,
+  PlusCircleIcon,
+} from "lucide-react";
 import { useState } from "react";
 
 export function NodeSearchResult({ node }: { node: Vertex }) {
@@ -51,27 +55,30 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
             </div>
           </div>
         </div>
-        <div className="flex size-8 shrink-0 items-center justify-center">
-          {hasBeenAdded ? (
-            <Button
-              icon={<Trash2Icon />}
-              variant="text"
-              className="text-warning-dark hover:text-warning-main"
-              onPress={removeFromGraph}
-            >
-              <span className="sr-only">Remove</span>
-            </Button>
-          ) : (
-            <Button
-              icon={<PlusCircleIcon />}
-              variant="text"
-              className="text-primary-dark hover:text-primary-main"
-              onPress={addToGraph}
-            >
-              <span className="sr-only">Add to Graph</span>
-            </Button>
-          )}
-        </div>
+        <Tooltip
+          text={hasBeenAdded ? "Remove from graph" : "Add to graph"}
+          delayEnter={200}
+        >
+          <div className="flex size-8 shrink-0 items-center justify-center">
+            {hasBeenAdded ? (
+              <Button
+                icon={<MinusCircleIcon />}
+                variant="text"
+                onPress={removeFromGraph}
+              >
+                <span className="sr-only">Remove from graph</span>
+              </Button>
+            ) : (
+              <Button
+                icon={<PlusCircleIcon />}
+                variant="text"
+                onPress={addToGraph}
+              >
+                <span className="sr-only">Add to Graph</span>
+              </Button>
+            )}
+          </div>
+        </Tooltip>
       </div>
       <div className="border-background-secondary px-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
         <ul>

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -26,7 +26,10 @@ import { useConfiguration, useWithTheme } from "@/core";
 import { edgesSelectedIdsAtom } from "@/core/StateProvider/edges";
 import { nodesSelectedIdsAtom } from "@/core/StateProvider/nodes";
 import { totalFilteredCount } from "@/core/StateProvider/filterCount";
-import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
+import {
+  SidebarItems,
+  userLayoutAtom,
+} from "@/core/StateProvider/userPreferences";
 import { usePrevious } from "@/hooks";
 import useTranslations from "@/hooks/useTranslations";
 import EdgesStyling from "@/modules/EdgesStyling/EdgesStyling";
@@ -73,7 +76,7 @@ const GraphExplorer = () => {
   }, [setUserLayout]);
 
   const toggleSidebar = useCallback(
-    (item: string) => () => {
+    (item: SidebarItems) => () => {
       setUserLayout(prev => {
         if (prev.activeSidebarItem === item) {
           return {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

New users should see the search sidebar open by default when they launch for the first time.

- Adjusted add and remove buttons for search results
  - Use primary button colors for both add and remove
  - Change remove icon to circle with minus
  - Add tooltip
- Made search sidebar open by default for new users
- Add padding to empty states in connection screen

## Validation

- Verified locally by deleting my local graph explorer database to simulate a new user

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

- Related to #665 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
