### PR TITLE
QueryEngine as a type

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
@@ -20,7 +20,7 @@ import {
 import { Schema } from "../ConfigurationProvider";
 import { MutableSnapshot } from "recoil";
 import { schemaAtom } from "./schema";
-import { ConnectionConfig } from "@shared/types";
+import { QueryEngine } from "@shared/types";
 
 describe("useDisplayEdgeFromEdge", () => {
   it("should keep the same ID", () => {
@@ -226,10 +226,7 @@ describe("useDisplayEdgeFromEdge", () => {
     };
   }
 
-  function withSchemaAndConnection(
-    schema: Schema,
-    queryEngine: ConnectionConfig["queryEngine"]
-  ) {
+  function withSchemaAndConnection(schema: Schema, queryEngine: QueryEngine) {
     const config = createRandomRawConfiguration();
     config.connection!.queryEngine = queryEngine;
     return (snapshot: MutableSnapshot) => {

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
@@ -20,7 +20,7 @@ import { DisplayAttribute } from "./displayAttribute";
 import { createRandomDate } from "@shared/utils/testing";
 import { MISSING_DISPLAY_VALUE } from "@/utils/constants";
 import { mapToDisplayVertexTypeConfig } from "./displayTypeConfigs";
-import { ConnectionConfig } from "@shared/types";
+import { QueryEngine } from "@shared/types";
 
 describe("useDisplayVertexFromVertex", () => {
   it("should keep the same ID", () => {
@@ -252,10 +252,7 @@ describe("useDisplayVertexFromVertex", () => {
     };
   }
 
-  function withSchemaAndConnection(
-    schema: Schema,
-    queryEngine: ConnectionConfig["queryEngine"]
-  ) {
+  function withSchemaAndConnection(schema: Schema, queryEngine: QueryEngine) {
     const config = createRandomRawConfiguration();
     config.connection!.queryEngine = queryEngine;
     return (snapshot: MutableSnapshot) => {

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -5,7 +5,7 @@ import { InfoTooltip, TextArea } from "@/components";
 import Button from "@/components/Button";
 import Input from "@/components/Input";
 import Select from "@/components/Select";
-import { ConnectionConfig } from "@shared/types";
+import { ConnectionConfig, QueryEngine } from "@shared/types";
 import {
   ConfigurationContextProps,
   RawConfiguration,
@@ -28,7 +28,7 @@ import { Checkbox, Label } from "@/components/radix";
 type ConnectionForm = {
   name?: string;
   url?: string;
-  queryEngine?: "gremlin" | "sparql" | "openCypher";
+  queryEngine?: QueryEngine;
   proxyConnection?: boolean;
   graphDbUrl?: string;
   awsAuthEnabled?: boolean;
@@ -42,7 +42,7 @@ type ConnectionForm = {
 
 export const CONNECTIONS_OP: {
   label: string;
-  value: NonNullable<ConnectionConfig["queryEngine"]>;
+  value: QueryEngine;
 }[] = [
   { label: "Gremlin - PG (Property Graph)", value: "gremlin" },
   { label: "OpenCypher - PG (Property Graph)", value: "openCypher" },

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
@@ -1,5 +1,5 @@
 import useKeywordSearch from "./useKeywordSearch";
-import { ConnectionConfig } from "@shared/types";
+import { QueryEngine } from "@shared/types";
 import { createRandomSchema, renderHookWithRecoilRoot } from "@/utils/testing";
 import { createRandomRawConfiguration } from "@/utils/testing";
 import {
@@ -17,9 +17,7 @@ vi.mock("./useKeywordSearchQuery", () => ({
   }),
 }));
 
-function initializeConfigWithQueryEngine(
-  queryEngine: ConnectionConfig["queryEngine"]
-) {
+function initializeConfigWithQueryEngine(queryEngine: QueryEngine) {
   return (snapshot: MutableSnapshot) => {
     // Create config and setup schema
     const config = createRandomRawConfiguration();

--- a/packages/graph-explorer/src/utils/isValidConfigurationFile.ts
+++ b/packages/graph-explorer/src/utils/isValidConfigurationFile.ts
@@ -4,6 +4,7 @@ import {
   EdgeTypeConfig,
   VertexTypeConfig,
 } from "@/core";
+import { queryEngineOptions } from "@shared/types";
 
 const isValidHttpUrl = (str: string) => {
   let url;
@@ -60,7 +61,7 @@ const isValidConfigurationFile = (
     !data.connection.url ||
     !data.connection.queryEngine ||
     !isValidHttpUrl(data.connection.url) ||
-    !["gremlin", "sparql", "openCypher"].includes(data.connection.queryEngine)
+    !queryEngineOptions.includes(data.connection.queryEngine)
   ) {
     return false;
   }

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -27,6 +27,7 @@ import {
 } from "@/core/StateProvider/userPreferences";
 import { toNodeMap } from "@/core/StateProvider/nodes";
 import { toEdgeMap } from "@/core/StateProvider/edges";
+import { queryEngineOptions } from "@shared/types";
 
 /*
 
@@ -207,11 +208,7 @@ export function createRandomRawConfiguration(): RawConfiguration {
   const serviceType = randomlyUndefined(
     pickRandomElement(["neptune-db", "neptune-graph"] as const)
   );
-  const queryEngine = pickRandomElement([
-    "gremlin",
-    "openCypher",
-    "sparql",
-  ] as const);
+  const queryEngine = pickRandomElement([...queryEngineOptions]);
 
   return {
     id: createRandomName("id"),

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,3 +1,6 @@
+export const queryEngineOptions = ["gremlin", "sparql", "openCypher"] as const;
+export type QueryEngine = (typeof queryEngineOptions)[number];
+
 export type ConnectionConfig = {
   /**
    * Base URL to access to the database through HTTPs endpoints
@@ -7,7 +10,7 @@ export type ConnectionConfig = {
    * Choose between gremlin or sparQL engines.
    * By default, it uses gremlin
    */
-  queryEngine?: "gremlin" | "sparql" | "openCypher";
+  queryEngine?: QueryEngine;
   /**
    * If the service is Neptune,
    * all requests should be sent through the nodejs proxy-server.


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Moves the query engine options to a const array of values and a specific type.

This is a small refactor that I pulled out of another branch for a simple review.

## Validation

- Smoke test locally

## Related Issues

- None (tech debt)

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
