### PR TITLE
ESLint rule to fix curly braces around prop literals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,7 @@ export default [
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
       "react/display-name": "off",
+      "react/jsx-curly-brace-presence": "error",
 
       // Hooks
       "react-hooks/rules-of-hooks": "error",

--- a/packages/graph-explorer/src/App.tsx
+++ b/packages/graph-explorer/src/App.tsx
@@ -12,14 +12,14 @@ import {
 const App = () => {
   return (
     <Routes>
-      <Route path={"/connections"} element={<Connections />} />
-      <Route path={"/data-explorer/:vertexType"} element={<DataExplorer />} />
-      <Route path={"/graph-explorer"} element={<GraphExplorer />} />
-      <Route path={"/settings"} element={<SettingsRoot />}>
+      <Route path="/connections" element={<Connections />} />
+      <Route path="/data-explorer/:vertexType" element={<DataExplorer />} />
+      <Route path="/graph-explorer" element={<GraphExplorer />} />
+      <Route path="/settings" element={<SettingsRoot />}>
         <Route path="general" element={<SettingsGeneral />} />
         <Route path="about" element={<SettingsAbout />} />
       </Route>
-      <Route path={"*"} element={<Redirect to={"/graph-explorer"} />} />
+      <Route path="*" element={<Redirect to="/graph-explorer" />} />
     </Routes>
   );
 };

--- a/packages/graph-explorer/src/components/AdvancedList/AdvancedList.tsx
+++ b/packages/graph-explorer/src/components/AdvancedList/AdvancedList.tsx
@@ -198,7 +198,7 @@ const AdvancedList = <T extends object>(
             disableBorder
             title={
               hasHeader && (
-                <div className={"advanced-list-search-wrapper"}>
+                <div className="advanced-list-search-wrapper">
                   {children}
                   {onSearch && (
                     <SearchBar
@@ -239,7 +239,7 @@ const AdvancedList = <T extends object>(
               />
             )}
             {isPlainListVisible && (
-              <div className={"advanced-list-nogroup"}>
+              <div className="advanced-list-nogroup">
                 {!disableVirtualization && (
                   <Virtuoso
                     ref={ref}
@@ -286,7 +286,7 @@ const AdvancedList = <T extends object>(
                 {disableVirtualization &&
                   filteredItems.map((item, index) => (
                     <div
-                      className={"advanced-list-nogroup-item-wrapper"}
+                      className="advanced-list-nogroup-item-wrapper"
                       key={item.id}
                     >
                       <ElementsListItem
@@ -311,7 +311,7 @@ const AdvancedList = <T extends object>(
           </Section>
         )}
         {isLoading && (
-          <div className={"advanced-list-loading"}>
+          <div className="advanced-list-loading">
             <LoadingSpinner />
           </div>
         )}

--- a/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
+++ b/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
@@ -49,20 +49,20 @@ const ColorInput: FC<ColorInputProps & ColorPickerProps> = ({
 
   return (
     <div className={cn(styleWithTheme(defaultStyles), className)}>
-      <div className={"color-input"}>
+      <div className="color-input">
         <UseLayer
           onClose={() => setColorPickerOpen(false)}
           isOpen={colorPickerOpen}
-          placement={"bottom-start"}
+          placement="bottom-start"
         >
           <UseLayerTrigger>
             <Input
               label={label}
               labelPlacement={labelPlacement}
               aria-label="color-input"
-              className={"input"}
+              className="input"
               onClick={() => setColorPickerOpen(true)}
-              type={"text"}
+              type="text"
               value={color}
               onChange={(newColor: string) => setColor(newColor)}
               endAdornment={

--- a/packages/graph-explorer/src/components/HumanReadableNumberFormatter/HumanReadableNumberFormatter.tsx
+++ b/packages/graph-explorer/src/components/HumanReadableNumberFormatter/HumanReadableNumberFormatter.tsx
@@ -42,7 +42,7 @@ export const HumanReadableNumberFormatter = forwardRef<
         {!!unit && unitPlacement === "start" && (
           <div className={cn(unitStyles, `unit`)}>{unit}</div>
         )}
-        <div className={`number`}>{!noFormat ? formattedValue : value}</div>
+        <div className="number">{!noFormat ? formattedValue : value}</div>
         {!noFormat && symbol && (
           <div className={cn(symbolStyles, `symbol`)}>{symbol}</div>
         )}

--- a/packages/graph-explorer/src/components/Input/Input.tsx
+++ b/packages/graph-explorer/src/components/Input/Input.tsx
@@ -119,13 +119,13 @@ export const Input = (
       )}
     >
       {label && (
-        <label className={"input-label"} {...labelProps}>
+        <label className="input-label" {...labelProps}>
           {label}
         </label>
       )}
-      <div className={"input-container"}>
+      <div className="input-container">
         {!!startAdornment && (
-          <span className={"start-adornment"}>{startAdornment}</span>
+          <span className="start-adornment">{startAdornment}</span>
         )}
         <input
           {...clickHandlers}
@@ -142,11 +142,11 @@ export const Input = (
         />
 
         {!!endAdornment && (
-          <span className={"end-adornment"}>{endAdornment}</span>
+          <span className="end-adornment">{endAdornment}</span>
         )}
-        {!!clearButton && <span className={"clearButton"}>{clearButton}</span>}
+        {!!clearButton && <span className="clearButton">{clearButton}</span>}
         {validationState === "invalid" && !!errorMessage && !hideError && (
-          <div className={"input-error"}>{errorMessage}</div>
+          <div className="input-error">{errorMessage}</div>
         )}
       </div>
     </div>

--- a/packages/graph-explorer/src/components/ListItem/ListItem.tsx
+++ b/packages/graph-explorer/src/components/ListItem/ListItem.tsx
@@ -81,11 +81,11 @@ export const ListItem = (
       {...allProps}
     >
       {startAdornment && (
-        <div className={"start-adornment"}>{startAdornment}</div>
+        <div className="start-adornment">{startAdornment}</div>
       )}
-      <div className={"content"}>
-        <div className={"primary"}>{children}</div>
-        <div className={"secondary"}>{secondary}</div>
+      <div className="content">
+        <div className="primary">{children}</div>
+        <div className="secondary">{secondary}</div>
       </div>
       {endAdornment && <div className="end-adornment">{endAdornment}</div>}
     </div>

--- a/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
+++ b/packages/graph-explorer/src/components/NotificationProvider/NotificationProvider.tsx
@@ -177,7 +177,7 @@ export const NotificationProvider: FC<NotificationProviderProps> = ({
                 nodeRef={nodeRef}
                 key={notification.id}
                 timeout={200}
-                classNames={"item"}
+                classNames="item"
                 style={{
                   pointerEvents: "all",
                   ...(notification.anchorOrigin

--- a/packages/graph-explorer/src/components/PanelError.tsx
+++ b/packages/graph-explorer/src/components/PanelError.tsx
@@ -14,7 +14,7 @@ export default function PanelError({
   const displayError = createDisplayError(error);
   return (
     <PanelEmptyState
-      variant={"error"}
+      variant="error"
       icon={<GraphIcon />}
       title={displayError.title}
       subtitle={displayError.message}

--- a/packages/graph-explorer/src/components/Section/Section.tsx
+++ b/packages/graph-explorer/src/components/Section/Section.tsx
@@ -91,23 +91,23 @@ export const Section = ({
     );
     return (
       <div
-        className={"header-container"}
+        className="header-container"
         onClick={ev =>
           collapseAction === "all" && onCollapseChange?.(!isCollapse, ev)
         }
       >
         {collapsible && collapseIndicatorPosition === "start" && (
           <div
-            className={"collapse-action"}
+            className="collapse-action"
             onClick={ev => onCollapseChange?.(!isCollapse, ev)}
           >
             {collapseIndicator}
           </div>
         )}
-        <div className={"title"}>{title}</div>
+        <div className="title">{title}</div>
         {collapsible && collapseIndicatorPosition === "end" && (
           <div
-            className={"collapse-action"}
+            className="collapse-action"
             onClick={ev => onCollapseChange?.(!isCollapse, ev)}
           >
             {collapseIndicator}
@@ -151,7 +151,7 @@ export const Section = ({
     >
       {headerContainer}
       {Children.count(children) > 0 && (
-        <div className={"content"}>
+        <div className="content">
           {collapsible ? (
             <div
               className={cn("collapsible-container", {

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectBox.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectBox.tsx
@@ -159,8 +159,8 @@ const SelectBox = (
         items.length > 0 && setMenuOpen(!menuOpen);
       }}
     >
-      {label && <label className={"input-label"}>{label}</label>}
-      <div className={"input-container"} aria-label={props["aria-label"]}>
+      {label && <label className="input-label">{label}</label>}
+      <div className="input-container" aria-label={props["aria-label"]}>
         <button
           ref={mergeRefs(triggerProps.ref, ref)}
           type="button"
@@ -170,16 +170,16 @@ const SelectBox = (
           })}
         >
           {selectedOptions !== "" ? (
-            <span className={"selection"}>{selectedOptions}</span>
+            <span className="selection">{selectedOptions}</span>
           ) : (
-            <span className={"placeholder"}>
+            <span className="placeholder">
               {props.placeholder || "Select an option..."}
             </span>
           )}
-          <span className={"dropdown-indicator"}>
+          <span className="dropdown-indicator">
             {clearable && selectedOptions !== "" && (
               <IconButton
-                className={"clear-button"}
+                className="clear-button"
                 variant="text"
                 icon={<CloseIcon />}
                 onClick={() => onSelectionChange?.(new Set())}
@@ -194,7 +194,7 @@ const SelectBox = (
           </span>
         </button>
         {validationState === "invalid" && !!errorMessage && !hideError && (
-          <div className={"input-error"}>{errorMessage}</div>
+          <div className="input-error">{errorMessage}</div>
         )}
       </div>
       {items.length > 0 &&

--- a/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.tsx
+++ b/packages/graph-explorer/src/components/Select/internalComponents/SelectHeader/SelectHeader.tsx
@@ -20,8 +20,8 @@ const SelectHeader = ({
   }
   return (
     <div className={cn(styleWithTheme(defaultStyles), className)}>
-      {title && <div className={"select-header-title"}>{title}</div>}
-      {subtitle && <div className={"select-header-subtitle"}>{subtitle}</div>}
+      {title && <div className="select-header-title">{title}</div>}
+      {subtitle && <div className="select-header-subtitle">{subtitle}</div>}
     </div>
   );
 };

--- a/packages/graph-explorer/src/components/Switch/Switch.tsx
+++ b/packages/graph-explorer/src/components/Switch/Switch.tsx
@@ -79,8 +79,8 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
             }
           )}
         >
-          <div className={"switch-track"}>
-            <div className={"switch-handle"}>
+          <div className="switch-track">
+            <div className="switch-handle">
               {isSelected && onIcon} {!isSelected && offIcon}
             </div>
           </div>

--- a/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/ModuleContainerTabularHeader/ModuleContainerTabularHeader.tsx
@@ -29,17 +29,17 @@ const ModuleContainerTabularHeader = ({
     <div
       className={cn(styleWithTheme(defaultStyles), "entities-tabular-header")}
     >
-      <div className={"title"}>
+      <div className="title">
         {startAdornment ? (
-          <div className={"start-adornment"}>{startAdornment}</div>
+          <div className="start-adornment">{startAdornment}</div>
         ) : (
-          <GridIcon className={"icon"} />
+          <GridIcon className="icon" />
         )}
         {moduleName}
       </div>
-      <div className={"select-table"}>
+      <div className="select-table">
         <Select
-          aria-label={"Table"}
+          aria-label="Table"
           value={selectedTable}
           onChange={option => onTableChange(option as string)}
           options={tables}

--- a/packages/graph-explorer/src/components/Tabular/Tabular.tsx
+++ b/packages/graph-explorer/src/components/Tabular/Tabular.tsx
@@ -198,7 +198,7 @@ const TabularContent = <T extends object>({
       }}
     >
       {headerControlsChildren}
-      <div {...getTableProps()} className={"table"}>
+      <div {...getTableProps()} className="table">
         <div
           className={cn("headers", {
             ["headers-sticky"]: !disableStickyHeader,
@@ -217,7 +217,7 @@ const TabularContent = <T extends object>({
             />
           ))}
         </div>
-        <div {...getTableBodyProps()} className={"body"}>
+        <div {...getTableBodyProps()} className="body">
           {emptyBodyControlsChildren}
           {actualRows.map(row => {
             return (

--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
@@ -15,7 +15,7 @@ const TabularHeader = <T extends object>({
   const { key, ...otherProps } = headerGroup.getHeaderGroupProps();
 
   return (
-    <div key={key} {...otherProps} className={"row"}>
+    <div key={key} {...otherProps} className="row">
       {headerGroup.headers.map(column => {
         const { key, style, ...restHeaderProps } = column.getHeaderProps(
           column.getSortByToggleProps({
@@ -56,7 +56,7 @@ const TabularHeader = <T extends object>({
               </div>
               <div>
                 <div
-                  className={"header-label-sorter"}
+                  className="header-label-sorter"
                   style={{
                     opacity: column.isSorted ? 1 : 0,
                     transform: column.isSortedDesc ? "unset" : "rotate(180deg)",
@@ -67,12 +67,12 @@ const TabularHeader = <T extends object>({
               </div>
             </div>
             {column.canFilter && (
-              <div className={"header-filter"}>{column.render("Filter")}</div>
+              <div className="header-filter">{column.render("Filter")}</div>
             )}
             {column.canResize && (
               <div
                 {...(column.getResizerProps?.() || {})}
-                className={"col-resizer"}
+                className="col-resizer"
               />
             )}
           </div>

--- a/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
@@ -80,7 +80,7 @@ const TabularRow = <T extends object>({
             {cell.column.canResize && (
               <div
                 {...(cell.column.getResizerProps?.() || {})}
-                className={"cell-resizer"}
+                className="cell-resizer"
               />
             )}
           </div>

--- a/packages/graph-explorer/src/components/Tabular/builders/makeIconActionCell.tsx
+++ b/packages/graph-explorer/src/components/Tabular/builders/makeIconActionCell.tsx
@@ -40,8 +40,8 @@ export const makeIconActionCell =
       <div className={styles()}>
         <IconButton
           icon={getIcon?.(props) || icon}
-          size={"small"}
-          variant={"text"}
+          size="small"
+          variant="text"
           onClick={() => onPress(props)}
         />
       </div>

--- a/packages/graph-explorer/src/components/Tabular/builders/makeIconToggleCell.tsx
+++ b/packages/graph-explorer/src/components/Tabular/builders/makeIconToggleCell.tsx
@@ -36,8 +36,8 @@ export const makeIconActionCell =
       <div className={styles()}>
         <IconButton
           icon={getValue(props) ? on : off}
-          size={"small"}
-          variant={"text"}
+          size="small"
+          variant="text"
           onClick={() => onPress?.(props)}
         />
       </div>

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ColumnItem.tsx
@@ -25,22 +25,22 @@ const ColumnItem = <T extends object>({
         <div
           ref={provided.innerRef}
           {...provided.draggableProps}
-          className={"column-item"}
+          className="column-item"
         >
-          <div className={"column-item-switch"}>
+          <div className="column-item-switch">
             <Switch
-              size={"sm"}
+              size="sm"
               isSelected={visibleColumns[columnId] || false}
               onChange={() => toggleHideColumn(columnId)}
               isDisabled={column.definition?.unhideable}
             >
-              <div className={"column-item-label"}>
+              <div className="column-item-label">
                 {column.instance.render("Header")}
               </div>
             </Switch>
           </div>
           <div
-            className={"column-item-drag-handler"}
+            className="column-item-drag-handler"
             {...provided.dragHandleProps}
           >
             <DragIcon />

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
@@ -101,8 +101,8 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
   return (
     <div id="columns-settings-control" className={rootStyles()}>
       <IconButton
-        variant={"text"}
-        size={"base"}
+        variant="text"
+        size="base"
         icon={<ManageColumnsIcon />}
         onClick={() => setIsContentVisible(visible => !visible)}
         {...triggerProps}
@@ -110,14 +110,14 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
       {renderLayer(
         <div {...layerProps} className={cn(defaultStyles(), className)}>
           {isContentVisible && (
-            <Card className={"card"}>
+            <Card className="card">
               <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="columns-list">
                   {provided => (
                     <div
                       ref={provided.innerRef}
                       {...provided.droppableProps}
-                      className={"columns-list"}
+                      className="columns-list"
                     >
                       {columnOrder.map((columnId, index) => {
                         const currentColumn = columns.find(
@@ -137,10 +137,10 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
                         );
                       })}
                       {provided.placeholder}
-                      <div className={"action-item"}>
+                      <div className="action-item">
                         <Button
-                          variant={"text"}
-                          size={"small"}
+                          variant="text"
+                          size="small"
                           onPress={onReset}
                         >
                           Reset

--- a/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ColumnSettingsControl/ExternalColumnSettingsControl.tsx
@@ -138,11 +138,7 @@ export const ColumnSettingsControl = <T extends Record<string, unknown>>({
                       })}
                       {provided.placeholder}
                       <div className="action-item">
-                        <Button
-                          variant="text"
-                          size="small"
-                          onPress={onReset}
-                        >
+                        <Button variant="text" size="small" onPress={onReset}>
                           Reset
                         </Button>
                       </div>

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
@@ -134,7 +134,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
         <div className="flex flex-col gap-2">
           <Label>
             <Checkbox
-              aria-label={`Keep filtering and sorting`}
+              aria-label="Keep filtering and sorting"
               checked={options["include-filters"]}
               onCheckedChange={isSelected => {
                 setOptions(prev => ({
@@ -147,7 +147,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
           </Label>
           <Label>
             <Checkbox
-              aria-label={`Only current page`}
+              aria-label="Only current page"
               checked={options["only-page"]}
               onCheckedChange={isSelected => {
                 setOptions(prev => ({
@@ -179,7 +179,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
         <Label htmlFor="exportName">Save as</Label>
         <Input
           name="exportName"
-          aria-label={"Export name"}
+          aria-label="Export name"
           value={name}
           placeholder={`export-${new Date().getTime()}.${format}`}
           onChange={setName}

--- a/packages/graph-explorer/src/components/Tabular/controls/ExternalPaginationControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExternalPaginationControl.tsx
@@ -141,18 +141,18 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
   return (
     <div className={cn(defaultStyles(), className)}>
       {totalRows > 0 && (
-        <div className={"pagination-totals"}>
+        <div className="pagination-totals">
           Displaying {pageRange} of{" "}
           <HumanReadableNumberFormatter value={totalRows} /> results
         </div>
       )}
-      {totalRows === 0 && <div className={"pagination-totals"}>No results</div>}
+      {totalRows === 0 && <div className="pagination-totals">No results</div>}
       {totalRows > 0 && (
-        <div className={"pagination-controls"}>
+        <div className="pagination-controls">
           <Select
             label="Page size:"
             labelPlacement="left"
-            className={"page-options-menu"}
+            className="page-options-menu"
             options={pageOptions.map(pageOption => ({
               label: pageOption.toString(),
               value: pageOption.toString(),
@@ -164,26 +164,26 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
           />
           <IconButton
             disabled={pageIndex - 1 < 0}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<SkipBackwardIcon />}
             onClick={() => onPageIndexChange(0)}
           />
           <IconButton
             disabled={pageIndex - 1 < 0}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<BackwardIcon />}
             onClick={() => onPageIndexChange(pageIndex - 1)}
           />
-          <div className={"page-viz"}>
+          <div className="page-viz">
             {pagesToRender.map(page => {
               return (
                 <Button
                   key={page}
-                  className={"page-button"}
+                  className="page-button"
                   variant={
                     pageIndex === parseInt(page) - 1 ? "filled" : "default"
                   }
@@ -197,15 +197,15 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
           </div>
           <IconButton
             disabled={pageIndex + 1 >= pageCount}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<ForwardIcon />}
             onClick={() => onPageIndexChange(pageIndex + 1)}
           />
           <IconButton
             disabled={pageIndex + 1 >= pageCount}
-            variant={"text"}
+            variant="text"
             className={cn("page-button", "page-control")}
             icon={<SkipForwardIcon />}
             onClick={() => onPageIndexChange(pageCount - 1)}

--- a/packages/graph-explorer/src/components/Tabular/controls/GlobalFilterControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/GlobalFilterControl.tsx
@@ -41,13 +41,13 @@ export const GlobalFilterControl: FunctionComponent = () => {
   return (
     <div className={defaultStyles(isDarkTheme)}>
       <Input
-        aria-label={"global filter"}
-        className={"global-filter-input-root"}
-        type={"text"}
+        aria-label="global filter"
+        className="global-filter-input-root"
+        type="text"
         noMargin
         hideError
         size="sm"
-        placeholder={"Search..."}
+        placeholder="Search..."
         value={(instance?.globalFilter as string) || ""}
         onChange={value => {
           // do not use value || undefined because
@@ -57,7 +57,7 @@ export const GlobalFilterControl: FunctionComponent = () => {
             : instance?.setGlobalFilter(undefined);
         }}
         startAdornment={
-          <div className={"global-filter-start-adornment"}>
+          <div className="global-filter-start-adornment">
             <SearchIcon />
           </div>
         }

--- a/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
@@ -148,18 +148,18 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
   return (
     <div className={cn(defaultStyles(), className)}>
       {totalRows > 0 && (
-        <div className={"pagination-totals"}>
+        <div className="pagination-totals">
           Displaying {pageRange} of{" "}
           <HumanReadableNumberFormatter value={totalRows} /> results
         </div>
       )}
-      {totalRows === 0 && <div className={"pagination-totals"}>No results</div>}
+      {totalRows === 0 && <div className="pagination-totals">No results</div>}
       {totalRows > 0 && (
-        <div className={"pagination-controls"}>
+        <div className="pagination-controls">
           <Select
             label="Page size:"
             labelPlacement="left"
-            className={"page-options-menu"}
+            className="page-options-menu"
             options={pageOptions.map(pageOption => ({
               label: pageOption.toString(),
               value: pageOption.toString(),
@@ -171,26 +171,26 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
           />
           <IconButton
             disabled={!canPreviousPage}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<SkipBackwardIcon />}
             onClick={() => gotoPage(0)}
           />
           <IconButton
             disabled={!canPreviousPage}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<BackwardIcon />}
             onClick={previousPage}
           />
-          <div className={"page-viz"}>
+          <div className="page-viz">
             {pagesToRender.map(page => {
               return (
                 <Button
                   key={page}
-                  className={"page-button"}
+                  className="page-button"
                   variant={
                     pageIndex === parseInt(page) - 1 ? "filled" : "default"
                   }
@@ -204,15 +204,15 @@ export const PaginationControl: FunctionComponent<PaginationControlProps> = ({
           </div>
           <IconButton
             disabled={!canNextPage}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             className={cn("page-button", "page-control")}
             icon={<ForwardIcon />}
             onClick={nextPage}
           />
           <IconButton
             disabled={!canNextPage}
-            variant={"text"}
+            variant="text"
             className={cn("page-button", "page-control")}
             icon={<SkipForwardIcon />}
             onClick={() => gotoPage(pageCount - 1)}

--- a/packages/graph-explorer/src/components/Tabular/filters/SingleSelectFilter.tsx
+++ b/packages/graph-explorer/src/components/Tabular/filters/SingleSelectFilter.tsx
@@ -51,7 +51,7 @@ export const SingleSelectFilter =
           size="sm"
           noMargin
           hideError
-          className={"menu-root"}
+          className="menu-root"
           value={column.filterValue || "all"}
           onChange={option =>
             option === "all" ? setFilter(undefined) : setFilter(option)

--- a/packages/graph-explorer/src/components/Tabular/filters/TextFilter.tsx
+++ b/packages/graph-explorer/src/components/Tabular/filters/TextFilter.tsx
@@ -40,8 +40,8 @@ export const TextFilter =
         <div className={defaultStyles(activeTheme?.isDarkTheme)}>
           <Input
             aria-label={`filter by ${column.id}`}
-            className={"input-root"}
-            type={"text"}
+            className="input-root"
+            type="text"
             size="sm"
             noMargin
             hideError
@@ -55,7 +55,7 @@ export const TextFilter =
                 : column.setFilter(undefined);
             }}
             startAdornment={
-              <div className={"start-adornment"}>
+              <div className="start-adornment">
                 {startAdornment || <FilterIcon />}
               </div>
             }

--- a/packages/graph-explorer/src/components/TextArea/TextArea.tsx
+++ b/packages/graph-explorer/src/components/TextArea/TextArea.tsx
@@ -90,13 +90,13 @@ export const TextArea = (
       )}
     >
       {label && (
-        <label className={"input-label"} {...labelProps}>
+        <label className="input-label" {...labelProps}>
           {label}
         </label>
       )}
-      <div className={"input-container"}>
+      <div className="input-container">
         {!!startAdornment && (
-          <span className={"start-adornment"}>{startAdornment}</span>
+          <span className="start-adornment">{startAdornment}</span>
         )}
         <textarea
           {...clickHandlers}
@@ -109,11 +109,11 @@ export const TextArea = (
           {...overrideInputProps}
         />
         {!!endAdornment && (
-          <span className={"end-adornment"}>{endAdornment}</span>
+          <span className="end-adornment">{endAdornment}</span>
         )}
-        {!!clearButton && <span className={"clearButton"}>{clearButton}</span>}
+        {!!clearButton && <span className="clearButton">{clearButton}</span>}
         {validationState === "invalid" && !!errorMessage && !hideError && (
-          <div className={"input-error"}>{errorMessage}</div>
+          <div className="input-error">{errorMessage}</div>
         )}
       </div>
     </div>

--- a/packages/graph-explorer/src/components/Toast/Toast.tsx
+++ b/packages/graph-explorer/src/components/Toast/Toast.tsx
@@ -49,11 +49,11 @@ export const Toast: FC<ToastProps> = ({
   return (
     <div className={cn(stylesWithTheme(defaultStyles), className)}>
       <Card className={cn("card", type)} transparent>
-        <div className={"icon"}>
+        <div className="icon">
           <Icon width={24} height={24} />
         </div>
-        <div className={"content"}>
-          {title && <div className={"title"}>{title}</div>}
+        <div className="content">
+          {title && <div className="title">{title}</div>}
           {children}
         </div>
         {closeable && (

--- a/packages/graph-explorer/src/components/UseLayer/UseLayer.tsx
+++ b/packages/graph-explorer/src/components/UseLayer/UseLayer.tsx
@@ -81,7 +81,7 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
         className={cn("layer-container", className)}
         style={{ display: "inline-block" }}
       >
-        <div {...triggerProps} className={"trigger-container"}>
+        <div {...triggerProps} className="trigger-container">
           {triggerChild}
         </div>
         {renderLayer(
@@ -91,10 +91,10 @@ const UseLayer = forwardRef<HTMLDivElement, PropsWithChildren<UseLayerProps>>(
               ...layerProps.style,
               zIndex: 9999,
             }}
-            className={"overlay-container"}
+            className="overlay-container"
           >
             {layerOptions.isOpen && (
-              <div className={"overlay-inner-container"}>
+              <div className="overlay-inner-container">
                 {showArrow && <Arrow {...layerArrowProps} {...arrowProps} />}
                 {overlayChild}
               </div>

--- a/packages/graph-explorer/src/components/Workspace/components/NavBarLogo.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/NavBarLogo.tsx
@@ -11,7 +11,7 @@ export default function NavBarLogo({ className, ...rest }: ComponentBaseProps) {
       )}
       {...rest}
     >
-      <GraphExplorerIcon width={"2em"} height={"2em"} />
+      <GraphExplorerIcon width="2em" height="2em" />
     </div>
   );
 }

--- a/packages/graph-explorer/src/core/AppStatusLoader.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.tsx
@@ -136,7 +136,7 @@ const AppStatusLoader = ({
       !location.pathname.match(/\/connections/) &&
       !location.pathname.match(/\/settings/)
     ) {
-      return <Redirect to={"/connections"} />;
+      return <Redirect to="/connections" />;
     }
   }
 

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -115,7 +115,7 @@ const AvailableConnections = ({
         <PanelHeaderActions>
           <FileButton
             onChange={payload => payload && onConfigImport(payload)}
-            accept={"application/json"}
+            accept="application/json"
           >
             {props => (
               <PanelHeaderActionButton

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -228,17 +228,17 @@ const CreateConnection = ({
 
   return (
     <div className={styleWithTheme(defaultStyles)}>
-      <div className={"configuration-form"}>
+      <div className="configuration-form">
         <Input
-          label={"Name"}
+          label="Name"
           value={form.name}
           onChange={onFormChange("name")}
-          errorMessage={"Name is required"}
+          errorMessage="Name is required"
           validationState={hasError && !form.name ? "invalid" : "valid"}
           isDisabled={disabledFields.includes("name")}
         />
         <Select
-          label={"Graph Type"}
+          label="Graph Type"
           options={CONNECTIONS_OP}
           value={form.queryEngine}
           onChange={onFormChange("queryEngine")}
@@ -247,7 +247,7 @@ const CreateConnection = ({
             form.serviceType === "neptune-graph"
           }
         />
-        <div className={"input-url"}>
+        <div className="input-url">
           <TextArea
             data-autofocus={true}
             label={
@@ -263,16 +263,16 @@ const CreateConnection = ({
             }
             value={form.url}
             onChange={onFormChange("url")}
-            errorMessage={"URL is required"}
-            placeholder={"https://example.com"}
+            errorMessage="URL is required"
+            placeholder="https://example.com"
             validationState={hasError && !form.url ? "invalid" : "valid"}
             isDisabled={disabledFields.includes("url")}
           />
         </div>
-        <div className={"input-url"}>
+        <div className="input-url">
           <Label className="cursor-pointer">
             <Checkbox
-              value={"proxyConnection"}
+              value="proxyConnection"
               checked={form.proxyConnection}
               onCheckedChange={checked => {
                 onFormChange("proxyConnection")(checked);
@@ -282,14 +282,14 @@ const CreateConnection = ({
           </Label>
         </div>
         {form.proxyConnection && (
-          <div className={"input-url"}>
+          <div className="input-url">
             <TextArea
               data-autofocus={true}
-              label={"Graph Connection URL"}
+              label="Graph Connection URL"
               value={form.graphDbUrl}
               onChange={onFormChange("graphDbUrl")}
-              errorMessage={"URL is required"}
-              placeholder={"https://neptune-cluster.amazonaws.com"}
+              errorMessage="URL is required"
+              placeholder="https://neptune-cluster.amazonaws.com"
               validationState={
                 hasError && !form.graphDbUrl ? "invalid" : "valid"
               }
@@ -297,10 +297,10 @@ const CreateConnection = ({
           </div>
         )}
         {form.proxyConnection && (
-          <div className={"input-url"}>
+          <div className="input-url">
             <Label className="cursor-pointer">
               <Checkbox
-                value={"awsAuthEnabled"}
+                value="awsAuthEnabled"
                 checked={form.awsAuthEnabled}
                 onCheckedChange={checked => {
                   onFormChange("awsAuthEnabled")(checked);
@@ -312,22 +312,22 @@ const CreateConnection = ({
         )}
         {form.proxyConnection && form.awsAuthEnabled && (
           <>
-            <div className={"input-url"}>
+            <div className="input-url">
               <Input
                 data-autofocus={true}
-                label={"AWS Region"}
+                label="AWS Region"
                 value={form.awsRegion}
                 onChange={onFormChange("awsRegion")}
-                errorMessage={"Region is required"}
-                placeholder={"us-east-1"}
+                errorMessage="Region is required"
+                placeholder="us-east-1"
                 validationState={
                   hasError && !form.awsRegion ? "invalid" : "valid"
                 }
               />
             </div>
-            <div className={"input-url"}>
+            <div className="input-url">
               <Select
-                label={"Service Type"}
+                label="Service Type"
                 options={[
                   { label: "Neptune DB", value: "neptune-db" },
                   { label: "Neptune Graph", value: "neptune-graph" },
@@ -340,10 +340,10 @@ const CreateConnection = ({
           </>
         )}
       </div>
-      <div className={"configuration-form"}>
+      <div className="configuration-form">
         <Label className="cursor-pointer">
           <Checkbox
-            value={"fetchTimeoutEnabled"}
+            value="fetchTimeoutEnabled"
             checked={form.fetchTimeoutEnabled}
             onCheckedChange={checked => {
               onFormChange("fetchTimeoutEnabled")(checked);
@@ -358,10 +358,10 @@ const CreateConnection = ({
           </div>
         </Label>
         {form.fetchTimeoutEnabled && (
-          <div className={"input-url"}>
+          <div className="input-url">
             <Input
               label="Fetch Timeout (ms)"
-              type={"number"}
+              type="number"
               value={form.fetchTimeoutMs}
               onChange={onFormChange("fetchTimeoutMs")}
               min={0}
@@ -369,10 +369,10 @@ const CreateConnection = ({
           </div>
         )}
       </div>
-      <div className={"configuration-form"}>
+      <div className="configuration-form">
         <Label className="cursor-pointer">
           <Checkbox
-            value={"nodeExpansionLimitEnabled"}
+            value="nodeExpansionLimitEnabled"
             checked={form.nodeExpansionLimitEnabled}
             onCheckedChange={checked => {
               onFormChange("nodeExpansionLimitEnabled")(checked);
@@ -387,7 +387,7 @@ const CreateConnection = ({
           </div>
         </Label>
         {form.nodeExpansionLimitEnabled && (
-          <div className={"input-url"}>
+          <div className="input-url">
             <Input
               label="Node Expansion Limit"
               type="number"
@@ -398,11 +398,11 @@ const CreateConnection = ({
           </div>
         )}
       </div>
-      <div className={"actions"}>
-        <Button variant={"default"} onPress={onClose}>
+      <div className="actions">
+        <Button variant="default" onPress={onClose}>
           Cancel
         </Button>
-        <Button variant={"filled"} onPress={onSubmit}>
+        <Button variant="filled" onPress={onSubmit}>
           {!configId ? "Add Connection" : "Update Connection"}
         </Button>
       </div>

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -90,14 +90,14 @@ export default function SingleEdgeStyling({
 
   return (
     <div className={cn(styleWithTheme(defaultStyles), className)} {...rest}>
-      <div className={"title"}>
-        <div className={"edge-name"}>{edgeType}</div>
+      <div className="title">
+        <div className="edge-name">{edgeType}</div>
       </div>
-      <div className={"label-container"}>
+      <div className="label-container">
         <Input
-          className={"label-display"}
-          label={"Display As"}
-          labelPlacement={"inner"}
+          className="label-display"
+          label="Display As"
+          labelPlacement="inner"
           value={displayAs}
           onChange={setDisplayAs}
           hideError={true}
@@ -105,8 +105,8 @@ export default function SingleEdgeStyling({
         />
         <Button
           icon={<StylingIcon />}
-          variant={"text"}
-          size={"small"}
+          variant="text"
+          size="small"
           onPress={onOpen}
         >
           Customize
@@ -126,13 +126,13 @@ export default function SingleEdgeStyling({
           backgroundOpacity: 0.1,
         }}
       >
-        <div className={"modal-container"}>
+        <div className="modal-container">
           <div>
             <p>Display Attributes</p>
-            <div className={"attrs-container"}>
+            <div className="attrs-container">
               <Select
-                label={"Display Name Attribute"}
-                labelPlacement={"inner"}
+                label="Display Name Attribute"
+                labelPlacement="inner"
                 value={etConfig.displayNameAttribute || "type"}
                 onChange={value =>
                   onUserPrefsChange({ displayNameAttribute: value as string })
@@ -145,19 +145,19 @@ export default function SingleEdgeStyling({
           </div>
           <div>
             <p>Label Styling</p>
-            <div className={"attrs-container"}>
+            <div className="attrs-container">
               <ColorInput
-                label={"Color"}
-                labelPlacement={"inner"}
+                label="Color"
+                labelPlacement="inner"
                 startColor={edgePreferences?.labelColor || "#17457b"}
                 onChange={(color: string) =>
                   onUserPrefsChange({ labelColor: color })
                 }
               />
               <Input
-                label={"Background Opacity"}
-                labelPlacement={"inner"}
-                type={"number"}
+                label="Background Opacity"
+                labelPlacement="inner"
+                type="number"
                 min={0}
                 max={1}
                 step={0.1}
@@ -171,19 +171,19 @@ export default function SingleEdgeStyling({
             </div>
           </div>
           <div>
-            <div className={"attrs-container"}>
+            <div className="attrs-container">
               <ColorInput
-                label={"Border Color"}
-                labelPlacement={"inner"}
+                label="Border Color"
+                labelPlacement="inner"
                 startColor={edgePreferences?.labelBorderColor || "#17457b"}
                 onChange={(color: string) =>
                   onUserPrefsChange({ labelBorderColor: color })
                 }
               />
               <Input
-                label={"Border Width"}
-                labelPlacement={"inner"}
-                type={"number"}
+                label="Border Width"
+                labelPlacement="inner"
+                type="number"
                 min={0}
                 value={edgePreferences?.labelBorderWidth ?? 0}
                 onChange={(value: number) =>
@@ -193,8 +193,8 @@ export default function SingleEdgeStyling({
                 noMargin={true}
               />
               <Select
-                label={"Border Style"}
-                labelPlacement={"inner"}
+                label="Border Style"
+                labelPlacement="inner"
                 value={edgePreferences?.labelBorderStyle || "solid"}
                 onChange={value =>
                   onUserPrefsChange({ labelBorderStyle: value as LineStyle })
@@ -207,19 +207,19 @@ export default function SingleEdgeStyling({
           </div>
           <div>
             <p>Line Styling</p>
-            <div className={"attrs-container"}>
+            <div className="attrs-container">
               <ColorInput
-                label={"Color"}
-                labelPlacement={"inner"}
+                label="Color"
+                labelPlacement="inner"
                 startColor={edgePreferences?.lineColor || "#b3b3b3"}
                 onChange={(color: string) =>
                   onUserPrefsChange({ lineColor: color })
                 }
               />
               <Input
-                label={"Thickness"}
-                labelPlacement={"inner"}
-                type={"number"}
+                label="Thickness"
+                labelPlacement="inner"
+                type="number"
                 min={1}
                 value={edgePreferences?.lineThickness || 2}
                 onChange={(value: number) =>
@@ -229,8 +229,8 @@ export default function SingleEdgeStyling({
                 noMargin={true}
               />
               <Select
-                label={"Style"}
-                labelPlacement={"inner"}
+                label="Style"
+                labelPlacement="inner"
                 value={edgePreferences?.lineStyle || "solid"}
                 onChange={value =>
                   onUserPrefsChange({ lineStyle: value as LineStyle })
@@ -243,10 +243,10 @@ export default function SingleEdgeStyling({
           </div>
           <div>
             <p>Arrows Styling</p>
-            <div className={"attrs-container"}>
+            <div className="attrs-container">
               <Select
-                label={"Source"}
-                labelPlacement={"inner"}
+                label="Source"
+                labelPlacement="inner"
                 value={edgePreferences?.sourceArrowStyle || "none"}
                 onChange={value =>
                   onUserPrefsChange({ sourceArrowStyle: value as ArrowStyle })
@@ -256,8 +256,8 @@ export default function SingleEdgeStyling({
                 noMargin={true}
               />
               <Select
-                label={"Target"}
-                labelPlacement={"inner"}
+                label="Target"
+                labelPlacement="inner"
                 value={edgePreferences?.targetArrowStyle || "triangle"}
                 onChange={value =>
                   onUserPrefsChange({ targetArrowStyle: value as ArrowStyle })
@@ -268,7 +268,7 @@ export default function SingleEdgeStyling({
               />
             </div>
           </div>
-          <div className={"actions"}>
+          <div className="actions">
             <Button onPress={onUserPrefsReset}>Reset to Default</Button>
           </div>
         </div>

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/EdgesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/EdgesTabular.tsx
@@ -123,7 +123,7 @@ const EdgesTabular = forwardRef<TabularInstance<ToggleEdge>, any>(
       <Tabular
         ref={ref}
         fullWidth
-        rowSelectionMode={"row"}
+        rowSelectionMode="row"
         selectedRowIds={selectedRowsIds}
         toggleRowSelected={onSelectRows}
         data={data}

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
@@ -144,7 +144,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
       <Tabular
         ref={ref}
         fullWidth
-        rowSelectionMode={"row"}
+        rowSelectionMode="row"
         selectedRowIds={selectedRowsIds}
         toggleRowSelected={onSelectRows}
         data={data}

--- a/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
@@ -68,49 +68,49 @@ const EdgeDetail = ({ edge }: EdgeDetailProps) => {
 
   return (
     <div className={styleWithTheme(defaultStyles(style.lineColor))}>
-      <div className={"header"}>
-        <div className={"icon"}>
+      <div className="header">
+        <div className="icon">
           <EdgeIcon />
         </div>
-        <div className={"content"}>
-          <div className={"title"}>{edge.displayTypes}</div>
+        <div className="content">
+          <div className="title">{edge.displayTypes}</div>
           {edge.hasUniqueId ? <div>{edge.displayId}</div> : null}
         </div>
       </div>
       <div className={cn("header", "source-vertex")}>
         <div className={cn("start-line", `line-${style.lineStyle || "solid"}`)}>
           {style.sourceArrowStyle === "triangle" && (
-            <ArrowTriangle className={"source-arrow-type"} />
+            <ArrowTriangle className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "triangle-tee" && (
-            <ArrowTriangleTee className={"source-arrow-type"} />
+            <ArrowTriangleTee className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "circle-triangle" && (
-            <ArrowTriangleCircle className={"source-arrow-type"} />
+            <ArrowTriangleCircle className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "triangle-cross" && (
-            <ArrowTriangleCross className={"source-arrow-type"} />
+            <ArrowTriangleCross className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "triangle-backcurve" && (
-            <ArrowTriangleBackCurve className={"source-arrow-type"} />
+            <ArrowTriangleBackCurve className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "tee" && (
-            <ArrowTee className={"source-arrow-type"} />
+            <ArrowTee className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "vee" && (
-            <ArrowVee className={"source-arrow-type"} />
+            <ArrowVee className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "square" && (
-            <ArrowSquare className={"source-arrow-type"} />
+            <ArrowSquare className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "circle" && (
-            <ArrowCircle className={"source-arrow-type"} />
+            <ArrowCircle className="source-arrow-type" />
           )}
           {style.sourceArrowStyle === "diamond" && (
-            <ArrowDiamond className={"source-arrow-type"} />
+            <ArrowDiamond className="source-arrow-type" />
           )}
           {(style.sourceArrowStyle === "none" || !style.sourceArrowStyle) && (
-            <ArrowNone className={"source-arrow-type"} />
+            <ArrowNone className="source-arrow-type" />
           )}
         </div>
         <VertexRow vertex={sourceVertex} />
@@ -119,37 +119,37 @@ const EdgeDetail = ({ edge }: EdgeDetailProps) => {
         <div className={cn("end-line", `line-${style.lineStyle || "solid"}`)}>
           {(style.targetArrowStyle === "triangle" ||
             !style.targetArrowStyle) && (
-            <ArrowTriangle className={"target-arrow-type"} />
+            <ArrowTriangle className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "triangle-tee" && (
-            <ArrowTriangleTee className={"target-arrow-type"} />
+            <ArrowTriangleTee className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "circle-triangle" && (
-            <ArrowTriangleCircle className={"target-arrow-type"} />
+            <ArrowTriangleCircle className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "triangle-cross" && (
-            <ArrowTriangleCross className={"target-arrow-type"} />
+            <ArrowTriangleCross className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "triangle-backcurve" && (
-            <ArrowTriangleBackCurve className={"target-arrow-type"} />
+            <ArrowTriangleBackCurve className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "tee" && (
-            <ArrowTee className={"target-arrow-type"} />
+            <ArrowTee className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "vee" && (
-            <ArrowVee className={"target-arrow-type"} />
+            <ArrowVee className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "square" && (
-            <ArrowSquare className={"target-arrow-type"} />
+            <ArrowSquare className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "circle" && (
-            <ArrowCircle className={"target-arrow-type"} />
+            <ArrowCircle className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "diamond" && (
-            <ArrowDiamond className={"target-arrow-type"} />
+            <ArrowDiamond className="target-arrow-type" />
           )}
           {style.targetArrowStyle === "none" && (
-            <ArrowNone className={"target-arrow-type"} />
+            <ArrowNone className="target-arrow-type" />
           )}
         </div>
         <VertexRow vertex={targetVertex} />

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
@@ -54,15 +54,15 @@ const EntityDetails = ({ onClose }: EntityDetailsProps) => {
         {isEmptySelection && (
           <PanelEmptyState
             icon={<GraphIcon />}
-            title={"Empty Selection"}
-            subtitle={"Select an entity to see its details"}
+            title="Empty Selection"
+            subtitle="Select an entity to see its details"
           />
         )}
         {isMultiSelection && (
           <PanelEmptyState
             icon={<GraphIcon />}
-            title={"Multiple Selection"}
-            subtitle={"Select a single entity to see its details"}
+            title="Multiple Selection"
+            subtitle="Select a single entity to see its details"
           />
         )}
         {!isMultiSelection && selectedNodes.length === 1 && selectedNode && (

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -292,9 +292,7 @@ function Legend({ onClose }: { onClose: () => void }) {
 
   return (
     <Card
-      className={
-        "z-panes absolute bottom-2 right-2 top-2 min-w-48 max-w-80 overflow-auto"
-      }
+      className="z-panes absolute bottom-2 right-2 top-2 min-w-48 max-w-80 overflow-auto"
     >
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-base font-bold">Legend</h1>

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -291,9 +291,7 @@ function Legend({ onClose }: { onClose: () => void }) {
   const vtConfigs = useDisplayVertexTypeConfigs().values().toArray();
 
   return (
-    <Card
-      className="z-panes absolute bottom-2 right-2 top-2 min-w-48 max-w-80 overflow-auto"
-    >
+    <Card className="z-panes absolute bottom-2 right-2 top-2 min-w-48 max-w-80 overflow-auto">
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-base font-bold">Legend</h1>
         <IconButton

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -198,16 +198,16 @@ const ContextMenu = ({
       <div
         className={cn(styleWithTheme(defaultStyles), "context-menu", className)}
       >
-        <Card className={"card-root"}>
+        <Card className="card-root">
           <ListItem
             className={cn("context-menu-list-item", "list-item-header")}
             startAdornment={<GraphIcon />}
           >
             {affectedNode.displayName}
           </ListItem>
-          <div className={"divider"} />
+          <div className="divider" />
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -215,7 +215,7 @@ const ContextMenu = ({
             Details panel
           </ListItem>
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={openSidebarPanel("expand")}
             startAdornment={<ExpandGraphIcon />}
@@ -223,7 +223,7 @@ const ContextMenu = ({
             Expand panel
           </ListItem>
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={openSidebarPanel("nodes-styling", {
               nodeType: affectedNode.typeConfig.type,
@@ -232,9 +232,9 @@ const ContextMenu = ({
           >
             Customize panel
           </ListItem>
-          <div className={"divider"} />
+          <div className="divider" />
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={handleRemoveFromCanvas([affectedNode.id], [])}
             startAdornment={<MinusCircleIcon className="size-5" />}
@@ -251,16 +251,16 @@ const ContextMenu = ({
       <div
         className={cn(styleWithTheme(defaultStyles), "context-menu", className)}
       >
-        <Card className={"card-root"}>
+        <Card className="card-root">
           <ListItem
             className={cn("context-menu-list-item", "list-item-header")}
             startAdornment={<EdgeIcon />}
           >
             {affectedEdge.displayTypes}
           </ListItem>
-          <div className={"divider"} />
+          <div className="divider" />
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={openSidebarPanel("details")}
             startAdornment={<DetailsIcon />}
@@ -268,7 +268,7 @@ const ContextMenu = ({
             Details Panel
           </ListItem>
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={openSidebarPanel("edges-styling", {
               edgeType: affectedEdge.typeConfig.type,
@@ -277,12 +277,12 @@ const ContextMenu = ({
           >
             Customize Panel
           </ListItem>
-          <div className={"divider"} />
+          <div className="divider" />
           <ListItem
-            className={"context-menu-list-item"}
+            className="context-menu-list-item"
             clickable={true}
             onClick={handleRemoveFromCanvas([], [affectedEdge.id])}
-            startAdornment={<RemoveFromCanvasIcon color={"red"} />}
+            startAdornment={<RemoveFromCanvasIcon color="red" />}
           >
             Remove {t("graph-viewer.edge")} from canvas
           </ListItem>
@@ -295,9 +295,9 @@ const ContextMenu = ({
     <div
       className={cn(styleWithTheme(defaultStyles), "context-menu", className)}
     >
-      <Card className={"card-root"}>
+      <Card className="card-root">
         <ListItem
-          className={"context-menu-list-item"}
+          className="context-menu-list-item"
           clickable={true}
           onClick={handleFitToFrame}
           startAdornment={<FitToFrameIcon />}
@@ -305,7 +305,7 @@ const ContextMenu = ({
           {nonEmptySelection ? "Fit Selection to Frame" : "Fit to Frame"}
         </ListItem>
         <ListItem
-          className={"context-menu-list-item"}
+          className="context-menu-list-item"
           clickable={true}
           onClick={handleCenter}
           startAdornment={<CenterGraphIcon />}
@@ -313,16 +313,16 @@ const ContextMenu = ({
           {nonEmptySelection ? "Center Selection" : "Center"}
         </ListItem>
         <ListItem
-          className={"context-menu-list-item"}
+          className="context-menu-list-item"
           clickable={true}
           onClick={handleDownloadScreenshot}
           startAdornment={<ScreenshotIcon />}
         >
           Download Screenshot
         </ListItem>
-        <div className={"divider"} />
+        <div className="divider" />
         <ListItem
-          className={"context-menu-list-item"}
+          className="context-menu-list-item"
           clickable={true}
           onClick={handleZoomIn}
           startAdornment={<ZoomInIcon />}
@@ -330,7 +330,7 @@ const ContextMenu = ({
           Zoom in
         </ListItem>
         <ListItem
-          className={"context-menu-list-item"}
+          className="context-menu-list-item"
           clickable={true}
           onClick={handleZoomOut}
           startAdornment={<ZoomOutIcon />}
@@ -339,15 +339,15 @@ const ContextMenu = ({
         </ListItem>
         {selectedButNoAffected && (
           <>
-            <div className={"divider"} />
+            <div className="divider" />
             <ListItem
-              className={"context-menu-list-item"}
+              className="context-menu-list-item"
               clickable={true}
               onClick={handleRemoveFromCanvas(
                 Array.from(nodesSelectedIds),
                 Array.from(edgesSelectedIds)
               )}
-              startAdornment={<RemoveFromCanvasIcon color={"red"} />}
+              startAdornment={<RemoveFromCanvasIcon color="red" />}
             >
               Remove selection from canvas
             </ListItem>
@@ -355,12 +355,12 @@ const ContextMenu = ({
         )}
         {noSelectionOrNotAffected && (
           <>
-            <div className={"divider"} />
+            <div className="divider" />
             <ListItem
-              className={"context-menu-list-item"}
+              className="context-menu-list-item"
               clickable={true}
               onClick={handleRemoveAllFromCanvas}
-              startAdornment={<RemoveFromCanvasIcon color={"red"} />}
+              startAdornment={<RemoveFromCanvasIcon color="red" />}
             >
               Clear canvas
             </ListItem>

--- a/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
@@ -22,7 +22,7 @@ const CommonPrefixes = () => {
   return (
     <div className={styleWithTheme(defaultStyles)}>
       <AdvancedList
-        searchPlaceholder={"Search for Namespaces or URIs"}
+        searchPlaceholder="Search for Namespaces or URIs"
         search={search}
         onSearch={setSearch}
         items={COMMON_PREFIXES_ITEMS}

--- a/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
@@ -33,14 +33,14 @@ const GeneratedPrefixes = () => {
     <div className={styleWithTheme(defaultStyles)}>
       {items.length === 0 && (
         <PanelEmptyState
-          title={"No Namespaces"}
-          subtitle={"No automatically generated Namespaces"}
+          title="No Namespaces"
+          subtitle="No automatically generated Namespaces"
           icon={<NamespaceIcon />}
         />
       )}
       {items.length > 0 && (
         <AdvancedList
-          searchPlaceholder={"Search for Namespaces or URIs"}
+          searchPlaceholder="Search for Namespaces or URIs"
           search={search}
           onSearch={setSearch}
           items={items}

--- a/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
@@ -67,9 +67,9 @@ const UserPrefixes = () => {
             subtitle: prefixConfig.uri,
             endAdornment: (
               <IconButton
-                variant={"text"}
-                size={"small"}
-                color={"error"}
+                variant="text"
+                size="small"
+                color="error"
                 icon={<DeleteIcon />}
                 onClick={onDeletePrefix(prefixConfig.prefix)}
               />
@@ -136,18 +136,18 @@ const UserPrefixes = () => {
     <div className={styleWithTheme(defaultStyles)}>
       {items.length === 0 && (
         <PanelEmptyState
-          title={"No Namespaces"}
-          subtitle={"No Custom Namespaces stored"}
+          title="No Namespaces"
+          subtitle="No Custom Namespaces stored"
           icon={<NamespaceIcon />}
-          actionLabel={"Start creating a new namespace"}
+          actionLabel="Start creating a new namespace"
           onAction={() => setOpened(true)}
           actionVariant="text"
         />
       )}
       {items.length > 0 && (
         <AdvancedList
-          className={"advanced-list"}
-          searchPlaceholder={"Search for Namespaces or URIs"}
+          className="advanced-list"
+          searchPlaceholder="Search for Namespaces or URIs"
           search={search}
           onSearch={setSearch}
           items={items}
@@ -157,10 +157,10 @@ const UserPrefixes = () => {
         />
       )}
       {items.length > 0 && (
-        <div className={"actions"}>
+        <div className="actions">
           <Button
             icon={<AddIcon />}
-            variant={"filled"}
+            variant="filled"
             onPress={() => setOpened(true)}
           >
             Create
@@ -171,30 +171,30 @@ const UserPrefixes = () => {
         opened={opened}
         onClose={() => setOpened(false)}
         centered={true}
-        title={"Create a new Namespace"}
+        title="Create a new Namespace"
         className={styleWithTheme(modalDefaultStyles)}
       >
         <div>
           <Input
-            label={"Namespace"}
+            label="Namespace"
             value={form.prefix}
             onChange={onFormChange("prefix")}
-            placeholder={"Namespace"}
+            placeholder="Namespace"
             validationState={hasError && !form.prefix ? "invalid" : "valid"}
-            errorMessage={"Namespace is required"}
+            errorMessage="Namespace is required"
           />
           <Input
-            className={"input-uri"}
-            label={"URI"}
+            className="input-uri"
+            label="URI"
             value={form.uri}
             onChange={onFormChange("uri")}
-            placeholder={"URI"}
+            placeholder="URI"
             validationState={hasError && !form.uri ? "invalid" : "valid"}
-            errorMessage={"URI is required"}
+            errorMessage="URI is required"
           />
         </div>
-        <div className={"actions"}>
-          <Button icon={<SaveIcon />} variant={"filled"} onPress={onSubmit}>
+        <div className="actions">
+          <Button icon={<SaveIcon />} variant="filled" onPress={onSubmit}>
             Save
           </Button>
         </div>

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -48,7 +48,7 @@ function ExpandSidebarContent({ id }: { id: VertexId }) {
 
   if (query.isPending) {
     return (
-      <PanelEmptyState icon={<LoadingSpinner />} title={"Loading Neighbors"} />
+      <PanelEmptyState icon={<LoadingSpinner />} title="Loading Neighbors" />
     );
   }
 
@@ -102,7 +102,7 @@ function ExpansionOptions({
   if (!hasUnfetchedNeighbors) {
     return (
       <PanelEmptyState
-        className={"empty-panel-state"}
+        className="empty-panel-state"
         icon={<GraphIcon />}
         title={t("node-expand.no-unfetched-title")}
         subtitle={t("node-expand.no-unfetched-subtitle")}
@@ -161,7 +161,7 @@ function ExpandButton({
           <ExpandGraphIcon />
         )
       }
-      variant={"filled"}
+      variant="filled"
       isDisabled={isPending || isDisabled}
       onPress={() => expandNode(vertex, filters)}
     >

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -77,10 +77,10 @@ const NodeExpandFilters = ({
   );
 
   return (
-    <div className={"filters-section"}>
-      <div className={"title"}>{t("node-expand.neighbors-of-type")}</div>
+    <div className="filters-section">
+      <div className="title">{t("node-expand.neighbors-of-type")}</div>
       <Select
-        aria-label={"neighbor type"}
+        aria-label="neighbor type"
         value={selectedType}
         onChange={v => {
           onSelectedTypeChange(v as string);
@@ -88,22 +88,22 @@ const NodeExpandFilters = ({
         options={neighborsOptions}
       />
       {hasSearchableAttributes && (
-        <div className={"title"}>
+        <div className="title">
           <div>Filter to narrow results</div>
           <IconButton
             icon={<AddIcon />}
-            variant={"text"}
-            size={"small"}
+            variant="text"
+            size="small"
             onClick={onFilterAdd}
           />
         </div>
       )}
       {filters.length > 0 && (
-        <div className={"filters"}>
+        <div className="filters">
           {filters.map((filter, filterIndex) => (
-            <div key={filterIndex} className={"single-filter"}>
+            <div key={filterIndex} className="single-filter">
               <Select
-                aria-label={"Attribute"}
+                aria-label="Attribute"
                 value={filter.name}
                 onChange={value => {
                   onFilterChange(filterIndex, value as string, filter.value);

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -21,7 +21,7 @@ export default function NeighborsList({ id }: NeighborsListProps) {
 
   return (
     <div className={cn(styleWithTheme(defaultStyles), "section")}>
-      <div className={"title"}>Neighbors ({vertex.neighborsCount})</div>
+      <div className="title">Neighbors ({vertex.neighborsCount})</div>
       {neighborsOptions
         .slice(0, showMore ? undefined : MAX_NEIGHBOR_TYPE_ROWS)
         .map(op => {
@@ -29,8 +29,8 @@ export default function NeighborsList({ id }: NeighborsListProps) {
             vertex.neighborsCountByType[op.value] -
             (vertex.__unfetchedNeighborCounts?.[op.value] ?? 0);
           return (
-            <div key={op.value} className={"node-item"}>
-              <div className={"vertex-type"}>
+            <div key={op.value} className="node-item">
+              <div className="vertex-type">
                 <div
                   style={{
                     color: op.config.style.color,

--- a/packages/graph-explorer/src/workspaces/Connections/Connections.tsx
+++ b/packages/graph-explorer/src/workspaces/Connections/Connections.tsx
@@ -63,9 +63,9 @@ const Connections = () => {
             >
               <Button
                 isDisabled={!activeConfig || !config?.schema?.lastUpdate}
-                className={"button"}
+                className="button"
                 icon={<ExplorerIcon />}
-                variant={"filled"}
+                variant="filled"
               >
                 Open {APP_NAME}
               </Button>

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -116,11 +116,7 @@ function DataExplorerContent({ vertexType }: ConnectionsProps) {
         </Workspace.TopBar.Version>
         <Workspace.TopBar.AdditionalControls>
           <Link to="/graph-explorer">
-            <Button
-              className="button"
-              icon={<ExplorerIcon />}
-              variant="filled"
-            >
+            <Button className="button" icon={<ExplorerIcon />} variant="filled">
               Open {APP_NAME}
             </Button>
           </Link>

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -115,11 +115,11 @@ function DataExplorerContent({ vertexType }: ConnectionsProps) {
           {__GRAPH_EXP_VERSION__}
         </Workspace.TopBar.Version>
         <Workspace.TopBar.AdditionalControls>
-          <Link to={"/graph-explorer"}>
+          <Link to="/graph-explorer">
             <Button
-              className={"button"}
+              className="button"
               icon={<ExplorerIcon />}
-              variant={"filled"}
+              variant="filled"
             >
               Open {APP_NAME}
             </Button>
@@ -143,9 +143,9 @@ function DataExplorerContent({ vertexType }: ConnectionsProps) {
         <Panel>
           <PanelHeader>
             <PanelTitle>
-              <div className={"container-header"}>
+              <div className="container-header">
                 <div>{displayTypeConfig.displayLabel}</div>
-                {query.isFetching && <LoadingSpinner className={"spinner"} />}
+                {query.isFetching && <LoadingSpinner className="spinner" />}
               </div>
             </PanelTitle>
           </PanelHeader>
@@ -245,26 +245,26 @@ function DisplayNameAndDescriptionOptions({
   );
 
   return (
-    <div className={"header-children"}>
+    <div className="header-children">
       <Select
-        className={"header-select"}
+        className="header-select"
         value={vertexConfig?.displayNameAttribute || ""}
         onChange={onDisplayNameChange("name")}
         options={selectOptions}
         hideError={true}
         noMargin={true}
-        label={"Display Name"}
-        labelPlacement={"inner"}
+        label="Display Name"
+        labelPlacement="inner"
       />
       <Select
-        className={"header-select"}
+        className="header-select"
         value={vertexConfig?.longDisplayNameAttribute || ""}
         onChange={onDisplayNameChange("longName")}
         options={selectOptions}
         hideError={true}
         noMargin={true}
-        label={"Display Description"}
-        labelPlacement={"inner"}
+        label="Display Description"
+        labelPlacement="inner"
       />
     </div>
   );
@@ -280,9 +280,9 @@ function AddToExplorerButton({ vertex }: { vertex: Vertex }) {
       <Button
         isDisabled={isInExplorer}
         icon={isInExplorer ? <CheckIcon /> : <SendIcon />}
-        variant={"default"}
-        size={"small"}
-        iconPlacement={"start"}
+        variant="default"
+        size="small"
+        iconPlacement="start"
         onPress={addToGraph}
       >
         {isInExplorer ? "Sent to Explorer" : "Send to Explorer"}

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -161,11 +161,7 @@ const GraphExplorer = () => {
           />
           <div className="v-divider" />
           <Link to="/connections">
-            <Button
-              className="button"
-              icon={<DatabaseIcon />}
-              variant="filled"
-            >
+            <Button className="button" icon={<DatabaseIcon />} variant="filled">
               Open Connections
             </Button>
           </Link>

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -145,7 +145,7 @@ const GraphExplorer = () => {
                 ? "Hide Graph View"
                 : "Show Graph View"
             }
-            tooltipPlacement={"bottom-center"}
+            tooltipPlacement="bottom-center"
             variant={toggles.has("graph-viewer") ? "filled" : "text"}
             icon={<GraphIcon />}
             onClick={toggleView("graph-viewer")}
@@ -154,17 +154,17 @@ const GraphExplorer = () => {
             tooltipText={
               toggles.has("table-view") ? "Hide Table View" : "Show Table View"
             }
-            tooltipPlacement={"bottom-center"}
+            tooltipPlacement="bottom-center"
             variant={toggles.has("table-view") ? "filled" : "text"}
             icon={<GridIcon />}
             onClick={toggleView("table-view")}
           />
-          <div className={"v-divider"} />
-          <Link to={"/connections"}>
+          <div className="v-divider" />
+          <Link to="/connections">
             <Button
-              className={"button"}
+              className="button"
               icon={<DatabaseIcon />}
-              variant={"filled"}
+              variant="filled"
             >
               Open Connections
             </Button>
@@ -177,10 +177,8 @@ const GraphExplorer = () => {
           <div style={{ width: "100%", flexGrow: 1 }}>
             <PanelEmptyState
               icon={<EmptyWidgetIcon />}
-              title={"No active views"}
-              subtitle={
-                "Use toggles in the top-right corner to show/hide views"
-              }
+              title="No active views"
+              subtitle="Use toggles in the top-right corner to show/hide views"
             />
           </div>
         )}
@@ -188,10 +186,8 @@ const GraphExplorer = () => {
           <div style={{ width: "100%", flexGrow: 1 }}>
             <PanelEmptyState
               icon={<EmptyWidgetIcon />}
-              title={"No active views"}
-              subtitle={
-                "Use toggles in the top-right corner to show/hide views"
-              }
+              title="No active views"
+              subtitle="Use toggles in the top-right corner to show/hide views"
             />
           </div>
         )}
@@ -222,7 +218,7 @@ const GraphExplorer = () => {
         )}
       </Workspace.Content>
 
-      <Workspace.SideBar direction={"row"}>
+      <Workspace.SideBar direction="row">
         <Workspace.SideBar.Button
           title="Search"
           icon={<SearchIcon />}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

React props do not need curly braces around string literals. This code base has a lot of instances of this, though, which adds noise.

This PR adds an ESLint rule to disallow curly braces around string literals and applies an automatic fix.

## Validation

- Smoke test

## Related Issues

- None (tech debt)

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
