### PR TITLE
Rollback serialized id type

### DIFF
--- a/packages/graph-explorer/src/components/Graph/hooks/useRenderBadges.ts
+++ b/packages/graph-explorer/src/components/Graph/hooks/useRenderBadges.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Vertex } from "@/core";
+import { RenderedVertex } from "@/core";
 import { DrawBoxWithAdornmentOptions } from "@/components/utils";
 import drawBoxWithAdornment from "@/components/utils/canvas/drawBoxWithAdornment";
 import type {
@@ -17,7 +17,7 @@ export type Badge = DrawBoxWithAdornmentOptions & {
 };
 
 export type BadgeRenderer = (
-  nodeData: Vertex,
+  nodeData: RenderedVertex["data"],
   boundingBox: BoundingBox,
   options: {
     context: CanvasRenderingContext2D;
@@ -113,7 +113,7 @@ const useRenderBadges = ({
         // Draw model elements
         cy.nodes().forEach(node => {
           const zoomLevel = getZoomLevel(cy);
-          const nodeData = node.data() as Vertex;
+          const nodeData = node.data() as RenderedVertex["data"];
 
           if (
             node.style("display") === "none" ||

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -39,6 +39,10 @@ export function searchQuery(
   });
 }
 
+export type NeighborCountsQueryRequest = {
+  vertexId: VertexId;
+};
+
 export type NeighborCountsQueryResponse = {
   nodeId: VertexId;
   totalCount: number;
@@ -53,16 +57,15 @@ export type NeighborCountsQueryResponse = {
  * @returns The count of neighbors for the given node as a total and per type.
  */
 export function neighborsCountQuery(
-  vertexId: VertexId,
+  request: NeighborCountsQueryRequest,
   explorer: Explorer | null
 ) {
   return queryOptions({
-    queryKey: ["neighborsCount", vertexId, explorer],
-    enabled: Boolean(explorer),
+    queryKey: ["neighborsCount", request, explorer],
     queryFn: async (): Promise<NeighborCountsQueryResponse> => {
       if (!explorer) {
         return {
-          nodeId: vertexId,
+          nodeId: request.vertexId,
           totalCount: 0,
           counts: {},
         };
@@ -71,12 +74,12 @@ export function neighborsCountQuery(
       const limit = explorer.connection.nodeExpansionLimit;
 
       const result = await explorer.fetchNeighborsCount({
-        vertexId,
+        vertexId: request.vertexId,
         limit,
       });
 
       return {
-        nodeId: vertexId,
+        nodeId: request.vertexId,
         totalCount: result.totalCount,
         counts: result.counts,
       };
@@ -108,14 +111,13 @@ export function vertexDetailsQuery(
   request: VertexDetailsRequest,
   explorer: Explorer | null
 ) {
-  const vertexId = request.vertexId;
   return queryOptions({
-    queryKey: ["db", "vertex", "details", vertexId, explorer],
+    queryKey: ["db", "vertex", "details", request, explorer],
     queryFn: async ({ signal }): Promise<VertexDetailsResponse> => {
       if (!explorer) {
         return { vertex: null };
       }
-      return await explorer.vertexDetails({ vertexId }, { signal });
+      return await explorer.vertexDetails(request, { signal });
     },
   });
 }
@@ -124,14 +126,13 @@ export function edgeDetailsQuery(
   request: EdgeDetailsRequest,
   explorer: Explorer | null
 ) {
-  const edgeId = request.edgeId;
   return queryOptions({
-    queryKey: ["db", "edge", "details", edgeId, explorer],
+    queryKey: ["db", "edge", "details", request, explorer],
     queryFn: async ({ signal }): Promise<EdgeDetailsResponse> => {
       if (!explorer) {
         return { edge: null };
       }
-      return await explorer.edgeDetails({ edgeId }, { signal });
+      return await explorer.edgeDetails(request, { signal });
     },
   });
 }

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -1,5 +1,4 @@
 import {
-  createEdgeId,
   createVertexId,
   Edge,
   EdgeId,
@@ -256,7 +255,7 @@ export function parseEdgeId(edgeId: EdgeId): {
 
   return {
     source: createVertexId(match[1].trim()),
-    predicate: createEdgeId(match[2].trim()),
+    predicate: match[2].trim(),
     target: createVertexId(match[3].trim()),
   };
 }

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -169,7 +169,7 @@ export type BlankNodeItem = {
   };
 };
 
-export type BlankNodesMap = Map<string, BlankNodeItem>;
+export type BlankNodesMap = Map<VertexId, BlankNodeItem>;
 
 export type GraphSummary = {
   numDistinctSubjects: number;

--- a/packages/graph-explorer/src/core/StateProvider/edges.ts
+++ b/packages/graph-explorer/src/core/StateProvider/edges.ts
@@ -1,5 +1,10 @@
 import { atom, selector, selectorFamily } from "recoil";
-import type { Edge, EdgeId } from "@/core";
+import {
+  createRenderedEdgeId,
+  getEdgeIdFromRenderedEdgeId,
+  type Edge,
+  type EdgeId,
+} from "@/core";
 import isDefaultValue from "./isDefaultValue";
 import { nodesFilteredIdsAtom, nodesTypesFilteredAtom } from "./nodes";
 
@@ -59,9 +64,43 @@ export const edgesSelectedIdsAtom = atom<Set<EdgeId>>({
   default: new Set(),
 });
 
+export const edgesSelectedRenderedIdsAtom = selector({
+  key: "edges-selected-rendered-ids",
+  get: ({ get }) =>
+    new Set(get(edgesSelectedIdsAtom).values().map(createRenderedEdgeId)),
+  set: ({ set }, newValue) => {
+    if (isDefaultValue(newValue)) {
+      set(edgesSelectedIdsAtom, newValue);
+      return;
+    }
+
+    set(
+      edgesSelectedIdsAtom,
+      new Set(newValue.values().map(getEdgeIdFromRenderedEdgeId))
+    );
+  },
+});
+
 export const edgesOutOfFocusIdsAtom = atom<Set<EdgeId>>({
   key: "edges-out-of-focus-ids",
   default: new Set(),
+});
+
+export const edgesOutOfFocusRenderedIdsAtom = selector({
+  key: "edges-out-of-focus-rendered-ids",
+  get: ({ get }) =>
+    new Set(get(edgesOutOfFocusIdsAtom).values().map(createRenderedEdgeId)),
+  set: ({ set }, newValue) => {
+    if (isDefaultValue(newValue)) {
+      set(edgesOutOfFocusIdsAtom, newValue);
+      return;
+    }
+
+    set(
+      edgesOutOfFocusIdsAtom,
+      new Set(newValue.values().map(getEdgeIdFromRenderedEdgeId))
+    );
+  },
 });
 
 export const edgesFilteredIdsAtom = atom<Set<EdgeId>>({

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -45,7 +45,7 @@ export function useNeighborsCallback() {
     );
     const explorer = await snapshot.getPromise(explorerSelector);
     const response = await queryClient.ensureQueryData(
-      neighborsCountQuery(vertexId, explorer)
+      neighborsCountQuery({ vertexId }, explorer)
     );
 
     const neighbors = calculateNeighbors(

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -1,5 +1,10 @@
 import { atom, selector, selectorFamily, useRecoilValue } from "recoil";
-import type { Vertex, VertexId } from "@/core";
+import {
+  createRenderedVertexId,
+  getVertexIdFromRenderedVertexId,
+  type Vertex,
+  type VertexId,
+} from "@/core";
 import isDefaultValue from "./isDefaultValue";
 
 export function toNodeMap(nodes: Vertex[]): Map<VertexId, Vertex> {
@@ -55,9 +60,43 @@ export const nodesSelectedIdsAtom = atom<Set<VertexId>>({
   default: new Set(),
 });
 
+export const nodesSelectedRenderedIdsAtom = selector({
+  key: "nodes-selected-rendered-ids",
+  get: ({ get }) =>
+    new Set(get(nodesSelectedIdsAtom).values().map(createRenderedVertexId)),
+  set: ({ set }, newValue) => {
+    if (isDefaultValue(newValue)) {
+      set(nodesSelectedIdsAtom, newValue);
+      return;
+    }
+
+    set(
+      nodesSelectedIdsAtom,
+      new Set(newValue.values().map(getVertexIdFromRenderedVertexId))
+    );
+  },
+});
+
 export const nodesOutOfFocusIdsAtom = atom<Set<VertexId>>({
   key: "nodes-out-of-focus-ids",
   default: new Set(),
+});
+
+export const nodesOutOfFocusRenderedIdsAtom = selector({
+  key: "nodes-out-of-focus-rendered-ids",
+  get: ({ get }) =>
+    new Set(get(nodesOutOfFocusIdsAtom).values().map(createRenderedVertexId)),
+  set: ({ set }, newValue) => {
+    if (isDefaultValue(newValue)) {
+      set(nodesOutOfFocusIdsAtom, newValue);
+      return;
+    }
+
+    set(
+      nodesOutOfFocusIdsAtom,
+      new Set(newValue.values().map(getVertexIdFromRenderedVertexId))
+    );
+  },
 });
 
 export const nodesFilteredIdsAtom = atom<Set<VertexId>>({

--- a/packages/graph-explorer/src/core/entities.ts
+++ b/packages/graph-explorer/src/core/entities.ts
@@ -1,7 +1,7 @@
 import { Branded } from "@/utils";
 
-export type EdgeId = Branded<string, "EdgeId">;
-export type VertexId = Branded<string, "VertexId">;
+export type EdgeId = Branded<string | number, "EdgeId">;
+export type VertexId = Branded<string | number, "VertexId">;
 
 export type Vertex = {
   /**

--- a/packages/graph-explorer/src/core/entityIdType.test.ts
+++ b/packages/graph-explorer/src/core/entityIdType.test.ts
@@ -4,35 +4,35 @@ import { createEdgeId, createVertexId, getRawId } from "./entityIdType";
 describe("createVertexId", () => {
   it("should create a vertex id out of a string", () => {
     const id = createVertexId("123");
-    expect(id).toBe("(str)123");
+    expect(id).toBe("123");
   });
 
   it("should create a vertex id out of a number", () => {
     const id = createVertexId(123);
-    expect(id).toBe("(num)123");
+    expect(id).toBe(123);
   });
 });
 
 describe("createEdgeId", () => {
   it("should create an edge id out of a string", () => {
     const id = createEdgeId("123");
-    expect(id).toBe("(str)123");
+    expect(id).toBe("123");
   });
 
   it("should create an edge id out of a number", () => {
     const id = createEdgeId(123);
-    expect(id).toBe("(num)123");
+    expect(id).toBe(123);
   });
 });
 
 describe("getRawId", () => {
   it("should return the raw string id without the prefix", () => {
-    const id = getRawId("(str)123" as VertexId);
+    const id = getRawId(createVertexId("123"));
     expect(id).toBe("123");
   });
 
   it("should return the raw number id without the prefix", () => {
-    const id = getRawId("(num)123" as VertexId);
+    const id = getRawId(createVertexId(123));
     expect(id).toBe(123);
   });
 

--- a/packages/graph-explorer/src/core/entityIdType.ts
+++ b/packages/graph-explorer/src/core/entityIdType.ts
@@ -1,21 +1,19 @@
 import { VertexId, EdgeId } from "@/core";
 
 /**
- * Creates a VertexId that is a string prefixed with the ID type.
+ * Creates a VertexId from the given database ID.
  * @param id The original database ID
- * @returns A VertexId that is a string prefixed with the ID type
  */
 export function createVertexId(id: string | number): VertexId {
-  return prefixIdWithType(id) as VertexId;
+  return id as VertexId;
 }
 
 /**
- * Creates an EdgeId that is a string prefixed with the ID type.
+ * Creates an EdgeId from the given database ID.
  * @param id The original database ID
- * @returns An EdgeId that is a string prefixed with the ID type
  */
 export function createEdgeId(id: string | number): EdgeId {
-  return prefixIdWithType(id) as EdgeId;
+  return id as EdgeId;
 }
 
 /**
@@ -24,40 +22,5 @@ export function createEdgeId(id: string | number): EdgeId {
  * @returns The original database ID without the ID type prefix
  */
 export function getRawId(id: VertexId | EdgeId): string | number {
-  if (isIdNumber(id)) {
-    return parseInt(stripIdTypePrefix(id));
-  }
-  if (isIdString(id)) {
-    return stripIdTypePrefix(id);
-  }
-  return id;
-}
-
-const ID_TYPE_NUM_PREFIX = "(num)";
-const ID_TYPE_STR_PREFIX = "(str)";
-
-function prefixIdWithType(id: string | number): string {
-  if (typeof id === "number") {
-    return `${ID_TYPE_NUM_PREFIX}${id}`;
-  }
-
-  return `${ID_TYPE_STR_PREFIX}${id}`;
-}
-
-function isIdNumber(id: string): boolean {
-  return id.startsWith(ID_TYPE_NUM_PREFIX);
-}
-
-function isIdString(id: string): boolean {
-  return id.startsWith(ID_TYPE_STR_PREFIX);
-}
-
-function stripIdTypePrefix(id: string): string {
-  if (isIdNumber(id)) {
-    return id.slice(ID_TYPE_NUM_PREFIX.length);
-  }
-  if (isIdString(id)) {
-    return id.slice(ID_TYPE_STR_PREFIX.length);
-  }
   return id;
 }

--- a/packages/graph-explorer/src/core/index.ts
+++ b/packages/graph-explorer/src/core/index.ts
@@ -5,3 +5,4 @@ export * from "./StateProvider";
 export * from "./connector";
 export * from "./entityIdType";
 export * from "./entities";
+export * from "./renderedEntities";

--- a/packages/graph-explorer/src/core/renderedEntities.test.ts
+++ b/packages/graph-explorer/src/core/renderedEntities.test.ts
@@ -1,0 +1,75 @@
+import { createEdgeId, createVertexId } from "./entityIdType";
+import {
+  createRenderedEdgeId,
+  createRenderedVertexId,
+  getEdgeIdFromRenderedEdgeId,
+  getVertexIdFromRenderedVertexId,
+  RenderedEdgeId,
+  RenderedVertexId,
+} from "./renderedEntities";
+
+describe("createRenderedVertexId", () => {
+  it("should create a rendered vertex id out of a string", () => {
+    const id = createRenderedVertexId(createVertexId("123"));
+    expect(id).toBe("(str)123");
+  });
+
+  it("should create a rendered vertex id out of a number", () => {
+    const id = createRenderedVertexId(createVertexId(123));
+    expect(id).toBe("(num)123");
+  });
+});
+
+describe("createRenderedEdgeId", () => {
+  it("should create a rendered edge id out of a string", () => {
+    const id = createRenderedEdgeId(createEdgeId("123"));
+    expect(id).toBe("(str)123");
+  });
+
+  it("should create a rendered edge id out of a number", () => {
+    const id = createRenderedEdgeId(createEdgeId(123));
+    expect(id).toBe("(num)123");
+  });
+});
+
+describe("getVertexIdFromRenderedVertexId", () => {
+  it("should return the raw string id without the prefix", () => {
+    const id = getVertexIdFromRenderedVertexId(
+      createRenderedVertexId(createVertexId("123"))
+    );
+    expect(id).toBe("123");
+  });
+
+  it("should return the raw number id without the prefix", () => {
+    const id = getVertexIdFromRenderedVertexId(
+      createRenderedVertexId(createVertexId(123))
+    );
+    expect(id).toBe(123);
+  });
+
+  it("should return the id as is if it is not marked as a string or number", () => {
+    const id = getVertexIdFromRenderedVertexId("123" as RenderedVertexId);
+    expect(id).toBe("123");
+  });
+});
+
+describe("getEdgeIdFromRenderedEdgeId", () => {
+  it("should return the raw string id without the prefix", () => {
+    const id = getEdgeIdFromRenderedEdgeId(
+      createRenderedEdgeId(createEdgeId("123"))
+    );
+    expect(id).toBe("123");
+  });
+
+  it("should return the raw number id without the prefix", () => {
+    const id = getEdgeIdFromRenderedEdgeId(
+      createRenderedEdgeId(createEdgeId(123))
+    );
+    expect(id).toBe(123);
+  });
+
+  it("should return the id as is if it is not marked as a string or number", () => {
+    const id = getEdgeIdFromRenderedEdgeId("123" as RenderedEdgeId);
+    expect(id).toBe("123");
+  });
+});

--- a/packages/graph-explorer/src/core/renderedEntities.ts
+++ b/packages/graph-explorer/src/core/renderedEntities.ts
@@ -1,0 +1,167 @@
+import {
+  type Edge,
+  type EdgeId,
+  filteredEdgesSelector,
+  filteredNodesSelector,
+  type Vertex,
+  type VertexId,
+} from "@/core";
+import { Branded } from "@/utils";
+import { useMemo } from "react";
+import { useRecoilValue } from "recoil";
+
+/** A string representation of a vertex ID that encodes the original type. Cytoscape requires IDs to be strings. */
+export type RenderedVertexId = Branded<string, "RenderedVertexId">;
+
+/** A string representation of an edge ID that encodes the original type. Cytoscape requires IDs to be strings. */
+export type RenderedEdgeId = Branded<string, "RenderedEdgeId">;
+
+/** A representation of a vertex that Cytoscape can use. */
+export type RenderedVertex = ReturnType<typeof createRenderedVertex>;
+
+/** A representation of an edge that Cytoscape can use. */
+export type RenderedEdge = ReturnType<typeof createRenderedEdge>;
+
+/** Returns the filtered array of `RenderedVertex` instances for use by Cytoscape. */
+export function useRenderedVertices(): RenderedVertex[] {
+  const vertices = useRecoilValue(filteredNodesSelector);
+  return useMemo(
+    () => vertices.values().map(createRenderedVertex).toArray(),
+    [vertices]
+  );
+}
+
+/** Returns the filtered array of `RenderedEdge` instances for use by Cytoscape. */
+export function useRenderedEdges(): RenderedEdge[] {
+  const edges = useRecoilValue(filteredEdgesSelector);
+  return useMemo(
+    () => edges.values().map(createRenderedEdge).toArray(),
+    [edges]
+  );
+}
+
+/**
+ * Maps a rendered vertex back to a regular vertex.
+ * @param renderedVertex The rendered vertex
+ * @returns A vertex instance
+ */
+export function createVertexFromRenderedVertex(
+  renderedVertex: RenderedVertex
+): Vertex {
+  return {
+    ...renderedVertex.data,
+    id: getVertexIdFromRenderedVertexId(renderedVertex.data.id),
+  };
+}
+
+/**
+ * Maps a rendered edge back to a regular edge.
+ * @param renderedEdge The rendered edge
+ * @returns An edge instance
+ */
+export function createEdgeFromRenderedEdge(renderedEdge: RenderedEdge): Edge {
+  return {
+    ...renderedEdge.data,
+    id: getEdgeIdFromRenderedEdgeId(renderedEdge.data.id),
+    source: getVertexIdFromRenderedVertexId(renderedEdge.data.source),
+    target: getVertexIdFromRenderedVertexId(renderedEdge.data.target),
+  };
+}
+
+/** Maps a VertexId to a string with the original type prefixed. */
+export function createRenderedVertexId(id: VertexId): RenderedVertexId {
+  return prefixIdWithType(id) as RenderedVertexId;
+}
+
+/** Maps an EdgeId to a string with the original type prefixed. */
+export function createRenderedEdgeId(id: EdgeId): RenderedEdgeId {
+  return prefixIdWithType(id) as RenderedEdgeId;
+}
+
+/** Strips the ID type prefix from the given ID and returns the value as a VertexId. */
+export function getVertexIdFromRenderedVertexId(
+  id: RenderedVertexId
+): VertexId {
+  if (isIdNumber(id)) {
+    return parseInt(stripIdTypePrefix(id)) as VertexId;
+  }
+  if (isIdString(id)) {
+    return stripIdTypePrefix(id) as VertexId;
+  }
+  return String(id) as VertexId;
+}
+
+/** Strips the ID type prefix from the given ID and returns the value as an EdgeId. */
+export function getEdgeIdFromRenderedEdgeId(id: RenderedEdgeId): EdgeId {
+  if (isIdNumber(id)) {
+    return parseInt(stripIdTypePrefix(id)) as EdgeId;
+  }
+  if (isIdString(id)) {
+    return stripIdTypePrefix(id) as EdgeId;
+  }
+  return String(id) as EdgeId;
+}
+
+const ID_TYPE_NUM_PREFIX = "(num)";
+const ID_TYPE_STR_PREFIX = "(str)";
+
+function prefixIdWithType(id: string | number): string {
+  if (typeof id === "number") {
+    return `${ID_TYPE_NUM_PREFIX}${id}`;
+  }
+
+  return `${ID_TYPE_STR_PREFIX}${id}`;
+}
+
+function isIdNumber(id: string): boolean {
+  return id.startsWith(ID_TYPE_NUM_PREFIX);
+}
+
+function isIdString(id: string): boolean {
+  return id.startsWith(ID_TYPE_STR_PREFIX);
+}
+
+function stripIdTypePrefix(id: string): string {
+  if (isIdNumber(id)) {
+    return id.slice(ID_TYPE_NUM_PREFIX.length);
+  }
+  if (isIdString(id)) {
+    return id.slice(ID_TYPE_STR_PREFIX.length);
+  }
+  return id;
+}
+
+/**
+ * Creates a representation of a vertex that Cytoscape can use.
+ *
+ * Cytoscape expects a few things:
+ * - The `id` property is a string
+ * - There exists a `data` property where any custom data is stored
+ */
+function createRenderedVertex(vertex: Vertex) {
+  return {
+    data: {
+      ...vertex,
+      id: createRenderedVertexId(vertex.id),
+    },
+  };
+}
+
+/**
+ * Creates a representation of an edge that Cytoscape can use.
+ *
+ * Cytoscape expects a few things:
+ * - The `id` property is a string
+ * - The `source` and `target` properties are strings
+ * - There exists a `data` property where any custom data is stored
+ */
+function createRenderedEdge(edge: Edge) {
+  return {
+    data: {
+      ...edge,
+      id: createRenderedEdgeId(edge.id),
+      source: createRenderedVertexId(edge.source),
+      target: createRenderedVertexId(edge.target),
+    },
+  };
+}

--- a/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
+++ b/packages/graph-explorer/src/hooks/useUpdateNodeCounts.ts
@@ -5,14 +5,16 @@ import { VertexId } from "@/core";
 
 export function useUpdateNodeCountsQuery(vertexId: VertexId) {
   const explorer = useExplorer();
-  return useQuery(neighborsCountQuery(vertexId, explorer));
+  return useQuery(neighborsCountQuery({ vertexId }, explorer));
 }
 
 export function useAllNeighborCountsQuery(vertexIds: VertexId[]) {
   const explorer = useExplorer();
 
   return useQueries({
-    queries: vertexIds.map(vertex => neighborsCountQuery(vertex, explorer)),
+    queries: vertexIds.map(vertexId =>
+      neighborsCountQuery({ vertexId }, explorer)
+    ),
     combine: results => ({
       data: results.map(result => result.data),
       pending: results.some(result => result.isPending),

--- a/packages/graph-explorer/src/modules/GraphViewer/useContextMenu.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useContextMenu.ts
@@ -1,6 +1,13 @@
 import { useCallback, useRef, useState } from "react";
 import { useLayer, useMousePositionAsTrigger } from "react-laag";
-import type { Edge, EdgeId, Vertex, VertexId } from "@/core";
+import {
+  getEdgeIdFromRenderedEdgeId,
+  getVertexIdFromRenderedVertexId,
+  type RenderedEdge,
+  type RenderedVertex,
+  type EdgeId,
+  type VertexId,
+} from "@/core";
 import type {
   ElementEventCallback,
   GraphEventCallback,
@@ -48,44 +55,46 @@ const useContextMenu = () => {
       onOutsideClick: clearAllLayers,
     });
 
-  const onNodeRightClick: ElementEventCallback<Vertex> = useCallback(
-    (event, node, bounds) => {
-      const parentBounds = parentRef.current?.getBoundingClientRect() || {
-        top: 0,
-        left: 0,
-      };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      handleMouseEvent({
-        ...event.originalEvent,
-        // Override the event position to node bounds and parent offsets
-        clientY: parentBounds.top + bounds.top + bounds.height / 2,
-        clientX: parentBounds.left + bounds.left + bounds.width,
-      });
-      setContextNodeId(node.id);
-    },
-    [handleMouseEvent]
-  );
+  const onNodeRightClick: ElementEventCallback<RenderedVertex["data"]> =
+    useCallback(
+      (event, node, bounds) => {
+        const parentBounds = parentRef.current?.getBoundingClientRect() || {
+          top: 0,
+          left: 0,
+        };
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        handleMouseEvent({
+          ...event.originalEvent,
+          // Override the event position to node bounds and parent offsets
+          clientY: parentBounds.top + bounds.top + bounds.height / 2,
+          clientX: parentBounds.left + bounds.left + bounds.width,
+        });
+        setContextNodeId(getVertexIdFromRenderedVertexId(node.id));
+      },
+      [handleMouseEvent]
+    );
 
-  const onEdgeRightClick: ElementEventCallback<Edge> = useCallback(
-    (event, edge) => {
-      const parentBounds = parentRef.current?.getBoundingClientRect() || {
-        top: 0,
-        left: 0,
-      };
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      handleMouseEvent({
-        ...event.originalEvent,
-        // Override the event position to event position and parent offsets
-        clientY: event.renderedPosition.y + parentBounds.top,
-        clientX: event.renderedPosition.x + parentBounds.left,
-      });
-      setContextEdgeId(edge.id);
-      event.preventDefault();
-    },
-    [handleMouseEvent]
-  );
+  const onEdgeRightClick: ElementEventCallback<RenderedEdge["data"]> =
+    useCallback(
+      (event, edge) => {
+        const parentBounds = parentRef.current?.getBoundingClientRect() || {
+          top: 0,
+          left: 0,
+        };
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        handleMouseEvent({
+          ...event.originalEvent,
+          // Override the event position to event position and parent offsets
+          clientY: event.renderedPosition.y + parentBounds.top,
+          clientX: event.renderedPosition.x + parentBounds.left,
+        });
+        setContextEdgeId(getEdgeIdFromRenderedEdgeId(edge.id));
+        event.preventDefault();
+      },
+      [handleMouseEvent]
+    );
 
   const onGraphRightClick: GraphEventCallback = useCallback(
     (event, position) => {

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -1,6 +1,6 @@
 import Color from "color";
 import { useEffect, useState } from "react";
-import { EdgeId } from "@/core";
+import { getEdgeIdFromRenderedEdgeId, RenderedEdgeId } from "@/core";
 import type { GraphProps } from "@/components";
 import useTextTransform from "@/hooks/useTextTransform";
 import { renderNode } from "./renderNode";
@@ -64,8 +64,10 @@ const useGraphStyles = () => {
 
         styles[`edge[type="${et}"]`] = {
           label: (el: cytoscape.EdgeSingular) => {
-            const edgeId = el.id() as EdgeId;
-            const displayEdge = displayEdges.get(edgeId);
+            const edgeId = el.id() as RenderedEdgeId;
+            const displayEdge = displayEdges.get(
+              getEdgeIdFromRenderedEdgeId(edgeId)
+            );
             return displayEdge
               ? displayEdge.displayName
               : MISSING_DISPLAY_VALUE;

--- a/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useNodeBadges.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
-import { BadgeRenderer } from "@/components/Graph/hooks/useRenderBadges";
-import { VertexId } from "@/core";
+import { Badge, BadgeRenderer } from "@/components/Graph/hooks/useRenderBadges";
+import { getVertexIdFromRenderedVertexId, RenderedVertexId } from "@/core";
 import { useDisplayVerticesInCanvas } from "@/core";
 import { useAllNeighbors } from "@/core";
 
@@ -9,10 +9,11 @@ const useNodeBadges = () => {
   const neighborCounts = useAllNeighbors();
 
   return useCallback(
-    (outOfFocusIds: Set<VertexId>): BadgeRenderer =>
+    (outOfFocusIds: Set<RenderedVertexId>): BadgeRenderer =>
       (nodeData, boundingBox, { zoomLevel }) => {
-        const displayNode = displayNodes.get(nodeData.id);
-        const neighbors = neighborCounts.get(nodeData.id);
+        const vertexId = getVertexIdFromRenderedVertexId(nodeData.id);
+        const displayNode = displayNodes.get(vertexId);
+        const neighbors = neighborCounts.get(vertexId);
         // Ensure we have the node name and title
         const name = displayNode?.displayName ?? "";
         const title = displayNode?.displayTypes ?? "";
@@ -38,7 +39,7 @@ const useNodeBadges = () => {
               width: "auto",
               height: "auto",
             },
-          },
+          } satisfies Badge,
           {
             hidden:
               zoomLevel === "small" ||

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearchQuery.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearchQuery.ts
@@ -36,7 +36,10 @@ export function useKeywordSearchQuery({
     if (!query.data) {
       return;
     }
-    updatePrefixes(query.data.vertices.map(v => v.id));
+    const vertexIds = query.data.vertices
+      .map(v => v.id)
+      .filter(id => typeof id === "string");
+    updatePrefixes(vertexIds);
   }, [query.data, updatePrefixes]);
 
   return query;

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -393,7 +393,10 @@ function useDataExplorerQuery(
       return;
     }
 
-    updatePrefixes(query.data.vertices.map(v => v.id));
+    const vertexIds = query.data.vertices
+      .map(v => v.id)
+      .filter(id => typeof id === "string");
+    updatePrefixes(vertexIds);
   }, [query.data, updatePrefixes]);
 
   return query;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Updates the logic to allow `VertexId` and `EdgeId` to be either `string` or `number`. This requires a workaround to interface with Cytoscape, since they require the IDs to be a `string`.

So I've introduced `RenderedVertex` and `RenderedEdge` that map the IDs to string with the prefixed type encoded.

## Validation

- Verified across all query languages

## Related Issues

- Resolves #771 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
