### PR TITLE
Reduce dependence on Recoil and useEntities()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,15 @@
   ([#743](https://github.com/aws/graph-explorer/pull/743))
 - **Improved** pagination controls by using a single shared component
   ([#742](https://github.com/aws/graph-explorer/pull/742))
+- **Updated** graph foundations to accommodate loading a graph from a set of IDs
+  ([#756](https://github.com/aws/graph-explorer/pull/756),
+  [#758](https://github.com/aws/graph-explorer/pull/758),
+  [#761](https://github.com/aws/graph-explorer/pull/761),
+  [#762](https://github.com/aws/graph-explorer/pull/762),
+  [#767](https://github.com/aws/graph-explorer/pull/767),
+  [#768](https://github.com/aws/graph-explorer/pull/768),
+  [#769](https://github.com/aws/graph-explorer/pull/769),
+  [#770](https://github.com/aws/graph-explorer/pull/770))
 - **Updated** dependencies
   ([#764](https://github.com/aws/graph-explorer/pull/764))
 

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -54,11 +54,10 @@ export type NeighborCountsQueryResponse = {
  */
 export function neighborsCountQuery(
   vertexId: VertexId,
-  limit: number | undefined,
   explorer: Explorer | null
 ) {
   return queryOptions({
-    queryKey: ["neighborsCount", vertexId, limit, explorer],
+    queryKey: ["neighborsCount", vertexId, explorer],
     enabled: Boolean(explorer),
     queryFn: async (): Promise<NeighborCountsQueryResponse> => {
       if (!explorer) {
@@ -68,6 +67,8 @@ export function neighborsCountQuery(
           counts: {},
         };
       }
+
+      const limit = explorer.connection.nodeExpansionLimit;
 
       const result = await explorer.fetchNeighborsCount({
         vertexId,

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -9,7 +9,7 @@ import {
 import { useEffect, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { neighborsCountQuery } from "@/connector";
-import { activeConnectionSelector, explorerSelector } from "../connector";
+import { explorerSelector } from "../connector";
 import { useNotification } from "@/components/NotificationProvider";
 
 export type NeighborCounts = {
@@ -44,9 +44,8 @@ export function useNeighborsCallback() {
       fetchedNeighborsSelector(vertexId)
     );
     const explorer = await snapshot.getPromise(explorerSelector);
-    const connection = await snapshot.getPromise(activeConnectionSelector);
     const response = await queryClient.ensureQueryData(
-      neighborsCountQuery(vertexId, connection?.nodeExpansionLimit, explorer)
+      neighborsCountQuery(vertexId, explorer)
     );
 
     const neighbors = calculateNeighbors(

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -1,4 +1,4 @@
-import { VertexId } from "@/core";
+import { useDisplayVerticesInCanvas, VertexId } from "@/core";
 import { selectorFamily, useRecoilCallback, useRecoilValue } from "recoil";
 import { edgesAtom } from "./edges";
 import { nodesAtom } from "./nodes";
@@ -96,11 +96,14 @@ export function useNeighborByType(vertexId: VertexId, type: string) {
   return neighbors;
 }
 
-export function useAllNeighbors(vertices: VertexId[]) {
+export function useAllNeighbors() {
+  const vertices = useDisplayVerticesInCanvas();
+  const vertexIds = useMemo(() => vertices.keys().toArray(), [vertices]);
+
   const fetchedNeighbors = useRecoilValue(
-    allFetchedNeighborsSelector(vertices)
+    allFetchedNeighborsSelector(vertexIds)
   );
-  const query = useAllNeighborCountsQuery(vertices);
+  const query = useAllNeighborCountsQuery(vertexIds);
 
   const { enqueueNotification, clearNotification } = useNotification();
 

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -19,7 +19,7 @@ import { Explorer } from "@/connector/useGEFetchTypes";
  * Active connection where the value will only change when one of the
  * properties we care about are changed.
  */
-export const activeConnectionSelector = equalSelector({
+const activeConnectionSelector = equalSelector({
   key: "activeConnection",
   get: ({ get }) => {
     const config = get(mergedConfigurationSelector);

--- a/packages/graph-explorer/src/core/connector.ts
+++ b/packages/graph-explorer/src/core/connector.ts
@@ -75,6 +75,14 @@ export const explorerSelector = selector({
   },
 });
 
+export function useExplorer() {
+  const explorer = useRecoilValue(explorerSelector);
+  if (!explorer) {
+    throw new Error("No explorer found");
+  }
+  return explorer;
+}
+
 /** CAUTION: This atom is only for testing purposes. */
 export const explorerForTestingAtom = atom<Explorer | null>({
   key: "explorerForTesting",

--- a/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
@@ -13,14 +13,14 @@ import { nodesAtom, toNodeMap } from "@/core/StateProvider/nodes";
 test("should add one node", async () => {
   const vertex = createRandomVertex();
   const { result } = renderHookWithRecoilRoot(() => {
-    const callback = useAddToGraph(vertex);
+    const callback = useAddToGraph();
     const [entities] = useEntities();
 
     return { callback, entities };
   });
 
   await act(async () => {
-    result.current.callback();
+    result.current.callback({ vertices: [vertex] });
   });
 
   const actual = result.current.entities.nodes.get(vertex.id);
@@ -34,7 +34,7 @@ test("should add one edge", async () => {
 
   const { result } = renderHookWithRecoilRoot(
     () => {
-      const callback = useAddToGraph(edge);
+      const callback = useAddToGraph();
       const [entities] = useEntities();
 
       return { callback, entities };
@@ -45,7 +45,7 @@ test("should add one edge", async () => {
   );
 
   await act(async () => {
-    result.current.callback();
+    result.current.callback({ edges: [edge] });
   });
 
   const actual = result.current.entities.edges.get(edge.id);
@@ -55,17 +55,17 @@ test("should add one edge", async () => {
 test("should add multiple nodes and edges", async () => {
   const randomEntities = createRandomEntities();
   const { result } = renderHookWithRecoilRoot(() => {
-    const callback = useAddToGraph(
-      ...randomEntities.nodes.values(),
-      ...randomEntities.edges.values()
-    );
+    const callback = useAddToGraph();
     const [entities] = useEntities();
 
     return { callback, entities };
   });
 
   await act(async () => {
-    result.current.callback();
+    result.current.callback({
+      vertices: [...randomEntities.nodes.values()],
+      edges: [...randomEntities.edges.values()],
+    });
   });
 
   const actualNodes = result.current.entities.nodes.values().toArray();

--- a/packages/graph-explorer/src/hooks/useAddToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.ts
@@ -6,20 +6,32 @@ import { useCallback } from "react";
 import { useSetRecoilState } from "recoil";
 
 /** Returns a callback that adds an array of nodes and edges to the graph. */
-export function useAddToGraph(...entitiesToAdd: (Vertex | Edge)[]) {
+export function useAddToGraph() {
   const setEntities = useSetRecoilState(entitiesSelector);
 
-  return useCallback(() => {
-    const nodes = entitiesToAdd.filter(e => e.entityType === "vertex");
-    const edges = entitiesToAdd.filter(e => e.entityType === "edge");
+  return useCallback(
+    (entities: { vertices?: Vertex[]; edges?: Edge[] }) => {
+      const vertices = entities.vertices ?? [];
+      const edges = entities.edges ?? [];
 
-    if (nodes.length === 0 && edges.length === 0) {
-      return;
-    }
+      if (vertices.length === 0 && edges.length === 0) {
+        return;
+      }
 
-    setEntities({
-      nodes: toNodeMap(nodes),
-      edges: toEdgeMap(edges),
-    });
-  }, [entitiesToAdd, setEntities]);
+      setEntities({
+        nodes: toNodeMap(vertices),
+        edges: toEdgeMap(edges),
+      });
+    },
+    [setEntities]
+  );
+}
+
+/** Returns a callback the given vertex to the graph. */
+export function useAddVertexToGraph(vertex: Vertex) {
+  const callback = useAddToGraph();
+  return useCallback(
+    () => callback({ vertices: [vertex] }),
+    [callback, vertex]
+  );
 }

--- a/packages/graph-explorer/src/hooks/useEdgeDetailsQuery.ts
+++ b/packages/graph-explorer/src/hooks/useEdgeDetailsQuery.ts
@@ -1,10 +1,9 @@
 import { edgeDetailsQuery } from "@/connector";
-import { EdgeId, explorerSelector } from "@/core";
+import { EdgeId, useExplorer } from "@/core";
 import { useQuery } from "@tanstack/react-query";
-import { useRecoilValue } from "recoil";
 
 export function useEdgeDetailsQuery(edgeId: EdgeId) {
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const query = useQuery(edgeDetailsQuery({ edgeId }, explorer));
   return query;
 }

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -8,8 +8,8 @@ import {
 } from "@/connector";
 import {
   activeConnectionSelector,
-  explorerSelector,
   loggerSelector,
+  useExplorer,
 } from "@/core/connector";
 import useEntities from "./useEntities";
 import { useRecoilValue } from "recoil";
@@ -36,7 +36,7 @@ export type ExpandNodeRequest = {
  */
 export default function useExpandNode() {
   const queryClient = useQueryClient();
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const [_, setEntities] = useEntities();
   const { enqueueNotification, clearNotification } = useNotification();
   const remoteLogger = useRecoilValue(loggerSelector);

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -7,14 +7,12 @@ import {
   type NeighborsResponse,
 } from "@/connector";
 import { loggerSelector, useExplorer } from "@/core/connector";
-import useEntities from "./useEntities";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Vertex } from "@/core";
 import { createDisplayError } from "@/utils/createDisplayError";
-import { toNodeMap } from "@/core/StateProvider/nodes";
-import { toEdgeMap } from "@/core/StateProvider/edges";
 import { useNeighborsCallback } from "@/core";
+import { useAddToGraph } from "./useAddToGraph";
 
 export type ExpandNodeFilters = Omit<
   NeighborsRequest,
@@ -33,7 +31,7 @@ export type ExpandNodeRequest = {
 export default function useExpandNode() {
   const queryClient = useQueryClient();
   const explorer = useExplorer();
-  const [_, setEntities] = useEntities();
+  const addToGraph = useAddToGraph();
   const { enqueueNotification, clearNotification } = useNotification();
   const remoteLogger = useRecoilValue(loggerSelector);
 
@@ -82,10 +80,7 @@ export default function useExpandNode() {
       updateEdgeDetailsCache(explorer, queryClient, data.edges);
 
       // Update nodes and edges in the graph
-      setEntities({
-        nodes: toNodeMap(data.vertices),
-        edges: toEdgeMap(data.edges),
-      });
+      addToGraph(data);
     },
     onError: error => {
       remoteLogger.error(`Failed to expand node: ${error.message}`);

--- a/packages/graph-explorer/src/hooks/useRemoveFromGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useRemoveFromGraph.test.ts
@@ -8,13 +8,16 @@ import useEntities from "./useEntities";
 import { act } from "react";
 import { nodesAtom, toNodeMap } from "@/core/StateProvider/nodes";
 import {
+  useClearGraph,
   useRemoveEdgeFromGraph,
   useRemoveNodeFromGraph,
 } from "./useRemoveFromGraph";
 import { edgesAtom, toEdgeMap } from "@/core/StateProvider/edges";
+import { createArray } from "@shared/utils/testing";
 
 test("should remove one node", async () => {
   const vertex = createRandomVertex();
+  const noise = createArray(10, createRandomVertex);
   const { result } = renderHookWithRecoilRoot(
     () => {
       const callback = useRemoveNodeFromGraph(vertex.id);
@@ -23,7 +26,7 @@ test("should remove one node", async () => {
       return { callback, entities };
     },
     snapshot => {
-      snapshot.set(nodesAtom, toNodeMap([vertex]));
+      snapshot.set(nodesAtom, toNodeMap([vertex, ...noise]));
     }
   );
 
@@ -32,23 +35,25 @@ test("should remove one node", async () => {
   });
 
   expect(result.current.entities.nodes.has(vertex.id)).toBeFalsy();
+  expect(result.current.entities.nodes.size).toBe(noise.length);
 });
 
 test("should remove one edge", async () => {
   const node1 = createRandomVertex();
   const node2 = createRandomVertex();
-  const edge = createRandomEdge(node1, node2);
+  const edge1 = createRandomEdge(node1, node2);
+  const edge2 = createRandomEdge(node2, node1);
 
   const { result } = renderHookWithRecoilRoot(
     () => {
-      const callback = useRemoveEdgeFromGraph(edge.id);
+      const callback = useRemoveEdgeFromGraph(edge1.id);
       const [entities] = useEntities();
 
       return { callback, entities };
     },
     snapshot => {
       snapshot.set(nodesAtom, toNodeMap([node1, node2]));
-      snapshot.set(edgesAtom, toEdgeMap([edge]));
+      snapshot.set(edgesAtom, toEdgeMap([edge1, edge2]));
     }
   );
 
@@ -56,5 +61,34 @@ test("should remove one edge", async () => {
     result.current.callback();
   });
 
-  expect(result.current.entities.edges.has(edge.id)).toBeFalsy();
+  expect(result.current.entities.edges.has(edge1.id)).toBeFalsy();
+  expect(result.current.entities.edges.has(edge2.id)).toBeTruthy();
+  expect(result.current.entities.nodes.size).toBe(2);
+});
+
+test("should remove all nodes and edges", async () => {
+  const node1 = createRandomVertex();
+  const node2 = createRandomVertex();
+  const edge1 = createRandomEdge(node1, node2);
+  const edge2 = createRandomEdge(node2, node1);
+
+  const { result } = renderHookWithRecoilRoot(
+    () => {
+      const callback = useClearGraph();
+      const [entities] = useEntities();
+
+      return { callback, entities };
+    },
+    snapshot => {
+      snapshot.set(nodesAtom, toNodeMap([node1, node2]));
+      snapshot.set(edgesAtom, toEdgeMap([edge1, edge2]));
+    }
+  );
+
+  await act(async () => {
+    result.current.callback();
+  });
+
+  expect(result.current.entities.nodes.size).toBe(0);
+  expect(result.current.entities.edges.size).toBe(0);
 });

--- a/packages/graph-explorer/src/hooks/useRemoveFromGraph.ts
+++ b/packages/graph-explorer/src/hooks/useRemoveFromGraph.ts
@@ -1,30 +1,57 @@
 import { EdgeId, VertexId } from "@/core";
-import useEntities from "./useEntities";
+import entitiesSelector from "@/core/StateProvider/entitiesSelector";
+import { useSetRecoilState } from "recoil";
+import { useCallback } from "react";
+
+export function useRemoveFromGraph() {
+  const setEntities = useSetRecoilState(entitiesSelector);
+
+  return useCallback(
+    (entities: { vertices?: VertexId[]; edges?: EdgeId[] }) => {
+      const vertices = new Set(entities.vertices ?? []);
+      const edges = new Set(entities.edges ?? []);
+
+      // Ensure there is something to remove
+      if (vertices.size === 0 && edges.size === 0) {
+        return;
+      }
+
+      setEntities(prev => ({
+        nodes: new Map(
+          prev.nodes.entries().filter(([id]) => !vertices.has(id))
+        ),
+        edges: new Map(prev.edges.entries().filter(([id]) => !edges.has(id))),
+        forceSet: true,
+      }));
+    },
+    [setEntities]
+  );
+}
 
 export function useRemoveNodeFromGraph(nodeId: VertexId) {
-  const [, setEntities] = useEntities();
+  const removeFromGraph = useRemoveFromGraph();
 
-  return () => {
-    setEntities(prev => {
-      return {
-        ...prev,
-        nodes: new Map(prev.nodes.entries().filter(([id]) => id !== nodeId)),
-        forceSet: true,
-      };
-    });
-  };
+  return useCallback(() => {
+    removeFromGraph({ vertices: [nodeId] });
+  }, [nodeId, removeFromGraph]);
 }
 
 export function useRemoveEdgeFromGraph(edgeId: EdgeId) {
-  const [, setEntities] = useEntities();
+  const removeFromGraph = useRemoveFromGraph();
 
-  return () => {
-    setEntities(prev => {
-      return {
-        ...prev,
-        edges: new Map(prev.edges.entries().filter(([id]) => id !== edgeId)),
-        forceSet: true,
-      };
+  return useCallback(() => {
+    removeFromGraph({ edges: [edgeId] });
+  }, [edgeId, removeFromGraph]);
+}
+
+export function useClearGraph() {
+  const setEntities = useSetRecoilState(entitiesSelector);
+
+  return useCallback(() => {
+    setEntities({
+      nodes: new Map(),
+      edges: new Map(),
+      forceSet: true,
     });
-  };
+  }, [setEntities]);
 }

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from "react";
 import { useNotification } from "@/components/NotificationProvider";
 import { useConfiguration } from "@/core/ConfigurationProvider";
-import { explorerSelector, loggerSelector } from "@/core/connector";
+import { loggerSelector, useExplorer } from "@/core/connector";
 import usePrefixesUpdater from "./usePrefixesUpdater";
 import useUpdateSchema from "./useUpdateSchema";
 import { createDisplayError } from "@/utils/createDisplayError";
@@ -9,7 +9,7 @@ import { useRecoilValue } from "recoil";
 
 const useSchemaSync = (onSyncChange?: (isSyncing: boolean) => void) => {
   const config = useConfiguration();
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const remoteLogger = useRecoilValue(loggerSelector);
 
   const updatePrefixes = usePrefixesUpdater();

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -1,25 +1,18 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { useRecoilValue } from "recoil";
 import { neighborsCountQuery } from "@/connector";
-import { activeConnectionSelector, useExplorer } from "@/core/connector";
+import { useExplorer } from "@/core/connector";
 import { VertexId } from "@/core";
 
 export function useUpdateNodeCountsQuery(vertexId: VertexId) {
-  const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useExplorer();
-  return useQuery(
-    neighborsCountQuery(vertexId, connection?.nodeExpansionLimit, explorer)
-  );
+  return useQuery(neighborsCountQuery(vertexId, explorer));
 }
 
 export function useAllNeighborCountsQuery(vertexIds: VertexId[]) {
-  const connection = useRecoilValue(activeConnectionSelector);
   const explorer = useExplorer();
 
   return useQueries({
-    queries: vertexIds.map(vertex =>
-      neighborsCountQuery(vertex, connection?.nodeExpansionLimit, explorer)
-    ),
+    queries: vertexIds.map(vertex => neighborsCountQuery(vertex, explorer)),
     combine: results => ({
       data: results.map(result => result.data),
       pending: results.some(result => result.isPending),

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -1,12 +1,12 @@
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { useRecoilValue } from "recoil";
 import { neighborsCountQuery } from "@/connector";
-import { activeConnectionSelector, explorerSelector } from "@/core/connector";
+import { activeConnectionSelector, useExplorer } from "@/core/connector";
 import { VertexId } from "@/core";
 
 export function useUpdateNodeCountsQuery(vertexId: VertexId) {
   const connection = useRecoilValue(activeConnectionSelector);
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   return useQuery(
     neighborsCountQuery(vertexId, connection?.nodeExpansionLimit, explorer)
   );
@@ -14,7 +14,7 @@ export function useUpdateNodeCountsQuery(vertexId: VertexId) {
 
 export function useAllNeighborCountsQuery(vertexIds: VertexId[]) {
   const connection = useRecoilValue(activeConnectionSelector);
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
 
   return useQueries({
     queries: vertexIds.map(vertex =>

--- a/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateVertexTypeCounts.ts
@@ -1,13 +1,11 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { explorerSelector } from "@/core/connector";
+import { useExplorer } from "@/core";
 import useUpdateSchema from "./useUpdateSchema";
-import { useRecoilValue } from "recoil";
 import { nodeCountByNodeTypeQuery } from "@/connector";
 
 export default function useUpdateVertexTypeCounts(vertexType: string) {
-  const explorer = useRecoilValue(explorerSelector);
-
+  const explorer = useExplorer();
   const query = useQuery(nodeCountByNodeTypeQuery(vertexType, explorer));
 
   // Sync the result over to the schema in Recoil state

--- a/packages/graph-explorer/src/hooks/useVertexDetailsQuery.ts
+++ b/packages/graph-explorer/src/hooks/useVertexDetailsQuery.ts
@@ -1,10 +1,9 @@
 import { vertexDetailsQuery } from "@/connector";
-import { explorerSelector, VertexId } from "@/core";
+import { useExplorer, VertexId } from "@/core";
 import { useQuery } from "@tanstack/react-query";
-import { useRecoilValue } from "recoil";
 
 export function useVertexDetailsQuery(vertexId: VertexId) {
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const query = useQuery(vertexDetailsQuery({ vertexId }, explorer));
   return query;
 }

--- a/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesTabular/components/NodesTabular.tsx
@@ -30,12 +30,7 @@ const NodesTabular = forwardRef<TabularInstance<ToggleVertex>, any>(
   (_props, ref) => {
     const t = useTranslations();
     const displayNodes = useDisplayVerticesInCanvas();
-    const neighborCounts = useAllNeighbors(
-      displayNodes
-        .values()
-        .map(v => v.id)
-        .toArray()
-    );
+    const neighborCounts = useAllNeighbors();
     const setNodesOut = useSetRecoilState(nodesOutOfFocusIdsAtom);
     const [hiddenNodesIds, setHiddenNodesIds] =
       useRecoilState(nodesFilteredIdsAtom);

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -32,7 +32,7 @@ import {
   nodesOutOfFocusIdsAtom,
   nodesSelectedIdsAtom,
 } from "@/core/StateProvider/nodes";
-import { useEntities, useExpandNode } from "@/hooks";
+import { useClearGraph, useEntities, useExpandNode } from "@/hooks";
 import ContextMenu from "./internalComponents/ContextMenu";
 import useContextMenu from "./useContextMenu";
 import useGraphGlobalActions from "./useGraphGlobalActions";
@@ -93,7 +93,7 @@ export default function GraphViewer({
   onEdgeCustomize,
 }: GraphViewerProps) {
   const graphRef = useRef<GraphRef | null>(null);
-  const [entities, setEntities] = useEntities();
+  const [entities] = useEntities();
 
   const [nodesSelectedIds, setNodesSelectedIds] =
     useRecoilState(nodesSelectedIdsAtom);
@@ -155,13 +155,7 @@ export default function GraphViewer({
   );
 
   const [layout, setLayout] = useState("F_COSE");
-  const onClearCanvas = useCallback(() => {
-    setEntities({
-      nodes: new Map(),
-      edges: new Map(),
-      forceSet: true,
-    });
-  }, [setEntities]);
+  const onClearGraph = useClearGraph();
 
   const nodes = useMemo(
     () =>
@@ -226,7 +220,7 @@ export default function GraphViewer({
               label="Clear canvas"
               icon={<RemoveFromCanvasIcon />}
               color="error"
-              onActionClick={onClearCanvas}
+              onActionClick={onClearGraph}
             />
             <PanelHeaderActionButton
               label="Legend"

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -146,6 +146,7 @@ export default function GraphViewer({
     async (_, vertex) => {
       const neighborCount = await neighborCallback(vertex.id);
       const offset = neighborCount ? neighborCount.fetched : undefined;
+
       expandNode(vertex, {
         limit: 10,
         offset,

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -20,13 +20,13 @@ import {
   ZoomOutIcon,
 } from "@/components/icons";
 import { useDisplayEdgesInCanvas, useDisplayVerticesInCanvas } from "@/core";
-import { edgesSelectedIdsAtom, toEdgeMap } from "@/core/StateProvider/edges";
-import { nodesSelectedIdsAtom, toNodeMap } from "@/core/StateProvider/nodes";
+import { edgesSelectedIdsAtom } from "@/core/StateProvider/edges";
+import { nodesSelectedIdsAtom } from "@/core/StateProvider/nodes";
 import {
   SidebarItems,
   userLayoutAtom,
 } from "@/core/StateProvider/userPreferences";
-import { useEntities, useTranslations } from "@/hooks";
+import { useClearGraph, useRemoveFromGraph, useTranslations } from "@/hooks";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import { EdgeId, VertexId } from "@/core";
 import { MinusCircleIcon } from "lucide-react";
@@ -49,7 +49,6 @@ const ContextMenu = ({
   onEdgeCustomize,
 }: ContextMenuProps) => {
   const t = useTranslations();
-  const [_, setEntities] = useEntities();
   const displayNodes = useDisplayVerticesInCanvas();
   const displayEdges = useDisplayEdgesInCanvas();
   const [nodesSelectedIds, setNodesSelectedIds] =
@@ -135,41 +134,20 @@ const ContextMenu = ({
     onClose?.();
   }, [onClose, onZoomOut]);
 
+  const removeFromGraph = useRemoveFromGraph();
   const handleRemoveFromCanvas = useCallback(
     (nodesIds: VertexId[], edgesIds: EdgeId[]) => () => {
-      setEntities(prev => {
-        // const newNodes = new Map(prev.nodes);
-        // nodesIds.forEach(id => newNodes.delete(id));
-        return {
-          // nodes: newNodes,
-          nodes: toNodeMap(
-            prev.nodes
-              .values()
-              .filter(n => !nodesIds.includes(n.id))
-              .toArray()
-          ),
-          edges: toEdgeMap(
-            prev.edges
-              .values()
-              .filter(e => !edgesIds.includes(e.id))
-              .toArray()
-          ),
-          forceSet: true,
-        };
-      });
+      removeFromGraph({ vertices: nodesIds, edges: edgesIds });
       onClose?.();
     },
-    [onClose, setEntities]
+    [onClose, removeFromGraph]
   );
 
+  const clearGraph = useClearGraph();
   const handleRemoveAllFromCanvas = useCallback(() => {
-    setEntities({
-      nodes: new Map(),
-      edges: new Map(),
-      forceSet: true,
-    });
+    clearGraph();
     onClose?.();
-  }, [onClose, setEntities]);
+  }, [onClose, clearGraph]);
 
   const noSelectionOrNotAffected =
     affectedNodesIds?.length === 0 &&

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
@@ -6,12 +6,7 @@ import { useAllNeighbors } from "@/core";
 
 const useNodeBadges = () => {
   const displayNodes = useDisplayVerticesInCanvas();
-  const neighborCounts = useAllNeighbors(
-    displayNodes
-      .values()
-      .map(v => v.id)
-      .toArray()
-  );
+  const neighborCounts = useAllNeighbors();
 
   return useCallback(
     (outOfFocusIds: Set<VertexId>): BadgeRenderer =>

--- a/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
@@ -7,7 +7,7 @@ import {
   VertexRow,
 } from "@/components";
 import {
-  useAddToGraph,
+  useAddVertexToGraph,
   useHasVertexBeenAddedToGraph,
   useRemoveNodeFromGraph,
 } from "@/hooks";
@@ -25,7 +25,7 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
   const [expanded, setExpanded] = useState(false);
   const displayNode = useDisplayVertexFromVertex(node);
 
-  const addToGraph = useAddToGraph(node);
+  const addToGraph = useAddVertexToGraph(node);
   const removeFromGraph = useRemoveNodeFromGraph(node.id);
   const hasBeenAdded = useHasVertexBeenAddedToGraph(node.id);
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -60,7 +60,7 @@ export function SearchResultsList({
 }
 
 function LoadedResults({ vertices, edges, scalars }: MappedQueryResults) {
-  const sendToGraph = useAddToGraph(...vertices, ...edges);
+  const sendToGraph = useAddToGraph();
   const canSendToGraph = vertices.length > 0 || edges.length > 0;
 
   const counts = [
@@ -89,7 +89,7 @@ function LoadedResults({ vertices, edges, scalars }: MappedQueryResults) {
       <PanelFooter className="sticky bottom-0 flex flex-row items-center justify-between">
         <Button
           icon={<PlusCircleIcon />}
-          onPress={sendToGraph}
+          onPress={() => sendToGraph({ vertices, edges })}
           isDisabled={!canSendToGraph}
         >
           Add all

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearchQuery.ts
@@ -1,8 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { explorerSelector } from "@/core/connector";
+import { useExplorer } from "@/core/connector";
 import usePrefixesUpdater from "@/hooks/usePrefixesUpdater";
 import { useCallback, useEffect } from "react";
-import { useRecoilValue } from "recoil";
 import { KeywordSearchRequest, searchQuery } from "@/connector";
 
 export type SearchQueryRequest = {
@@ -18,7 +17,7 @@ export function useKeywordSearchQuery({
   searchByAttributes,
   exactMatch,
 }: SearchQueryRequest) {
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const queryClient = useQueryClient();
   const updatePrefixes = usePrefixesUpdater();
 

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { Vertex } from "@/core";
 import {
   CheckIcon,
@@ -40,7 +40,7 @@ import {
   useDisplayVerticesFromVertices,
   useWithTheme,
 } from "@/core";
-import { explorerSelector } from "@/core/connector";
+import { useExplorer } from "@/core/connector";
 import {
   userStylingAtom,
   VertexPreferences,
@@ -373,7 +373,7 @@ function useDataExplorerQuery(
   pageSize: number,
   pageIndex: number
 ) {
-  const explorer = useRecoilValue(explorerSelector);
+  const explorer = useExplorer();
   const queryClient = useQueryClient();
 
   const updatePrefixes = usePrefixesUpdater();

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -45,7 +45,7 @@ import {
   userStylingAtom,
   VertexPreferences,
 } from "@/core/StateProvider/userPreferences";
-import { useAddToGraph, useHasVertexBeenAddedToGraph } from "@/hooks";
+import { useAddVertexToGraph, useHasVertexBeenAddedToGraph } from "@/hooks";
 import usePrefixesUpdater from "@/hooks/usePrefixesUpdater";
 import useTranslations from "@/hooks/useTranslations";
 import useUpdateVertexTypeCounts from "@/hooks/useUpdateVertexTypeCounts";
@@ -264,7 +264,7 @@ function DisplayNameAndDescriptionOptions({
 }
 
 function AddToExplorerButton({ vertex }: { vertex: Vertex }) {
-  const addToGraph = useAddToGraph(vertex);
+  const addToGraph = useAddVertexToGraph(vertex);
   const isInExplorer = useHasVertexBeenAddedToGraph(vertex.id);
 
   return (


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Moves manipulation of the `entitiesSelector` Recoil state behind domain specific hooks. This will aid in the switch to entity ID as a base for the graph.

- Add `useExplorer()` hook to abstract away dependency on Recoil
- Update `useAllNeighbors()` hook to get the graph entities internally
- Add `useClearGraph()` to remove all entities from the graph (used in `GraphViewer` and `ContextMenu`)
- Update `useRemoveFromGraph()` to push the parameters in to the callback function
  - Updated the convenience hooks to call the one main hook
- Update `useAddToGraph()` to pass the entities to the callback
  - Change the convenience hook `useAddVertexToGraph()` to us the main hook
  - Ensure `useExpandNode()` uses `useAddToGraph()`
- For neighbor count and expansion queries, get the expansion limit set on the connection from the `explorer` object passed in

## Validation

- Verified expansion limit set in the connection
  - This seems buggy, but I compared it to what was there before and it is the same behavior. I'm not exactly sure what the behavior should be, so I'm leaving it as is.
- Verified all query languages
- Verified clearing the graph
- Verified removing nodes
- Verified expansion

## Related Issues

- Part of #771 
- Part of #628

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
