### PR TITLE
Fix console warnings for missing aria-label

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,8 @@
   graph" button off the screen
   ([#824](https://github.com/aws/graph-explorer/pull/824))
 - **Updated** styling of input, textarea, and select fields
-  ([#832](https://github.com/aws/graph-explorer/pull/832))
+  ([#832](https://github.com/aws/graph-explorer/pull/832),
+  [#834](https://github.com/aws/graph-explorer/pull/834))
 - **Updated** dependencies
   ([#827](https://github.com/aws/graph-explorer/pull/827))
 

--- a/packages/graph-explorer/src/components/Input.tsx
+++ b/packages/graph-explorer/src/components/Input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/packages/graph-explorer/src/components/InputField/InputField.tsx
+++ b/packages/graph-explorer/src/components/InputField/InputField.tsx
@@ -88,9 +88,6 @@ export const InputField = (
     <FormItem>
       {label && <Label {...labelProps}>{label}</Label>}
       <Input
-        className={cn(
-          validationState === "invalid" && "ring-error-main ring-1"
-        )}
         disabled={isDisabled}
         min={isNumberInput(props) ? props.min : undefined}
         max={isNumberInput(props) ? props.max : undefined}

--- a/packages/graph-explorer/src/components/TextArea/TextArea.tsx
+++ b/packages/graph-explorer/src/components/TextArea/TextArea.tsx
@@ -31,8 +31,7 @@ export const TextArea = (
     <div className={cn("space-y-1", className)}>
       <textarea
         className={cn(
-          "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover flex w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
-          validationState === "invalid" && "ring-error-main ring-1",
+          "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref || localRef}

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -238,6 +238,7 @@ const CreateConnection = ({
         <FormItem>
           <Label>Name</Label>
           <InputField
+            aria-label="Name"
             value={form.name}
             onChange={onFormChange("name")}
             errorMessage="Name is required"
@@ -263,6 +264,7 @@ const CreateConnection = ({
             </InfoTooltip>
           </Label>
           <TextArea
+            aria-label="Public or Proxy Endpoint"
             data-autofocus={true}
             value={form.url}
             onChange={onFormChange("url")}
@@ -286,6 +288,7 @@ const CreateConnection = ({
           <FormItem>
             <Label>Graph Connection URL</Label>
             <TextArea
+              aria-label="Graph Connection URL"
               data-autofocus={true}
               value={form.graphDbUrl}
               onChange={onFormChange("graphDbUrl")}
@@ -314,6 +317,7 @@ const CreateConnection = ({
             <FormItem>
               <Label>AWS Region</Label>
               <InputField
+                aria-label="AWS Region"
                 data-autofocus={true}
                 value={form.awsRegion}
                 onChange={onFormChange("awsRegion")}
@@ -359,6 +363,7 @@ const CreateConnection = ({
           <FormItem>
             <Label>Fetch Timeout (ms)</Label>
             <InputField
+              aria-label="Fetch Timeout (ms)"
               type="number"
               value={form.fetchTimeoutMs}
               onChange={onFormChange("fetchTimeoutMs")}
@@ -388,6 +393,7 @@ const CreateConnection = ({
           <FormItem>
             <Label>Node Expansion Limit</Label>
             <InputField
+              aria-label="Node Expansion Limit"
               type="number"
               value={form.nodeExpansionLimit}
               onChange={onFormChange("nodeExpansionLimit")}

--- a/packages/graph-explorer/tailwind.config.ts
+++ b/packages/graph-explorer/tailwind.config.ts
@@ -115,6 +115,9 @@ export default {
       extraBold: "700",
     },
     extend: {
+      aria: {
+        invalid: 'invalid="true"',
+      },
       transitionProperty: {
         width: "width",
       },


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes issue that I introduced in #832 where the Aria hooks don't like when you don't provide a proper label for input fields.

This is the simple fix for the issue: provide an `aria-label` for each input. I have a much larger change that converts the create connection modal to use React Hook Form instead. But that code needs a bit more testing before I push it up.

### Other Changes

- Added `aria-invalid` to Tailwind config so I can style with it
- Use `aria-invalid` in `Input` and `TextArea` to style with red border

### Example of the issue

![CleanShot 2025-03-14 at 09 53 31@2x](https://github.com/user-attachments/assets/ec01e453-4b00-4341-ab13-6784ed4ef9be)

#### Warning in console

> If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility Error Component Stack


## Validation

- Verified all inputs and text areas have labels and no more warnings in the console

## Related Issues

- PR #832

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
