### PR TITLE
feat: add /status endpoint to verify proxy health

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+- **Added** add /status endpoint to verify proxy health
+  ([#833](https://github.com/aws/graph-explorer/pull/833))
 - **Added** ability to restore the graph from the previous session
   ([#826](https://github.com/aws/graph-explorer/pull/826))
 - **Updated** styling of the connections screen

--- a/README.md
+++ b/README.md
@@ -378,6 +378,17 @@ For further information on how AWS credentials are resolved in Graph Explorer,
 refer to this
 [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html).
 
+
+## Health Check Status
+
+The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring its health and readiness. This endpoint is crucial for ensuring reliable service operation and can be utilized in various deployment scenarios.
+
+**Key Features:**
+
+* **Health Check:** The `/status` endpoint serves as a basic health check, confirming that the Express server is running and responding. This is essential for load balancers (like AWS ALB) to determine if the server is operational and should receive traffic.
+* **Readiness Probe:** It also functions as a readiness probe in container orchestration systems (like Kubernetes). This allows the orchestrator to know when the server is ready to accept requests, preventing traffic from being routed to instances that are still starting up or experiencing issues.
+* **Expected Response:** A successful health check or readiness probe will result in an HTTP `200 OK` response with the body containing `OK`.
+
 ## Logging
 
 Logs are, by default, sent to the console and will be visible as output to the

--- a/README.md
+++ b/README.md
@@ -378,16 +378,24 @@ For further information on how AWS credentials are resolved in Graph Explorer,
 refer to this
 [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html).
 
-
 ## Health Check Status
 
-The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring its health and readiness. This endpoint is crucial for ensuring reliable service operation and can be utilized in various deployment scenarios.
+The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring
+its health and readiness. This endpoint is crucial for ensuring reliable service
+operation and can be utilized in various deployment scenarios.
 
 **Key Features:**
 
-* **Health Check:** The `/status` endpoint serves as a basic health check, confirming that the Express server is running and responding. This is essential for load balancers (like AWS ALB) to determine if the server is operational and should receive traffic.
-* **Readiness Probe:** It also functions as a readiness probe in container orchestration systems (like Kubernetes). This allows the orchestrator to know when the server is ready to accept requests, preventing traffic from being routed to instances that are still starting up or experiencing issues.
-* **Expected Response:** A successful health check or readiness probe will result in an HTTP `200 OK` response with the body containing `OK`.
+- **Health Check:** The `/status` endpoint serves as a basic health check,
+  confirming that the Express server is running and responding. This is
+  essential for load balancers (like AWS ALB) to determine if the server is
+  operational and should receive traffic.
+- **Readiness Probe:** It also functions as a readiness probe in container
+  orchestration systems (like Kubernetes). This allows the orchestrator to know
+  when the server is ready to accept requests, preventing traffic from being
+  routed to instances that are still starting up or experiencing issues.
+- **Expected Response:** A successful health check or readiness probe will
+  result in an HTTP `200 OK` response with the body containing `OK`.
 
 ## Logging
 

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -488,6 +488,10 @@ app.get("/rdf/statistics/summary", (req, res, next) => {
   );
 });
 
+app.get("/status", (_req, res) => {
+  res.send("OK");
+});
+
 app.post("/logger", (req, res, next) => {
   const headers = req.headers as LoggerIncomingHttpHeaders;
   let message;

--- a/packages/graph-explorer/vite.config.ts
+++ b/packages/graph-explorer/vite.config.ts
@@ -38,6 +38,10 @@ export default defineConfig(({ mode }) => {
           target: expressServerUrl,
           changeOrigin: true,
         },
+        "/status": {
+          target: expressServerUrl,
+          changeOrigin: true,
+        },
       },
     },
     base: env.GRAPH_EXP_ENV_ROOT_FOLDER,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Add a new `/status` endpoint to get the health of proxy

## Validation

- Checked by building the image locally and hitting the `/status` endpoint

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #765

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
