### PR TITLE
Fix deleting default connections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,8 @@ schema sync errors to aid in diagnosing issues.
 - **Improved** handling of errors when fetching data from the database
   ([#812](https://github.com/aws/graph-explorer/pull/812))
 - **Changed** to allow editing and deleting default connections
-  ([#801](https://github.com/aws/graph-explorer/pull/801))
+  ([#801](https://github.com/aws/graph-explorer/pull/801),
+  [#821](https://github.com/aws/graph-explorer/pull/821))
 - **Changed** service type label to be "Neptune Analytics"
   ([#811](https://github.com/aws/graph-explorer/pull/811))
 - **Fixed** issue where nodes and edges without any labels were causing the app

--- a/packages/graph-explorer/src/hooks/useDeleteConfig.test.ts
+++ b/packages/graph-explorer/src/hooks/useDeleteConfig.test.ts
@@ -1,0 +1,64 @@
+import { activeConfigurationAtom, configurationAtom, schemaAtom } from "@/core";
+import {
+  createRandomRawConfiguration,
+  createRandomSchema,
+  renderHookWithRecoilRoot,
+} from "@/utils/testing";
+import { waitFor } from "@testing-library/react";
+import { act } from "react";
+import { useRecoilValue } from "recoil";
+import { useDeleteActiveConfiguration } from "./useDeleteConfig";
+
+test("should delete the active configuration", async () => {
+  const config1 = createRandomRawConfiguration();
+
+  const { result } = renderHookWithRecoilRoot(
+    () => {
+      const callback = useDeleteActiveConfiguration();
+      const allConfigs = useRecoilValue(configurationAtom);
+      const activeConfig = useRecoilValue(activeConfigurationAtom);
+
+      return { callback, allConfigs, activeConfig };
+    },
+    snapshot => {
+      snapshot.set(activeConfigurationAtom, config1.id);
+      snapshot.set(configurationAtom, new Map([[config1.id, config1]]));
+    }
+  );
+
+  act(() => {
+    result.current.callback();
+  });
+
+  await waitFor(() => {
+    expect(result.current.activeConfig).toBeNull();
+    expect(result.current.allConfigs.size).toBe(0);
+  });
+});
+
+test("should delete the active schema", async () => {
+  const config1 = createRandomRawConfiguration();
+  const schema1 = createRandomSchema();
+
+  const { result } = renderHookWithRecoilRoot(
+    () => {
+      const callback = useDeleteActiveConfiguration();
+      const allSchemas = useRecoilValue(schemaAtom);
+
+      return { callback, allSchemas };
+    },
+    snapshot => {
+      snapshot.set(activeConfigurationAtom, config1.id);
+      snapshot.set(configurationAtom, new Map([[config1.id, config1]]));
+      snapshot.set(schemaAtom, new Map([[config1.id, schema1]]));
+    }
+  );
+
+  act(() => {
+    result.current.callback();
+  });
+
+  await waitFor(() => {
+    expect(result.current.allSchemas.size).toBe(0);
+  });
+});

--- a/packages/graph-explorer/src/hooks/useDeleteConfig.ts
+++ b/packages/graph-explorer/src/hooks/useDeleteConfig.ts
@@ -1,0 +1,50 @@
+import {
+  activeConfigurationAtom,
+  configurationAtom,
+  ConfigurationId,
+  schemaAtom,
+} from "@/core";
+import { logger } from "@/utils";
+import { useCallback } from "react";
+import { useRecoilCallback, useRecoilValue } from "recoil";
+
+export function useDeleteConfig() {
+  return useRecoilCallback(
+    ({ set }) =>
+      (id: ConfigurationId) => {
+        logger.log("Deleting connection:", id);
+        set(activeConfigurationAtom, prev => {
+          if (prev === id) {
+            return null;
+          }
+          return prev;
+        });
+
+        set(configurationAtom, prevConfigs => {
+          const updatedConfigs = new Map(prevConfigs);
+          updatedConfigs.delete(id);
+          return updatedConfigs;
+        });
+
+        set(schemaAtom, prevSchemas => {
+          const updatedSchemas = new Map(prevSchemas);
+          updatedSchemas.delete(id);
+          return updatedSchemas;
+        });
+      },
+    []
+  );
+}
+
+export function useDeleteActiveConfiguration() {
+  const activeConfigId = useRecoilValue(activeConfigurationAtom);
+  const deleteConfig = useDeleteConfig();
+
+  return useCallback(() => {
+    if (!activeConfigId) {
+      return;
+    }
+
+    deleteConfig(activeConfigId);
+  }, [activeConfigId, deleteConfig]);
+}

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -1,10 +1,6 @@
 import { Modal } from "@mantine/core";
 import { useCallback, useState } from "react";
-import {
-  useRecoilCallback,
-  useResetRecoilState,
-  useSetRecoilState,
-} from "recoil";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
 import {
   Button,
   Chip,
@@ -29,11 +25,7 @@ import {
   showDebugActionsAtom,
   useWithTheme,
 } from "@/core";
-import {
-  activeConfigurationAtom,
-  configurationAtom,
-} from "@/core/StateProvider/configuration";
-import { activeSchemaSelector, schemaAtom } from "@/core/StateProvider/schema";
+import { activeSchemaSelector } from "@/core/StateProvider/schema";
 import { useSchemaSync } from "@/hooks/useSchemaSync";
 import useTranslations from "@/hooks/useTranslations";
 import { cn, formatDate, logger } from "@/utils";
@@ -42,6 +34,7 @@ import CreateConnection from "@/modules/CreateConnection";
 import ConnectionData from "./ConnectionData";
 import defaultStyles from "./ConnectionDetail.styles";
 import { useQueryClient } from "@tanstack/react-query";
+import { useDeleteActiveConfiguration } from "@/hooks/useDeleteConfig";
 
 export type ConnectionDetailProps = {
   config: ConfigurationContextProps;
@@ -66,29 +59,7 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
     saveConfigurationToFile(config);
   }, [config]);
 
-  const onConfigDelete = useRecoilCallback(
-    ({ set }) =>
-      () => {
-        if (!config?.id) {
-          return;
-        }
-
-        set(activeConfigurationAtom, null);
-
-        set(configurationAtom, prevConfigs => {
-          const updatedConfigs = new Map(prevConfigs);
-          updatedConfigs.delete(config.id);
-          return updatedConfigs;
-        });
-
-        set(schemaAtom, prevSchemas => {
-          const updatedSchemas = new Map(prevSchemas);
-          updatedSchemas.delete(config.id);
-          return updatedSchemas;
-        });
-      },
-    [config?.id]
-  );
+  const deleteActiveConfig = useDeleteActiveConfiguration();
 
   const lastSyncUpdate = config.schema?.lastUpdate;
   const lastSyncFail = config.schema?.lastSyncFail === true;
@@ -125,7 +96,7 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
             icon={<DeleteIcon />}
             color="error"
             isDisabled={isSync}
-            onActionClick={onConfigDelete}
+            onActionClick={deleteActiveConfig}
           />
         </PanelHeaderActions>
       </PanelHeader>

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -44,7 +44,7 @@ type ConnectionForm = {
   nodeExpansionLimit?: number;
 };
 
-export const CONNECTIONS_OP: {
+const CONNECTIONS_OP: {
   label: string;
   value: QueryEngine;
 }[] = [

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,4 +1,4 @@
-export const queryEngineOptions = ["gremlin", "sparql", "openCypher"] as const;
+export const queryEngineOptions = ["gremlin", "openCypher", "sparql"] as const;
 export type QueryEngine = (typeof queryEngineOptions)[number];
 
 export const neptuneServiceTypeOptions = [


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

There is an issue that seems to occur in a specific scenario:

1. Open Graph Explorer for the first time
2. Default connections created
3. Delete default connection

It should delete the connection, but instead it immediately recreates the deleted connection. Further deletions work correctly.

To fix, I rearranged the logic in the `AppStatusLoader` effect.

- Update default connection query to generate one connection per query engine, unless a specific query engine is specified
- Check if any connections exist, if so skip default connection logic
- Check if any default connections were received from the server, if not skip
- Add all default connections to the connections storage
- Set first connection as active
- Reorder the query engine options to put the property graph options together and RDF last

## Validation

- Tested locally by creating a `defaultConnection.json` and deleting my local Graph Explorer database to simulate a first run

## Related Issues

- Part of #817
- Part of #800 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
