### PR TITLE
Remove hidden flag on schema

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # graph-explorer Change Log
 
+## Upcoming
+
+- **Removed** unused `hidden` flag from schema types
+  ([#737](https://github.com/aws/graph-explorer/pull/737))
+
 ## Release 1.13.0
 
 This release is a maintenance release with improvements to app startup, default

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -51,10 +51,6 @@ export type VertexTypeConfig = {
    */
   longDisplayNameAttribute?: string;
   /**
-   * If hidden is true, vertices of this types won't be rendered
-   */
-  hidden?: boolean;
-  /**
    * List of attributes for the vertex type
    */
   attributes: Array<AttributeConfig>;
@@ -77,10 +73,6 @@ export type EdgeTypeConfig = {
    * Vertex attribute to be used as label
    */
   displayNameAttribute?: string;
-  /**
-   * If hidden is true, edges of this types won't be rendered
-   */
-  hidden?: boolean;
   /**
    * List of attributes for the edge type
    */

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -14,7 +14,6 @@ describe("schema", () => {
       const entity = createRandomVertex();
       const result = extractConfigFromEntity(entity);
       expect(result.type).toEqual(entity.type);
-      expect(result.hidden).toBeFalsy();
       expect(result.attributes).toHaveLength(
         Object.keys(entity.attributes).length
       );
@@ -26,7 +25,6 @@ describe("schema", () => {
       );
       const result = extractConfigFromEntity(entity);
       expect(result.type).toEqual(entity.type);
-      expect(result.hidden).toBeFalsy();
       expect(result.attributes).toHaveLength(
         Object.keys(entity.attributes).length
       );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes the hidden flag on `VertexTypeConfig` and `EdgeTypeConfig` as it was used, but never set.

I went back to the 1.0 code and it seems like it was never set back then as well. Perhaps this was intended to be used as the global type filters that we have today, but the original developers decided to implement the feature differently and didn't cleanup the old code.

## Validation

- Ensure schema sync still works
- Verified type filters still work
- Verified node & edge filters still work

## Related Issues

- Part of #710

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
