### PR TITLE
fix: https-connections link in documentation

### DIFF
--- a/additionaldocs/getting-started/README.md
+++ b/additionaldocs/getting-started/README.md
@@ -66,7 +66,7 @@ Docker image. You can find the latest version of the image on
    the application is set to use HTTPS by default and contains a self-signed
    certificate, you will need to add the Graph Explorer certificates to the
    trusted certificates directory and manually trust them. See the
-   [HTTPS Connections](#https-connections) section.
+   [HTTPS Connections](https://github.com/aws/graph-explorer/blob/main/additionaldocs/troubleshooting.md#https-connections) section.
 6. After completing the trusted certification step and refreshing the browser,
    you should now see the Connections UI. See below description on Connections
    UI to configure your first connection to Amazon Neptune.

--- a/additionaldocs/getting-started/README.md
+++ b/additionaldocs/getting-started/README.md
@@ -66,7 +66,7 @@ Docker image. You can find the latest version of the image on
    the application is set to use HTTPS by default and contains a self-signed
    certificate, you will need to add the Graph Explorer certificates to the
    trusted certificates directory and manually trust them. See the
-   [HTTPS Connections](https://github.com/aws/graph-explorer/blob/main/additionaldocs/troubleshooting.md#https-connections) section.
+   [HTTPS Connections](../troubleshooting.md#https-connections) section.
 6. After completing the trusted certification step and refreshing the browser,
    you should now see the Connections UI. See below description on Connections
    UI to configure your first connection to Amazon Neptune.


### PR DESCRIPTION
The https-connections section was moved under troubleshooting.md but the link is pointing to the old https-connections section which does not exist

<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix https-connections link in documentation.
The https-connections section was moved under troubleshooting.md but the link is pointing to the old https-connections section which does not exist.

## Validation

Manual Validation

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
