### PR TITLE
Simplify entities logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 - **Removed** unused `hidden` flag from schema types
   ([#737](https://github.com/aws/graph-explorer/pull/737))
+- **Improved** entity filtering logic reducing re-renders
+  ([#739](https://github.com/aws/graph-explorer/pull/739))
 
 ## Release 1.13.0
 

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -1,6 +1,7 @@
 import { atom, selector, selectorFamily } from "recoil";
 import type { Edge, EdgeId } from "@/types/entities";
 import isDefaultValue from "./isDefaultValue";
+import { nodesFilteredIdsAtom, nodesTypesFilteredAtom } from "./nodes";
 
 export type Edges = Map<EdgeId, Edge>;
 
@@ -77,4 +78,36 @@ export const edgesFilteredIdsAtom = atom<Set<EdgeId>>({
 export const edgesTypesFilteredAtom = atom<Set<string>>({
   key: "edges-types-filtered",
   default: new Set(),
+});
+
+/**
+ * Filters the edges added to the graph by:
+ *
+ * - Edge types unselected in the filter sidebar
+ * - Vertex types unselected in the filter sidebar
+ * - Individual edges hidden using the table view
+ * - Individual vertices hidden using the table view
+ *
+ * If either the source or target vertex is hidden, the edge is also hidden.
+ */
+export const filteredEdgesSelector = selector<Map<EdgeId, Edge>>({
+  key: "filtered-edges",
+  get: ({ get }) => {
+    const edges = get(edgesAtom);
+    const filteredEdgeIds = get(edgesFilteredIdsAtom);
+    const filteredEdgeTypes = get(edgesTypesFilteredAtom);
+    const filteredVertexIds = get(nodesFilteredIdsAtom);
+    const filteredVertexTypes = get(nodesTypesFilteredAtom);
+
+    return new Map(
+      edges
+        .entries()
+        .filter(([_id, edge]) => !filteredEdgeTypes.has(edge.type))
+        .filter(([_id, edge]) => !filteredVertexTypes.has(edge.sourceType))
+        .filter(([_id, edge]) => !filteredVertexTypes.has(edge.targetType))
+        .filter(([_id, edge]) => !filteredEdgeIds.has(edge.id))
+        .filter(([_id, edge]) => !filteredVertexIds.has(edge.source))
+        .filter(([_id, edge]) => !filteredVertexIds.has(edge.target))
+    );
+  },
 });

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -76,6 +76,27 @@ export const nodesTypesFilteredAtom = atom<Set<string>>({
   default: new Set(),
 });
 
+/**
+ * Filters the nodes added to the graph by:
+ *
+ * - Vertex types unselected in the filter sidebar
+ * - Individual nodes hidden using the table view
+ */
+export const filteredNodesSelector = selector<Map<VertexId, Vertex>>({
+  key: "filtered-nodes-selector",
+  get: ({ get }) => {
+    const filteredIds = get(nodesFilteredIdsAtom);
+    const filteredTypes = get(nodesTypesFilteredAtom);
+
+    return new Map(
+      get(nodesAtom)
+        .entries()
+        .filter(([_id, node]) => !filteredTypes.has(node.type))
+        .filter(([_id, node]) => !filteredIds.has(node.id))
+    );
+  },
+});
+
 export function useNode(id: VertexId) {
   const node = useRecoilValue(nodesAtom).get(id);
 

--- a/packages/graph-explorer/src/hooks/index.ts
+++ b/packages/graph-explorer/src/hooks/index.ts
@@ -3,6 +3,7 @@ export { default as useDeepMemo } from "./useDeepMemo";
 export { default as useEntities } from "./useEntities";
 export { default as useExpandNode } from "./useExpandNode";
 export * from "./useAddToGraph";
+export * from "./useHasVertexBeenAddedToGraph";
 export * from "./useRemoveFromGraph";
 export { default as useTextTransform } from "./useTextTransform";
 export * from "./useTextTransform";

--- a/packages/graph-explorer/src/hooks/useAddToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.ts
@@ -1,5 +1,4 @@
-import { useMemo } from "react";
-import { Edge, EdgeId, Vertex, VertexId } from "@/types/entities";
+import { Edge, Vertex } from "@/types/entities";
 import useEntities from "./useEntities";
 import { toNodeMap } from "@/core/StateProvider/nodes";
 import { toEdgeMap } from "@/core/StateProvider/edges";
@@ -21,18 +20,4 @@ export function useAddToGraph(...entitiesToAdd: (Vertex | Edge)[]) {
       edges: toEdgeMap(edges),
     });
   };
-}
-
-/** Returns a callback that adds an array of nodes and edges to the graph. */
-export function useHasNodeBeenAddedToGraph(id: VertexId) {
-  const [entities, _] = useEntities();
-
-  return useMemo(() => entities.nodes.has(id), [entities, id]);
-}
-
-/** Returns a callback that adds an array of nodes and edges to the graph. */
-export function useHasEdgeBeenAddedToGraph(id: EdgeId) {
-  const [entities, _] = useEntities();
-
-  return useMemo(() => entities.edges.has(id), [entities, id]);
 }

--- a/packages/graph-explorer/src/hooks/useAddToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.ts
@@ -1,16 +1,18 @@
 import { Edge, Vertex } from "@/types/entities";
-import useEntities from "./useEntities";
 import { toNodeMap } from "@/core/StateProvider/nodes";
 import { toEdgeMap } from "@/core/StateProvider/edges";
+import entitiesSelector from "@/core/StateProvider/entitiesSelector";
+import { useCallback } from "react";
+import { useSetRecoilState } from "recoil";
 
 /** Returns a callback that adds an array of nodes and edges to the graph. */
 export function useAddToGraph(...entitiesToAdd: (Vertex | Edge)[]) {
-  const [, setEntities] = useEntities();
+  const setEntities = useSetRecoilState(entitiesSelector);
 
-  const nodes = entitiesToAdd.filter(e => e.entityType === "vertex");
-  const edges = entitiesToAdd.filter(e => e.entityType === "edge");
+  return useCallback(() => {
+    const nodes = entitiesToAdd.filter(e => e.entityType === "vertex");
+    const edges = entitiesToAdd.filter(e => e.entityType === "edge");
 
-  return () => {
     if (nodes.length === 0 && edges.length === 0) {
       return;
     }
@@ -19,5 +21,5 @@ export function useAddToGraph(...entitiesToAdd: (Vertex | Edge)[]) {
       nodes: toNodeMap(nodes),
       edges: toEdgeMap(edges),
     });
-  };
+  }, [entitiesToAdd, setEntities]);
 }

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from "recoil";
 import useEntities from "./useEntities";
-import { Vertex, VertexId } from "@/types/entities";
+import { Edge, Vertex, VertexId } from "@/types/entities";
 import {
   createRandomEdge,
   createRandomEntities,
@@ -15,8 +15,18 @@ import { renderHookWithRecoilRoot } from "@/utils/testing";
 import { waitForValueToChange } from "@/utils/testing/waitForValueToChange";
 import { vi } from "vitest";
 import { createRandomInteger, createRandomName } from "@shared/utils/testing";
-import { toNodeMap } from "@/core/StateProvider/nodes";
-import { toEdgeMap } from "@/core/StateProvider/edges";
+import {
+  nodesAtom,
+  nodesFilteredIdsAtom,
+  nodesTypesFilteredAtom,
+  toNodeMap,
+} from "@/core/StateProvider/nodes";
+import {
+  edgesAtom,
+  edgesFilteredIdsAtom,
+  edgesTypesFilteredAtom,
+  toEdgeMap,
+} from "@/core/StateProvider/edges";
 
 describe("useEntities", () => {
   beforeEach(() => {
@@ -168,6 +178,124 @@ describe("useEntities", () => {
     expect(actualNode3?.neighborsCountByType).toEqual({});
     expect(actualNode3?.__unfetchedNeighborCounts).toEqual({});
     expect(actualNode3?.__unfetchedNeighborCount).toEqual(0);
+  });
+
+  it("should filter nodes by id", () => {
+    const node1: Vertex = createRandomVertex();
+    const node2: Vertex = createRandomVertex();
+    const node3: Vertex = createRandomVertex();
+
+    const { result } = renderHookWithRecoilRoot(
+      () => {
+        const [entities, setEntities] = useEntities();
+        return { entities, setEntities };
+      },
+      snapshot => {
+        snapshot.set(nodesAtom, toNodeMap([node1, node2, node3]));
+        snapshot.set(nodesFilteredIdsAtom, new Set([node1.id, node2.id]));
+      }
+    );
+
+    expect(result.current.entities).toEqual({
+      nodes: toNodeMap([node3]),
+      edges: new Map(),
+    });
+  });
+
+  it("should filter nodes by type", () => {
+    const node1: Vertex = createRandomVertex();
+    const node2: Vertex = createRandomVertex();
+    const node3: Vertex = createRandomVertex();
+
+    const { result } = renderHookWithRecoilRoot(
+      () => {
+        const [entities, setEntities] = useEntities();
+        return { entities, setEntities };
+      },
+      snapshot => {
+        snapshot.set(nodesAtom, toNodeMap([node1, node2, node3]));
+        snapshot.set(nodesTypesFilteredAtom, new Set([node1.type]));
+      }
+    );
+
+    expect(result.current.entities).toEqual({
+      nodes: toNodeMap([node2, node3]),
+      edges: new Map(),
+    });
+  });
+
+  it("should filter edges by id", () => {
+    const node1: Vertex = createRandomVertex();
+    const node2: Vertex = createRandomVertex();
+    const edge1to2: Edge = createRandomEdge(node1, node2);
+    const edge2to1: Edge = createRandomEdge(node2, node1);
+
+    const { result } = renderHookWithRecoilRoot(
+      () => {
+        const [entities, setEntities] = useEntities();
+        return { entities, setEntities };
+      },
+      snapshot => {
+        snapshot.set(nodesAtom, toNodeMap([node1, node2]));
+        snapshot.set(edgesAtom, toEdgeMap([edge1to2, edge2to1]));
+        snapshot.set(edgesFilteredIdsAtom, new Set([edge1to2.id]));
+      }
+    );
+
+    expect(result.current.entities).toEqual({
+      nodes: toNodeMap([node1, node2]),
+      edges: toEdgeMap([edge2to1]),
+    });
+  });
+
+  it("should filter edges by type", () => {
+    const node1: Vertex = createRandomVertex();
+    const node2: Vertex = createRandomVertex();
+    const edge1to2: Edge = createRandomEdge(node1, node2);
+    const edge2to1: Edge = createRandomEdge(node2, node1);
+
+    const { result } = renderHookWithRecoilRoot(
+      () => {
+        const [entities, setEntities] = useEntities();
+        return { entities, setEntities };
+      },
+      snapshot => {
+        snapshot.set(nodesAtom, toNodeMap([node1, node2]));
+        snapshot.set(edgesAtom, toEdgeMap([edge1to2, edge2to1]));
+        snapshot.set(edgesTypesFilteredAtom, new Set([edge1to2.type]));
+      }
+    );
+
+    expect(result.current.entities).toEqual({
+      nodes: toNodeMap([node1, node2]),
+      edges: toEdgeMap([edge2to1]),
+    });
+  });
+
+  it("should filter edges if either source or target is filtered", () => {
+    const node1: Vertex = createRandomVertex();
+    const node2: Vertex = createRandomVertex();
+    const node3: Vertex = createRandomVertex();
+    const edge1to2: Edge = createRandomEdge(node1, node2);
+    const edge2to1: Edge = createRandomEdge(node2, node1);
+    const edge2to3: Edge = createRandomEdge(node2, node3);
+
+    const { result } = renderHookWithRecoilRoot(
+      () => {
+        const [entities, setEntities] = useEntities();
+        return { entities, setEntities };
+      },
+      snapshot => {
+        snapshot.set(nodesAtom, toNodeMap([node1, node2]));
+        snapshot.set(edgesAtom, toEdgeMap([edge1to2, edge2to1, edge2to3]));
+        snapshot.set(nodesFilteredIdsAtom, new Set([node1.id]));
+      }
+    );
+
+    expect(result.current.entities).toEqual({
+      nodes: toNodeMap([node2]),
+      edges: toEdgeMap([edge2to3]),
+    });
   });
 
   it("should calculate stats after adding new nodes and edges", async () => {

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -38,7 +38,7 @@ describe("useEntities", () => {
     };
 
     const { result } = renderHookWithRecoilRoot(() => {
-      const [entities, setEntities] = useEntities({ disableFilters: true });
+      const [entities, setEntities] = useEntities();
       return { entities, setEntities };
     });
 
@@ -127,7 +127,7 @@ describe("useEntities", () => {
     ]);
 
     const { result } = renderHookWithRecoilRoot(() => {
-      const [entities, setEntities] = useEntities({ disableFilters: true });
+      const [entities, setEntities] = useEntities();
       return { entities, setEntities };
     });
 
@@ -179,7 +179,7 @@ describe("useEntities", () => {
     const edge1to2 = createRandomEdge(node1, node2);
 
     const { result } = renderHookWithRecoilRoot(() => {
-      const [entities, setEntities] = useEntities({ disableFilters: true });
+      const [entities, setEntities] = useEntities();
       return { entities, setEntities };
     });
 

--- a/packages/graph-explorer/src/hooks/useEntities.ts
+++ b/packages/graph-explorer/src/hooks/useEntities.ts
@@ -18,15 +18,15 @@ export default function useEntities(): [
 ] {
   const setEntities = useSetRecoilState(entitiesSelector);
 
-  const preFilteredNodes = useRecoilValue(filteredNodesSelector);
-  const preFilteredEdges = useRecoilValue(filteredEdgesSelector);
+  const filteredNodes = useRecoilValue(filteredNodesSelector);
+  const filteredEdges = useRecoilValue(filteredEdgesSelector);
 
   const filteredEntities = useMemo(
     () => ({
-      nodes: preFilteredNodes,
-      edges: preFilteredEdges,
+      nodes: filteredNodes,
+      edges: filteredEdges,
     }),
-    [preFilteredEdges, preFilteredNodes]
+    [filteredEdges, filteredNodes]
   );
 
   return [filteredEntities, setEntities];

--- a/packages/graph-explorer/src/hooks/useEntities.ts
+++ b/packages/graph-explorer/src/hooks/useEntities.ts
@@ -1,86 +1,33 @@
 import { useMemo } from "react";
 import { SetterOrUpdater, useRecoilValue, useSetRecoilState } from "recoil";
 import type { Edge, EdgeId, Vertex, VertexId } from "@/types/entities";
-import {
-  edgesFilteredIdsAtom,
-  edgesSelector,
-  edgesTypesFilteredAtom,
-} from "@/core/StateProvider/edges";
 import entitiesSelector, {
   Entities,
 } from "@/core/StateProvider/entitiesSelector";
-import {
-  nodesFilteredIdsAtom,
-  nodesSelector,
-  nodesTypesFilteredAtom,
-} from "@/core/StateProvider/nodes";
-
-import useDeepMemo from "./useDeepMemo";
+import { filteredNodesSelector, filteredEdgesSelector } from "@/core";
 
 type ProcessedEntities = {
   nodes: Map<VertexId, Vertex>;
   edges: Map<EdgeId, Edge>;
 };
 
-const useEntities = (): [ProcessedEntities, SetterOrUpdater<Entities>] => {
-  const filteredNodesIds = useRecoilValue(nodesFilteredIdsAtom);
-  const filteredEdgesIds = useRecoilValue(edgesFilteredIdsAtom);
-  const nodes = useRecoilValue(nodesSelector);
-  const edges = useRecoilValue(edgesSelector);
-
+/** Returns the current set of filtered entities. */
+export default function useEntities(): [
+  ProcessedEntities,
+  SetterOrUpdater<Entities>,
+] {
   const setEntities = useSetRecoilState(entitiesSelector);
 
-  const vertexTypes = useRecoilValue(nodesTypesFilteredAtom);
-  const connectionTypes = useRecoilValue(edgesTypesFilteredAtom);
+  const preFilteredNodes = useRecoilValue(filteredNodesSelector);
+  const preFilteredEdges = useRecoilValue(filteredEdgesSelector);
 
-  const filteredEntitiesByGlobalFilters = useDeepMemo(() => {
-    const filteredNodes = new Map(
-      nodes.entries().filter(([_id, node]) => {
-        return vertexTypes.has(node.type) === false;
-      })
-    );
-
-    const filteredEdges = new Map(
-      edges.entries().filter(([_id, edge]) => {
-        return (
-          connectionTypes.has(edge.type) === false &&
-          filteredNodes.has(edge.source) &&
-          filteredNodes.has(edge.target)
-        );
-      })
-    );
-
-    return {
-      nodes: filteredNodes,
-      edges: filteredEdges,
-    };
-  }, [connectionTypes, edges, nodes, vertexTypes]);
-
-  const filteredEntities = useMemo(() => {
-    return <ProcessedEntities>{
-      nodes: new Map(
-        filteredEntitiesByGlobalFilters.nodes
-          .entries()
-          .filter(([id, _node]) => {
-            return !filteredNodesIds.has(id);
-          })
-      ),
-      edges: new Map(
-        filteredEntitiesByGlobalFilters.edges
-          .entries()
-          .filter(([_id, edge]) => {
-            // Edges should not be in the filteredEdgesIds neither be unconnected
-            return (
-              !filteredEdgesIds.has(edge.id) &&
-              !filteredNodesIds.has(edge.source) &&
-              !filteredNodesIds.has(edge.target)
-            );
-          })
-      ),
-    };
-  }, [filteredEdgesIds, filteredEntitiesByGlobalFilters, filteredNodesIds]);
+  const filteredEntities = useMemo(
+    () => ({
+      nodes: preFilteredNodes,
+      edges: preFilteredEdges,
+    }),
+    [preFilteredEdges, preFilteredNodes]
+  );
 
   return [filteredEntities, setEntities];
-};
-
-export default useEntities;
+}

--- a/packages/graph-explorer/src/hooks/useEntities.ts
+++ b/packages/graph-explorer/src/hooks/useEntities.ts
@@ -22,10 +22,7 @@ type ProcessedEntities = {
   edges: Map<EdgeId, Edge>;
 };
 
-const useEntities = ({ disableFilters }: { disableFilters?: boolean } = {}): [
-  ProcessedEntities,
-  SetterOrUpdater<Entities>,
-] => {
+const useEntities = (): [ProcessedEntities, SetterOrUpdater<Entities>] => {
   const filteredNodesIds = useRecoilValue(nodesFilteredIdsAtom);
   const filteredEdgesIds = useRecoilValue(edgesFilteredIdsAtom);
   const nodes = useRecoilValue(nodesSelector);
@@ -37,30 +34,27 @@ const useEntities = ({ disableFilters }: { disableFilters?: boolean } = {}): [
   const connectionTypes = useRecoilValue(edgesTypesFilteredAtom);
 
   const filteredEntitiesByGlobalFilters = useDeepMemo(() => {
-    let filteredNodes = nodes;
-    let filteredEdges = edges;
-    if (!disableFilters) {
-      filteredNodes = new Map(
-        nodes.entries().filter(([_id, node]) => {
-          return vertexTypes.has(node.type) === false;
-        })
-      );
+    const filteredNodes = new Map(
+      nodes.entries().filter(([_id, node]) => {
+        return vertexTypes.has(node.type) === false;
+      })
+    );
 
-      filteredEdges = new Map(
-        edges.entries().filter(([_id, edge]) => {
-          return (
-            connectionTypes.has(edge.type) === false &&
-            filteredNodes.has(edge.source) &&
-            filteredNodes.has(edge.target)
-          );
-        })
-      );
-    }
+    const filteredEdges = new Map(
+      edges.entries().filter(([_id, edge]) => {
+        return (
+          connectionTypes.has(edge.type) === false &&
+          filteredNodes.has(edge.source) &&
+          filteredNodes.has(edge.target)
+        );
+      })
+    );
+
     return {
       nodes: filteredNodes,
       edges: filteredEdges,
     };
-  }, [connectionTypes, disableFilters, edges, nodes, vertexTypes]);
+  }, [connectionTypes, edges, nodes, vertexTypes]);
 
   const filteredEntities = useMemo(() => {
     return <ProcessedEntities>{

--- a/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.test.ts
@@ -1,0 +1,55 @@
+import { createRandomVertex, renderHookWithRecoilRoot } from "@/utils/testing";
+import { useHasVertexBeenAddedToGraph } from "./useHasVertexBeenAddedToGraph";
+import {
+  nodesAtom,
+  nodesFilteredIdsAtom,
+  nodesTypesFilteredAtom,
+  toNodeMap,
+} from "@/core";
+
+test("returns false if vertex has not been added to graph", () => {
+  const vertex = createRandomVertex();
+  const { result } = renderHookWithRecoilRoot(() =>
+    useHasVertexBeenAddedToGraph(vertex.id)
+  );
+
+  expect(result.current).toBe(false);
+});
+
+test("returns true if vertex has been added to graph", () => {
+  const vertex = createRandomVertex();
+  const { result } = renderHookWithRecoilRoot(
+    () => useHasVertexBeenAddedToGraph(vertex.id),
+    snapshot => {
+      snapshot.set(nodesAtom, toNodeMap([vertex]));
+    }
+  );
+
+  expect(result.current).toBe(true);
+});
+
+test("returns true if vertex has been added to graph and is filtered out by id", () => {
+  const vertex = createRandomVertex();
+  const { result } = renderHookWithRecoilRoot(
+    () => useHasVertexBeenAddedToGraph(vertex.id),
+    snapshot => {
+      snapshot.set(nodesAtom, toNodeMap([vertex]));
+      snapshot.set(nodesFilteredIdsAtom, new Set([vertex.id]));
+    }
+  );
+
+  expect(result.current).toBe(true);
+});
+
+test("returns true if vertex has been added to graph and is filtered out by type", () => {
+  const vertex = createRandomVertex();
+  const { result } = renderHookWithRecoilRoot(
+    () => useHasVertexBeenAddedToGraph(vertex.id),
+    snapshot => {
+      snapshot.set(nodesAtom, toNodeMap([vertex]));
+      snapshot.set(nodesTypesFilteredAtom, new Set([vertex.type]));
+    }
+  );
+
+  expect(result.current).toBe(true);
+});

--- a/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.ts
@@ -1,0 +1,8 @@
+import { VertexId } from "@/@types/entities";
+import { nodesAtom } from "@/core";
+import { useRecoilValue } from "recoil";
+
+/** Returns true if the given vertex has been added to the graph. */
+export function useHasVertexBeenAddedToGraph(id: VertexId) {
+  return useRecoilValue(nodesAtom).has(id);
+}

--- a/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components";
 import {
   useAddToGraph,
-  useHasNodeBeenAddedToGraph,
+  useHasVertexBeenAddedToGraph,
   useRemoveNodeFromGraph,
 } from "@/hooks";
 import { cn } from "@/utils";
@@ -27,7 +27,7 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
 
   const addToGraph = useAddToGraph(node);
   const removeFromGraph = useRemoveNodeFromGraph(node.id);
-  const hasBeenAdded = useHasNodeBeenAddedToGraph(node.id);
+  const hasBeenAdded = useHasVertexBeenAddedToGraph(node.id);
 
   return (
     <div

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -41,8 +41,7 @@ import {
   userStylingAtom,
   VertexPreferences,
 } from "@/core/StateProvider/userPreferences";
-import { useEntities } from "@/hooks";
-import { useAddToGraph } from "@/hooks/useAddToGraph";
+import { useAddToGraph, useHasVertexBeenAddedToGraph } from "@/hooks";
 import usePrefixesUpdater from "@/hooks/usePrefixesUpdater";
 import useTranslations from "@/hooks/useTranslations";
 import useUpdateVertexTypeCounts from "@/hooks/useUpdateVertexTypeCounts";
@@ -263,8 +262,7 @@ function DisplayNameAndDescriptionOptions({
 
 function AddToExplorerButton({ vertex }: { vertex: Vertex }) {
   const addToGraph = useAddToGraph(vertex);
-  const [entities] = useEntities({ disableFilters: true });
-  const isInExplorer = entities.nodes.has(vertex.id);
+  const isInExplorer = useHasVertexBeenAddedToGraph(vertex.id);
 
   return (
     <div style={{ display: "inline-block" }}>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR finally teases apart some logic that always seemed more complex than it needed to be: `useEntities()`.

- Updated hook for checking if a node is added to the graph
  - Renamed to use "vertex" instead of "node" (slowly trying to standardize the codebase on "vertex")
  - Moved to its own file
  - Added tests
  - Check for existence in graph in `nodesAtom` to skip any filters
  - Removed unused hook for checking if edge is added to graph
- Updated `useAddToGraph` hook to use `useCallback` to reduce re-renders
- Use `useHasVertexBeenAddedToGraph` in Data Explorer, which was only use of `useEntities({ disableFilters: true })`
- Removed `disableFilters` param from `useEntities`
- Move node and edge filtering logic to Recoil
- Added tests to `useEntities` for filtering

## Validation

- Verified filtering logic in filter sidebar
- Verified filtering logic in node & edge table views
- Verified has been added logic in Data Explorer and search sidebar

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
