### PR TITLE
Better error messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- **Improved** error logs in the browser console
+  ([#721](https://github.com/aws/graph-explorer/pull/721))
 - **Updated** dependencies
   ([#718](https://github.com/aws/graph-explorer/pull/718),
   [#720](https://github.com/aws/graph-explorer/pull/720))


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The logic in place for error parsing was not logging the important parts of the error to the console log in the browser. For some reason, Chrome does not print the `cause` field of the error object, as it should.

So, I've added a new log statement that always prints out the error object from the response. Also, I attempt to parse for Neptune errors a bit more generously. So there is a better chance of extracting the message details if the error object contains it.

## Validation

- Verified by schema sync with my SSH tunnel off so I receive connection refused errors

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
