### PR TITLE
Update label to be Neptune Analytics (not Graph)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 - **Changed** to allow editing and deleting default connections
   ([#801](https://github.com/aws/graph-explorer/pull/801))
+- **Changed** service type label to be "Neptune Analytics"
+  ([#811](https://github.com/aws/graph-explorer/pull/811))
 - **Fixed** issue where nodes and edges without any labels were causing the app
   to crash ([#799](https://github.com/aws/graph-explorer/pull/799))
 

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -326,7 +326,7 @@ const CreateConnection = ({
                 label="Service Type"
                 options={[
                   { label: "Neptune DB", value: "neptune-db" },
-                  { label: "Neptune Graph", value: "neptune-graph" },
+                  { label: "Neptune Analytics", value: "neptune-graph" },
                 ]}
                 value={form.serviceType}
                 onChange={onFormChange("serviceType")}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Update the service type drop down to be "Neptune Analytics" instead of "Neptune Graph".

I searched the codebase for any other occurrences, but I didn't find any.

## Validation

![CleanShot 2025-02-28 at 15 24 06@2x](https://github.com/user-attachments/assets/95dc0c49-cf75-4ae1-9327-9e3b799a688f)


## Related Issues

- Resolves #798

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
