### PR TITLE
Combine vertex id and idType

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
@@ -1,6 +1,7 @@
 import globalMockFetch from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighbors from "./fetchNeighbors";
+import { VertexId } from "@/@types/entities";
 
 describe("Gremlin > fetchNeighbors", () => {
   beforeEach(globalMockFetch);
@@ -89,8 +90,7 @@ describe("Gremlin > fetchNeighbors", () => {
     ];
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
-      vertexId: "2018",
-      idType: "string",
+      vertex: { id: "2018" as VertexId, idType: "string" },
       vertexType: "airport",
     });
 
@@ -224,8 +224,7 @@ describe("Gremlin > fetchNeighbors", () => {
     ];
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
-      vertexId: "2018",
-      idType: "string",
+      vertex: { id: "2018" as VertexId, idType: "string" },
       vertexType: "airport",
       filterByVertexTypes: ["airport"],
       filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighborsCount.test.ts
@@ -1,14 +1,17 @@
 import globalMockFetch from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighborsCount from "./fetchNeighborsCount";
+import { VertexId } from "@/@types/entities";
 
 describe("Gremlin > fetchNeighborsCount", () => {
   beforeEach(globalMockFetch);
 
   it("Should return neighbors counts for node 2018", async () => {
     const response = await fetchNeighborsCount(mockGremlinFetch(), {
-      vertexId: "123",
-      idType: "string",
+      vertex: {
+        id: "123" as VertexId,
+        idType: "string",
+      },
     });
 
     expect(response).toMatchObject({

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.test.ts
@@ -1,11 +1,11 @@
+import { VertexId } from "@/@types/entities";
 import neighborsCountTemplate from "./neighborsCountTemplate";
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 
 describe("Gremlin > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
     });
 
     expect(normalize(template)).toBe(
@@ -17,8 +17,7 @@ describe("Gremlin > neighborsCountTemplate", () => {
 
   it("Should return a template for the given vertex id with number type", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "number",
+      vertex: { id: "12" as VertexId, idType: "number" },
     });
 
     expect(normalize(template)).toBe(
@@ -30,8 +29,7 @@ describe("Gremlin > neighborsCountTemplate", () => {
 
   it("Should return a template for the given vertex id with defined limit", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       limit: 20,
     });
 
@@ -44,8 +42,7 @@ describe("Gremlin > neighborsCountTemplate", () => {
 
   it("Should return a template for the given vertex id with no limit", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       limit: 0,
     });
 

--- a/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/neighborsCountTemplate.ts
@@ -12,15 +12,14 @@ import type { NeighborsCountRequest } from "@/connector/useGEFetchTypes";
  *  .group().by(label).by(count())
  */
 export default function neighborsCountTemplate({
-  vertexId,
+  vertex,
   limit = 0,
-  idType,
 }: NeighborsCountRequest) {
   let template = "";
-  if (idType === "number") {
-    template = `g.V(${vertexId}L).both()`;
+  if (vertex.idType === "number") {
+    template = `g.V(${vertex.id}L).both()`;
   } else {
-    template = `g.V("${vertexId}").both()`;
+    template = `g.V("${vertex.id}").both()`;
   }
 
   if (limit > 0) {

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.test.ts
@@ -1,11 +1,11 @@
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 import oneHopTemplate from "./oneHopTemplate";
+import { VertexId } from "@/@types/entities";
 
 describe("Gremlin > oneHopTemplate", () => {
   it("Should return a template for a simple vertex id", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
     });
 
     expect(normalize(template)).toBe(
@@ -25,8 +25,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
   it("Should return a template for a simple vertex id with number type", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "number",
+      vertex: { id: "12" as VertexId, idType: "number" },
     });
 
     expect(normalize(template)).toBe(
@@ -46,8 +45,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
   it("Should return a template with an offset and limit", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       offset: 5,
       limit: 5,
     });
@@ -69,8 +67,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
   it("Should return a template for specific vertex type", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country"],
       offset: 5,
       limit: 10,
@@ -93,8 +90,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
   it("Should return a template for multiple vertex type", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country", "airport", "continent"],
       offset: 5,
       limit: 10,
@@ -117,8 +113,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
   it("Should return a template with specific filter criteria", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country"],
       filterCriteria: [
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },

--- a/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/templates/oneHopTemplate.ts
@@ -127,15 +127,15 @@ function criterionTemplate(criterion: Criterion): string {
  *  )
  */
 export default function oneHopTemplate({
-  vertexId,
-  idType,
+  vertex,
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
   limit = 0,
   offset = 0,
 }: Omit<NeighborsRequest, "vertexType">): string {
-  const idTemplate = idType === "number" ? `${vertexId}L` : `"${vertexId}"`;
+  const idTemplate =
+    vertex.idType === "number" ? `${vertex.id}L` : `"${vertex.id}"`;
   const range = limit > 0 ? `.range(${offset}, ${offset + limit})` : "";
 
   const vertexTypes = filterByVertexTypes.flatMap(type => type.split("::"));

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.test.ts
@@ -1,11 +1,11 @@
 import { normalize } from "@/utils/testing";
 import neighborsCountTemplate from "./neighborsCountTemplate";
+import { VertexId } from "@/@types/entities";
 
 describe("OpenCypher > neighborsCountTemplate", () => {
   it("Should return a template for the given vertex id", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
     });
 
     expect(normalize(template)).toBe(
@@ -22,8 +22,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
 
   it("Should return a template for the given vertex id with defined limit", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       limit: 20,
     });
 
@@ -42,8 +41,7 @@ describe("OpenCypher > neighborsCountTemplate", () => {
 
   it("Should return a template for the given vertex id with no limit", () => {
     const template = neighborsCountTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       limit: 0,
     });
 

--- a/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/neighborsCountTemplate.ts
@@ -16,12 +16,12 @@ import type { NeighborsCountRequest } from "@/connector/useGEFetchTypes";
  *
  */
 export default function neighborsCountTemplate({
-  vertexId,
+  vertex,
   limit = 0,
 }: NeighborsCountRequest) {
   return query`
       MATCH (v)-[]-(neighbor)
-      WHERE ID(v) = "${vertexId}" 
+      WHERE ID(v) = "${vertex.id}" 
       WITH DISTINCT neighbor
       ${limit > 0 ? `LIMIT ${limit}` : ``}
       RETURN labels(neighbor) AS vertexLabel, count(DISTINCT neighbor) AS count

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.test.ts
@@ -1,11 +1,11 @@
 import { normalize } from "@/utils/testing";
 import oneHopTemplate from "./oneHopTemplate";
+import { VertexId } from "@/@types/entities";
 
 describe("OpenCypher > oneHopTemplate", () => {
   it("Should return a template for a simple vertex id", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
     });
 
     expect(normalize(template)).toEqual(
@@ -25,8 +25,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
   it("Should return a template with an offset and limit", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       offset: 5,
       limit: 5,
     });
@@ -50,8 +49,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
   it("Should return a template for specific vertex type", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country"],
       offset: 5,
       limit: 10,
@@ -76,8 +74,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
   it("Should return a template for many vertex types", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country", "continent", "airport", "person"],
     });
 
@@ -98,8 +95,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
   it("Should return a template for specific edge type", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       edgeTypes: ["locatedIn"],
       offset: 5,
       limit: 10,
@@ -124,8 +120,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
   it("Should return a template with specific filter criteria", () => {
     const template = oneHopTemplate({
-      vertexId: "12",
-      idType: "string",
+      vertex: { id: "12" as VertexId, idType: "string" },
       filterByVertexTypes: ["country"],
       filterCriteria: [
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },

--- a/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/templates/oneHopTemplate.ts
@@ -103,7 +103,7 @@ const criterionTemplate = (criterion: Criterion): string => {
  * LIMIT 10
  */
 const oneHopTemplate = ({
-  vertexId,
+  vertex,
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
@@ -129,7 +129,7 @@ const oneHopTemplate = ({
 
   // Combine all the WHERE conditions
   const whereConditions = [
-    `ID(v) = "${vertexId}"`,
+    `ID(v) = "${vertex.id}"`,
     formattedVertexTypes,
     ...(filterCriteria?.map(criterionTemplate) ?? []),
   ]

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -72,12 +72,11 @@ export const neighborsCountQuery = (
   explorer: Explorer | null
 ) =>
   queryOptions({
-    queryKey: ["neighborsCount", vertex.id, vertex.idType, limit, explorer],
+    queryKey: ["neighborsCount", vertex, limit, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
       const result = await explorer?.fetchNeighborsCount({
-        vertexId: vertex.id,
-        idType: vertex.idType,
+        vertex,
         limit,
       });
 

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -66,17 +66,20 @@ export type NeighborCountsQueryResponse = {
  * @param explorer The service client to use for fetching the neighbors count.
  * @returns The count of neighbors for the given node as a total and per type.
  */
-export const neighborsCountQuery = (
+export function neighborsCountQuery(
   vertex: VertexRef,
   limit: number | undefined,
   explorer: Explorer | null
-) =>
-  queryOptions({
-    queryKey: ["neighborsCount", vertex, limit, explorer],
+) {
+  // Ensure the query key remains stable by removing extra properties from the vertex
+  const { id, idType } = vertex;
+
+  return queryOptions({
+    queryKey: ["neighborsCount", id, idType, limit, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
       const result = await explorer?.fetchNeighborsCount({
-        vertex,
+        vertex: { id, idType },
         limit,
       });
 
@@ -85,12 +88,13 @@ export const neighborsCountQuery = (
       }
 
       return {
-        nodeId: vertex.id,
+        nodeId: id,
         totalCount: result.totalCount,
         counts: result.counts,
       };
     },
   });
+}
 
 /**
  * Retrieves the count of nodes for a specific node type.

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -6,7 +6,7 @@ import {
   KeywordSearchResponse,
   NeighborsRequest,
   NeighborsResponse,
-  VertexIdAndType,
+  VertexRef,
 } from "./useGEFetchTypes";
 import { VertexId } from "@/@types/entities";
 
@@ -67,7 +67,7 @@ export type NeighborCountsQueryResponse = {
  * @returns The count of neighbors for the given node as a total and per type.
  */
 export const neighborsCountQuery = (
-  vertex: VertexIdAndType,
+  vertex: VertexRef,
   limit: number | undefined,
   explorer: Explorer | null
 ) =>

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -6,7 +6,7 @@ import {
   KeywordSearchResponse,
   NeighborsRequest,
   NeighborsResponse,
-  VertexIdType,
+  VertexIdAndType,
 } from "./useGEFetchTypes";
 import { VertexId } from "@/@types/entities";
 
@@ -67,18 +67,17 @@ export type NeighborCountsQueryResponse = {
  * @returns The count of neighbors for the given node as a total and per type.
  */
 export const neighborsCountQuery = (
-  id: VertexId,
-  idType: VertexIdType,
+  vertex: VertexIdAndType,
   limit: number | undefined,
   explorer: Explorer | null
 ) =>
   queryOptions({
-    queryKey: ["neighborsCount", id, idType, limit, explorer],
+    queryKey: ["neighborsCount", vertex.id, vertex.idType, limit, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
       const result = await explorer?.fetchNeighborsCount({
-        vertexId: id.toString(),
-        idType: idType,
+        vertexId: vertex.id,
+        idType: vertex.idType,
         limit,
       });
 
@@ -87,7 +86,7 @@ export const neighborsCountQuery = (
       }
 
       return {
-        nodeId: id,
+        nodeId: vertex.id,
         totalCount: result.totalCount,
         counts: result.counts,
       };

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -4,8 +4,6 @@ import {
   Explorer,
   KeywordSearchRequest,
   KeywordSearchResponse,
-  NeighborsRequest,
-  NeighborsResponse,
   VertexRef,
 } from "./useGEFetchTypes";
 import { VertexId } from "@/@types/entities";
@@ -31,28 +29,6 @@ export function searchQuery(
     },
   });
 }
-
-/**
- * Retrieves the neighbor info for the given node using the provided filters to
- * limit the results.
- * @param request The node and filters.
- * @param explorer The service client to use for fetching the neighbors count.
- * @returns The nodes and edges for the neighbors or null.
- */
-export const neighborsQuery = (
-  request: NeighborsRequest | null,
-  explorer: Explorer | null
-) =>
-  queryOptions({
-    queryKey: ["neighbors", request, explorer],
-    enabled: Boolean(explorer) && Boolean(request),
-    queryFn: async (): Promise<NeighborsResponse | null> => {
-      if (!explorer || !request) {
-        return null;
-      }
-      return await explorer.fetchNeighbors(request);
-    },
-  });
 
 export type NeighborCountsQueryResponse = {
   nodeId: VertexId;

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -249,7 +249,7 @@ export function createSparqlExplorer(
     },
     async fetchNeighborsCount(req, options) {
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors count...");
-      const bNode = blankNodes.get(req.vertexId);
+      const bNode = blankNodes.get(req.vertex.id);
 
       if (bNode?.neighbors) {
         return {
@@ -268,7 +268,7 @@ export function createSparqlExplorer(
           }
         );
 
-        blankNodes.set(req.vertexId, {
+        blankNodes.set(req.vertex.id, {
           ...bNode,
           vertex: {
             ...bNode.vertex,
@@ -287,7 +287,7 @@ export function createSparqlExplorer(
       return fetchNeighborsCount(
         _sparqlFetch(connection, featureFlags, options),
         {
-          resourceURI: req.vertexId,
+          resourceURI: req.vertex.id,
           limit: req.limit,
         }
       );

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -220,7 +220,7 @@ export function createSparqlExplorer(
     async fetchNeighbors(req, options) {
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors...");
       const request: SPARQLNeighborsRequest = {
-        resourceURI: req.vertexId,
+        resourceURI: req.vertex.id,
         resourceClass: req.vertexType,
         subjectClasses: req.filterByVertexTypes,
         filterCriteria: req.filterCriteria?.map((c: Criterion) => ({
@@ -231,7 +231,7 @@ export function createSparqlExplorer(
         offset: req.offset,
       };
 
-      const bNode = blankNodes.get(req.vertexId);
+      const bNode = blankNodes.get(req.vertex.id);
       if (bNode?.neighbors) {
         return storedBlankNodeNeighborsRequest(blankNodes, request);
       }

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -5,6 +5,7 @@ import {
 } from "@/core";
 import { ConnectionConfig } from "@shared/types";
 import { MappedQueryResults } from "./gremlin/mappers/mapResults";
+import { VertexId } from "@/@types/entities";
 
 export type QueryOptions = RequestInit & {
   queryId?: string;
@@ -14,6 +15,11 @@ export type QueryOptions = RequestInit & {
  * The type of the vertex ID.
  */
 export type VertexIdType = "string" | "number";
+
+export type VertexIdAndType = {
+  id: VertexId;
+  idType: VertexIdType;
+};
 
 export type VertexSchemaResponse = Pick<
   VertexTypeConfig,

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -16,7 +16,7 @@ export type QueryOptions = RequestInit & {
  */
 export type VertexIdType = "string" | "number";
 
-export type VertexIdAndType = {
+export type VertexRef = {
   id: VertexId;
   idType: VertexIdType;
 };
@@ -89,7 +89,7 @@ export type NeighborsRequest = {
   /**
    * Source vertex ID & type.
    */
-  vertex: VertexIdAndType;
+  vertex: VertexRef;
   /**
    * Source vertex type.
    */
@@ -123,7 +123,7 @@ export type NeighborsCountRequest = {
   /**
    * Source vertex ID & type.
    */
-  vertex: VertexIdAndType;
+  vertex: VertexRef;
   /**
    * Limit the number of results.
    * 0 = No limit.

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -87,13 +87,9 @@ export type Criterion = {
 
 export type NeighborsRequest = {
   /**
-   * Source vertex ID.
+   * Source vertex ID & type.
    */
-  vertexId: string;
-  /**
-   * The type of the vertex ID.
-   */
-  idType: VertexIdType;
+  vertex: VertexIdAndType;
   /**
    * Source vertex type.
    */

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -125,13 +125,9 @@ export type NeighborsResponse = MappedQueryResults;
 
 export type NeighborsCountRequest = {
   /**
-   * Source vertex ID.
+   * Source vertex ID & type.
    */
-  vertexId: string;
-  /**
-   * The type of the vertex ID.
-   */
-  idType: VertexIdType;
+  vertex: VertexIdAndType;
   /**
    * Limit the number of results.
    * 0 = No limit.

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -34,10 +34,7 @@ will be run regardless if the view is unmounted.
 
 */
 
-type ExpandNodeFilters = Omit<
-  NeighborsRequest,
-  "vertexId" | "idType" | "vertexType"
->;
+type ExpandNodeFilters = Omit<NeighborsRequest, "vertex" | "vertexType">;
 
 export type ExpandNodeRequest = {
   vertex: Vertex;
@@ -66,8 +63,7 @@ export function ExpandNodeProvider(props: PropsWithChildren) {
     ): Promise<NeighborsResponse | null> => {
       // Perform the query when a request exists
       const request: NeighborsRequest | null = expandNodeRequest && {
-        vertexId: expandNodeRequest.vertex.id,
-        idType: expandNodeRequest.vertex.idType,
+        vertex: expandNodeRequest.vertex,
         vertexType:
           expandNodeRequest.vertex.types?.join("::") ??
           expandNodeRequest.vertex.type,

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -6,9 +6,9 @@ import { useNotification } from "@/components/NotificationProvider";
 import { neighborsCountQuery } from "@/connector/queries";
 import { activeConnectionSelector, explorerSelector } from "@/core/connector";
 import useEntities from "./useEntities";
-import { VertexIdAndType } from "@/connector/useGEFetchTypes";
+import { VertexRef } from "@/connector/useGEFetchTypes";
 
-export function useUpdateNodeCountsQuery(vertex: VertexIdAndType) {
+export function useUpdateNodeCountsQuery(vertex: VertexRef) {
   const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useRecoilValue(explorerSelector);
   return useQuery(

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -1,26 +1,18 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
-import { Vertex, VertexId } from "@/types/entities";
+import { Vertex } from "@/types/entities";
 import { useNotification } from "@/components/NotificationProvider";
 import { neighborsCountQuery } from "@/connector/queries";
 import { activeConnectionSelector, explorerSelector } from "@/core/connector";
 import useEntities from "./useEntities";
-import { VertexIdType } from "@/connector/useGEFetchTypes";
+import { VertexIdAndType } from "@/connector/useGEFetchTypes";
 
-export function useUpdateNodeCountsQuery(
-  nodeId: VertexId,
-  nodeIdType: VertexIdType
-) {
+export function useUpdateNodeCountsQuery(vertex: VertexIdAndType) {
   const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useRecoilValue(explorerSelector);
   return useQuery(
-    neighborsCountQuery(
-      nodeId,
-      nodeIdType,
-      connection?.nodeExpansionLimit,
-      explorer
-    )
+    neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
   );
 }
 
@@ -38,13 +30,8 @@ export function useUpdateAllNodeCounts() {
   const query = useQueries({
     queries: entities.nodes
       .values()
-      .map(node =>
-        neighborsCountQuery(
-          node.id,
-          node.idType,
-          connection?.nodeExpansionLimit,
-          explorer
-        )
+      .map(vertex =>
+        neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
       )
       .toArray(),
     combine: results => {

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -39,7 +39,7 @@ export default function NodeExpandContent({ vertex }: NodeExpandContentProps) {
 function ExpandSidebarContent({ id }: { id: VertexId }) {
   const vertex = useNode(id);
   const t = useTranslations();
-  const query = useUpdateNodeCountsQuery(vertex.id, vertex.idType);
+  const query = useUpdateNodeCountsQuery(vertex);
   const neighborsOptions = useNeighborsOptions(vertex);
 
   if (query.isError) {

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -151,7 +151,7 @@ export function createRandomVertex(): Vertex {
   return {
     entityType: "vertex",
     id: createRandomName("VertexId") as VertexId,
-    idType: "string",
+    idType: pickRandomElement(["number", "string"]),
     type: createRandomName("VertexType"),
     attributes: createRecord(3, createRandomEntityAttribute),
     neighborsCount: 0,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Gremlin queries that are targeting a specific vertex ID need to know both the ID value and the original type (i.e. string or number). This will result in slightly different queries depending on the ID type.

This change is to create a type definition that combines the id value and type in to a single object. This will be more useful in future pull requests.

- Adds `VertexRef` type and updates usages
- Remove unused `neighborsQuery`

## Validation

- Verified integer ID queries work with Gremlin Server
- Verified string ID queries work Neptune
- Verified neighbor count queries are only executed once per ID

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Part of #710

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
