### PR TITLE
Fix search result wrapping

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # graph-explorer Change Log
 
+## Upcoming
+
+- **Fixed** issue with long node titles or descriptions pushing the "add to
+  graph" button off the screen
+  ([#824](https://github.com/aws/graph-explorer/pull/824))
+
 ## Release v1.14.1
 
 This release is a minor bug fix release, with a primary focus on surfacing

--- a/packages/graph-explorer/src/components/VertexRow.tsx
+++ b/packages/graph-explorer/src/components/VertexRow.tsx
@@ -18,10 +18,10 @@ export function VertexRow({
         className="size-11 p-[8px]"
       />
       <div className="flex grow flex-col items-start">
-        <div className="text-base font-bold leading-snug">
+        <div className="text-balance break-all text-base font-bold leading-snug">
           {vertex.displayTypes} &rsaquo; {vertex.displayName}
         </div>
-        <div className="text-text-secondary/90 line-clamp-2 text-base leading-snug">
+        <div className="text-text-secondary/90 line-clamp-2 text-balance break-all text-base leading-snug">
           {vertex.displayDescription}
         </div>
       </div>

--- a/packages/graph-explorer/src/utils/replacePrefixes.test.ts
+++ b/packages/graph-explorer/src/utils/replacePrefixes.test.ts
@@ -1,0 +1,48 @@
+import replacePrefixes from "./replacePrefixes";
+
+test("should do nothing when no URI is provided", () => {
+  const result = replacePrefixes(undefined);
+  expect(result).toBe("");
+});
+
+test("should replace using common prefixes", () => {
+  const result = replacePrefixes("http://example.com/foo/bar");
+  expect(result).toBe("meat:foo/bar");
+});
+
+test("should replace using custom prefixes", () => {
+  const result = replacePrefixes("http://example.com/foo/bar", [
+    { prefix: "foo", uri: "http://example.com/foo/" },
+  ]);
+  expect(result).toBe("foo:bar");
+});
+
+test("should use generated prefixes", () => {
+  const result = replacePrefixes("http://foo.com/foo/bar", [
+    {
+      prefix: "foo",
+      uri: "http://foo.com/foo/",
+      __inferred: true,
+      __matches: new Set(["http://foo.com/foo/bar"]),
+    },
+  ]);
+  expect(result).toBe("foo:bar");
+});
+
+test("should prefer common prefixes over generated prefixes", () => {
+  const result = replacePrefixes("http://example.com/foo/bar", [
+    {
+      prefix: "foo",
+      uri: "http://example.com/foo/",
+      __inferred: true,
+      __matches: new Set(["http://example.com/foo/bar"]),
+    },
+  ]);
+  expect(result).toBe("meat:foo/bar");
+});
+
+test("should ignore case", () => {
+  expect(replacePrefixes("HTTP://example.com/foo/bar")).toBe("meat:foo/bar");
+  expect(replacePrefixes("http://Example.COM/foo/bar")).toBe("meat:foo/bar");
+  expect(replacePrefixes("http://example.com/Foo/Bar")).toBe("meat:Foo/Bar");
+});

--- a/packages/graph-explorer/src/utils/replacePrefixes.ts
+++ b/packages/graph-explorer/src/utils/replacePrefixes.ts
@@ -22,7 +22,7 @@ const replacePrefixes = (
   // 3. automatically generated
   const customPrefixes = prefixes.filter(p => !p.__inferred);
   const generatedPrefixes = prefixes.filter(
-    p => p.__inferred === true && p.__matches && p.__matches.size > 1
+    p => p.__inferred === true && p.__matches && p.__matches.size > 0
   );
   const allPrefixes = [
     ...customPrefixes,
@@ -30,15 +30,20 @@ const replacePrefixes = (
     ...generatedPrefixes,
   ];
 
+  // Find matching prefix ignoring case
   const prefixConfig = allPrefixes.find(prefixConfig =>
-    uri.match(new RegExp(`^${prefixConfig.uri}`))
+    uri.match(new RegExp(`^${prefixConfig.uri}`, "i"))
   );
 
   if (!prefixConfig) {
     return uri;
   }
 
-  return uri.replace(prefixConfig.uri, `${prefixConfig.prefix}:`);
+  // Replace the matching part of the URI with the prefix, ignoring case
+  return uri.replace(
+    new RegExp(`^${prefixConfig.uri}`, "i"),
+    `${prefixConfig.prefix}:`
+  );
 };
 
 export default replacePrefixes;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes two issues:

- Ensure long text is wrapped no matter what on search result items to ensure the add to graph button is visible
- Update `replacePrefix()` to ignore case for its matching
- Also include generated prefixes that only match a single type

## Validation

- Tested in RDF dataset

### With prefixes
![CleanShot 2025-03-05 at 16 14 40@2x](https://github.com/user-attachments/assets/7431a995-f756-434b-92d3-15439aec2f20)

### Without prefixes
![CleanShot 2025-03-05 at 16 14 58@2x](https://github.com/user-attachments/assets/1ff475c9-099b-4957-ae1d-92ffc5febcea)

## Related Issues

- Resolves #823 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
