### PR TITLE
Add ID type to Edge

### DIFF
--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -3,6 +3,11 @@ import { Branded } from "@/utils";
 export type EdgeId = Branded<string, "EdgeId">;
 export type VertexId = Branded<string, "VertexId">;
 
+/**
+ * The type of the vertex ID.
+ */
+export type VertexIdType = "string" | "number";
+
 export type Vertex = {
   /**
    * Indicates the type in order to discriminate from the `Edge` type in unions.

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -24,7 +24,7 @@ export type Vertex = {
    * - For Gremlin, could be string or number
    * - For openCypher and SPARQL, always string
    */
-  idType: "string" | "number";
+  idType: EntityIdType;
   /**
    * Single vertex type.
    * - For PG, the node label

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -4,9 +4,9 @@ export type EdgeId = Branded<string, "EdgeId">;
 export type VertexId = Branded<string, "VertexId">;
 
 /**
- * The type of the vertex ID.
+ * The type of the vertex or edge ID.
  */
-export type VertexIdType = "string" | "number";
+export type EntityIdType = "string" | "number";
 
 export type Vertex = {
   /**

--- a/packages/graph-explorer/src/@types/entities.ts
+++ b/packages/graph-explorer/src/@types/entities.ts
@@ -71,6 +71,12 @@ export type Edge = {
    */
   id: EdgeId;
   /**
+   * Data type for the edge id.
+   * - For Gremlin, could be string or number
+   * - For openCypher and SPARQL, always string
+   */
+  idType: EntityIdType;
+  /**
    * Edge type.
    * - For PG, the label which identifies the relation type
    * - For RDF, the predicate

--- a/packages/graph-explorer/src/connector/gremlin/mappers/detectIdType.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/detectIdType.ts
@@ -1,4 +1,6 @@
-import { GInt64 } from "../types";
+import { EntityIdType } from "@/@types/entities";
+import { GInt64, JanusID } from "../types";
+import { isJanusID } from "./toStringId";
 
 /**
  * This function will detect the type of the id value passed in.
@@ -8,8 +10,12 @@ import { GInt64 } from "../types";
  * @param id The id value to investigate.
  * @returns Either string or number.
  */
-export function detectIdType(id: string | GInt64): "string" | "number" {
+export function detectIdType(id: string | GInt64 | JanusID): EntityIdType {
   if (typeof id === "string") {
+    return "string";
+  }
+
+  if (isJanusID(id)) {
     return "string";
   }
 

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiEdge.ts
@@ -2,12 +2,14 @@ import type { Edge, EdgeId, VertexId } from "@/@types/entities";
 import type { GEdge } from "../types";
 import parseEdgePropertiesValues from "./parseEdgePropertiesValues";
 import toStringId from "./toStringId";
+import { detectIdType } from "./detectIdType";
 
 const mapApiEdge = (apiEdge: GEdge): Edge => {
   const isFragment = apiEdge["@value"].properties == null;
   return {
     entityType: "edge",
     id: toStringId(apiEdge["@value"].id) as EdgeId,
+    idType: detectIdType(apiEdge["@value"].id),
     type: apiEdge["@value"].label,
     source: toStringId(apiEdge["@value"].outV) as VertexId,
     sourceType: apiEdge["@value"].outVLabel,

--- a/packages/graph-explorer/src/connector/gremlin/mappers/toStringId.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/toStringId.ts
@@ -1,6 +1,6 @@
 import { GInt64, JanusID } from "../types";
 
-const isJanusID = (id: any): id is JanusID => {
+export const isJanusID = (id: any): id is JanusID => {
   return (
     typeof id === "object" &&
     "@type" in id &&

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
@@ -9,6 +9,7 @@ const mapApiEdge = (
   return {
     entityType: "edge",
     id: apiEdge["~id"] as EdgeId,
+    idType: "string",
     type: apiEdge["~type"],
     source: apiEdge["~start"] as VertexId,
     sourceType: sourceType,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
@@ -15,6 +15,7 @@ const mapIncomingToEdge = (
   return {
     entityType: "edge",
     id: `${result.subject.value}-[${result.predFromSubject.value}]->${resourceURI}` as EdgeId,
+    idType: "string",
     type: result.predFromSubject.value,
     source: result.subject.value as VertexId,
     sourceType: result.subjectClass.value,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
@@ -15,6 +15,7 @@ const mapOutgoingToEdge = (
   return {
     entityType: "edge",
     id: `${resourceURI}-[${result.predToSubject.value}]->${result.subject.value}` as EdgeId,
+    idType: "string",
     type: result.predToSubject.value,
     source: resourceURI as VertexId,
     sourceType: resourceClass,

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -5,16 +5,11 @@ import {
 } from "@/core";
 import { ConnectionConfig } from "@shared/types";
 import { MappedQueryResults } from "./gremlin/mappers/mapResults";
-import { VertexId } from "@/@types/entities";
+import { VertexId, VertexIdType } from "@/@types/entities";
 
 export type QueryOptions = RequestInit & {
   queryId?: string;
 };
-
-/**
- * The type of the vertex ID.
- */
-export type VertexIdType = "string" | "number";
 
 export type VertexRef = {
   id: VertexId;

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -5,7 +5,7 @@ import {
 } from "@/core";
 import { ConnectionConfig } from "@shared/types";
 import { MappedQueryResults } from "./gremlin/mappers/mapResults";
-import { VertexId, VertexIdType } from "@/@types/entities";
+import { VertexId, EntityIdType } from "@/@types/entities";
 
 export type QueryOptions = RequestInit & {
   queryId?: string;
@@ -13,7 +13,7 @@ export type QueryOptions = RequestInit & {
 
 export type VertexRef = {
   id: VertexId;
-  idType: VertexIdType;
+  idType: EntityIdType;
 };
 
 export type VertexSchemaResponse = Pick<

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -1,4 +1,4 @@
-import { Edge, EdgeId, VertexId } from "@/@types/entities";
+import { Edge, EdgeId, EntityIdType, VertexId } from "@/@types/entities";
 import { selector, selectorFamily, useRecoilValue } from "recoil";
 import { textTransformSelector } from "@/hooks";
 import {
@@ -23,6 +23,7 @@ import {
 export type DisplayEdge = {
   entityType: "edge";
   id: EdgeId;
+  idType: EntityIdType;
   displayId: string;
   displayName: string;
   displayTypes: string;
@@ -142,6 +143,7 @@ const displayEdgeSelector = selectorFamily({
       const displayEdge: DisplayEdge = {
         entityType: "edge",
         id: edge.id,
+        idType: edge.idType,
         displayId,
         displayName,
         displayTypes,

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -1,5 +1,5 @@
 import { selector, selectorFamily, useRecoilValue } from "recoil";
-import { Vertex, VertexId } from "@/@types/entities";
+import { Vertex, VertexId, VertexIdType } from "@/@types/entities";
 import {
   DisplayAttribute,
   getSortedDisplayAttributes,
@@ -17,7 +17,6 @@ import {
   RESERVED_ID_PROPERTY,
   RESERVED_TYPES_PROPERTY,
 } from "@/utils";
-import { VertexIdType } from "@/connector";
 
 /** Represents a vertex's display information after all transformations have been applied. */
 export type DisplayVertex = {

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -1,5 +1,5 @@
 import { selector, selectorFamily, useRecoilValue } from "recoil";
-import { Vertex, VertexId, VertexIdType } from "@/@types/entities";
+import { Vertex, VertexId, EntityIdType } from "@/@types/entities";
 import {
   DisplayAttribute,
   getSortedDisplayAttributes,
@@ -22,7 +22,7 @@ import {
 export type DisplayVertex = {
   entityType: "vertex";
   id: VertexId;
-  idType: VertexIdType;
+  idType: EntityIdType;
   displayId: string;
   displayTypes: string;
   displayName: string;

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -170,6 +170,7 @@ export function createRandomEdge(source: Vertex, target: Vertex): Edge {
   return {
     entityType: "edge",
     id: createRandomName("EdgeId") as EdgeId,
+    idType: pickRandomElement(["number", "string"]),
     type: createRandomName("EdgeType"),
     attributes: createRecord(3, createRandomEntityAttribute),
     source: source.id,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In order to pull back edge details, we need to have the `idType` defined on the edge. I've updated the code and mapping logic to properly set this data.

## Validation

- Verified in all three query languages with Neptune
- Verified with Gremlin Server
- Verified with JanusGraph

## Related Issues

- Part of #626

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
