### PR TITLE
Better error handling for database requests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming Release
 
+- **Improved** handling of errors when fetching data from the database
+  ([#812](https://github.com/aws/graph-explorer/pull/812))
 - **Changed** to allow editing and deleting default connections
   ([#801](https://github.com/aws/graph-explorer/pull/801))
 - **Changed** service type label to be "Neptune Analytics"

--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -40,7 +40,7 @@ export function errorHandlingMiddleware() {
     logger.error(
       `[${getRequestLoggerPrefix(request)}] Request headers: %s`,
       Object.entries(request.headers)
-        .filter(([key]) => HEADER_WHITE_LIST.includes(key))
+        .filter(([key]) => HEADER_WHITE_LIST.includes(key.toLowerCase()))
         .map(
           ([key, value]) =>
             `\n\t- ${key}: ${Array.isArray(value) ? value.join(", ") : value}`

--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { logger } from "./logging.js";
+import { getRequestLoggerPrefix, logger } from "./logging.js";
 
 /**
  * Global error handler
@@ -14,7 +14,7 @@ export function handleError(error: unknown) {
 export function errorHandlingMiddleware() {
   return (
     error: unknown,
-    _request: Request,
+    request: Request,
     response: Response,
     _next: NextFunction
   ) => {
@@ -25,6 +25,16 @@ export function errorHandlingMiddleware() {
     response.send({
       error: errorInfo,
     });
+    // Log the headers of the request
+    logger.error(
+      `[${getRequestLoggerPrefix(request)}] Request headers: %s`,
+      Object.entries(request.headers)
+        .map(
+          ([key, value]) =>
+            `\n\t- ${key}: ${Array.isArray(value) ? value.join(", ") : value}`
+        )
+        .join("")
+    );
 
     handleError(error);
   };

--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -10,6 +10,17 @@ export function handleError(error: unknown) {
   logger.error(error);
 }
 
+/** List of headers that can be logged safely without accidentally logging sensitive information. */
+const HEADER_WHITE_LIST = [
+  "host",
+  "user-agent",
+  "graph-db-connection-url",
+  "db-query-logging-enabled",
+  "accept",
+  "content-type",
+  "origin",
+];
+
 /** Handles any errors thrown within Express routes. */
 export function errorHandlingMiddleware() {
   return (
@@ -29,6 +40,7 @@ export function errorHandlingMiddleware() {
     logger.error(
       `[${getRequestLoggerPrefix(request)}] Request headers: %s`,
       Object.entries(request.headers)
+        .filter(([key]) => HEADER_WHITE_LIST.includes(key))
         .map(
           ([key, value]) =>
             `\n\t- ${key}: ${Array.isArray(value) ? value.join(", ") : value}`

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -45,11 +45,15 @@ function logLevelFromStatusCode(statusCode: number): LogLevel {
   return "debug";
 }
 
+export function getRequestLoggerPrefix(req: Request) {
+  return `${req.method} ${req.path}`;
+}
+
 /** Logs the request path and response status using the given logger. */
 export function logRequestAndResponse(req: Request, res: Response) {
   const logLevel = logLevelFromStatusCode(res.statusCode);
 
-  const requestMessage = `[${req.method} ${req.path}] Response ${res.statusCode} ${res.statusMessage}`;
+  const requestMessage = `[${getRequestLoggerPrefix(req)}] Response ${res.statusCode} ${res.statusMessage}`;
 
   switch (logLevel) {
     case "debug":

--- a/packages/graph-explorer/src/connector/LoggerConnector.ts
+++ b/packages/graph-explorer/src/connector/LoggerConnector.ts
@@ -53,7 +53,7 @@ export class ServerLoggerConnector implements LoggerConnector {
         level,
         message: JSON.stringify(message),
       },
-    });
+    }).catch(err => logger.error("Failed to send log to server", err));
   }
 }
 

--- a/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
+++ b/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
@@ -28,32 +28,31 @@ async function decodeErrorSafely(response: Response): Promise<any> {
   const isJson =
     !contentTypeHasValue || contentType.includes("application/json");
 
+  // Extract the raw text from the response
+  const rawText = await response.text();
+
+  // Check for empty response
+  if (!rawText) {
+    return undefined;
+  }
+
   if (isJson) {
     try {
-      const data = await response.json();
+      // Try parsing the response as JSON
+      const data = JSON.parse(rawText);
 
       // Flatten the error if it contains an error object
       return data?.error ?? data;
     } catch (error) {
       console.error("Failed to decode the error response as JSON", {
         error,
-        response,
+        rawText,
       });
-      return undefined;
+      return rawText;
     }
   }
 
-  try {
-    const message = await response.text();
-    return { message };
-  } catch (error) {
-    console.error("Failed to decode the error response as text", {
-      error,
-      response,
-    });
-  }
-
-  return undefined;
+  return { message: rawText };
 }
 
 // Construct the request headers based on the connection settings

--- a/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
+++ b/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
@@ -3,7 +3,7 @@ import { DEFAULT_SERVICE_TYPE } from "@/utils/constants";
 import { anySignal } from "./utils/anySignal";
 import { FeatureFlags } from "@/core";
 import { z } from "zod";
-import { logger } from "@/utils";
+import { logger, NetworkError } from "@/utils";
 
 const NeptuneErrorSchema = z.object({
   code: z.string(),
@@ -119,12 +119,10 @@ export async function fetchDatabaseRequest(
         parseNeptuneError.data.message ??
         defaultMessage;
 
-      throw new Error(message, {
-        cause: parseNeptuneError.data,
-      });
+      throw new NetworkError(message, response.status, parseNeptuneError.data);
     }
     // Or just throw a generic error
-    throw new Error(defaultMessage, { cause: error });
+    throw new NetworkError(defaultMessage, response.status, error);
   }
 
   // A successful response is assumed to be JSON

--- a/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
+++ b/packages/graph-explorer/src/core/ConnectedProvider/ConnectedProvider.tsx
@@ -1,5 +1,9 @@
 import { type PropsWithChildren } from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { NotificationProvider } from "@/components/NotificationProvider";
 import Toast from "@/components/Toast";
 import AppStatusLoader from "@/core/AppStatusLoader";
@@ -10,6 +14,7 @@ import { emotionTransform, MantineEmotionProvider } from "@mantine/emotion";
 import { ErrorBoundary } from "react-error-boundary";
 import AppErrorPage from "@/core/AppErrorPage";
 import { TooltipProvider } from "@/components";
+import { logger } from "@/utils";
 
 function exponentialBackoff(attempt: number): number {
   return Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000);
@@ -24,6 +29,11 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
     },
   },
+  queryCache: new QueryCache({
+    onError(error, query) {
+      logger.error("Query failed to execute:", query.queryKey, error);
+    },
+  }),
 });
 
 export default function ConnectedProvider({ children }: PropsWithChildren) {

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from "recoil";
+import { atom, DefaultValue, selector } from "recoil";
 import {
   EdgeTypeConfig,
   PrefixTypeConfig,
@@ -44,7 +44,7 @@ export const activeSchemaSelector = selector({
       const updatedSchemaMap = new Map(prevSchemaMap);
 
       // Handle reset value
-      if (!newValue || isDefaultValue(newValue)) {
+      if (newValue instanceof DefaultValue || !newValue) {
         updatedSchemaMap.delete(schemaId);
         return updatedSchemaMap;
       }

--- a/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
@@ -21,7 +21,7 @@ const GeneratedPrefixes = () => {
         prefixConfig =>
           prefixConfig.__inferred === true &&
           prefixConfig.__matches &&
-          prefixConfig.__matches.size > 1
+          prefixConfig.__matches.size > 0
       )
       .map(mapToPrefixData)
       .toSorted((a, b) => a.title.localeCompare(b.title));

--- a/packages/graph-explorer/src/utils/NetworkError.ts
+++ b/packages/graph-explorer/src/utils/NetworkError.ts
@@ -1,0 +1,11 @@
+export class NetworkError extends Error {
+  statusCode: number;
+  data: any;
+  constructor(message: string, statusCode: number, data: any) {
+    super(message);
+    this.name = "NetworkError";
+    this.statusCode = statusCode;
+    this.data = data;
+    Object.setPrototypeOf(this, NetworkError.prototype);
+  }
+}

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -65,7 +65,7 @@ describe("createDisplayError", () => {
   });
 
   it("Should handle AbortError", () => {
-    const result = createDisplayError({ name: "AbortError" });
+    const result = createDisplayError(new FakeError("AbortError", "Aborted"));
     expect(result).toStrictEqual({
       title: "Request cancelled",
       message: "The request exceeded the configured timeout length.",
@@ -89,4 +89,32 @@ describe("createDisplayError", () => {
         "The executed query was rejected by the database. It is possible the query structure is not supported by your database.",
     });
   });
+
+  it("Should handle TimeoutError", () => {
+    const result = createDisplayError(
+      new FakeError("TimeoutError", "Timed out")
+    );
+    expect(result).toStrictEqual({
+      title: "Fetch Timeout Exceeded",
+      message: "The request exceeded the configured fetch timeout.",
+    });
+  });
+
+  it("Should handle failed to fetch error", () => {
+    const result = createDisplayError(
+      new FakeError("TypeError", "Failed to fetch")
+    );
+    expect(result).toStrictEqual({
+      title: "Connection Error",
+      message: "Please check your connection and try again.",
+    });
+  });
 });
+
+/** Used to create errors for test code. */
+class FakeError extends Error {
+  constructor(name: string, message: string) {
+    super(message);
+    this.name = name;
+  }
+}

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -1,4 +1,5 @@
 import { createDisplayError } from "./createDisplayError";
+import { NetworkError } from "./NetworkError";
 
 const defaultResult = {
   title: "Something went wrong",
@@ -107,6 +108,26 @@ describe("createDisplayError", () => {
     expect(result).toStrictEqual({
       title: "Connection Error",
       message: "Please check your connection and try again.",
+    });
+  });
+
+  it("Should handle too many requests error", () => {
+    const result = createDisplayError(
+      new NetworkError("Network error", 429, null)
+    );
+    expect(result).toStrictEqual({
+      title: "Too Many Requests",
+      message: "The database is currently overloaded. Please try again later.",
+    });
+  });
+
+  it("Should handle network error", () => {
+    const result = createDisplayError(
+      new NetworkError("Network error", 500, { message: "Some error" })
+    );
+    expect(result).toStrictEqual({
+      title: "Network Response 500",
+      message: "Some error",
     });
   });
 });

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -33,12 +33,21 @@ export function createDisplayError(error: any): DisplayError {
         message: "Please check your connection and try again.",
       };
     }
-
-    // Server timeout
+    if (
+      error?.code === "ERR_INVALID_URL" ||
+      error?.cause?.code === "ERR_INVALID_URL"
+    ) {
+      return {
+        title: "Invalid URL",
+        message:
+          "Please check the database URL in the connection and try again.",
+      };
+    }
     if (
       error?.code === "TimeLimitExceededException" ||
       error?.cause?.code === "TimeLimitExceededException"
     ) {
+      // Server timeout
       return {
         title: "Deadline exceeded",
         message:
@@ -58,12 +67,28 @@ export function createDisplayError(error: any): DisplayError {
       };
     }
 
-    // Fetch timeout
-    if (error?.name === "AbortError") {
-      return {
-        title: "Request cancelled",
-        message: "The request exceeded the configured timeout length.",
-      };
+    if (error instanceof Error) {
+      // Fetch timeout
+      if (error.name === "AbortError") {
+        return {
+          title: "Request cancelled",
+          message: "The request exceeded the configured timeout length.",
+        };
+      }
+      if (error.name === "TimeoutError") {
+        return {
+          title: "Fetch Timeout Exceeded",
+          message: "The request exceeded the configured fetch timeout.",
+        };
+      }
+
+      // Internet issues
+      if (error.name === "TypeError" && error.message === "Failed to fetch") {
+        return {
+          title: "Connection Error",
+          message: "Please check your connection and try again.",
+        };
+      }
     }
   }
   return defaultDisplayError;

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -1,3 +1,5 @@
+import { NetworkError } from "./NetworkError";
+
 export type DisplayError = {
   title: string;
   message: string;
@@ -90,6 +92,34 @@ export function createDisplayError(error: any): DisplayError {
         };
       }
     }
+
+    if (error instanceof NetworkError) {
+      if (error.statusCode === 429) {
+        return {
+          title: "Too Many Requests",
+          message:
+            "The database is currently overloaded. Please try again later.",
+        };
+      }
+
+      return {
+        title: `Network Response ${error.statusCode}`,
+        message:
+          extractMessageFromData(error.data) ?? defaultDisplayError.message,
+      };
+    }
   }
   return defaultDisplayError;
+}
+
+function extractMessageFromData(data: any): string | null {
+  if (Boolean(data) === false) {
+    return null;
+  }
+  if (typeof data === "string") {
+    return data;
+  } else if (typeof data === "object") {
+    return data.message ?? data.error ?? null;
+  }
+  return null;
 }

--- a/packages/graph-explorer/src/utils/index.ts
+++ b/packages/graph-explorer/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from "./cn";
 export * from "./set";
 export * from "./env";
 export * from "./constants";
+export * from "./NetworkError";


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR has a grab bag of changes, but mostly focused around error handling during fetch requests.

- Fix "Delete Schema" debug action (it wasn't actually deleting it)
- Client side logging
  - Add support for timeout errors in `createDisplayError()`
  - Ensure all errors that happen within TanStack Query are logged
  - Log to the browser console when the `ServerLogger` fails (prevents an uncaught Promise error)
  - Add some extra safety around decoding error response payloads (handles non-JSON responses better)
  - Add `NetworkError` type so that the status code and parsed error can be included
  - Use `NetworkError` in `fetchDatabaseRequest()`
  - Handle `NetworkError` in `createDisplayError()`
  - Prevent retrying in TanStack Query when the network response is in a given set of status codes (i.e. 401, 404, etc)
- Proxy server
  - Pipe the database response directly to the Express response (before we were trying to decode the response, which sometimes fails, and we didn't forward the headers at all)
  - Ensure server logs the request headers when an error occurs since it contains some connection information that could be helpful in debugging issues
- RDF prefixes
  - Use `activeSchemaSelector` in RDF prefix update logic
  - Fix issue where not all generated prefixes would show up in the UI

## Validation

It might be worth reviewing this PR one commit at a time.

- Tested with Neptune
- Tested with public RDF servers

## Related Issues

- None (aiming to help with support work load)

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
