### PR TITLE
Remove logic that disables fields on default connection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+- **Changed** to allow editing and deleting default connections
+  ([#801](https://github.com/aws/graph-explorer/pull/801))
 - **Fixed** issue where nodes and edges without any labels were causing the app
   to crash ([#799](https://github.com/aws/graph-explorer/pull/799))
 

--- a/packages/graph-explorer/src/core/AppStatusLoader.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.tsx
@@ -55,7 +55,6 @@ const AppStatusLoader = ({ children }: PropsWithChildren) => {
       !configuration.get(defaultConnectionConfig.id)
     ) {
       const newConfig: RawConfiguration = cloneDeep(defaultConnectionConfig);
-      newConfig.__fileBase = true;
       let activeConfigId = defaultConnectionConfig.id;
 
       logger.debug("Adding new config to store", newConfig);

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -137,10 +137,6 @@ export type RawConfiguration = {
    * Database schema: types, names, labels, icons, ...
    */
   schema?: Schema;
-  /**
-   * Mark as created from a file
-   */
-  __fileBase?: boolean;
 };
 
 export type ConfigurationContextProps = RawConfiguration & {

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -119,7 +119,6 @@ export function mergeConfiguration(
   return {
     id: currentConfig.id,
     displayLabel: currentConfig.displayLabel,
-    __fileBase: currentConfig.__fileBase,
     connection: {
       ...(currentConfig.connection || {}),
       // Remove trailing slash

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -96,7 +96,6 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
 
   const lastSyncUpdate = config?.schema?.lastUpdate;
   const lastSyncFail = config?.schema?.lastSyncFail === true;
-  const isFileBased = config.__fileBase === true;
 
   return (
     <Panel className={cn(styleWithTheme(defaultStyles))}>
@@ -126,10 +125,10 @@ const ConnectionDetail = ({ isSync, onSyncChange }: ConnectionDetailProps) => {
             onActionClick={() => setEdit(true)}
           />
           <PanelHeaderActionButton
-            label={isFileBased ? "File (read-only)" : "Delete connection"}
+            label="Delete connection"
             icon={<DeleteIcon />}
             color="error"
-            isDisabled={isFileBased || isSync}
+            isDisabled={isSync}
             onActionClick={onConfigDelete}
           />
         </PanelHeaderActions>

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -81,9 +81,6 @@ const CreateConnection = ({
   const styleWithTheme = useWithTheme();
 
   const configId = existingConfig?.id;
-  const disabledFields: (keyof ConnectionForm)[] = existingConfig?.__fileBase
-    ? ["queryEngine", "url", "serviceType"]
-    : [];
   const initialData: ConnectionForm | undefined = existingConfig
     ? {
         ...(existingConfig.connection || {}),
@@ -239,17 +236,13 @@ const CreateConnection = ({
           onChange={onFormChange("name")}
           errorMessage="Name is required"
           validationState={hasError && !form.name ? "invalid" : "valid"}
-          isDisabled={disabledFields.includes("name")}
         />
         <Select
           label="Graph Type"
           options={CONNECTIONS_OP}
           value={form.queryEngine}
           onChange={onFormChange("queryEngine")}
-          isDisabled={
-            disabledFields.includes("queryEngine") ||
-            form.serviceType === "neptune-graph"
-          }
+          isDisabled={form.serviceType === "neptune-graph"}
         />
         <div className="input-url">
           <TextArea
@@ -270,7 +263,6 @@ const CreateConnection = ({
             errorMessage="URL is required"
             placeholder="https://example.com"
             validationState={hasError && !form.url ? "invalid" : "valid"}
-            isDisabled={disabledFields.includes("url")}
           />
         </div>
         <div className="input-url">
@@ -338,7 +330,6 @@ const CreateConnection = ({
                 ]}
                 value={form.serviceType}
                 onChange={onFormChange("serviceType")}
-                isDisabled={disabledFields.includes("serviceType")}
               />
             </div>
           </>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes the logic that disabled some fields on the edit connection modal and disabled the delete button.

## Validation

- Ensured existing default connections are no longer disabled
- Ensured newly created default connections are no longer disabled

## Related Issues

- Resolves #800 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
