### PR TITLE
Rewrite neighbor counts logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- **Improved** neighbor count retrieval to be more efficient
+  ([#744](https://github.com/aws/graph-explorer/pull/744))
 - **Removed** unused `hidden` flag from schema types
   ([#737](https://github.com/aws/graph-explorer/pull/737))
 - **Improved** entity filtering logic reducing re-renders

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -40,19 +40,6 @@ export type Vertex = {
    * - For RDF, subjects can be connected to other subjects which are literals
    */
   attributes: Record<string, string | number>;
-  /**
-   * The total number of neighbors.
-   * - For PG, all connected nodes independently of their direction (in/out)
-   * - For RDF, all subjects which be compliant with:
-   *   1. <resourceURI> ?pred ?subject
-   *   2. ?subject ?pred <resourceURI>
-   *   3. FILTER(!isLiteral(?subject))
-   */
-  neighborsCount: number;
-  /**
-   * The total number of neighbors by type.
-   */
-  neighborsCountByType: Record<string, number>;
 
   // The following properties are computed on run-time
   /**

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -64,14 +64,6 @@ export type Vertex = {
    * Internal flag to mark the resource as blank node in RDF.
    */
   __isBlank?: boolean;
-  /**
-   * Total number of non-fetched neighbors
-   */
-  __unfetchedNeighborCount?: number;
-  /**
-   * Non-fetched neighbors by type
-   */
-  __unfetchedNeighborCounts?: Record<string, number>;
 };
 
 export type Edge = {

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -1,14 +1,10 @@
 import type { Vertex, VertexId } from "@/@types/entities";
-import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import type { GVertex } from "../types";
 import { detectIdType } from "./detectIdType";
 import parsePropertiesValues from "./parsePropertiesValues";
 import toStringId from "./toStringId";
 
-const mapApiVertex = (
-  apiVertex: GVertex,
-  neighborsCount: NeighborsCountResponse = { totalCount: 0, counts: {} }
-): Vertex => {
+const mapApiVertex = (apiVertex: GVertex): Vertex => {
   const labels = apiVertex["@value"].label.split("::");
   const vt = labels[0];
   const isFragment = apiVertex["@value"].properties == null;
@@ -19,8 +15,6 @@ const mapApiVertex = (
     idType: detectIdType(apiVertex["@value"].id),
     type: vt,
     types: labels,
-    neighborsCount: neighborsCount?.totalCount || 0,
-    neighborsCountByType: neighborsCount?.counts || {},
     attributes: parsePropertiesValues(apiVertex["@value"].properties ?? {}),
     __isFragment: isFragment,
   };

--- a/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/fetchNeighbors.test.ts
@@ -12,8 +12,6 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "486",
         type: "airport",
         types: ["airport"],
-        neighborsCount: 107,
-        neighborsCountByType: { continent: 1, country: 1, airport: 105 },
         attributes: {
           country: "ES",
           longest: 10499,
@@ -33,8 +31,6 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "228",
         type: "airport",
         types: ["airport"],
-        neighborsCount: 97,
-        neighborsCountByType: { continent: 1, country: 1, airport: 95 },
         attributes: {
           country: "ES",
           longest: 10171,
@@ -54,8 +50,6 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "124",
         type: "airport",
         types: ["airport"],
-        neighborsCount: 28,
-        neighborsCountByType: { continent: 1, country: 1, airport: 26 },
         attributes: {
           country: "ES",
           longest: 11155,
@@ -75,16 +69,12 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "3741",
         type: "continent",
         types: ["continent"],
-        neighborsCount: 605,
-        neighborsCountByType: { airport: 605 },
         attributes: { code: "EU", type: "continent", desc: "Europe" },
       },
       {
         id: "3701",
         type: "country",
         types: ["country"],
-        neighborsCount: 43,
-        neighborsCountByType: { airport: 43 },
         attributes: { code: "ES", type: "country", desc: "Spain" },
       },
     ];
@@ -95,11 +85,7 @@ describe("Gremlin > fetchNeighbors", () => {
     });
 
     expect(response).toMatchObject({
-      vertices: expectedVertices.map(v => ({
-        ...v,
-        neighborsCount: 0,
-        neighborsCountByType: {},
-      })),
+      vertices: expectedVertices,
       edges: [
         {
           id: "49540",
@@ -183,8 +169,6 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "486",
         type: "airport",
         types: ["airport"],
-        neighborsCount: 107,
-        neighborsCountByType: { continent: 1, country: 1, airport: 105 },
         attributes: {
           country: "ES",
           longest: 10499,
@@ -204,8 +188,6 @@ describe("Gremlin > fetchNeighbors", () => {
         id: "124",
         type: "airport",
         types: ["airport"],
-        neighborsCount: 28,
-        neighborsCountByType: { continent: 1, country: 1, airport: 26 },
         attributes: {
           country: "ES",
           longest: 11155,
@@ -231,11 +213,7 @@ describe("Gremlin > fetchNeighbors", () => {
     });
 
     expect(response).toMatchObject({
-      vertices: expectedVertices.map(v => ({
-        ...v,
-        neighborsCount: 0,
-        neighborsCountByType: {},
-      })),
+      vertices: expectedVertices,
       edges: [
         {
           id: "49540",

--- a/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/queries/keywordSearch.test.ts
@@ -16,8 +16,6 @@ describe("Gremlin > keywordSearch", () => {
           id: "1",
           type: "airport",
           types: ["airport"],
-          neighborsCount: 0,
-          neighborsCountByType: {},
           attributes: {
             country: "US",
             longest: 12390,
@@ -50,8 +48,6 @@ describe("Gremlin > keywordSearch", () => {
           id: "836",
           type: "airport",
           types: ["airport"],
-          neighborsCount: 0,
-          neighborsCountByType: {},
           attributes: {
             country: "TN",
             longest: 9843,

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
@@ -1,4 +1,3 @@
-import { createRandomInteger, createRandomName } from "@shared/utils/testing";
 import mapApiVertex from "./mapApiVertex";
 import { Vertex, VertexId } from "@/@types/entities";
 
@@ -18,35 +17,6 @@ test("maps empty vertex", () => {
     type: "",
     types: [],
     attributes: {},
-    neighborsCount: 0,
-    neighborsCountByType: {},
-  } satisfies Vertex);
-});
-
-test("applies the given counts", () => {
-  const input = {
-    "~labels": [],
-    "~entityType": "node",
-    "~id": "",
-    "~properties": {},
-  };
-  const counts = {
-    totalCount: createRandomInteger(),
-    counts: {
-      [`${createRandomName("label")}`]: createRandomInteger(),
-    },
-  };
-  const result = mapApiVertex(input, counts);
-
-  expect(result).toEqual({
-    entityType: "vertex",
-    id: "" as VertexId,
-    idType: "string",
-    type: "",
-    types: [],
-    attributes: {},
-    neighborsCount: counts.totalCount,
-    neighborsCountByType: counts.counts,
   } satisfies Vertex);
 });
 
@@ -93,7 +63,5 @@ test("maps airport node", () => {
       runways: 5,
       type: "airport",
     },
-    neighborsCount: 0,
-    neighborsCountByType: {},
   } satisfies Vertex);
 });

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -1,11 +1,7 @@
 import type { Vertex, VertexId } from "@/@types/entities";
-import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import type { OCVertex } from "../types";
 
-export default function mapApiVertex(
-  apiVertex: OCVertex,
-  neighborsCount: NeighborsCountResponse = { totalCount: 0, counts: {} }
-): Vertex {
+export default function mapApiVertex(apiVertex: OCVertex): Vertex {
   const labels = apiVertex["~labels"];
   const vt = labels[0] ?? "";
 
@@ -15,8 +11,6 @@ export default function mapApiVertex(
     idType: "string",
     type: vt,
     types: labels,
-    neighborsCount: neighborsCount?.totalCount || 0,
-    neighborsCountByType: neighborsCount?.counts || {},
     attributes: apiVertex["~properties"],
   };
 }

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -53,15 +53,19 @@ export function neighborsCountQuery(
   return queryOptions({
     queryKey: ["neighborsCount", id, idType, limit, explorer],
     enabled: Boolean(explorer),
-    queryFn: async (): Promise<NeighborCountsQueryResponse | undefined> => {
-      const result = await explorer?.fetchNeighborsCount({
+    queryFn: async (): Promise<NeighborCountsQueryResponse> => {
+      if (!explorer) {
+        return {
+          nodeId: id,
+          totalCount: 0,
+          counts: {},
+        };
+      }
+
+      const result = await explorer.fetchNeighborsCount({
         vertex: { id, idType },
         limit,
       });
-
-      if (!result) {
-        return;
-      }
 
       return {
         nodeId: id,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -1,18 +1,12 @@
 import { Vertex, VertexId } from "@/@types/entities";
-import type { NeighborsCountResponse } from "@/connector/useGEFetchTypes";
 import { RawResult } from "../types";
 
-const mapRawResultToVertex = (
-  rawResult: RawResult,
-  neighborsCount?: NeighborsCountResponse
-): Vertex => {
+const mapRawResultToVertex = (rawResult: RawResult): Vertex => {
   return {
     entityType: "vertex",
     id: rawResult.uri as VertexId,
     idType: "string",
     type: rawResult.class,
-    neighborsCount: neighborsCount?.totalCount || 0,
-    neighborsCountByType: neighborsCount?.counts || {},
     attributes: rawResult.attributes,
     __isBlank: rawResult.isBlank,
   };

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -47,6 +47,10 @@ const replaceBlankNodeFromSearch = (
         id: vertex.id,
         subQueryTemplate: keywordSearchBlankNodesIdsTemplate(request),
         vertex,
+        neighborCounts: {
+          totalCount: 0,
+          counts: {},
+        },
       });
     }
 
@@ -73,6 +77,10 @@ const replaceBlankNodeFromNeighbors = (
         id: vertex.id,
         subQueryTemplate: oneHopNeighborsBlankNodesIdsTemplate(request),
         vertex,
+        neighborCounts: {
+          totalCount: 0,
+          counts: {},
+        },
       });
     }
 
@@ -252,10 +260,7 @@ export function createSparqlExplorer(
       const bNode = blankNodes.get(req.vertex.id);
 
       if (bNode?.neighbors) {
-        return {
-          totalCount: bNode.vertex.neighborsCount,
-          counts: bNode.vertex.neighborsCountByType,
-        };
+        return bNode.neighborCounts;
       }
 
       if (bNode && !bNode.neighbors) {
@@ -270,10 +275,9 @@ export function createSparqlExplorer(
 
         blankNodes.set(req.vertex.id, {
           ...bNode,
-          vertex: {
-            ...bNode.vertex,
-            neighborsCount: response.totalCount,
-            neighborsCountByType: response.counts,
+          neighborCounts: {
+            totalCount: response.totalCount,
+            counts: response.counts,
           },
           neighbors: response.neighbors,
         });

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -149,6 +149,10 @@ export type BlankNodeItem = {
   id: string;
   subQueryTemplate: string;
   vertex: Vertex;
+  neighborCounts: {
+    totalCount: number;
+    counts: Record<string, number>;
+  };
   neighbors?: {
     vertices: Array<Vertex>;
     edges: Array<Edge>;

--- a/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
+++ b/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
@@ -7,7 +7,6 @@ import StateProvider from "@/core/StateProvider/StateProvider";
 import ThemeProvider from "@/core/ThemeProvider/ThemeProvider";
 import { MantineProvider } from "@mantine/core";
 import { emotionTransform, MantineEmotionProvider } from "@mantine/emotion";
-import { ExpandNodeProvider } from "@/hooks/useExpandNode";
 import { ErrorBoundary } from "react-error-boundary";
 import AppErrorPage from "@/core/AppErrorPage";
 import { TooltipProvider } from "@/components";
@@ -37,9 +36,7 @@ export default function ConnectedProvider({ children }: PropsWithChildren) {
               <ThemeProvider>
                 <NotificationProvider component={Toast}>
                   <StateProvider>
-                    <AppStatusLoader>
-                      <ExpandNodeProvider>{children}</ExpandNodeProvider>
-                    </AppStatusLoader>
+                    <AppStatusLoader>{children}</AppStatusLoader>
                   </StateProvider>
                 </NotificationProvider>
               </ThemeProvider>

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -17,11 +17,13 @@ import {
   RESERVED_ID_PROPERTY,
   RESERVED_TYPES_PROPERTY,
 } from "@/utils";
+import { VertexIdType } from "@/connector/useGEFetchTypes";
 
 /** Represents a vertex's display information after all transformations have been applied. */
 export type DisplayVertex = {
   entityType: "vertex";
   id: VertexId;
+  idType: VertexIdType;
   displayId: string;
   displayTypes: string;
   displayName: string;
@@ -131,6 +133,7 @@ const displayVertexSelector = selectorFamily({
       const result: DisplayVertex = {
         entityType: "vertex",
         id: vertex.id,
+        idType: vertex.idType,
         displayId,
         displayTypes,
         displayName,

--- a/packages/graph-explorer/src/core/StateProvider/index.ts
+++ b/packages/graph-explorer/src/core/StateProvider/index.ts
@@ -5,5 +5,6 @@ export * from "./displayTypeConfigs";
 export * from "./displayVertex";
 export * from "./edges";
 export * from "./entitiesSelector";
+export * from "./neighbors";
 export * from "./nodes";
 export * from "./userPreferences";

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.test.ts
@@ -1,0 +1,36 @@
+import { VertexId } from "@/@types/entities";
+import { calculateNeighbors } from "./neighbors";
+
+describe("calculateNeighbors", () => {
+  it("should calculate neighbors correctly", () => {
+    const total = {
+      total: 10,
+      byType: new Map([
+        ["type1", 6],
+        ["type2", 4],
+      ]),
+    };
+    const fetchedNeighbors = [
+      { id: "1" as VertexId, type: "type1" },
+      { id: "2" as VertexId, type: "type2" },
+      { id: "3" as VertexId, type: "type1" },
+      { id: "4" as VertexId, type: "type2" },
+    ];
+
+    const result = calculateNeighbors(
+      total.total,
+      total.byType,
+      fetchedNeighbors
+    );
+
+    expect(result.all).toEqual(total.total);
+    expect(result.fetched).toEqual(4);
+    expect(result.unfetched).toEqual(6);
+    expect(result.byType).toEqual(
+      new Map([
+        ["type1", { all: 6, fetched: 2, unfetched: 4 }],
+        ["type2", { all: 4, fetched: 2, unfetched: 2 }],
+      ])
+    );
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -163,20 +163,27 @@ export function calculateNeighbors(
   totalByType: Map<string, number>,
   fetchedNeighbors: NeighborStub[]
 ): NeighborCounts {
-  const fetchedTotal = new Set(fetchedNeighbors.map(n => n.id)).size;
+  const fetchNeighborsMap = new Map(fetchedNeighbors.map(n => [n.id, n]));
+
+  const fetchedTotal = fetchNeighborsMap.size;
   const totals = {
     all: total,
     fetched: fetchedTotal,
     unfetched: total - fetchedTotal,
   };
 
-  const fetchedNeighborsByType = Map.groupBy(fetchedNeighbors, n => n.type);
+  const fetchedNeighborsByType = fetchNeighborsMap
+    .values()
+    .reduce((map, neighbor) => {
+      const type = neighbor.type;
+      const fetched = map.get(type) ?? 0;
+      return map.set(type, fetched + 1);
+    }, new Map<string, number>());
 
   const byType = new Map(
     totalByType.entries().map(([type, count]) => {
       // Count of unique neighbors that have been fetched
-      const fetched = new Set(fetchedNeighborsByType.get(type)?.map(n => n.id))
-        .size;
+      const fetched = fetchedNeighborsByType.get(type) ?? 0;
 
       // Total neighbors minus the fetched neighbors
       const unfetched = count - fetched;

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -35,7 +35,6 @@ export type NeighborStub = {
 
 /**
  * Provides a callback to fetch the neighbor counts for a given vertex.
- * @param id The vertex id for which to fetch the neighbor counts.
  * @returns The neighbor counts for the given vertex.
  */
 export function useNeighborsCallback() {
@@ -63,7 +62,7 @@ export function useNeighborsCallback() {
 
 /**
  * Provides the neighbor counts for a given vertex.
- * @param id The vertex id for which to fetch the neighbor counts.
+ * @param vertex The vertex for which to fetch the neighbor counts.
  * @returns The neighbor counts for the given vertex.
  */
 export function useNeighbors(vertex: VertexRef) {
@@ -87,7 +86,7 @@ export function useNeighbors(vertex: VertexRef) {
 
 /**
  * Provides the neighbor counts for a given vertex and neighbor type.
- * @param id The vertex id for which to fetch the neighbors counts.
+ * @param vertex The vertex for which to fetch the neighbors counts.
  * @param type The neighbor type for which to fetch the neighbors counts.
  * @returns The neighbor counts for the given vertex and neighbor type.
  */

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -1,0 +1,210 @@
+import { VertexId } from "@/@types/entities";
+import { selectorFamily, useRecoilCallback, useRecoilValue } from "recoil";
+import { edgesAtom } from "./edges";
+import { nodesAtom } from "./nodes";
+import {
+  useAllNeighborCountsQuery,
+  useUpdateNodeCountsQuery,
+} from "@/hooks/useUpdateNodeCounts";
+import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { neighborsCountQuery } from "@/connector/queries";
+import { activeConnectionSelector, explorerSelector } from "../connector";
+import { VertexRef } from "@/connector/useGEFetchTypes";
+
+export type NeighborCounts = {
+  all: number;
+  fetched: number;
+  unfetched: number;
+  byType: Map<string, { all: number; fetched: number; unfetched: number }>;
+};
+
+const defaultNeighborCounts: NeighborCounts = {
+  all: 0,
+  fetched: 0,
+  unfetched: 0,
+  byType: new Map(),
+};
+
+/** Represents the minimum information needed about a neighbor to calculate the neighbor counts. */
+export type NeighborStub = {
+  id: VertexId;
+  type: string;
+};
+
+/**
+ * Provides a callback to fetch the neighbor counts for a given vertex.
+ * @param id The vertex id for which to fetch the neighbor counts.
+ * @returns The neighbor counts for the given vertex.
+ */
+export function useNeighborsCallback() {
+  const queryClient = useQueryClient();
+
+  return useRecoilCallback(({ snapshot }) => async (vertex: VertexRef) => {
+    const fetchedNeighbors = await snapshot.getPromise(
+      fetchedNeighborsSelector(vertex.id)
+    );
+    const explorer = await snapshot.getPromise(explorerSelector);
+    const connection = await snapshot.getPromise(activeConnectionSelector);
+    const response = await queryClient.ensureQueryData(
+      neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
+    );
+
+    const neighbors = calculateNeighbors(
+      response.totalCount,
+      new Map(Object.entries(response.counts)),
+      fetchedNeighbors
+    );
+
+    return neighbors;
+  });
+}
+
+/**
+ * Provides the neighbor counts for a given vertex.
+ * @param id The vertex id for which to fetch the neighbor counts.
+ * @returns The neighbor counts for the given vertex.
+ */
+export function useNeighbors(vertex: VertexRef) {
+  const fetchedNeighbors = useRecoilValue(fetchedNeighborsSelector(vertex.id));
+  const query = useUpdateNodeCountsQuery(vertex);
+
+  return useMemo(() => {
+    if (!query.data) {
+      return defaultNeighborCounts;
+    }
+
+    const neighbors = calculateNeighbors(
+      query.data.totalCount,
+      new Map(Object.entries(query.data.counts)),
+      fetchedNeighbors
+    );
+
+    return neighbors;
+  }, [query.data, fetchedNeighbors]);
+}
+
+/**
+ * Provides the neighbor counts for a given vertex and neighbor type.
+ * @param id The vertex id for which to fetch the neighbors counts.
+ * @param type The neighbor type for which to fetch the neighbors counts.
+ * @returns The neighbor counts for the given vertex and neighbor type.
+ */
+export function useNeighborByType(vertex: VertexRef, type: string) {
+  const neighbors = useNeighbors(vertex)?.byType.get(type);
+  if (!neighbors) {
+    return { all: 0, fetched: 0, unfetched: 0 };
+  }
+  return neighbors;
+}
+
+export function useAllNeighbors(vertices: VertexRef[]) {
+  const fetchedNeighbors = useRecoilValue(
+    allFetchedNeighborsSelector(vertices.map(v => v.id))
+  );
+  const query = useAllNeighborCountsQuery(vertices);
+
+  const results = new Map(
+    query
+      .values()
+      .map(q => q.data)
+      .filter(d => d != null)
+      .map(data => {
+        const neighbors = fetchedNeighbors.get(data.nodeId) ?? [];
+        return [
+          data.nodeId,
+          calculateNeighbors(
+            data.totalCount,
+            new Map(Object.entries(data.counts)),
+            neighbors
+          ),
+        ];
+      })
+  );
+
+  return results;
+}
+
+/**
+ * Calculates the neighbor counts for a given vertex.
+ * @param total The total number of neighbors.
+ * @param totalByType The total number of neighbors by type.
+ * @param fetchedNeighbors A list of neighbors that have been fetched.
+ * @returns The neighbor counts for the given vertex.
+ */
+export function calculateNeighbors(
+  total: number,
+  totalByType: Map<string, number>,
+  fetchedNeighbors: NeighborStub[]
+): NeighborCounts {
+  const fetchedTotal = new Set(fetchedNeighbors.map(n => n.id)).size;
+  const totals = {
+    all: total,
+    fetched: fetchedTotal,
+    unfetched: total - fetchedTotal,
+  };
+
+  const fetchedNeighborsByType = Map.groupBy(fetchedNeighbors, n => n.type);
+
+  const byType = new Map(
+    totalByType.entries().map(([type, count]) => {
+      // Count of unique neighbors that have been fetched
+      const fetched = new Set(fetchedNeighborsByType.get(type)?.map(n => n.id))
+        .size;
+
+      // Total neighbors minus the fetched neighbors
+      const unfetched = count - fetched;
+
+      return [
+        type,
+        {
+          all: count,
+          fetched,
+          unfetched,
+        },
+      ];
+    })
+  );
+
+  return {
+    ...totals,
+    byType,
+  };
+}
+
+const fetchedNeighborsSelector = selectorFamily({
+  key: "fetched-neighbors",
+  get:
+    (id: VertexId) =>
+    ({ get }) => {
+      const nodes = get(nodesAtom);
+      const edges = get(edgesAtom);
+
+      const neighbors = edges
+        .values()
+        .map(edge => {
+          // Get all OUT connected edges: current node is source and target should exist
+          if (edge.source === id && nodes.has(edge.target)) {
+            return { id: edge.target, type: edge.targetType };
+          }
+          // Get all IN connected edges: current node is target and source should exist
+          if (edge.target === id && nodes.has(edge.source)) {
+            return { id: edge.source, type: edge.sourceType };
+          }
+          return null;
+        })
+        .filter(neighbor => neighbor !== null)
+        .toArray();
+
+      return neighbors;
+    },
+});
+
+const allFetchedNeighborsSelector = selectorFamily({
+  key: "all-fetched-neighbors",
+  get:
+    (ids: VertexId[]) =>
+    ({ get }) => {
+      return new Map(ids.map(id => [id, get(fetchedNeighborsSelector(id))]));
+    },
+});

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -8,11 +8,12 @@ import { createGremlinExplorer } from "@/connector/gremlin/gremlinExplorer";
 import { createOpenCypherExplorer } from "@/connector/openCypher/openCypherExplorer";
 import { createSparqlExplorer } from "@/connector/sparql/sparqlExplorer";
 import { mergedConfigurationSelector } from "./StateProvider/configuration";
-import { selector, useRecoilValue } from "recoil";
+import { atom, selector, useRecoilValue } from "recoil";
 import { equalSelector } from "@/utils/recoilState";
 import { ConnectionConfig } from "@shared/types";
 import { logger } from "@/utils";
 import { featureFlagsSelector } from "./featureFlags";
+import { Explorer } from "@/connector/useGEFetchTypes";
 
 /**
  * Active connection where the value will only change when one of the
@@ -51,6 +52,12 @@ export const activeConnectionSelector = equalSelector({
 export const explorerSelector = selector({
   key: "explorer",
   get: ({ get }) => {
+    // Use this explorer override when testing
+    const explorerForTesting = get(explorerForTestingAtom);
+    if (explorerForTesting) {
+      return explorerForTesting;
+    }
+
     const connection = get(activeConnectionSelector);
     const featureFlags = get(featureFlagsSelector);
 
@@ -66,6 +73,12 @@ export const explorerSelector = selector({
         return createGremlinExplorer(connection, featureFlags);
     }
   },
+});
+
+/** CAUTION: This atom is only for testing purposes. */
+export const explorerForTestingAtom = atom<Explorer | null>({
+  key: "explorerForTesting",
+  default: null,
 });
 
 export const queryEngineSelector = selector({

--- a/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
@@ -24,11 +24,7 @@ test("should add one node", async () => {
   });
 
   const actual = result.current.entities.nodes.get(vertex.id);
-  expect(actual).toEqual({
-    ...vertex,
-    __unfetchedNeighborCount: 0,
-    __unfetchedNeighborCounts: {},
-  });
+  expect(actual).toEqual(vertex);
 });
 
 test("should add one edge", async () => {
@@ -73,14 +69,7 @@ test("should add multiple nodes and edges", async () => {
   });
 
   const actualNodes = result.current.entities.nodes.values().toArray();
-  const expectedNodes = randomEntities.nodes
-    .values()
-    .map(n => ({
-      ...n,
-      __unfetchedNeighborCount: 0,
-      __unfetchedNeighborCounts: {},
-    }))
-    .toArray();
+  const expectedNodes = randomEntities.nodes.values().toArray();
   expect(actualNodes).toEqual(expectedNodes);
 
   const actualEdges = result.current.entities.edges.values().toArray();

--- a/packages/graph-explorer/src/hooks/useEntities.test.tsx
+++ b/packages/graph-explorer/src/hooks/useEntities.test.tsx
@@ -37,12 +37,9 @@ describe("useEntities", () => {
     const randomNode = {
       id: Math.random().toString() as VertexId,
       type: "type1",
-      neighborsCount: Math.floor(Math.random() * 100),
-      neighborsCountByType: {},
     } as Vertex;
     const expectedRandomNodes: Vertex = {
       ...randomNode,
-      neighborsCountByType: {},
     };
 
     const { result } = renderHookWithRecoilRoot(() => {
@@ -64,8 +61,6 @@ describe("useEntities", () => {
     const actualNode = result.current.entities.nodes.get(randomNode.id);
     expect(actualNode?.id).toEqual(randomNode.id);
     expect(actualNode?.type).toEqual(randomNode.type);
-    expect(actualNode?.neighborsCount).toEqual(randomNode.neighborsCount);
-    expect(actualNode?.neighborsCountByType).toEqual({});
   });
 
   it("should handle multiple nodes correctly", async () => {
@@ -75,8 +70,6 @@ describe("useEntities", () => {
       idType: "string",
       type: "type1",
       attributes: {},
-      neighborsCount: 1,
-      neighborsCountByType: {},
     };
     const node2: Vertex = {
       entityType: "vertex",
@@ -84,8 +77,6 @@ describe("useEntities", () => {
       idType: "string",
       type: "type2",
       attributes: {},
-      neighborsCount: 2,
-      neighborsCountByType: {},
     };
     const node3: Vertex = {
       entityType: "vertex",
@@ -93,8 +84,6 @@ describe("useEntities", () => {
       idType: "string",
       type: "type3",
       attributes: {},
-      neighborsCount: 3,
-      neighborsCountByType: {},
     };
     const expectedNodes = toNodeMap([
       {
@@ -103,8 +92,6 @@ describe("useEntities", () => {
         idType: "string",
         type: node1.type,
         attributes: {},
-        neighborsCount: node1.neighborsCount,
-        neighborsCountByType: {},
       },
       {
         entityType: "vertex",
@@ -112,8 +99,6 @@ describe("useEntities", () => {
         idType: "string",
         type: node2.type,
         attributes: {},
-        neighborsCount: node2.neighborsCount,
-        neighborsCountByType: {},
       },
       {
         entityType: "vertex",
@@ -121,8 +106,6 @@ describe("useEntities", () => {
         idType: "string",
         type: node3.type,
         attributes: {},
-        neighborsCount: node3.neighborsCount,
-        neighborsCountByType: {},
       },
     ]);
 
@@ -146,22 +129,16 @@ describe("useEntities", () => {
     expect(actualNode1).not.toBeUndefined();
     expect(actualNode1?.id).toEqual(node1.id);
     expect(actualNode1?.type).toEqual(node1.type);
-    expect(actualNode1?.neighborsCount).toEqual(node1.neighborsCount);
-    expect(actualNode1?.neighborsCountByType).toEqual({});
 
     const actualNode2 = result.current.entities.nodes.get(node2.id);
     expect(actualNode2).not.toBeUndefined();
     expect(actualNode2?.id).toEqual(node2.id);
     expect(actualNode2?.type).toEqual(node2.type);
-    expect(actualNode2?.neighborsCount).toEqual(node2.neighborsCount);
-    expect(actualNode2?.neighborsCountByType).toEqual({});
 
     const actualNode3 = result.current.entities.nodes.get(node3.id);
     expect(actualNode3).not.toBeUndefined();
     expect(actualNode3?.id).toEqual(node3.id);
     expect(actualNode3?.type).toEqual(node3.type);
-    expect(actualNode3?.neighborsCount).toEqual(node3.neighborsCount);
-    expect(actualNode3?.neighborsCountByType).toEqual({});
   });
 
   it("should filter nodes by id", () => {

--- a/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
+++ b/packages/graph-explorer/src/hooks/useNeighborsOptions.test.ts
@@ -1,23 +1,51 @@
 import useNeighborsOptions from "./useNeighborsOptions";
-import { Vertex } from "@/types/entities";
 import {
   activeConfigurationAtom,
   configurationAtom,
 } from "@/core/StateProvider/configuration";
 import {
+  createRandomEdge,
   createRandomRawConfiguration,
   createRandomSchema,
+  createRandomVertex,
   renderHookWithRecoilRoot,
 } from "@/utils/testing";
 import { schemaAtom } from "@/core/StateProvider/schema";
+import { NeighborCountsQueryResponse } from "@/connector/queries";
+import {
+  edgesAtom,
+  explorerForTestingAtom,
+  nodesAtom,
+  toEdgeMap,
+  toNodeMap,
+} from "@/core";
+import { waitFor } from "@testing-library/react";
+import { createArray } from "@shared/utils/testing";
+import { createMockExplorer } from "@/utils/testing/createMockExplorer";
 
 describe("useNeighborsOptions", () => {
-  const vertex = {
-    neighborsCountByType: { nodeType1: 5, nodeType2: 3 },
-    __unfetchedNeighborCounts: { nodeType1: 0, nodeType2: 1 },
-  } as unknown as Vertex;
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
 
-  it("should return neighbors options correctly", () => {
+  it("should return neighbors options correctly", async () => {
+    const vertex = createRandomVertex();
+    const nodeType1Neighbors = createArray(5, () => {
+      const neighbors = createRandomVertex();
+      neighbors.type = "nodeType1";
+      return neighbors;
+    });
+    const edges = nodeType1Neighbors.map(neighbor =>
+      createRandomEdge(vertex, neighbor)
+    );
+    const mockExplorer = createMockExplorer();
+    const response: NeighborCountsQueryResponse = {
+      nodeId: vertex.id,
+      totalCount: 8,
+      counts: { nodeType1: 5, nodeType2: 3 },
+    };
+    vi.mocked(mockExplorer.fetchNeighborsCount).mockResolvedValueOnce(response);
+
     const { result } = renderHookWithRecoilRoot(
       () => useNeighborsOptions(vertex),
       snapshot => {
@@ -38,28 +66,33 @@ describe("useNeighborsOptions", () => {
         snapshot.set(configurationAtom, new Map([[config.id, config]]));
         snapshot.set(schemaAtom, new Map([[config.id, schema]]));
         snapshot.set(activeConfigurationAtom, config.id);
+        snapshot.set(explorerForTestingAtom, mockExplorer);
+        snapshot.set(nodesAtom, toNodeMap([vertex, ...nodeType1Neighbors]));
+        snapshot.set(edgesAtom, toEdgeMap(edges));
       }
     );
 
-    expect(
-      result.current.map(option => ({
-        ...option,
-        // We only care about verifying the displayLabel property
-        config: { displayLabel: option.config?.displayLabel },
-      }))
-    ).toEqual([
-      {
-        label: "Label nodeType1",
-        value: "nodeType1",
-        isDisabled: true,
-        config: { displayLabel: "Label nodeType1" },
-      },
-      {
-        label: "Label nodeType2",
-        value: "nodeType2",
-        isDisabled: false,
-        config: { displayLabel: "Label nodeType2" },
-      },
-    ]);
+    await waitFor(() =>
+      expect(
+        result.current.map(option => ({
+          ...option,
+          // We only care about verifying the displayLabel property
+          config: { displayLabel: option.config?.displayLabel },
+        }))
+      ).toEqual([
+        {
+          label: "Label nodeType1",
+          value: "nodeType1",
+          isDisabled: true,
+          config: { displayLabel: "Label nodeType1" },
+        },
+        {
+          label: "Label nodeType2",
+          value: "nodeType2",
+          isDisabled: false,
+          config: { displayLabel: "Label nodeType2" },
+        },
+      ])
+    );
   });
 });

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -15,9 +15,16 @@ export function useUpdateNodeCountsQuery(vertex: VertexRef) {
 export function useAllNeighborCountsQuery(vertexIds: VertexRef[]) {
   const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useRecoilValue(explorerSelector);
+
   return useQueries({
     queries: vertexIds.map(vertex =>
       neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
     ),
+    combine: results => ({
+      data: results.map(result => result.data),
+      pending: results.some(result => result.isPending),
+      errors: results.map(result => result.error),
+      hasErrors: results.some(result => result.isError),
+    }),
   });
 }

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -1,11 +1,7 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
-import { Vertex } from "@/types/entities";
-import { useNotification } from "@/components/NotificationProvider";
 import { neighborsCountQuery } from "@/connector/queries";
 import { activeConnectionSelector, explorerSelector } from "@/core/connector";
-import useEntities from "./useEntities";
 import { VertexRef } from "@/connector/useGEFetchTypes";
 
 export function useUpdateNodeCountsQuery(vertex: VertexRef) {
@@ -16,92 +12,12 @@ export function useUpdateNodeCountsQuery(vertex: VertexRef) {
   );
 }
 
-/**
- * Hook that watches nodes added to the graph and queries the database for
- * neighbor counts. There should be only one instance of this hook in the render
- * pipeline since it uses effects for progress and error notifications.
- */
-export function useUpdateAllNodeCounts() {
-  const [entities, setEntities] = useEntities();
+export function useAllNeighborCountsQuery(vertexIds: VertexRef[]) {
   const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useRecoilValue(explorerSelector);
-  const { enqueueNotification, clearNotification } = useNotification();
-
-  const query = useQueries({
-    queries: entities.nodes
-      .values()
-      .map(vertex =>
-        neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
-      )
-      .toArray(),
-    combine: results => {
-      // Combines data with existing node data and filters out undefined
-      const data = results
-        .flatMap(result => (result.data ? [result.data] : []))
-        .map(data => {
-          const prevNode = entities.nodes.get(data.nodeId);
-          const node: Vertex | undefined = prevNode
-            ? {
-                ...prevNode,
-                neighborsCount: data.totalCount,
-                neighborsCountByType: data.counts,
-              }
-            : undefined;
-          return node;
-        });
-
-      return {
-        data: data,
-        pending: results.some(result => result.isPending),
-        errors: results.map(result => result.error),
-        hasErrors: results.some(result => result.isError),
-      };
-    },
+  return useQueries({
+    queries: vertexIds.map(vertex =>
+      neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
+    ),
   });
-
-  // Update the graph with the node counts from the query results
-  useEffect(() => {
-    // Ensure we have expanded and finished all count queries
-    if (query.pending) {
-      return;
-    }
-
-    // Update node graph with counts
-    setEntities(prev => ({
-      nodes: new Map(
-        prev.nodes.entries().map(([id, node]) => {
-          const nodeWithCounts = query.data.find(n => n?.id === id);
-
-          return [id, nodeWithCounts ?? node];
-        })
-      ),
-      edges: prev.edges,
-    }));
-  }, [query.data, query.pending, setEntities]);
-
-  // Show loading notification
-  useEffect(() => {
-    if (!query.pending) {
-      return;
-    }
-    const notificationId = enqueueNotification({
-      title: "Updating Neighbors",
-      message: `Updating neighbor counts for new nodes`,
-      autoHideDuration: null,
-    });
-    return () => clearNotification(notificationId);
-  }, [clearNotification, query.pending, enqueueNotification]);
-
-  // Show error notification
-  useEffect(() => {
-    if (query.pending || !query.hasErrors) {
-      return;
-    }
-    const notificationId = enqueueNotification({
-      title: "Some Errors Occurred",
-      message: `While requesting counts for neighboring nodes, some errors occurred.`,
-      type: "error",
-    });
-    return () => clearNotification(notificationId);
-  }, [clearNotification, query.pending, query.hasErrors, enqueueNotification]);
 }

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
@@ -19,6 +19,7 @@ import {
 
 import { useDeepMemo, useTranslations } from "@/hooks";
 import { recoilDiffSets } from "@/utils/recoilState";
+import { useAllNeighbors } from "@/core";
 
 type ToggleVertex = DisplayVertex & {
   __is_visible: boolean;
@@ -29,6 +30,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
   (_props, ref) => {
     const t = useTranslations();
     const displayNodes = useDisplayVerticesInCanvas();
+    const neighborCounts = useAllNeighbors(displayNodes.values().toArray());
     const setNodesOut = useSetRecoilState(nodesOutOfFocusIdsAtom);
     const [hiddenNodesIds, setHiddenNodesIds] =
       useRecoilState(nodesFilteredIdsAtom);
@@ -95,7 +97,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
           width: 300,
         },
         {
-          accessor: "neighborsCount",
+          accessor: row => neighborCounts.get(row.id)?.all ?? 0,
           label: "Total Neighbors",
           overflow: "ellipsis",
           oneLine: true,
@@ -107,7 +109,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
           },
         },
       ] satisfies ColumnDefinition<ToggleVertex>[];
-    }, [t, onToggleVisibility]);
+    }, [t, onToggleVisibility, neighborCounts]);
 
     const data: ToggleVertex[] = useDeepMemo(() => {
       return displayNodes

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
@@ -23,7 +23,7 @@ import { useAllNeighbors } from "@/core";
 
 type ToggleVertex = DisplayVertex & {
   __is_visible: boolean;
-  neighborsCount: number;
+  neighborCounts: number;
 };
 
 const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
@@ -97,7 +97,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
           width: 300,
         },
         {
-          accessor: row => neighborCounts.get(row.id)?.all ?? 0,
+          accessor: "neighborCounts",
           label: "Total Neighbors",
           overflow: "ellipsis",
           oneLine: true,
@@ -109,7 +109,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
           },
         },
       ] satisfies ColumnDefinition<ToggleVertex>[];
-    }, [t, onToggleVisibility, neighborCounts]);
+    }, [t, onToggleVisibility]);
 
     const data: ToggleVertex[] = useDeepMemo(() => {
       return displayNodes
@@ -117,10 +117,10 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
         .map(node => ({
           ...node,
           __is_visible: !hiddenNodesIds.has(node.id),
-          neighborsCount: node.original.neighborsCount ?? 0,
+          neighborCounts: neighborCounts.get(node.id)?.all ?? 0,
         }))
         .toArray();
-    }, [hiddenNodesIds, displayNodes]);
+    }, [hiddenNodesIds, displayNodes, neighborCounts]);
 
     const onSelectRows = useCallback(
       (rowIndex: string) => {

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -40,7 +40,7 @@ import useGraphStyles from "./useGraphStyles";
 import useNodeBadges from "./useNodeBadges";
 import { SelectedElements } from "@/components/Graph/Graph.model";
 import { useAutoOpenDetailsSidebar } from "./useAutoOpenDetailsSidebar";
-import { useDisplayVertexTypeConfigs } from "@/core";
+import { useDisplayVertexTypeConfigs, useNeighborsCallback } from "@/core";
 
 export type GraphViewerProps = {
   onNodeCustomize(nodeType?: string): void;
@@ -141,17 +141,17 @@ export default function GraphViewer({
   const getNodeBadges = useNodeBadges();
 
   const { expandNode } = useExpandNode();
+  const neighborCallback = useNeighborsCallback();
   const onNodeDoubleClick: ElementEventCallback<Vertex> = useCallback(
-    (_, vertex) => {
-      const offset = vertex.__unfetchedNeighborCount
-        ? Math.max(0, vertex.neighborsCount - vertex.__unfetchedNeighborCount)
-        : undefined;
+    async (_, vertex) => {
+      const neighborCount = await neighborCallback(vertex);
+      const offset = neighborCount ? neighborCount.fetched : undefined;
       expandNode(vertex, {
         limit: 10,
         offset,
       });
     },
-    [expandNode]
+    [expandNode, neighborCallback]
   );
 
   const [layout, setLayout] = useState("F_COSE");

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
@@ -2,17 +2,21 @@ import { useCallback } from "react";
 import { BadgeRenderer } from "@/components/Graph/hooks/useRenderBadges";
 import { VertexId } from "@/@types/entities";
 import { useDisplayVerticesInCanvas } from "@/core";
+import { useAllNeighbors } from "@/core";
 
 const useNodeBadges = () => {
   const displayNodes = useDisplayVerticesInCanvas();
+  const neighborCounts = useAllNeighbors(displayNodes.values().toArray());
 
   return useCallback(
     (outOfFocusIds: Set<VertexId>): BadgeRenderer =>
       (nodeData, boundingBox, { zoomLevel }) => {
         const displayNode = displayNodes.get(nodeData.id);
+        const neighbors = neighborCounts.get(nodeData.id);
         // Ensure we have the node name and title
         const name = displayNode?.displayName ?? "";
         const title = displayNode?.displayTypes ?? "";
+        const unfetched = neighbors?.unfetched ?? 0;
 
         return [
           {
@@ -39,8 +43,8 @@ const useNodeBadges = () => {
             hidden:
               zoomLevel === "small" ||
               outOfFocusIds.has(nodeData.id) ||
-              !nodeData.__unfetchedNeighborCount,
-            text: String(nodeData.__unfetchedNeighborCount),
+              !unfetched,
+            text: String(unfetched),
             anchor: "center",
             fontSize: 5,
             borderRadius: 4,
@@ -56,7 +60,7 @@ const useNodeBadges = () => {
           },
         ];
       },
-    [displayNodes]
+    [displayNodes, neighborCounts]
   );
 };
 

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -6,7 +6,7 @@ import ExpandGraphIcon from "@/components/icons/ExpandGraphIcon";
 import GraphIcon from "@/components/icons/GraphIcon";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import PanelEmptyState from "@/components/PanelEmptyState/PanelEmptyState";
-import { DisplayVertex, useNode, useWithTheme } from "@/core";
+import { DisplayVertex, useNeighbors, useNode, useWithTheme } from "@/core";
 import { useExpandNode } from "@/hooks";
 import useNeighborsOptions, {
   NeighborOption,
@@ -82,6 +82,7 @@ function ExpansionOptions({
   neighborsOptions: NeighborOption[];
 }) {
   const t = useTranslations();
+  const neighbors = useNeighbors(vertex);
 
   const [selectedType, setSelectedType] = useState<string>(
     firstNeighborAvailableForExpansion(neighborsOptions)?.value ?? ""
@@ -89,8 +90,10 @@ function ExpansionOptions({
   const [filters, setFilters] = useState<Array<NodeExpandFilter>>([]);
   const [limit, setLimit] = useState<number | null>(null);
 
-  const hasUnfetchedNeighbors = Boolean(vertex.__unfetchedNeighborCount);
   const hasSelectedType = Boolean(selectedType);
+  const hasUnfetchedNeighbors = (neighbors?.unfetched ?? 0) > 0;
+  const expandOffset =
+    limit !== null && neighbors ? neighbors.fetched : undefined;
 
   // Reset filters when selected type changes
   const [prevSelectedType, setPrevSelectedType] = useState(selectedType);
@@ -133,11 +136,7 @@ function ExpansionOptions({
               value: filter.value,
             })),
             limit: limit || undefined,
-            offset:
-              limit !== null && vertex.__unfetchedNeighborCounts
-                ? vertex.neighborsCountByType[selectedType] -
-                  vertex.__unfetchedNeighborCounts[selectedType]
-                : undefined,
+            offset: expandOffset,
           }}
         />
       </PanelFooter>

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -9,7 +9,11 @@ import {
   VertexIcon,
   VisibleIcon,
 } from "@/components";
-import { useNeighborByType as useNeighborsByType, useNode } from "@/core";
+import {
+  useNeighbors,
+  useNeighborByType as useNeighborsByType,
+  useNode,
+} from "@/core";
 import useNeighborsOptions, {
   NeighborOption,
 } from "@/hooks/useNeighborsOptions";
@@ -28,6 +32,7 @@ export default function NeighborsList({
   ...props
 }: NeighborsListProps) {
   const vertex = useNode(id);
+  const neighbors = useNeighbors(vertex);
   const neighborsOptions = useNeighborsOptions(vertex);
   const [showMore, setShowMore] = useState(false);
 
@@ -36,7 +41,7 @@ export default function NeighborsList({
       className={cn("flex flex-col gap-3 border-b p-3", className)}
       {...props}
     >
-      <div className="font-bold">Neighbors ({vertex.neighborsCount})</div>
+      <div className="font-bold">Neighbors ({neighbors.all})</div>
       <ul className="flex flex-col gap-3">
         {neighborsOptions
           .slice(0, showMore ? undefined : MAX_NEIGHBOR_TYPE_ROWS)

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -9,7 +9,7 @@ import {
   VertexIcon,
   VisibleIcon,
 } from "@/components";
-import { useNode } from "@/core";
+import { useNeighborByType as useNeighborsByType, useNode } from "@/core";
 import useNeighborsOptions, {
   NeighborOption,
 } from "@/hooks/useNeighborsOptions";
@@ -63,9 +63,7 @@ function NeighborTypeRow({
   vertex: Vertex;
   op: NeighborOption;
 }) {
-  const neighborsInView =
-    vertex.neighborsCountByType[op.value] -
-    (vertex.__unfetchedNeighborCounts?.[op.value] ?? 0);
+  const neighbors = useNeighborsByType(vertex, op.value);
 
   return (
     <div className="flex items-center justify-between gap-2">
@@ -78,16 +76,14 @@ function NeighborTypeRow({
           <TooltipTrigger asChild>
             <Chip className="min-w-12">
               <VisibleIcon />
-              {neighborsInView}
+              {neighbors.fetched}
             </Chip>
           </TooltipTrigger>
           <TooltipContent>
-            {`${neighborsInView} ${op.label} in the Graph View`}
+            {`${neighbors.fetched} ${op.label} in the Graph View`}
           </TooltipContent>
         </Tooltip>
-        <Chip className="min-w-12">
-          {vertex.neighborsCountByType[op.value]}
-        </Chip>
+        <Chip className="min-w-12">{neighbors.all}</Chip>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/utils/testing/DbState.ts
+++ b/packages/graph-explorer/src/utils/testing/DbState.ts
@@ -1,0 +1,52 @@
+import { Vertex } from "@/@types/entities";
+import {
+  activeConfigurationAtom,
+  configurationAtom,
+  nodesAtom,
+  RawConfiguration,
+  Schema,
+  toNodeMap,
+} from "@/core";
+import {
+  extractConfigFromEntity,
+  schemaAtom,
+} from "@/core/StateProvider/schema";
+import { MutableSnapshot } from "recoil";
+import { createRandomSchema, createRandomRawConfiguration } from "./randomData";
+
+/**
+ * Helps build up the state of the recoil database with common data.
+ */
+export class DbState {
+  activeSchema: Schema;
+  activeConfig: RawConfiguration;
+  vertices: Vertex[] = [];
+
+  constructor() {
+    this.activeSchema = createRandomSchema();
+
+    const config = createRandomRawConfiguration();
+    config.schema = this.activeSchema;
+    this.activeConfig = config;
+  }
+
+  /** Adds the vertex to the graph and updates the schema to include the type config. */
+  addVertexToGraph(vertex: Vertex) {
+    this.vertices.push(vertex);
+    this.activeSchema.vertices.push(extractConfigFromEntity(vertex));
+  }
+
+  /** Applies the state to the given Recoil snapshot. */
+  applyTo(snapshot: MutableSnapshot) {
+    snapshot.set(
+      configurationAtom,
+      new Map([[this.activeConfig.id, this.activeConfig]])
+    );
+    snapshot.set(
+      schemaAtom,
+      new Map([[this.activeConfig.id, this.activeSchema]])
+    );
+    snapshot.set(activeConfigurationAtom, this.activeConfig.id);
+    snapshot.set(nodesAtom, toNodeMap(this.vertices));
+  }
+}

--- a/packages/graph-explorer/src/utils/testing/createMockExplorer.ts
+++ b/packages/graph-explorer/src/utils/testing/createMockExplorer.ts
@@ -1,0 +1,13 @@
+import { Explorer } from "@/connector/useGEFetchTypes";
+import { createRandomRawConfiguration } from "./randomData";
+
+export function createMockExplorer(): Explorer {
+  return {
+    fetchNeighborsCount: vi.fn(),
+    keywordSearch: vi.fn(),
+    fetchNeighbors: vi.fn(),
+    fetchVertexCountsByType: vi.fn(),
+    connection: createRandomRawConfiguration().connection!,
+    fetchSchema: vi.fn(),
+  };
+}

--- a/packages/graph-explorer/src/utils/testing/index.ts
+++ b/packages/graph-explorer/src/utils/testing/index.ts
@@ -1,3 +1,4 @@
+export * from "./DbState";
 export * from "./normalize";
 export * from "./randomData";
 export * from "./randomSchemaResponse";

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -159,8 +159,6 @@ export function createRandomVertex(): Vertex {
     idType: pickRandomElement(["number", "string"]),
     type: createRandomName("VertexType"),
     attributes: createRecord(3, createRandomEntityAttribute),
-    neighborsCount: 0,
-    neighborsCountByType: {},
   };
 }
 

--- a/packages/graph-explorer/src/utils/testing/renderHookWithRecoilRoot.tsx
+++ b/packages/graph-explorer/src/utils/testing/renderHookWithRecoilRoot.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { RecoilRootProps, RecoilRoot, MutableSnapshot } from "recoil";
 
@@ -6,8 +7,13 @@ export default function renderHookWithRecoilRoot<TResult>(
   initializeState?: (mutableSnapshot: MutableSnapshot) => void
 ) {
   return renderHook(callback, {
-    wrapper: ({ children }) => (
-      <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>
-    ),
+    wrapper: ({ children }) => {
+      const queryClient = new QueryClient();
+      return (
+        <QueryClientProvider client={queryClient}>
+          <RecoilRoot initializeState={initializeState}>{children}</RecoilRoot>
+        </QueryClientProvider>
+      );
+    },
   });
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This change rewrites the neighbor count logic. The main goal was to remove the counts from the `Vertex` type. In doing so, there are some minor performance improvements when expanding nodes.

- Remove count properties from `Vertex` type
  - Update tests
  - Update query result mapping logic (unused)
  - Update all places where neighbor count is used
- Ensure neighbor count query always returns a value (no more null checking)
- Fix `Graph` logic that caused a layout to occur when only edges were added
- Add ability to mock `Explorer` for testing
- Add `DbState` helper for testing

## Validation

- Tested with all query languages

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #710 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
