### PR TITLE
Remove edge counts

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -72,10 +72,6 @@ export type Vertex = {
    * Non-fetched neighbors by type
    */
   __unfetchedNeighborCounts?: Record<string, number>;
-  /**
-   * Fetched incoming edges connected with the vertex
-   */
-  __fetchedInEdgeCount?: number;
 };
 
 export type Edge = {

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -76,10 +76,6 @@ export type Vertex = {
    * Fetched incoming edges connected with the vertex
    */
   __fetchedInEdgeCount?: number;
-  /**
-   * Fetched outgoing edges connected with the vertex
-   */
-  __fetchedOutEdgeCount?: number;
 };
 
 export type Edge = {

--- a/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
+++ b/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
@@ -126,7 +126,6 @@ const entitiesSelector = selector<Entities>({
           <Vertex>{
             ...node,
             __unfetchedNeighborCounts,
-            __fetchedInEdgeCount: inConnections.length,
             __unfetchedNeighborCount: Math.max(
               0,
               Object.values(__unfetchedNeighborCounts).reduce(

--- a/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
+++ b/packages/graph-explorer/src/core/StateProvider/entitiesSelector.ts
@@ -126,7 +126,6 @@ const entitiesSelector = selector<Entities>({
           <Vertex>{
             ...node,
             __unfetchedNeighborCounts,
-            __fetchedOutEdgeCount: outConnections.length,
             __fetchedInEdgeCount: inConnections.length,
             __unfetchedNeighborCount: Math.max(
               0,

--- a/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
@@ -27,7 +27,6 @@ test("should add one node", async () => {
   expect(actual).toEqual({
     ...vertex,
     __fetchedInEdgeCount: 0,
-    __fetchedOutEdgeCount: 0,
     __unfetchedNeighborCount: 0,
     __unfetchedNeighborCounts: {},
   });
@@ -80,7 +79,6 @@ test("should add multiple nodes and edges", async () => {
     .map(n => ({
       ...n,
       __fetchedInEdgeCount: 2,
-      __fetchedOutEdgeCount: 2,
       __unfetchedNeighborCount: 0,
       __unfetchedNeighborCounts: {},
     }))

--- a/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
@@ -26,7 +26,6 @@ test("should add one node", async () => {
   const actual = result.current.entities.nodes.get(vertex.id);
   expect(actual).toEqual({
     ...vertex,
-    __fetchedInEdgeCount: 0,
     __unfetchedNeighborCount: 0,
     __unfetchedNeighborCounts: {},
   });
@@ -78,7 +77,6 @@ test("should add multiple nodes and edges", async () => {
     .values()
     .map(n => ({
       ...n,
-      __fetchedInEdgeCount: 2,
       __unfetchedNeighborCount: 0,
       __unfetchedNeighborCounts: {},
     }))

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -34,7 +34,6 @@ describe("useEntities", () => {
       ...randomNode,
       neighborsCountByType: {},
       __unfetchedNeighborCounts: {},
-      __fetchedInEdgeCount: 0,
       __unfetchedNeighborCount: 0,
     };
 
@@ -60,7 +59,6 @@ describe("useEntities", () => {
     expect(actualNode?.neighborsCount).toEqual(randomNode.neighborsCount);
     expect(actualNode?.neighborsCountByType).toEqual({});
     expect(actualNode?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode?.__unfetchedNeighborCount).toEqual(0);
   });
 
@@ -102,7 +100,6 @@ describe("useEntities", () => {
         neighborsCount: node1.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
       {
@@ -114,7 +111,6 @@ describe("useEntities", () => {
         neighborsCount: node2.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
       {
@@ -126,7 +122,6 @@ describe("useEntities", () => {
         neighborsCount: node3.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
     ]);
@@ -154,7 +149,6 @@ describe("useEntities", () => {
     expect(actualNode1?.neighborsCount).toEqual(node1.neighborsCount);
     expect(actualNode1?.neighborsCountByType).toEqual({});
     expect(actualNode1?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode1?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode1?.__unfetchedNeighborCount).toEqual(0);
 
     const actualNode2 = result.current.entities.nodes.get(node2.id);
@@ -164,7 +158,6 @@ describe("useEntities", () => {
     expect(actualNode2?.neighborsCount).toEqual(node2.neighborsCount);
     expect(actualNode2?.neighborsCountByType).toEqual({});
     expect(actualNode2?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode2?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode2?.__unfetchedNeighborCount).toEqual(0);
 
     const actualNode3 = result.current.entities.nodes.get(node3.id);
@@ -174,7 +167,6 @@ describe("useEntities", () => {
     expect(actualNode3?.neighborsCount).toEqual(node3.neighborsCount);
     expect(actualNode3?.neighborsCountByType).toEqual({});
     expect(actualNode3?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode3?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode3?.__unfetchedNeighborCount).toEqual(0);
   });
 

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -34,7 +34,6 @@ describe("useEntities", () => {
       ...randomNode,
       neighborsCountByType: {},
       __unfetchedNeighborCounts: {},
-      __fetchedOutEdgeCount: 0,
       __fetchedInEdgeCount: 0,
       __unfetchedNeighborCount: 0,
     };
@@ -61,7 +60,6 @@ describe("useEntities", () => {
     expect(actualNode?.neighborsCount).toEqual(randomNode.neighborsCount);
     expect(actualNode?.neighborsCountByType).toEqual({});
     expect(actualNode?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode?.__fetchedOutEdgeCount).toEqual(0);
     expect(actualNode?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode?.__unfetchedNeighborCount).toEqual(0);
   });
@@ -104,7 +102,6 @@ describe("useEntities", () => {
         neighborsCount: node1.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedOutEdgeCount: 0,
         __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
@@ -117,7 +114,6 @@ describe("useEntities", () => {
         neighborsCount: node2.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedOutEdgeCount: 0,
         __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
@@ -130,7 +126,6 @@ describe("useEntities", () => {
         neighborsCount: node3.neighborsCount,
         neighborsCountByType: {},
         __unfetchedNeighborCounts: {},
-        __fetchedOutEdgeCount: 0,
         __fetchedInEdgeCount: 0,
         __unfetchedNeighborCount: 0,
       },
@@ -159,7 +154,6 @@ describe("useEntities", () => {
     expect(actualNode1?.neighborsCount).toEqual(node1.neighborsCount);
     expect(actualNode1?.neighborsCountByType).toEqual({});
     expect(actualNode1?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode1?.__fetchedOutEdgeCount).toEqual(0);
     expect(actualNode1?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode1?.__unfetchedNeighborCount).toEqual(0);
 
@@ -170,7 +164,6 @@ describe("useEntities", () => {
     expect(actualNode2?.neighborsCount).toEqual(node2.neighborsCount);
     expect(actualNode2?.neighborsCountByType).toEqual({});
     expect(actualNode2?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode2?.__fetchedOutEdgeCount).toEqual(0);
     expect(actualNode2?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode2?.__unfetchedNeighborCount).toEqual(0);
 
@@ -181,7 +174,6 @@ describe("useEntities", () => {
     expect(actualNode3?.neighborsCount).toEqual(node3.neighborsCount);
     expect(actualNode3?.neighborsCountByType).toEqual({});
     expect(actualNode3?.__unfetchedNeighborCounts).toEqual({});
-    expect(actualNode3?.__fetchedOutEdgeCount).toEqual(0);
     expect(actualNode3?.__fetchedInEdgeCount).toEqual(0);
     expect(actualNode3?.__unfetchedNeighborCount).toEqual(0);
   });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes the unused edge count values from `Vertex`. These values are set, but never used by the app.

## Validation

- Verified expansion and table views

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Part of #710

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
