### PR TITLE
Delete previous session on connection changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,8 @@
 - **Added** add /status endpoint to verify proxy health
   ([#833](https://github.com/aws/graph-explorer/pull/833))
 - **Added** ability to restore the graph from the previous session
-  ([#826](https://github.com/aws/graph-explorer/pull/826))
+  ([#826](https://github.com/aws/graph-explorer/pull/826),
+  [#840](https://github.com/aws/graph-explorer/pull/840))
 - **Added** query editor for Gremlin connections
   ([#842](https://github.com/aws/graph-explorer/pull/842),
   [#839](https://github.com/aws/graph-explorer/pull/839),

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -16,6 +16,7 @@ import {
   NeptuneServiceType,
 } from "@shared/types";
 import {
+  allGraphSessionsAtom,
   ConfigurationContextProps,
   createNewConfigurationId,
   RawConfiguration,
@@ -133,6 +134,7 @@ const CreateConnection = ({
         const typeChange = initialData?.queryEngine !== data.queryEngine;
 
         if (urlChange || typeChange) {
+          // Force a sync of the schema
           set(schemaAtom, prevSchemaMap => {
             const updatedSchema = new Map(prevSchemaMap);
             const currentSchema = updatedSchema.get(configId);
@@ -147,6 +149,13 @@ const CreateConnection = ({
             });
 
             return updatedSchema;
+          });
+
+          // Delete previous session data
+          set(allGraphSessionsAtom, prev => {
+            const updatedGraphs = new Map(prev);
+            updatedGraphs.delete(configId);
+            return updatedGraphs;
           });
         }
       },

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -131,9 +131,10 @@ const CreateConnection = ({
         });
 
         const urlChange = initialData?.url !== data.url;
+        const dbUrlChange = initialData?.graphDbUrl !== data.graphDbUrl;
         const typeChange = initialData?.queryEngine !== data.queryEngine;
 
-        if (urlChange || typeChange) {
+        if (urlChange || dbUrlChange || typeChange) {
           // Force a sync of the schema
           set(schemaAtom, prevSchemaMap => {
             const updatedSchema = new Map(prevSchemaMap);
@@ -159,7 +160,12 @@ const CreateConnection = ({
           });
         }
       },
-    [configId, initialData?.url, initialData?.queryEngine]
+    [
+      configId,
+      initialData?.url,
+      initialData?.graphDbUrl,
+      initialData?.queryEngine,
+    ]
   );
 
   const [form, setForm] = useState<ConnectionForm>({


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes an issue where the previous session is presented as available after changing the connection URL or query engine. If you attempt to restore this session it will fail.

The change was to ensure the previous session data is deleted when a connection is changed, specifically the proxy URL, database URL, or query engine.

## Validation

- Ensured editing a connection by changing url/db url/query engine would cause session data to be deleted
- Ensured changing other fields do not affect session data

## Related Issues

- Resolves #836 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
