### PR TITLE
Exclude existing neighbors in double click expansion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,8 @@
   ([#830](https://github.com/aws/graph-explorer/pull/830))
 - **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF
   databases ([#870](https://github.com/aws/graph-explorer/pull/870))
+- **Fixed** issue where double click expansion was inconsistent
+  ([#841](https://github.com/aws/graph-explorer/pull/841))
 - **Fixed** issue with table exports
   ([#860](https://github.com/aws/graph-explorer/pull/860))
 - **Fixed** issue with long node titles or descriptions pushing the "add to

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -3,6 +3,41 @@ import oneHopTemplate from "./oneHopTemplate";
 import { createVertexId } from "@/core";
 
 describe("Gremlin > oneHopTemplate", () => {
+  it("should produce documentation example", () => {
+    // This represents the filter criteria used in the example documentation
+    const template = oneHopTemplate({
+      vertexId: createVertexId("124"),
+      filterByVertexTypes: ["airport"],
+      filterCriteria: [
+        { name: "longest", dataType: "Number", operator: "gt", value: 10000 },
+        { name: "country", dataType: "String", operator: "like", value: "ES" },
+      ],
+      excludedVertices: new Set([createVertexId("256")]),
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(`
+        g.V("124")
+          .both()
+          .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
+          .filter(__.not(__.hasId("256")))
+          .dedup()
+          .order().by(id())
+          .range(0, 10)
+          .as("v")
+          .project("vertex", "edges")
+            .by()
+            .by(
+              __.select("v").bothE()
+                .where(otherV().id().is("124"))
+                .dedup().fold()
+            )
+      `)
+    );
+  });
+
   it("Should return a template for a simple vertex id", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
@@ -12,6 +47,29 @@ describe("Gremlin > oneHopTemplate", () => {
       normalize(`
         g.V("12")
           .both().dedup().order().by(id()).as("v")
+          .project("vertex", "edges")
+            .by()
+            .by(
+              __.select("v").bothE()
+                .where(otherV().id().is("12"))
+                .dedup().fold()
+            )
+      `)
+    );
+  });
+
+  it("should filter out excluded vertices", () => {
+    const template = oneHopTemplate({
+      vertexId: createVertexId("12"),
+      excludedVertices: new Set([createVertexId("256")]),
+    });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.V("12")
+          .both()
+          .filter(__.not(__.hasId("256")))
+          .dedup().order().by(id()).as("v")
           .project("vertex", "edges")
             .by()
             .by(

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -61,14 +61,14 @@ describe("Gremlin > oneHopTemplate", () => {
   it("should filter out excluded vertices", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      excludedVertices: new Set([createVertexId("256")]),
+      excludedVertices: new Set([createVertexId("256"), createVertexId("512")]),
     });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
           .both()
-          .filter(__.not(__.hasId("256")))
+          .filter(__.not(__.hasId("256", "512")))
           .dedup().order().by(id()).as("v")
           .project("vertex", "edges")
             .by()

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -23,6 +23,27 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
+  it("Should filter out excluded vertices", () => {
+    const template = oneHopTemplate({
+      vertexId: createVertexId("12"),
+      excludedVertices: new Set([createVertexId("256")]),
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(`
+        MATCH (v)-[e]-(tgt)
+        WHERE ID(v) = "12" AND NOT ID(tgt) IN ["256"]
+        WITH DISTINCT v, tgt 
+        ORDER BY toInteger(ID(tgt)) 
+        MATCH (v)-[e]-(tgt)
+        WITH
+          collect(DISTINCT tgt) AS vObjects,
+          collect({ edge: e, sourceTypes: labels(startNode(e)), targetTypes: labels(endNode(e)) }) AS eObjects
+        RETURN vObjects, eObjects
+      `)
+    );
+  });
+
   it("Should return a template with an offset and limit", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -26,13 +26,13 @@ describe("OpenCypher > oneHopTemplate", () => {
   it("Should filter out excluded vertices", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      excludedVertices: new Set([createVertexId("256")]),
+      excludedVertices: new Set([createVertexId("256"), createVertexId("512")]),
     });
 
     expect(normalize(template)).toEqual(
       normalize(`
         MATCH (v)-[e]-(tgt)
-        WHERE ID(v) = "12" AND NOT ID(tgt) IN ["256"]
+        WHERE ID(v) = "12" AND NOT ID(tgt) IN ["256", "512"]
         WITH DISTINCT v, tgt 
         ORDER BY toInteger(ID(tgt)) 
         MATCH (v)-[e]-(tgt)

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
@@ -108,9 +108,15 @@ const oneHopTemplate = ({
   filterByVertexTypes = [],
   edgeTypes = [],
   filterCriteria = [],
+  excludedVertices = new Set(),
   limit = 0,
   offset = 0,
 }: Omit<NeighborsRequest, "vertexTypes">): string => {
+  const formattedExcludedVertices =
+    excludedVertices.size > 0
+      ? `NOT ID(tgt) IN [${excludedVertices.values().map(idParam).toArray().join(", ")}]`
+      : "";
+
   // List of possible vertex labels when there are multiple (single label is handled elsewhere)
   const formattedVertexTypes =
     filterByVertexTypes.length > 1
@@ -131,6 +137,7 @@ const oneHopTemplate = ({
   // Combine all the WHERE conditions
   const whereConditions = [
     `ID(v) = ${idParam(vertexId)}`,
+    formattedExcludedVertices,
     formattedVertexTypes,
     ...(filterCriteria?.map(criterionTemplate) ?? []),
   ]

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -216,6 +216,7 @@ describe("oneHopNeighborsTemplate", () => {
       resourceClasses: [],
       excludedVertices: new Set([
         createVertexId("http://www.example.com/soccer/resource#EFL"),
+        createVertexId("http://www.example.com/soccer/resource#EFL2"),
       ]),
     });
 
@@ -236,7 +237,7 @@ describe("oneHopNeighborsTemplate", () => {
               }
               FILTER NOT EXISTS {
                 VALUES ?neighbor {
-                  <http://www.example.com/soccer/resource#EFL>
+                  <http://www.example.com/soccer/resource#EFL> <http://www.example.com/soccer/resource#EFL2>
                 }
               }
               FILTER NOT EXISTS {

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -209,6 +209,48 @@ describe("oneHopNeighborsTemplate", () => {
       `)
     );
   });
+
+  it("should produce query excluding resources", () => {
+    const template = oneHopNeighborsTemplate({
+      resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
+      resourceClasses: [],
+      excludedVertices: new Set([
+        createVertexId("http://www.example.com/soccer/resource#EFL"),
+      ]),
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?p ?value
+        WHERE {
+          {
+            SELECT DISTINCT ?neighbor
+            WHERE {
+              BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+              {
+                ?neighbor ?pIncoming ?source .
+              }
+              UNION
+              {
+                ?source ?pOutgoing ?neighbor .
+              }
+              FILTER NOT EXISTS {
+                VALUES ?neighbor {
+                  <http://www.example.com/soccer/resource#EFL>
+                }
+              }
+              FILTER NOT EXISTS {
+                ?anySubject a ?neighbor .
+              }
+            }
+            ORDER BY ?neighbor
+          }
+          ${commonPartOfQuery("http://www.example.com/soccer/resource#EPL")}
+        }
+        ORDER BY ?subject
+      `)
+    );
+  });
 });
 
 /**

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -83,6 +83,7 @@ export function oneHopNeighborsTemplate({
   resourceURI,
   subjectClasses = [],
   filterCriteria = [],
+  excludedVertices = new Set(),
   limit = 0,
   offset = 0,
 }: SPARQLNeighborsRequest): string {
@@ -118,6 +119,15 @@ export function oneHopNeighborsTemplate({
   const limitTemplate = getLimit(limit, offset);
   const rdfTypeUriTemplate = idParam(rdfTypeUri);
 
+  // Excluded vertices
+  const excludedVerticesTemplate = excludedVertices.size
+    ? query`FILTER NOT EXISTS {
+        VALUES ?neighbor {
+          ${excludedVertices.values().map(idParam).toArray().join(" ")}
+        }
+      }`
+    : "";
+
   return query`
     SELECT DISTINCT ?subject ?p ?value
     WHERE {
@@ -139,6 +149,7 @@ export function oneHopNeighborsTemplate({
           ${classBindingTemplate}
           ${valueBindingTemplate}
           ${filterTemplate}
+          ${excludedVerticesTemplate}
           # Remove any classes from the list of neighbors
           FILTER NOT EXISTS {
             ?anySubject a ?neighbor .

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -120,6 +120,7 @@ export function createSparqlExplorer(
           predicate: c.name,
           object: c.value,
         })),
+        excludedVertices: req.excludedVertices,
         limit: req.limit,
         offset: req.offset,
       };

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -48,6 +48,10 @@ export type SPARQLNeighborsRequest = {
    */
   filterCriteria?: Array<SPARQLCriterion>;
   /**
+   * Exclude vertices from the results.
+   */
+  excludedVertices?: Set<VertexId>;
+  /**
    * Limit the number of results.
    * 0 = No limit.
    */

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -114,6 +114,14 @@ export type NeighborsRequest = {
    * retrieve the resource class from the database.
    */
   vertexTypes: Vertex["types"];
+
+  /**
+   * Vertices to exclude from the results.
+   *
+   * Useful to exclude vertices already in the graph.
+   */
+  excludedVertices?: Set<VertexId>;
+
   /**
    * Filter by vertex types.
    */

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -234,6 +234,10 @@ const fetchedNeighborsSelector = selectorFamily({
     },
 });
 
+/**
+ * Provides a callback for getting the unique set of neighbors for a given vertex ID.
+ * @returns A callback that returns the unique set of neighbors for a given vertex ID.
+ */
 export function useFetchedNeighborsCallback() {
   const nodes = useRecoilValue(nodesAtom);
   const edges = useRecoilValue(edgesAtom);
@@ -243,8 +247,11 @@ export function useFetchedNeighborsCallback() {
       new Set(
         edges
           .values()
+          // Find edges matching the given vertex ID
           .filter(edge => edge.source === id || edge.target === id)
+          // Filter out edges where the source or target vertex is not in the graph
           .filter(edge => nodes.has(edge.source) && nodes.has(edge.target))
+          // Get the source or target vertex ID depending on the edge direction
           .map(edge => (edge.source === id ? edge.target : edge.source))
       ),
     [nodes, edges]

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -6,7 +6,7 @@ import {
   useAllNeighborCountsQuery,
   useUpdateNodeCountsQuery,
 } from "@/hooks/useUpdateNodeCounts";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { neighborsCountQuery } from "@/connector";
 import { explorerSelector } from "../connector";
@@ -233,6 +233,23 @@ const fetchedNeighborsSelector = selectorFamily({
       return neighbors;
     },
 });
+
+export function useFetchedNeighborsCallback() {
+  const nodes = useRecoilValue(nodesAtom);
+  const edges = useRecoilValue(edgesAtom);
+
+  return useCallback(
+    (id: VertexId) =>
+      new Set(
+        edges
+          .values()
+          .filter(edge => edge.source === id || edge.target === id)
+          .filter(edge => nodes.has(edge.source) && nodes.has(edge.target))
+          .map(edge => (edge.source === id ? edge.target : edge.source))
+      ),
+    [nodes, edges]
+  );
+}
 
 const allFetchedNeighborsSelector = selectorFamily({
   key: "all-fetched-neighbors",

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -19,11 +19,11 @@ export type ExpandNodeFilters = Omit<
   "vertexId" | "vertexTypes" | "excludedVertices"
 >;
 
-export interface ExpandNodeRequest {
+export type ExpandNodeRequest = {
   vertexId: NeighborsRequest["vertexId"];
   vertexTypes: NeighborsRequest["vertexTypes"];
   filters?: ExpandNodeFilters;
-}
+};
 
 /**
  * Provides a callback to submit a node expansion request, the query

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -9,21 +9,21 @@ import {
 import { loggerSelector, useExplorer } from "@/core/connector";
 import { useRecoilValue } from "recoil";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Vertex, VertexId } from "@/core";
+import { useFetchedNeighborsCallback, Vertex, VertexId } from "@/core";
 import { createDisplayError } from "@/utils/createDisplayError";
 import { useNeighborsCallback } from "@/core";
 import { useAddToGraph } from "./useAddToGraph";
 
 export type ExpandNodeFilters = Omit<
   NeighborsRequest,
-  "vertexId" | "vertexTypes"
+  "vertexId" | "vertexTypes" | "excludedVertices"
 >;
 
-export type ExpandNodeRequest = {
+export interface ExpandNodeRequest {
   vertexId: NeighborsRequest["vertexId"];
   vertexTypes: NeighborsRequest["vertexTypes"];
   filters?: ExpandNodeFilters;
-};
+}
 
 /**
  * Provides a callback to submit a node expansion request, the query
@@ -33,6 +33,7 @@ export default function useExpandNode() {
   const queryClient = useQueryClient();
   const explorer = useExplorer();
   const addToGraph = useAddToGraph();
+  const getFetchedNeighbors = useFetchedNeighborsCallback();
   const { enqueueNotification, clearNotification } = useNotification();
   const remoteLogger = useRecoilValue(loggerSelector);
 
@@ -40,6 +41,9 @@ export default function useExpandNode() {
     mutationFn: async (
       expandNodeRequest: ExpandNodeRequest
     ): Promise<NeighborsResponse | null> => {
+      // Get neighbors that have already been added so they can be excluded
+      const excludedNeighbors = getFetchedNeighbors(expandNodeRequest.vertexId);
+
       // Calculate the expansion limit based on the connection limit and the request limit
       const limit = (() => {
         if (!explorer.connection.nodeExpansionLimit) {
@@ -59,6 +63,7 @@ export default function useExpandNode() {
       const request: NeighborsRequest | null = expandNodeRequest && {
         vertexId: expandNodeRequest.vertexId,
         vertexTypes: expandNodeRequest.vertexTypes,
+        excludedVertices: excludedNeighbors,
         ...expandNodeRequest.filters,
         limit,
       };

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -6,7 +6,6 @@ import {
   type RenderedVertex,
   type RenderedVertexId,
   useDisplayVertexTypeConfigs,
-  useNeighborsCallback,
   useRenderedEdges,
   useRenderedVertices,
 } from "@/core";
@@ -153,20 +152,16 @@ export default function GraphViewer({
   const getNodeBadges = useNodeBadges();
 
   const { expandNode } = useExpandNode();
-  const neighborCallback = useNeighborsCallback();
   const onNodeDoubleClick: ElementEventCallback<RenderedVertex["data"]> =
     useCallback(
-      async (_, vertex) => {
+      (_, vertex) => {
         const vertexId = getVertexIdFromRenderedVertexId(vertex.id);
-        const neighborCount = await neighborCallback(vertexId);
-        const offset = neighborCount ? neighborCount.fetched : undefined;
 
         expandNode(vertexId, vertex.types, {
           limit: 10,
-          offset,
         });
       },
-      [expandNode, neighborCallback]
+      [expandNode]
     );
 
   const [layout, setLayout] = useState("F_COSE");


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes an issue with double click to expand explained in issue #462.

Expansion can now have a list of excluded nodes that are added to the query to skip.

## Validation

- Verified in air routes with all three query languages
- Verified in premiere league RDF data set with blank nodes

## Related Issues

- Resolves #462

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
