### PR TITLE
Fix edge type display

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # graph-explorer Change Log
 
+## Release 1.12.1
+
+- **Fixed** issue where the edge's display name value was not being displayed
+  properly ([#716](https://github.com/aws/graph-explorer/pull/716))
+
 ## Release 1.12.0
 
 This release is mostly a maintenance release, with a few new features and bug

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Graph Explorer",
   "author": "amazon",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "main": "dist/node-server.js",
   "type": "module",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Graph Explorer",
   "engines": {
     "node": ">=22.11.0"

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -54,6 +54,24 @@ export const vertexTypeAttributesSelector = selectorFamily({
     },
 });
 
+export const edgeTypeAttributesSelector = selectorFamily({
+  key: "edge-type-attributes",
+  get:
+    (edgeTypes: string[]) =>
+    ({ get }) => {
+      const attributesByNameMap = new Map(
+        edgeTypes
+          .values()
+          .map(et => get(edgeTypeConfigSelector(et)))
+          .filter(et => et != null)
+          .flatMap(et => et.attributes)
+          .map(attr => [attr.name, attr])
+      );
+
+      return attributesByNameMap.values().toArray();
+    },
+});
+
 export const vertexTypeConfigSelector = selectorFamily({
   key: "vertex-type-config",
   get:

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -15,6 +15,7 @@ import { RawConfiguration, VertexTypeConfig } from "../ConfigurationProvider";
 import { SchemaInference } from "./schema";
 import { UserStyling } from "./userPreferences";
 import { createRandomName } from "@shared/utils/testing";
+import { RESERVED_TYPES_PROPERTY } from "@/utils";
 
 describe("mergedConfiguration", () => {
   it("should produce empty defaults when empty object is passed", () => {
@@ -230,6 +231,32 @@ describe("mergedConfiguration", () => {
     );
 
     expect(actualEtConfig?.displayLabel).toEqual(customDisplayLabel);
+  });
+
+  it("should patch displayNameAttribute to be 'types' when it was 'type'", () => {
+    const etConfig = createRandomEdgeTypeConfig();
+
+    const config: RawConfiguration = createRandomRawConfiguration();
+    const styling: UserStyling = {
+      edges: [
+        {
+          type: etConfig.type,
+          displayNameAttribute: "type",
+        },
+      ],
+    };
+    const schema = createRandomSchema();
+    schema.edges = [etConfig];
+
+    const result = mergeConfiguration(schema, config, styling);
+
+    const actualEtConfig = result.schema?.edges.find(
+      e => e.type === etConfig.type
+    );
+
+    expect(actualEtConfig?.displayNameAttribute).toEqual(
+      RESERVED_TYPES_PROPERTY
+    );
   });
 });
 

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -198,7 +198,7 @@ const mergeEdge = (
   const et =
     preferences?.type || configEdge?.type || schemaEdge?.type || "unknown";
 
-  return {
+  const config: EdgeTypeConfig = {
     // Defaults
     ...getDefaultEdgeTypeConfig(et),
     // Automatic schema override
@@ -209,6 +209,15 @@ const mergeEdge = (
     ...(preferences || {}),
     attributes,
   };
+
+  if (config.displayNameAttribute === "type") {
+    // Patch displayNameAttribute to be "types" when it was "type" ensuring
+    // backwards compatibility if the user had customized the
+    // displayNameAttribute to be the edge type prior to this release.
+    config.displayNameAttribute = RESERVED_TYPES_PROPERTY;
+  }
+
+  return config;
 };
 
 export const allVertexTypeConfigsSelector = selector({

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -267,6 +267,7 @@ export const defaultEdgeTypeConfig = {
   targetArrowStyle: "triangle",
   lineStyle: "solid",
   lineColor: "#b3b3b3",
+  displayNameAttribute: RESERVED_TYPES_PROPERTY,
 } satisfies Omit<EdgeTypeConfig, "type">;
 
 export function getDefaultEdgeTypeConfig(edgeType: string): EdgeTypeConfig {

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
@@ -1,0 +1,241 @@
+import { Edge } from "@/@types/entities";
+import {
+  createRandomEdge,
+  createRandomEdgeTypeConfig,
+  createRandomRawConfiguration,
+  createRandomSchema,
+  createRandomVertex,
+  renderHookWithRecoilRoot,
+} from "@/utils/testing";
+import { useDisplayEdgeFromEdge } from "./displayEdge";
+import { formatDate, sanitizeText } from "@/utils";
+import { createRandomDate } from "@shared/utils/testing";
+import { DisplayAttribute } from "./displayAttribute";
+import { mapToDisplayEdgeTypeConfig } from "./displayTypeConfigs";
+import {
+  activeConfigurationAtom,
+  configurationAtom,
+  getDefaultEdgeTypeConfig,
+} from "./configuration";
+import { Schema } from "../ConfigurationProvider";
+import { MutableSnapshot } from "recoil";
+import { schemaAtom } from "./schema";
+import { ConnectionConfig } from "@shared/types";
+
+describe("useDisplayEdgeFromEdge", () => {
+  it("should keep the same ID", () => {
+    const edge = createEdge();
+    expect(act(edge).id).toEqual(edge.id);
+  });
+
+  it("should be an edge", () => {
+    const edge = createEdge();
+    expect(act(edge).entityType).toEqual("edge");
+  });
+
+  it("should have a display ID equal to the edge ID", () => {
+    const edge = createEdge();
+    expect(act(edge).displayId).toEqual(edge.id);
+  });
+
+  it("should have the display name be the types", () => {
+    const edge = createEdge();
+    expect(act(edge).displayName).toEqual(sanitizeText(edge.type));
+  });
+
+  it("should have display name that matches the attribute value", () => {
+    const edge = createEdge();
+    const schema = createRandomSchema();
+    // Get the first attribute
+    const attribute = Object.entries(edge.attributes).map(([name, value]) => ({
+      name,
+      value,
+    }))[0];
+
+    const etConfig = createRandomEdgeTypeConfig();
+    etConfig.type = edge.type;
+    etConfig.displayNameAttribute = attribute.name;
+    schema.edges.push(etConfig);
+
+    expect(
+      act(edge, withSchemaAndConnection(schema, "gremlin")).displayName
+    ).toEqual(`${attribute.value}`);
+  });
+
+  it("should have display name that matches the types when displayNameAttribute is 'type'", () => {
+    const edge = createEdge();
+    const schema = createRandomSchema();
+
+    const etConfig = createRandomEdgeTypeConfig();
+    delete etConfig.displayLabel;
+    etConfig.type = edge.type;
+    etConfig.displayNameAttribute = "type";
+    schema.edges.push(etConfig);
+
+    expect(
+      act(edge, withSchemaAndConnection(schema, "gremlin")).displayName
+    ).toEqual(sanitizeText(edge.type));
+  });
+
+  it("should have the default type config when edge type is not in the schema", () => {
+    const edge = createEdge();
+    const etConfig = getDefaultEdgeTypeConfig(edge.type);
+    const displayConfig = mapToDisplayEdgeTypeConfig(etConfig);
+    expect(act(edge).typeConfig).toEqual(displayConfig);
+  });
+
+  it("should use the type config from the merged schema", () => {
+    const edge = createEdge();
+    const etConfig = createRandomEdgeTypeConfig();
+    etConfig.type = edge.type;
+    const schema = createRandomSchema();
+    schema.edges.push(etConfig);
+
+    const expectedTypeConfig = mapToDisplayEdgeTypeConfig(etConfig);
+
+    expect(
+      act(edge, withSchemaAndConnection(schema, "gremlin")).typeConfig
+    ).toEqual(expectedTypeConfig);
+  });
+
+  it("should have display types that list all types in gremlin", () => {
+    const edge = createEdge();
+    const schema = createRandomSchema();
+
+    const etConfig = createRandomEdgeTypeConfig();
+    delete etConfig.displayLabel;
+    etConfig.type = edge.type;
+    schema.edges.push(etConfig);
+
+    edge.type = etConfig.type;
+
+    expect(
+      act(edge, withSchemaAndConnection(schema, "gremlin")).displayTypes
+    ).toEqual(`${sanitizeText(etConfig.type)}`);
+  });
+
+  it("should have display types that list all types in sparql", () => {
+    const edge = createEdge();
+    edge.type = "http://www.example.com/class#bar";
+    const schema = createRandomSchema();
+    schema.prefixes = [
+      {
+        prefix: "example-class",
+        uri: "http://www.example.com/class#",
+      },
+    ];
+
+    const etConfig = createRandomEdgeTypeConfig();
+    delete etConfig.displayLabel;
+    etConfig.type = edge.type;
+    schema.edges.push(etConfig);
+
+    edge.type = etConfig.type;
+
+    expect(
+      act(edge, withSchemaAndConnection(schema, "sparql")).displayTypes
+    ).toEqual(`example-class:bar`);
+  });
+
+  it("should have sorted attributes", () => {
+    const edge = createEdge();
+    const attributes: DisplayAttribute[] = Object.entries(edge.attributes)
+      .map(([key, value]) => ({
+        name: key,
+        displayLabel: sanitizeText(key),
+        displayValue: String(value),
+      }))
+      .toSorted((a, b) => a.displayLabel.localeCompare(b.displayLabel));
+
+    expect(act(edge).attributes).toEqual(attributes);
+  });
+
+  it("should format date values in attribute when type is Date", () => {
+    const edge = createEdge();
+    const schema = createRandomSchema();
+    const etConfig = createRandomEdgeTypeConfig();
+    etConfig.type = edge.type;
+    etConfig.attributes.push({
+      name: "created",
+      displayLabel: sanitizeText("created"),
+      dataType: "Date",
+    });
+    schema.edges.push(etConfig);
+
+    edge.attributes = {
+      ...edge.attributes,
+      created: createRandomDate().toISOString(),
+    };
+
+    const actualAttribute = act(edge, withSchema(schema)).attributes.find(
+      attr => attr.name === "created"
+    );
+    expect(actualAttribute?.displayValue).toEqual(
+      formatDate(new Date(edge.attributes.created))
+    );
+  });
+
+  it("should format date values in attribute when type is g:Date", () => {
+    const edge = createEdge();
+    const schema = createRandomSchema();
+    const etConfig = createRandomEdgeTypeConfig();
+    etConfig.type = edge.type;
+    etConfig.attributes.push({
+      name: "created",
+      displayLabel: sanitizeText("created"),
+      dataType: "g:Date",
+    });
+    schema.edges.push(etConfig);
+
+    edge.attributes = {
+      ...edge.attributes,
+      created: createRandomDate().toISOString(),
+    };
+
+    const actualAttribute = act(edge, withSchema(schema)).attributes.find(
+      attr => attr.name === "created"
+    );
+    expect(actualAttribute?.displayValue).toEqual(
+      formatDate(new Date(edge.attributes.created))
+    );
+  });
+
+  // Helpers
+
+  function createEdge() {
+    return createRandomEdge(createRandomVertex(), createRandomVertex());
+  }
+
+  function act(
+    edge: Edge,
+    initializeState?: (mutableSnapshot: MutableSnapshot) => void
+  ) {
+    const { result } = renderHookWithRecoilRoot(
+      () => useDisplayEdgeFromEdge(edge),
+      initializeState
+    );
+    return result.current;
+  }
+
+  function withSchema(schema: Schema) {
+    const config = createRandomRawConfiguration();
+    return (snapshot: MutableSnapshot) => {
+      snapshot.set(configurationAtom, new Map([[config.id, config]]));
+      snapshot.set(schemaAtom, new Map([[config.id, schema]]));
+      snapshot.set(activeConfigurationAtom, config.id);
+    };
+  }
+
+  function withSchemaAndConnection(
+    schema: Schema,
+    queryEngine: ConnectionConfig["queryEngine"]
+  ) {
+    const config = createRandomRawConfiguration();
+    config.connection!.queryEngine = queryEngine;
+    return (snapshot: MutableSnapshot) => {
+      snapshot.set(configurationAtom, new Map([[config.id, config]]));
+      snapshot.set(schemaAtom, new Map([[config.id, schema]]));
+      snapshot.set(activeConfigurationAtom, config.id);
+    };
+  }
+});

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -123,9 +123,7 @@ const displayEdgeSelector = selectorFamily({
       function getDisplayAttributeValueByName(name: string | undefined) {
         if (name === RESERVED_ID_PROPERTY) {
           return displayId;
-        } else if (name === RESERVED_TYPES_PROPERTY || name === "type") {
-          // The name === "type" is to fix a bug where the old default was
-          // incorrect and the value was written to storage
+        } else if (name === RESERVED_TYPES_PROPERTY) {
           return displayTypes;
         } else if (name) {
           return (

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -119,7 +119,9 @@ const displayEdgeSelector = selectorFamily({
       function getDisplayAttributeValueByName(name: string | undefined) {
         if (name === RESERVED_ID_PROPERTY) {
           return displayId;
-        } else if (name === RESERVED_TYPES_PROPERTY) {
+        } else if (name === RESERVED_TYPES_PROPERTY || name === "type") {
+          // The name === "type" is to fix a bug where the old default was
+          // incorrect and the value was written to storage
           return displayTypes;
         } else if (name) {
           return (

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -8,10 +8,10 @@ import {
   getSortedDisplayAttributes,
   edgesAtom,
   edgesSelectedIdsAtom,
-  vertexTypeAttributesSelector,
   vertexTypeConfigSelector,
   queryEngineSelector,
   edgeSelector,
+  edgeTypeAttributesSelector,
 } from "@/core";
 import {
   MISSING_DISPLAY_VALUE,
@@ -63,6 +63,10 @@ export function useSelectedDisplayEdges() {
   return useRecoilValue(selectedDisplayEdgesSelector);
 }
 
+export function useDisplayEdgeFromEdge(edge: Edge) {
+  return useRecoilValue(displayEdgeSelector(edge));
+}
+
 const displayEdgeSelector = selectorFamily({
   key: "display-edge",
   get:
@@ -84,7 +88,7 @@ const displayEdgeSelector = selectorFamily({
       // For SPARQL, display the edge type as the ID
       const displayId = isSparql ? displayTypes : edge.id;
 
-      const typeAttributes = get(vertexTypeAttributesSelector(edgeTypes));
+      const typeAttributes = get(edgeTypeAttributesSelector(edgeTypes));
       const sortedAttributes = getSortedDisplayAttributes(
         edge,
         typeAttributes,
@@ -115,7 +119,7 @@ const displayEdgeSelector = selectorFamily({
         )
         .join(", ");
 
-      // Get the display name and description for the vertex
+      // Get the display name and description for the edge
       function getDisplayAttributeValueByName(name: string | undefined) {
         if (name === RESERVED_ID_PROPERTY) {
           return displayId;

--- a/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
@@ -19,7 +19,7 @@ import {
   useDisplayVertexTypeConfig,
 } from "./displayTypeConfigs";
 import { createRandomName } from "@shared/utils/testing";
-import { sanitizeText } from "@/utils";
+import { RESERVED_TYPES_PROPERTY, sanitizeText } from "@/utils";
 
 describe("useDisplayVertexTypeConfig", () => {
   describe("when the vertex type is not in the schema", () => {
@@ -128,6 +128,11 @@ describe("useDisplayEdgeTypeConfig", () => {
   it("should have display label match the type transformed", () => {
     const type = createRandomName("type");
     expect(act(type).displayLabel).toBe(sanitizeText(type));
+  });
+
+  it("should have display name attribute for types", () => {
+    const type = createRandomName("type");
+    expect(act(type).displayNameAttribute).toBe(RESERVED_TYPES_PROPERTY);
   });
 
   it("should have style matching the default config", () => {

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -26,7 +26,7 @@ import defaultStyles from "./SingleEdgeStyling.style";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
 import { useEdgeTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
 import { useDebounceValue, usePrevious } from "@/hooks";
-import { cn } from "@/utils";
+import { cn, RESERVED_TYPES_PROPERTY } from "@/utils";
 
 export type SingleEdgeStylingProps = {
   edgeType: string;
@@ -62,7 +62,7 @@ export default function SingleEdgeStyling({
 
     options.unshift({
       label: t("edges-styling.edge-type"),
-      value: "type",
+      value: RESERVED_TYPES_PROPERTY,
     });
 
     return options;
@@ -133,7 +133,7 @@ export default function SingleEdgeStyling({
               <Select
                 label="Display Name Attribute"
                 labelPlacement="inner"
-                value={etConfig.displayNameAttribute || "type"}
+                value={etConfig.displayNameAttribute || RESERVED_TYPES_PROPERTY}
                 onChange={value =>
                   onUserPrefsChange({ displayNameAttribute: value as string })
                 }

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -24,7 +24,6 @@ import {
 import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import defaultStyles from "./SingleEdgeStyling.style";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
-import { useEdgeTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { cn, RESERVED_TYPES_PROPERTY } from "@/utils";
 
@@ -49,7 +48,6 @@ export default function SingleEdgeStyling({
   const [edgePreferences, setEdgePreferences] = useRecoilState(
     userStylingEdgeAtom(edgeType)
   );
-  const etConfig = useEdgeTypeConfig(edgeType);
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
@@ -118,7 +116,7 @@ export default function SingleEdgeStyling({
         centered={true}
         title={
           <div>
-            Customize <strong>{displayAs || edgeType}</strong>
+            Customize <strong>{displayConfig.displayLabel}</strong>
           </div>
         }
         className={styleWithTheme(modalDefaultStyles)}
@@ -133,7 +131,7 @@ export default function SingleEdgeStyling({
               <Select
                 label="Display Name Attribute"
                 labelPlacement="inner"
-                value={etConfig.displayNameAttribute || RESERVED_TYPES_PROPERTY}
+                value={displayConfig.displayNameAttribute}
                 onChange={value =>
                   onUserPrefsChange({ displayNameAttribute: value as string })
                 }

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -25,7 +25,6 @@ import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import { NODE_SHAPE } from "./nodeShape";
 import defaultStyles from "./SingleNodeStyling.style";
 import modalDefaultStyles from "./SingleNodeStylingModal.style";
-import { useVertexTypeConfig } from "@/core/ConfigurationProvider/useConfiguration";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { cn } from "@/utils";
 import {
@@ -64,7 +63,6 @@ export default function SingleNodeStyling({
     userStylingNodeAtom(vertexType)
   );
   const displayConfig = useDisplayVertexTypeConfig(vertexType);
-  const vtConfig = useVertexTypeConfig(vertexType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
 
@@ -172,7 +170,7 @@ export default function SingleNodeStyling({
               <Select
                 label="Display Name Attribute"
                 labelPlacement="inner"
-                value={vtConfig.displayNameAttribute || ""}
+                value={displayConfig.displayNameAttribute}
                 onChange={value => {
                   onUserPrefsChange({ displayNameAttribute: value as string });
                 }}
@@ -183,7 +181,7 @@ export default function SingleNodeStyling({
               <Select
                 label="Display Description Attribute"
                 labelPlacement="inner"
-                value={vtConfig.longDisplayNameAttribute || ""}
+                value={displayConfig.displayDescriptionAttribute}
                 onChange={value => {
                   onUserPrefsChange({
                     longDisplayNameAttribute: value as string,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Shared types and functions across client and server.",
   "author": "amazon",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes a bug that caused the edge display name to not be shown on the graph.

- Use "types" for value of dropdown option in edge style dialog
- Use attribute types from the edge config (was incorrectly vertex config)
- Add default value for `displayNameAttribute` to default edge config
- Use name & display attribute values from the display config inside the node & edge style dialogs (ensures the correct fallback is used)
- Patch any edge configs that were saved with "type" as the displayNameAttribute to be "types" instead (should be rare, but could happen)
- Updates the version numbers for a patch release

## Validation

- Added new tests for edge and edge type config
- Verified locally

## Related Issues

- Fixes #715 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
