### PR TITLE
Don’t require full vertex for expand

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -81,7 +81,7 @@ describe("Gremlin > fetchNeighbors", () => {
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
       vertexId: createVertexId("2018"),
-      vertexType: "airport",
+      vertexTypes: ["airport"],
     });
 
     expect(response).toMatchObject({
@@ -207,7 +207,7 @@ describe("Gremlin > fetchNeighbors", () => {
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
       vertexId: createVertexId("2018"),
-      vertexType: "airport",
+      vertexTypes: ["airport"],
       filterByVertexTypes: ["airport"],
       filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],
     });

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -134,7 +134,7 @@ export default function oneHopTemplate({
   filterCriteria = [],
   limit = 0,
   offset = 0,
-}: Omit<NeighborsRequest, "vertexType">): string {
+}: Omit<NeighborsRequest, "vertexTypes">): string {
   const idTemplate = idParam(vertexId);
   const range = limit > 0 ? `.range(${offset}, ${offset + limit})` : "";
 

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
@@ -110,7 +110,7 @@ const oneHopTemplate = ({
   filterCriteria = [],
   limit = 0,
   offset = 0,
-}: Omit<NeighborsRequest, "vertexType">): string => {
+}: Omit<NeighborsRequest, "vertexTypes">): string => {
   // List of possible vertex types
   const formattedVertexTypes =
     filterByVertexTypes.length > 1

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -6,6 +6,7 @@ const mapRawResultToVertex = (rawResult: RawResult): Vertex => {
     entityType: "vertex",
     id: createVertexId(rawResult.uri),
     type: rawResult.class,
+    types: [rawResult.class],
     attributes: rawResult.attributes,
     __isBlank: rawResult.isBlank,
   };

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -113,7 +113,7 @@ export function createSparqlExplorer(
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors...");
       const request: SPARQLNeighborsRequest = {
         resourceURI: req.vertexId,
-        resourceClass: req.vertexType,
+        resourceClass: req.vertexTypes.join("::"),
         subjectClasses: req.filterByVertexTypes,
         filterCriteria: req.filterCriteria?.map((c: Criterion) => ({
           predicate: c.name,

--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
@@ -104,10 +104,11 @@ function mapToVertex(
     throw new Error("Vertex type not found in bindings");
   }
 
-  const result = <Vertex>{
+  const result: Vertex = {
     entityType: "vertex",
     id,
     type: typeUri,
+    types: [typeUri],
     attributes,
   };
 

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -83,7 +83,11 @@ export type NeighborsRequest = {
   /**
    * Source vertex type.
    *
-   * Used only by the SPARQL implementation to patch the edges returned with the source vertex type.
+   * Used only by the SPARQL implementation to patch the edges returned with the
+   * source vertex type.
+   *
+   * NOTE: This should be removed once the SPARQL queries are updated to
+   * retrieve the resource class from the database.
    */
   vertexType: string;
   /**

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -81,7 +81,7 @@ export type NeighborsRequest = {
    */
   vertexId: VertexId;
   /**
-   * Source vertex type.
+   * Source vertex types.
    *
    * Used only by the SPARQL implementation to patch the edges returned with the
    * source vertex type.
@@ -89,7 +89,7 @@ export type NeighborsRequest = {
    * NOTE: This should be removed once the SPARQL queries are updated to
    * retrieve the resource class from the database.
    */
-  vertexType: string;
+  vertexTypes: Vertex["types"];
   /**
    * Filter by vertex types.
    */

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -82,6 +82,8 @@ export type NeighborsRequest = {
   vertexId: VertexId;
   /**
    * Source vertex type.
+   *
+   * Used only by the SPARQL implementation to patch the edges returned with the source vertex type.
    */
   vertexType: string;
   /**

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
@@ -214,6 +214,7 @@ describe("useDisplayVertexFromVertex", () => {
     const vertex = createRandomVertex();
     vertex.id = createVertexId("http://www.example.com/resources#foo");
     vertex.type = "http://www.example.com/class#bar";
+    vertex.types = ["http://www.example.com/class#bar"];
     const schema = createRandomSchema();
     schema.prefixes = [
       {

--- a/packages/graph-explorer/src/core/entities.ts
+++ b/packages/graph-explorer/src/core/entities.ts
@@ -27,7 +27,7 @@ export type Vertex = {
    * "John Doe" can be a "person" and a "worker"
    * types = ["person", "worker"]
    */
-  types?: string[];
+  types: string[];
   /**
    * List of attributes associated to the vertex.
    * - For PG, nodes can contain attributes.

--- a/packages/graph-explorer/src/core/renderedEntities.ts
+++ b/packages/graph-explorer/src/core/renderedEntities.ts
@@ -47,20 +47,6 @@ export function useRenderedEntities() {
 }
 
 /**
- * Maps a rendered vertex back to a regular vertex.
- * @param renderedVertex The rendered vertex
- * @returns A vertex instance
- */
-export function createVertexFromRenderedVertex(
-  renderedVertex: RenderedVertex
-): Vertex {
-  return {
-    ...renderedVertex.data,
-    id: getVertexIdFromRenderedVertexId(renderedVertex.data.id),
-  };
-}
-
-/**
  * Maps a rendered edge back to a regular edge.
  * @param renderedEdge The rendered edge
  * @returns An edge instance

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -9,7 +9,7 @@ import {
 import { loggerSelector, useExplorer } from "@/core/connector";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Vertex } from "@/core";
+import { VertexId } from "@/core";
 import { createDisplayError } from "@/utils/createDisplayError";
 import { useNeighborsCallback } from "@/core";
 import { useAddToGraph } from "./useAddToGraph";
@@ -20,7 +20,8 @@ export type ExpandNodeFilters = Omit<
 >;
 
 export type ExpandNodeRequest = {
-  vertex: Vertex;
+  vertexId: VertexId;
+  vertexType: string;
   filters?: ExpandNodeFilters;
 };
 
@@ -56,10 +57,8 @@ export default function useExpandNode() {
 
       // Perform the query when a request exists
       const request: NeighborsRequest | null = expandNodeRequest && {
-        vertexId: expandNodeRequest.vertex.id,
-        vertexType:
-          expandNodeRequest.vertex.types?.join("::") ??
-          expandNodeRequest.vertex.type,
+        vertexId: expandNodeRequest.vertexId,
+        vertexType: expandNodeRequest.vertexType,
         ...expandNodeRequest.filters,
         limit,
       };
@@ -111,8 +110,12 @@ export default function useExpandNode() {
   // Build the expand node callback
   const neighborCallback = useNeighborsCallback();
   const expandNode = useCallback(
-    async (vertex: Vertex, filters?: ExpandNodeFilters) => {
-      const neighbor = await neighborCallback(vertex.id);
+    async (
+      vertexId: VertexId,
+      vertexType: string,
+      filters?: ExpandNodeFilters
+    ) => {
+      const neighbor = await neighborCallback(vertexId);
       if (!neighbor) {
         enqueueNotification({
           title: "No neighbor information available",
@@ -121,7 +124,8 @@ export default function useExpandNode() {
         return;
       }
       const request: ExpandNodeRequest = {
-        vertex,
+        vertexId,
+        vertexType,
         filters,
       };
 

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -9,19 +9,19 @@ import {
 import { loggerSelector, useExplorer } from "@/core/connector";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { VertexId } from "@/core";
+import { Vertex, VertexId } from "@/core";
 import { createDisplayError } from "@/utils/createDisplayError";
 import { useNeighborsCallback } from "@/core";
 import { useAddToGraph } from "./useAddToGraph";
 
 export type ExpandNodeFilters = Omit<
   NeighborsRequest,
-  "vertexId" | "vertexType"
+  "vertexId" | "vertexTypes"
 >;
 
 export type ExpandNodeRequest = {
-  vertexId: VertexId;
-  vertexType: string;
+  vertexId: NeighborsRequest["vertexId"];
+  vertexTypes: NeighborsRequest["vertexTypes"];
   filters?: ExpandNodeFilters;
 };
 
@@ -58,7 +58,7 @@ export default function useExpandNode() {
       // Perform the query when a request exists
       const request: NeighborsRequest | null = expandNodeRequest && {
         vertexId: expandNodeRequest.vertexId,
-        vertexType: expandNodeRequest.vertexType,
+        vertexTypes: expandNodeRequest.vertexTypes,
         ...expandNodeRequest.filters,
         limit,
       };
@@ -112,7 +112,7 @@ export default function useExpandNode() {
   const expandNode = useCallback(
     async (
       vertexId: VertexId,
-      vertexType: string,
+      vertexTypes: Vertex["types"],
       filters?: ExpandNodeFilters
     ) => {
       const neighbor = await neighborCallback(vertexId);
@@ -125,7 +125,7 @@ export default function useExpandNode() {
       }
       const request: ExpandNodeRequest = {
         vertexId,
-        vertexType,
+        vertexTypes,
         filters,
       };
 

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -160,11 +160,8 @@ export default function GraphViewer({
         const vertexId = getVertexIdFromRenderedVertexId(vertex.id);
         const neighborCount = await neighborCallback(vertexId);
         const offset = neighborCount ? neighborCount.fetched : undefined;
-        const vertexType = vertex.types?.length
-          ? vertex.types.join("::")
-          : vertex.type;
 
-        expandNode(vertexId, vertexType, {
+        expandNode(vertexId, vertex.types, {
           limit: 10,
           offset,
         });

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -1,7 +1,6 @@
 import { MouseEvent, useCallback, useRef, useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
-  createVertexFromRenderedVertex,
   getVertexIdFromRenderedVertexId,
   type RenderedEdgeId,
   type RenderedVertex,
@@ -161,8 +160,11 @@ export default function GraphViewer({
         const vertexId = getVertexIdFromRenderedVertexId(vertex.id);
         const neighborCount = await neighborCallback(vertexId);
         const offset = neighborCount ? neighborCount.fetched : undefined;
+        const vertexType = vertex.types?.length
+          ? vertex.types.join("::")
+          : vertex.type;
 
-        expandNode(createVertexFromRenderedVertex({ data: vertex }), {
+        expandNode(vertexId, vertexType, {
           limit: 10,
           offset,
         });

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -154,6 +154,9 @@ function ExpandButton({
 }) {
   const vertex = useNode(vertexId);
   const { expandNode, isPending } = useExpandNode();
+  const vertexType = vertex.types?.length
+    ? vertex.types.join("::")
+    : vertex.type;
 
   return (
     <Button
@@ -166,7 +169,7 @@ function ExpandButton({
       }
       variant="filled"
       isDisabled={isPending || isDisabled}
-      onPress={() => expandNode(vertex, filters)}
+      onPress={() => expandNode(vertexId, vertexType, filters)}
     >
       Expand
     </Button>

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -154,9 +154,6 @@ function ExpandButton({
 }) {
   const vertex = useNode(vertexId);
   const { expandNode, isPending } = useExpandNode();
-  const vertexType = vertex.types?.length
-    ? vertex.types.join("::")
-    : vertex.type;
 
   return (
     <Button
@@ -169,7 +166,7 @@ function ExpandButton({
       }
       variant="filled"
       isDisabled={isPending || isDisabled}
-      onPress={() => expandNode(vertexId, vertexType, filters)}
+      onPress={() => expandNode(vertexId, vertex.types, filters)}
     >
       Expand
     </Button>

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -196,10 +196,12 @@ export function createRandomEdgeId(): EdgeId {
  * @returns A random Vertex object.
  */
 export function createRandomVertex(): Vertex {
+  const label = createRandomName("VertexType");
   return {
     entityType: "vertex",
     id: createRandomVertexId(),
-    type: createRandomName("VertexType"),
+    type: label,
+    types: [label],
     attributes: createRecord(3, createRandomEntityAttribute),
   };
 }
@@ -210,6 +212,7 @@ export function createRandomVertexForRdf(): Vertex {
     entityType: "vertex",
     id: createVertexId(createRandomUrlString()),
     type: label,
+    types: [label],
     attributes: createRecord(3, createRandomEntityAttributeForRdf),
   };
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Simplifies the expand node api just a bit by removing the need to send a full `Vertex` object.

Expanding a node only requires the vertex ID. Except for SPARQL. It requires the `vertexType` as well, which is used to path `Edge` instances during mapping with the source vertex type.

In the future I will remove the need to send the `vertexType` entirely when I redo all SPARQL queries. For now it remains

## Validation

- Tested on all three query engines

## Related Issues

- Tangentially related to #808

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
