### PR TITLE
Escape entity details queries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,8 @@
   [#770](https://github.com/aws/graph-explorer/pull/770),
   [#775](https://github.com/aws/graph-explorer/pull/775),
   [#781](https://github.com/aws/graph-explorer/pull/781),
-  [#786](https://github.com/aws/graph-explorer/pull/786))
+  [#786](https://github.com/aws/graph-explorer/pull/786),
+  [#793](https://github.com/aws/graph-explorer/pull/793))
 - **Updated** UI labels to refer to node & edge "labels" instead of "types"
   ([#766](https://github.com/aws/graph-explorer/pull/766))
 - **Improved** neighbor count retrieval to be more efficient

--- a/packages/graph-explorer/src/connector/gremlin/edgeDetails.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/edgeDetails.test.ts
@@ -1,0 +1,67 @@
+import { createRandomEdge, createRandomVertex } from "@/utils/testing";
+import { edgeDetails } from "./edgeDetails";
+import { Edge } from "@/core";
+
+describe("edgeDetails", () => {
+  it("should return the correct edge details", async () => {
+    const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+    edge.__isFragment = false;
+    const response = createGremlinResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await edgeDetails(mockFetch, {
+      edgeId: edge.id,
+    });
+
+    expect(result.edge).toEqual(edge);
+  });
+});
+
+function createGremlinResponseFromEdge(edge: Edge) {
+  return {
+    result: {
+      data: {
+        "@type": "g:List",
+        "@value": [
+          {
+            "@type": "g:Edge",
+            "@value": {
+              id: edge.id,
+              label: edge.type,
+              inV: edge.target,
+              outV: edge.source,
+              inVLabel: edge.targetType,
+              outVLabel: edge.sourceType,
+              properties: createProperties(edge.attributes),
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+function createProperties(attributes: Edge["attributes"]) {
+  const mapped = Object.entries(attributes).map(([key, value]) => ({
+    "@type": "g:EdgeProperty",
+    "@value": {
+      key,
+      value:
+        typeof value === "string"
+          ? value
+          : {
+              "@type": "g:Int64",
+              "@value": value,
+            },
+    },
+  }));
+
+  const result = {} as Record<string, any>;
+  mapped.forEach(prop => {
+    result[prop["@value"].key] = prop;
+  });
+
+  return result;
+}

--- a/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
@@ -1,0 +1,67 @@
+import { createRandomVertex } from "@/utils/testing";
+import { vertexDetails } from "./vertexDetails";
+import { Vertex } from "@/core";
+
+describe("vertexDetails", () => {
+  it("should return the correct vertex details", async () => {
+    const vertex = createRandomVertex();
+
+    // Align with the gremlin mapper
+    vertex.types = [vertex.type];
+    vertex.__isFragment = false;
+
+    const response = createGremlinResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await vertexDetails(mockFetch, {
+      vertexId: vertex.id,
+    });
+
+    expect(result.vertex).toEqual(vertex);
+  });
+});
+
+function createGremlinResponseFromVertex(vertex: Vertex) {
+  return {
+    result: {
+      data: {
+        "@type": "g:List",
+        "@value": [
+          {
+            "@type": "g:Vertex",
+            "@value": {
+              id: vertex.id,
+              label: vertex.type,
+              properties: createProperties(vertex.attributes),
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+function createProperties(attributes: Vertex["attributes"]) {
+  const mapped = Object.entries(attributes).map(([key, value]) => ({
+    "@type": "g:VertexProperty",
+    "@value": {
+      label: key,
+      value:
+        typeof value === "string"
+          ? value
+          : {
+              "@type": "g:Int64",
+              "@value": value,
+            },
+    },
+  }));
+
+  const result = {} as Record<string, any>;
+  mapped.forEach(prop => {
+    result[prop["@value"].label] = [prop];
+  });
+
+  return result;
+}

--- a/packages/graph-explorer/src/connector/openCypher/edgeDetails.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/edgeDetails.test.ts
@@ -1,0 +1,36 @@
+import { createRandomEdge, createRandomVertex } from "@/utils/testing";
+import { edgeDetails } from "./edgeDetails";
+import { Edge } from "@/core";
+
+describe("edgeDetails", () => {
+  it("should return the edge details", async () => {
+    const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+
+    const response = createResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await edgeDetails(mockFetch, { edgeId: edge.id });
+
+    expect(result.edge).toEqual(edge);
+  });
+});
+
+function createResponseFromEdge(edge: Edge) {
+  return {
+    results: [
+      {
+        edge: {
+          "~id": edge.id,
+          "~type": edge.type,
+          "~start": edge.source,
+          "~end": edge.target,
+          "~properties": edge.attributes,
+        },
+        sourceLabels: [edge.sourceType],
+        targetLabels: [edge.targetType],
+      },
+    ],
+  };
+}

--- a/packages/graph-explorer/src/connector/openCypher/idParam.ts
+++ b/packages/graph-explorer/src/connector/openCypher/idParam.ts
@@ -2,5 +2,9 @@ import { EdgeId, getRawId, VertexId } from "@/core";
 
 /** Formats the ID parameter for an openCypher query based on the ID type. */
 export function idParam(id: VertexId | EdgeId) {
-  return `"${getRawId(id)}"`;
+  const rawId = getRawId(id);
+  if (typeof rawId !== "string") {
+    throw new Error(`Invalid ID type: ${typeof rawId}`);
+  }
+  return `"${rawId}"`;
 }

--- a/packages/graph-explorer/src/connector/openCypher/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/vertexDetails.test.ts
@@ -1,0 +1,33 @@
+import { createRandomVertex } from "@/utils/testing";
+import { vertexDetails } from "./vertexDetails";
+import { Vertex } from "@/core";
+
+describe("vertexDetails", () => {
+  it("should return the vertex details", async () => {
+    const vertex = createRandomVertex();
+    vertex.types = [vertex.type];
+
+    const response = createResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await vertexDetails(mockFetch, { vertexId: vertex.id });
+
+    expect(result.vertex).toEqual(vertex);
+  });
+});
+
+function createResponseFromVertex(vertex: Vertex) {
+  return {
+    results: [
+      {
+        vertex: {
+          "~id": vertex.id,
+          "~labels": [vertex.type],
+          "~properties": vertex.attributes,
+        },
+      },
+    ],
+  };
+}

--- a/packages/graph-explorer/src/connector/sparql/createRdfEdgeId.ts
+++ b/packages/graph-explorer/src/connector/sparql/createRdfEdgeId.ts
@@ -1,0 +1,20 @@
+import { createEdgeId, VertexId } from "@/core";
+
+/**
+ * Combines the triple that makes up an edge into a single string.
+ *
+ * The format is:
+ * {source}-[{predicate}]->{target}
+ *
+ * @param source The source resource URI
+ * @param predicate The predicate URI
+ * @param target The target resource URI
+ * @returns A string that represents the relationship between the source and target
+ */
+export function createRdfEdgeId(
+  source: string | VertexId,
+  predicate: string,
+  target: string | VertexId
+) {
+  return createEdgeId(`${source}-[${predicate}]->${target}`);
+}

--- a/packages/graph-explorer/src/connector/sparql/edgeDetails.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/edgeDetails.test.ts
@@ -1,0 +1,108 @@
+import { Edge, EdgeId } from "@/core";
+import {
+  createRandomEdgeForRdf,
+  createRandomVertexForRdf,
+} from "@/utils/testing";
+import { edgeDetails } from "./edgeDetails";
+import { createRandomUrlString } from "@shared/utils/testing";
+
+describe("edgeDetails", () => {
+  it("should return the edge details", async () => {
+    const edge = createRandomEdgeForRdf(
+      createRandomVertexForRdf(),
+      createRandomVertexForRdf()
+    );
+    const response = createResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+    const result = await edgeDetails(mockFetch, { edgeId: edge.id });
+    expect(result.edge).toEqual(edge);
+  });
+
+  it("should throw an error when the edge ID is not in the RDF edge ID format", async () => {
+    const edge = createRandomEdgeForRdf(
+      createRandomVertexForRdf(),
+      createRandomVertexForRdf()
+    );
+    // Missing the brackets
+    edge.id = `${edge.source}-${edge.type}->${edge.target}` as EdgeId;
+    const response = createResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    await expect(edgeDetails(mockFetch, { edgeId: edge.id })).rejects.toThrow(
+      "Invalid RDF edge ID"
+    );
+  });
+
+  it("should throw an error when the source vertex ID doesn't match the response", async () => {
+    const edge = createRandomEdgeForRdf(
+      createRandomVertexForRdf(),
+      createRandomVertexForRdf()
+    );
+    edge.id =
+      `${createRandomUrlString()}-[${edge.type}]->${edge.target}` as EdgeId;
+    const response = createResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    await expect(edgeDetails(mockFetch, { edgeId: edge.id })).rejects.toThrow(
+      "Edge type not found in bindings"
+    );
+  });
+
+  it("should throw an error when the target vertex ID doesn't match the response", async () => {
+    const edge = createRandomEdgeForRdf(
+      createRandomVertexForRdf(),
+      createRandomVertexForRdf()
+    );
+    edge.id =
+      `${edge.source}-[${edge.type}]->${createRandomUrlString()}` as EdgeId;
+    const response = createResponseFromEdge(edge);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    await expect(edgeDetails(mockFetch, { edgeId: edge.id })).rejects.toThrow(
+      "Edge type not found in bindings"
+    );
+  });
+});
+
+function createResponseFromEdge(edge: Edge) {
+  const source = edge.source;
+  const target = edge.target;
+
+  return {
+    head: {
+      vars: ["resource", "type"],
+    },
+    results: {
+      bindings: [
+        {
+          resource: {
+            type: "uri",
+            value: source,
+          },
+          type: {
+            type: "uri",
+            value: edge.sourceType,
+          },
+        },
+        {
+          resource: {
+            type: "uri",
+            value: target,
+          },
+          type: {
+            type: "uri",
+            value: edge.targetType,
+          },
+        },
+      ],
+    },
+  };
+}

--- a/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
@@ -81,7 +81,6 @@ export async function edgeDetails(
   const edge = <Edge>{
     entityType: "edge",
     id: request.edgeId,
-    idType: "string",
     type: predicate,
     source: source,
     sourceType,

--- a/packages/graph-explorer/src/connector/sparql/idParam.ts
+++ b/packages/graph-explorer/src/connector/sparql/idParam.ts
@@ -2,5 +2,9 @@ import { EdgeId, getRawId, VertexId } from "@/core";
 
 /** Formats the ID parameter for a sparql query based on the ID type. */
 export function idParam(id: VertexId | EdgeId) {
-  return `<${getRawId(id)}>`;
+  const rawId = getRawId(id);
+  if (typeof rawId !== "string") {
+    throw new Error("ID must be a URI");
+  }
+  return `<${rawId}>`;
 }

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
@@ -1,5 +1,6 @@
-import { createEdgeId, createVertexId, Edge, getRawId, VertexId } from "@/core";
+import { createVertexId, Edge, VertexId } from "@/core";
 import { RawValue } from "../types";
+import { createRdfEdgeId } from "../createRdfEdgeId";
 
 export type IncomingPredicate = {
   subject: RawValue;
@@ -17,7 +18,7 @@ const mapIncomingToEdge = (
 
   return {
     entityType: "edge",
-    id: createEdgeId(`${sourceUri}-[${predicate}]->${getRawId(resourceURI)}`),
+    id: createRdfEdgeId(sourceUri, predicate, resourceURI),
     type: predicate,
     source: createVertexId(sourceUri),
     sourceType: result.subjectClass.value,

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
@@ -1,5 +1,6 @@
-import { createEdgeId, createVertexId, Edge, getRawId, VertexId } from "@/core";
+import { createVertexId, Edge, VertexId } from "@/core";
 import { RawValue } from "../types";
+import { createRdfEdgeId } from "../createRdfEdgeId";
 
 export type OutgoingPredicate = {
   subject: RawValue;
@@ -16,7 +17,7 @@ const mapOutgoingToEdge = (
   const predicate = result.predToSubject.value;
   return {
     entityType: "edge",
-    id: createEdgeId(`${getRawId(resourceURI)}-[${predicate}]->${targetUri}`),
+    id: createRdfEdgeId(resourceURI, predicate, targetUri),
     type: predicate,
     source: resourceURI,
     sourceType: resourceClass,

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -229,6 +229,7 @@ export function sparqlResponseSchema<T extends z.ZodTypeAny>(
     }),
   });
 }
+
 /**
  * Parses out the source, target, and predicate from the edge ID.
  *
@@ -245,17 +246,31 @@ export function parseEdgeId(edgeId: EdgeId): {
     throw new Error("SPARQL EdgeId values must be of type string");
   }
 
-  const regex = /^(.*?)-\[(.*?)\]->(.*)$/;
-  const match = rawEdgeId.match(regex);
+  const result = parseRdfEdgeIdString(rawEdgeId);
 
-  if (!match) {
+  if (!result) {
     logger.error("Couldn't parse SPARQL edge ID", edgeId);
-    throw new Error("Invalid edge ID");
+    throw new Error("Invalid RDF edge ID");
   }
 
   return {
-    source: createVertexId(match[1].trim()),
-    predicate: match[2].trim(),
-    target: createVertexId(match[3].trim()),
+    source: createVertexId(result.source),
+    predicate: result.predicate,
+    target: createVertexId(result.target),
   };
+}
+
+export function parseRdfEdgeIdString(value: string) {
+  const regex = /^(.*?)-\[(.*?)\]->(.*)$/;
+  const match = value.match(regex);
+
+  if (!match || match.length !== 4) {
+    return null;
+  }
+
+  const source = match[1].trim();
+  const predicate = match[2].trim();
+  const target = match[3].trim();
+
+  return { source, predicate, target };
 }

--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.test.ts
@@ -1,0 +1,82 @@
+import { createRandomVertexForRdf } from "@/utils/testing";
+import { vertexDetails } from "./vertexDetails";
+import { createVertexId, Vertex } from "@/core";
+import { createRandomInteger } from "@shared/utils/testing";
+
+describe("vertexDetails", () => {
+  it("should return the vertex details", async () => {
+    const vertex = createRandomVertexForRdf();
+    const response = createResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await vertexDetails(mockFetch, { vertexId: vertex.id });
+
+    expect(result.vertex).toEqual(vertex);
+  });
+
+  it("should throw an error when the vertex ID is not a string", async () => {
+    const vertex = createRandomVertexForRdf();
+    vertex.id = createVertexId(createRandomInteger());
+    const response = createResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    await expect(
+      vertexDetails(mockFetch, { vertexId: vertex.id })
+    ).rejects.toThrow("ID must be a URI");
+  });
+
+  it("should throw an error when the vertex ID is not a string", async () => {
+    const vertex = createRandomVertexForRdf();
+    vertex.id = createVertexId(createRandomInteger());
+    const response = createResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    await expect(
+      vertexDetails(mockFetch, { vertexId: vertex.id })
+    ).rejects.toThrow("ID must be a URI");
+  });
+});
+
+function createResponseFromVertex(vertex: Vertex) {
+  return {
+    head: {
+      vars: ["label", "value"],
+    },
+    results: {
+      bindings: [
+        {
+          label: {
+            type: "uri",
+            value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+          },
+          value: {
+            type: "uri",
+            value: vertex.type,
+          },
+        },
+        ...Object.entries(vertex.attributes).map(([key, value]) => ({
+          label: {
+            type: "uri",
+            value: key,
+          },
+          value: {
+            type: "literal",
+            value: value.toString(),
+            // Only include the datatype if the value is a number
+            ...(typeof value === "number" && {
+              datatype: value.toString().includes(".")
+                ? "http://www.w3.org/2001/XMLSchema#decimal"
+                : "http://www.w3.org/2001/XMLSchema#integer",
+            }),
+          },
+        })),
+      ],
+    },
+  };
+}

--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
@@ -107,7 +107,6 @@ function mapToVertex(
   const result = <Vertex>{
     entityType: "vertex",
     id,
-    idType: "string",
     type: typeUri,
     attributes,
   };

--- a/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.test.tsx
@@ -56,6 +56,36 @@ describe("createCompletionNotification", () => {
     );
   });
 
+  it("should create a completion notification when exactly 1 node was not found", () => {
+    const fetchResult = createRandomFetchEntityDetailsResult();
+    fetchResult.counts.notFound.vertices = 1;
+    fetchResult.counts.notFound.edges = 0;
+    fetchResult.counts.notFound.total =
+      fetchResult.counts.notFound.vertices + fetchResult.counts.notFound.edges;
+
+    const notification = createCompletionNotification(fetchResult);
+
+    expect(notification.type).toBe("info");
+    expect(notification.message).toBe(
+      `Finished loading the graph, but 1 node was not found.`
+    );
+  });
+
+  it("should create a completion notification when exactly 1 edge was not found", () => {
+    const fetchResult = createRandomFetchEntityDetailsResult();
+    fetchResult.counts.notFound.vertices = 0;
+    fetchResult.counts.notFound.edges = 1;
+    fetchResult.counts.notFound.total =
+      fetchResult.counts.notFound.vertices + fetchResult.counts.notFound.edges;
+
+    const notification = createCompletionNotification(fetchResult);
+
+    expect(notification.type).toBe("info");
+    expect(notification.message).toBe(
+      `Finished loading the graph, but 1 edge was not found.`
+    );
+  });
+
   it("should create a completion notification when all nodes and edges were not found", () => {
     const fetchResult = createRandomFetchEntityDetailsResult();
     fetchResult.entities.vertices = [];

--- a/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
@@ -148,8 +148,9 @@ export function createCompletionNotification(
       result.counts.notFound.vertices,
       result.counts.notFound.edges
     );
+    const verb = result.counts.notFound.total > 1 ? "were" : "was";
     return {
-      message: `Finished loading the graph, but ${errorMessage} were not found.`,
+      message: `Finished loading the graph, but ${errorMessage} ${verb} not found.`,
       type: "info",
     };
   }

--- a/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
@@ -18,8 +18,8 @@ import { FolderOpenIcon } from "lucide-react";
 import { useRecoilValue } from "recoil";
 import {
   ExportedGraphConnection,
-  exportedGraphSchema,
   isMatchingConnection,
+  parseExportedGraph,
 } from "./exportedGraph";
 import { useNotification } from "@/components/NotificationProvider";
 import { ZodError } from "zod";
@@ -72,20 +72,21 @@ function useImportGraphMutation() {
     mutationFn: async (file: File) => {
       // 1. Parse the file
       const data = await fromFileToJson(file);
-      const parsed = await exportedGraphSchema.parseAsync(data);
+      const graph = await parseExportedGraph(data);
 
       // 2. Check connection
-      if (!isMatchingConnection(explorer.connection, parsed.data.connection)) {
+      if (!isMatchingConnection(explorer.connection, graph.connection)) {
         throw new InvalidConnectionError(
           "Connection must match active connection",
-          parsed.data.connection
+          graph.connection
         );
       }
 
       // 3. Get the vertex and edge details from the database
-      const vertices = new Set(parsed.data.vertices);
-      const edges = new Set(parsed.data.edges);
-      const entityCountMessage = formatCount(vertices.size, edges.size);
+      const entityCountMessage = formatCount(
+        graph.vertices.size,
+        graph.edges.size
+      );
 
       const progressNotificationId = enqueueNotification({
         title: notificationTitle,
@@ -95,8 +96,8 @@ function useImportGraphMutation() {
       });
 
       const result = await fetchEntityDetails(
-        vertices,
-        edges,
+        graph.vertices,
+        graph.edges,
         queryClient,
         explorer
       );

--- a/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.test.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.test.ts
@@ -146,6 +146,19 @@ describe("parseExportedGraph", () => {
     expect(parsed.edges.has("" as EdgeId)).toBeFalsy();
   });
 
+  it("should allow number IDs", async () => {
+    const exportedGraph = createRandomExportedGraph();
+    const vertexId = createRandomInteger();
+    const edgeId = createRandomInteger();
+    exportedGraph.data.vertices.push(vertexId);
+    exportedGraph.data.edges.push(edgeId);
+
+    const parsed = await parseExportedGraph(exportedGraph);
+
+    expect(parsed.vertices.has(vertexId as VertexId)).toBeTruthy();
+    expect(parsed.edges.has(edgeId as EdgeId)).toBeTruthy();
+  });
+
   it("should escape strings with double quotes", async () => {
     const exportedGraph = createRandomExportedGraph();
     const maliciousVertexId = `${createRandomName("VertexId")}").constant("Hello, World!"`;

--- a/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
@@ -97,11 +97,12 @@ export async function parseExportedGraph(data: unknown) {
 }
 
 function isNotEmptyIfString(value: string | number) {
-  if (typeof value !== "string" || !value.length) {
-    logger.warn("Skipping empty ID value", value);
-    return false;
+  if (typeof value !== "string" || value.length > 0) {
+    return true;
   }
-  return true;
+
+  logger.warn("Skipping empty ID value", value);
+  return false;
 }
 
 function isNotMaliciousIfSparql(queryEngine: QueryEngine) {

--- a/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
@@ -123,9 +123,13 @@ function isNotMaliciousIfSparql(queryEngine: QueryEngine) {
 
 function isValidRdfEdgeIdIfSparql(queryEngine: QueryEngine) {
   return (value: string | number) => {
-    // Do nothing for numbers and property graph connections
-    if (typeof value !== "string" || queryEngine !== "sparql") {
+    if (queryEngine !== "sparql") {
       return true;
+    }
+
+    if (typeof value !== "string") {
+      logger.warn("Skipping edge ID because it is not a string", value);
+      return false;
     }
 
     // Try to parse the edge ID


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This change helps prevent the chances of an injection attack through the saved graph file.

In the process of importing the graph file we now do some basic sanity checks on the vertex and edge IDs.

- Trim any leading or trailing whitespace
- Ensure they are not empty string
- If property graph, escape strings
- If RDF, ensure no `>` exist
- If RDF, ensure edge format is correct

### Other changes

- Fixed toast notification where 1 node or edge was not found (said "were" instead of "was")
- Removed `idType` that was no longer necessary

## Validation

- Verified export and import still work properly
- Verified modified exported graph files fail gracefully

## Related Issues

- Fixes #789 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
