### PR TITLE
Add basic query logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,8 @@
 - **Added** ability to restore the graph from the previous session
   ([#826](https://github.com/aws/graph-explorer/pull/826))
 - **Added** query editor for Gremlin connections
-  ([#842](https://github.com/aws/graph-explorer/pull/842),
+  ([#843](https://github.com/aws/graph-explorer/pull/843),
+  [#842](https://github.com/aws/graph-explorer/pull/842),
   [#839](https://github.com/aws/graph-explorer/pull/839),
   [#837](https://github.com/aws/graph-explorer/pull/837),
   [#838](https://github.com/aws/graph-explorer/pull/838))

--- a/packages/graph-explorer/src/components/EdgeRow.tsx
+++ b/packages/graph-explorer/src/components/EdgeRow.tsx
@@ -1,18 +1,24 @@
-import { DisplayEdge, useDisplayVertex } from "@/core";
+import { DisplayEdge, DisplayVertex } from "@/core";
 import { ComponentPropsWithoutRef } from "react";
 import { EdgeSymbol } from "./EdgeSymbol";
 import { cn } from "@/utils";
 
+/**
+ * Visually represents an edge from the graph database.
+ *
+ * Used in the header of edge details and in search results lists.
+ */
 export function EdgeRow({
   edge,
+  source,
+  target,
   className,
   ...props
 }: {
   edge: DisplayEdge;
+  source: DisplayVertex;
+  target: DisplayVertex;
 } & ComponentPropsWithoutRef<"div">) {
-  const source = useDisplayVertex(edge.source.id);
-  const target = useDisplayVertex(edge.target.id);
-
   const title =
     edge.displayTypes === edge.displayName
       ? edge.displayTypes
@@ -24,11 +30,9 @@ export function EdgeRow({
       {...props}
     >
       <EdgeSymbol className="size-11 p-[8px]" />
-      <div className="flex grow flex-col items-start">
-        <div className="break-word text-balance text-base font-bold leading-snug">
-          {title}
-        </div>
-        <div className="text-text-secondary/90 break-word line-clamp-2 inline-flex items-center gap-1 text-balance text-base leading-snug">
+      <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
+        <div className="font-bold">{title}</div>
+        <div className="text-text-secondary/90 line-clamp-2">
           {source.displayName}&nbsp;&rarr; {target.displayName}
         </div>
       </div>

--- a/packages/graph-explorer/src/components/EdgeSymbol.tsx
+++ b/packages/graph-explorer/src/components/EdgeSymbol.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/utils";
 import { EdgeIcon } from "./icons";
 import { ComponentPropsWithoutRef } from "react";
 
+/** Icon representing an edge in the graph. */
 export function EdgeSymbol({
   className,
   ...props

--- a/packages/graph-explorer/src/components/VertexRow.tsx
+++ b/packages/graph-explorer/src/components/VertexRow.tsx
@@ -17,11 +17,7 @@ export function VertexRow({
         vertexStyle={vertex.typeConfig.style}
         className="size-11 p-[8px]"
       />
-      <div
-        className={cn(
-          "inline-block text-pretty text-base leading-snug [word-break:break-word]"
-        )}
-      >
+      <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
         <div className="font-bold">
           {vertex.displayTypes}&nbsp;&rsaquo; {vertex.displayName}
         </div>

--- a/packages/graph-explorer/src/connector/emptyExplorer.ts
+++ b/packages/graph-explorer/src/connector/emptyExplorer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
-import { Explorer } from "./useGEFetchTypes";
+import { Explorer, toMappedQueryResults } from "./useGEFetchTypes";
 
 /**
  * Empty explorer for when there is no connection.
@@ -24,26 +24,14 @@ export const emptyExplorer: Explorer = {
       total: 0,
     };
   },
-  fetchNeighbors: async () => {
-    return {
-      vertices: [],
-      edges: [],
-      scalars: [],
-    };
-  },
+  fetchNeighbors: async () => toMappedQueryResults({}),
   fetchNeighborsCount: async () => {
     return {
       totalCount: 0,
       counts: {},
     };
   },
-  keywordSearch: async () => {
-    return {
-      vertices: [],
-      edges: [],
-      scalars: [],
-    };
-  },
+  keywordSearch: async () => toMappedQueryResults({}),
   vertexDetails: async () => {
     return {
       vertex: null,
@@ -54,11 +42,5 @@ export const emptyExplorer: Explorer = {
       edge: null,
     };
   },
-  rawQuery: async () => {
-    return {
-      vertices: [],
-      edges: [],
-      scalars: [],
-    };
-  },
+  rawQuery: async () => toMappedQueryResults({}),
 };

--- a/packages/graph-explorer/src/connector/emptyExplorer.ts
+++ b/packages/graph-explorer/src/connector/emptyExplorer.ts
@@ -54,4 +54,11 @@ export const emptyExplorer: Explorer = {
       edge: null,
     };
   },
+  rawQuery: async () => {
+    return {
+      vertices: [],
+      edges: [],
+      scalars: [],
+    };
+  },
 };

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.ts
@@ -1,6 +1,7 @@
-import type {
-  NeighborsRequest,
-  NeighborsResponse,
+import {
+  toMappedQueryResults,
+  type NeighborsRequest,
+  type NeighborsResponse,
 } from "@/connector/useGEFetchTypes";
 import mapApiEdge from "../mappers/mapApiEdge";
 import mapApiVertex from "../mappers/mapApiVertex";
@@ -39,11 +40,10 @@ const fetchNeighbors = async (
   const vertices = verticesResponse.map(r => r.vertex);
   const edges = verticesResponse.flatMap(r => r.edges);
 
-  return {
+  return toMappedQueryResults({
     vertices,
     edges,
-    scalars: [],
-  };
+  });
 };
 
 export default fetchNeighbors;

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -137,5 +137,9 @@ export function createGremlinExplorer(
       );
       return result;
     },
+    async rawQuery(_req, _options) {
+      remoteLogger.info("[Gremlin Explorer] Fetching raw query...");
+      throw new Error("Raw query functionality is not implemented for Gremlin");
+    },
   } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -13,6 +13,7 @@ import { createLoggerFromConnection } from "@/core/connector";
 import { FeatureFlags } from "@/core";
 import { vertexDetails } from "./vertexDetails";
 import { edgeDetails } from "./edgeDetails";
+import { rawQuery } from "./rawQuery";
 
 function _gremlinFetch(
   connection: ConnectionConfig,
@@ -137,9 +138,15 @@ export function createGremlinExplorer(
       );
       return result;
     },
-    async rawQuery(_req, _options) {
+    async rawQuery(req, options) {
+      options ??= {};
+      options.queryId = v4();
       remoteLogger.info("[Gremlin Explorer] Fetching raw query...");
-      throw new Error("Raw query functionality is not implemented for Gremlin");
+      const result = await rawQuery(
+        _gremlinFetch(connection, featureFlags, options),
+        req
+      );
+      return result;
     },
   } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/index.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/index.ts
@@ -1,7 +1,8 @@
-import type {
-  ErrorResponse,
-  KeywordSearchRequest,
-  KeywordSearchResponse,
+import {
+  toMappedQueryResults,
+  type ErrorResponse,
+  type KeywordSearchRequest,
+  type KeywordSearchResponse,
 } from "@/connector/useGEFetchTypes";
 import isErrorResponse from "@/connector/utils/isErrorResponse";
 import mapApiVertex from "../mappers/mapApiVertex";
@@ -37,7 +38,7 @@ const keywordSearch = async (
     return mapApiVertex(value);
   });
 
-  return { vertices, edges: [], scalars: [] };
+  return toMappedQueryResults({ vertices });
 };
 
 export default keywordSearch;

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -1,0 +1,157 @@
+import { createEdgeId, createVertexId } from "@/core";
+import { mapResults, toMappedQueryResults } from "./mapResults";
+import {
+  createGEdge,
+  createGList,
+  createGVertex,
+  createRandomEdge,
+  createRandomVertex,
+} from "@/utils/testing";
+
+describe("mapResults", () => {
+  it("should handle empty g:List", () => {
+    const results = mapResults({
+      "@type": "g:List",
+      "@value": [],
+    });
+    expect(results).toEqual(toMappedQueryResults({}));
+  });
+
+  it("should handle empty g:Map", () => {
+    const results = mapResults({
+      "@type": "g:Map",
+      "@value": [],
+    });
+    expect(results).toEqual(toMappedQueryResults({}));
+  });
+
+  it("should handle empty g:Set", () => {
+    const results = mapResults({
+      "@type": "g:Set",
+      "@value": [],
+    });
+    expect(results).toEqual(toMappedQueryResults({}));
+  });
+
+  it("should handle g:List with g:Vertex", () => {
+    const results = mapResults({
+      "@type": "g:List",
+      "@value": [
+        {
+          "@type": "g:Vertex",
+          "@value": {
+            id: "1",
+            label: "Person",
+            properties: {
+              name: [
+                {
+                  "@type": "g:VertexProperty",
+                  "@value": {
+                    id: {
+                      "@type": "g:Int32",
+                      "@value": 1,
+                    },
+                    value: "Alice",
+                    label: "name",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+    expect(results).toEqual(
+      toMappedQueryResults({
+        vertices: [
+          {
+            entityType: "vertex",
+            id: createVertexId("1"),
+            type: "Person",
+            types: ["Person"],
+            attributes: {
+              name: "Alice",
+            },
+            __isFragment: false,
+          },
+        ],
+      })
+    );
+  });
+
+  it("should remove duplicate vertices", () => {
+    const vertex = createRandomVertex();
+    vertex.__isFragment = false;
+    const gVertex = createGVertex(vertex);
+    const gList = createGList([gVertex, gVertex]);
+    const results = mapResults(gList);
+    expect(results).toEqual(
+      toMappedQueryResults({
+        vertices: [vertex],
+      })
+    );
+  });
+
+  it("should remove duplicate vertices", () => {
+    const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+    edge.__isFragment = false;
+    const gEdge = createGEdge(edge);
+    const gList = createGList([gEdge, gEdge]);
+    const results = mapResults(gList);
+    expect(results).toEqual(
+      toMappedQueryResults({
+        edges: [edge],
+      })
+    );
+  });
+
+  it("should handle g:List with g:Edge", () => {
+    const results = mapResults({
+      "@type": "g:List",
+      "@value": [
+        {
+          "@type": "g:Edge",
+          "@value": {
+            id: "3",
+            label: "knows",
+            inVLabel: "Person",
+            outVLabel: "Person",
+            inV: "1",
+            outV: "2",
+            properties: {
+              since: {
+                "@type": "g:Property",
+                "@value": {
+                  key: "since",
+                  value: {
+                    "@type": "g:Int32",
+                    "@value": 20200101,
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(results).toEqual(
+      toMappedQueryResults({
+        edges: [
+          {
+            entityType: "edge",
+            id: createEdgeId("3"),
+            type: "knows",
+            source: createVertexId("2"),
+            target: createVertexId("1"),
+            sourceTypes: ["Person"],
+            targetTypes: ["Person"],
+            attributes: {
+              since: 20200101,
+            },
+            __isFragment: false,
+          },
+        ],
+      })
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -1,5 +1,5 @@
 import { createEdgeId, createVertexId } from "@/core";
-import { mapResults, toMappedQueryResults } from "./mapResults";
+import { mapResults } from "./mapResults";
 import {
   createGEdge,
   createGList,
@@ -7,6 +7,7 @@ import {
   createRandomEdge,
   createRandomVertex,
 } from "@/utils/testing";
+import { toMappedQueryResults } from "@/connector";
 
 describe("mapResults", () => {
   it("should handle empty g:List", () => {

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -1,4 +1,4 @@
-import { Vertex, Edge } from "@/core";
+import { Vertex, Edge, toNodeMap, toEdgeMap } from "@/core";
 import { GAnyValue } from "../types";
 import mapApiEdge from "./mapApiEdge";
 import mapApiVertex from "./mapApiVertex";
@@ -11,16 +11,32 @@ export type MappedQueryResults = {
   scalars: ScalarValue[];
 };
 
+export function toMappedQueryResults(
+  value: Partial<MappedQueryResults>
+): MappedQueryResults {
+  return {
+    vertices: value.vertices ?? [],
+    edges: value.edges ?? [],
+    scalars: value.scalars ?? [],
+  };
+}
+
 export function mapResults(data: GAnyValue) {
   const values = mapAnyValue(data);
 
-  const result: MappedQueryResults = {
-    vertices: values.filter(e => "vertex" in e).map(e => e.vertex),
-    edges: values.filter(e => "edge" in e).map(e => e.edge),
-    scalars: values.filter(s => "scalar" in s).map(s => s.scalar),
-  };
+  // Use maps to deduplicate vertices and edges
+  const vertexMap = toNodeMap(
+    values.filter(e => "vertex" in e).map(e => e.vertex)
+  );
+  const edgeMap = toEdgeMap(values.filter(e => "edge" in e).map(e => e.edge));
 
-  return result;
+  const vertices = vertexMap.values().toArray();
+  const edges = edgeMap.values().toArray();
+
+  // Scalars should not be deduplicated
+  const scalars = values.filter(s => "scalar" in s).map(s => s.scalar);
+
+  return toMappedQueryResults({ vertices, edges, scalars });
 }
 
 function mapAnyValue(

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -2,24 +2,7 @@ import { Vertex, Edge, toNodeMap, toEdgeMap } from "@/core";
 import { GAnyValue } from "../types";
 import mapApiEdge from "./mapApiEdge";
 import mapApiVertex from "./mapApiVertex";
-
-export type ScalarValue = number | string | Date;
-
-export type MappedQueryResults = {
-  vertices: Vertex[];
-  edges: Edge[];
-  scalars: ScalarValue[];
-};
-
-export function toMappedQueryResults(
-  value: Partial<MappedQueryResults>
-): MappedQueryResults {
-  return {
-    vertices: value.vertices ?? [],
-    edges: value.edges ?? [],
-    scalars: value.scalars ?? [],
-  };
-}
+import { toMappedQueryResults } from "@/connector";
 
 export function mapResults(data: GAnyValue) {
   const values = mapAnyValue(data);

--- a/packages/graph-explorer/src/connector/gremlin/rawQuery.ts
+++ b/packages/graph-explorer/src/connector/gremlin/rawQuery.ts
@@ -3,6 +3,7 @@ import {
   ErrorResponse,
   RawQueryRequest,
   RawQueryResponse,
+  toMappedQueryResults,
 } from "../useGEFetchTypes";
 import { GAnyValue, GremlinFetch } from "./types";
 import { mapResults } from "./mappers/mapResults";
@@ -26,11 +27,7 @@ export async function rawQuery(
   const template = query`${request.query}`;
 
   if (template.length <= 0) {
-    return {
-      scalars: [],
-      vertices: [],
-      edges: [],
-    };
+    return toMappedQueryResults({});
   }
 
   // Fetch the results

--- a/packages/graph-explorer/src/connector/gremlin/rawQuery.ts
+++ b/packages/graph-explorer/src/connector/gremlin/rawQuery.ts
@@ -1,0 +1,45 @@
+import { logger, query } from "@/utils";
+import {
+  ErrorResponse,
+  RawQueryRequest,
+  RawQueryResponse,
+} from "../useGEFetchTypes";
+import { GAnyValue, GremlinFetch } from "./types";
+import { mapResults } from "./mappers/mapResults";
+import isErrorResponse from "../utils/isErrorResponse";
+
+type Response = {
+  requestId: string;
+  status: {
+    message: string;
+    code: number;
+  };
+  result: {
+    data: GAnyValue;
+  };
+};
+
+export async function rawQuery(
+  gremlinFetch: GremlinFetch,
+  request: RawQueryRequest
+): Promise<RawQueryResponse> {
+  const template = query`${request.query}`;
+
+  if (template.length <= 0) {
+    return {
+      scalars: [],
+      vertices: [],
+      edges: [],
+    };
+  }
+
+  // Fetch the results
+  const data = await gremlinFetch<Response | ErrorResponse>(template);
+  if (isErrorResponse(data)) {
+    logger.error(data.detailedMessage);
+    throw new Error(data.detailedMessage);
+  }
+
+  // Map the results
+  return mapResults(data.result.data);
+}

--- a/packages/graph-explorer/src/connector/gremlin/types.ts
+++ b/packages/graph-explorer/src/connector/gremlin/types.ts
@@ -39,7 +39,7 @@ export type GVertexProperty = {
 export type GProperty = {
   "@type": "g:Property";
   "@value": {
-    id: GInt32;
+    id?: GInt32;
     key: string;
     value: GScalar;
   };

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/index.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/index.ts
@@ -1,6 +1,7 @@
-import type {
-  NeighborsRequest,
-  NeighborsResponse,
+import {
+  toMappedQueryResults,
+  type NeighborsRequest,
+  type NeighborsResponse,
 } from "@/connector/useGEFetchTypes";
 import mapApiEdge from "../mappers/mapApiEdge";
 import mapApiVertex from "../mappers/mapApiVertex";
@@ -38,11 +39,10 @@ const fetchNeighbors = async (
   const vertices: NeighborsResponse["vertices"] =
     oneHopData.results[0].vObjects.map(vertex => mapApiVertex(vertex));
 
-  return {
+  return toMappedQueryResults({
     vertices,
     edges,
-    scalars: [],
-  };
+  });
 };
 
 export default fetchNeighbors;

--- a/packages/graph-explorer/src/connector/openCypher/keywordSearch/index.ts
+++ b/packages/graph-explorer/src/connector/openCypher/keywordSearch/index.ts
@@ -1,8 +1,9 @@
 import { Vertex } from "@/core";
-import type {
-  ErrorResponse,
-  KeywordSearchRequest,
-  KeywordSearchResponse,
+import {
+  toMappedQueryResults,
+  type ErrorResponse,
+  type KeywordSearchRequest,
+  type KeywordSearchResponse,
 } from "@/connector/useGEFetchTypes";
 import isErrorResponse from "@/connector/utils/isErrorResponse";
 import mapApiVertex from "../mappers/mapApiVertex";
@@ -24,7 +25,7 @@ const keywordSearch = async (
 ): Promise<KeywordSearchResponse> => {
   const vertices = await vertexKeywordSearch(openCypherFetch, req);
 
-  return { vertices: vertices, edges: [], scalars: [] };
+  return toMappedQueryResults({ vertices });
 };
 
 const vertexKeywordSearch = async (

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -103,6 +103,13 @@ export function createOpenCypherExplorer(
         req
       );
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async rawQuery(_req, _options) {
+      remoteLogger.info("[openCypher Explorer] Fetching raw query...");
+      throw new Error(
+        "Raw query functionality is not implemented for openCypher"
+      );
+    },
   } satisfies Explorer;
 }
 

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -182,10 +182,10 @@ export function updateVertexDetailsCache(
   vertices: Vertex[]
 ) {
   for (const vertex of vertices.filter(v => !v.__isFragment)) {
-    queryClient.setQueryData(
-      ["db", "vertex", "details", vertex.id, explorer],
-      vertex
-    );
+    const request: VertexDetailsRequest = {
+      vertexId: vertex.id,
+    };
+    queryClient.setQueriesData(vertexDetailsQuery(request, explorer), vertex);
   }
 }
 
@@ -196,9 +196,9 @@ export function updateEdgeDetailsCache(
   edges: Edge[]
 ) {
   for (const edge of edges.filter(e => !e.__isFragment)) {
-    queryClient.setQueryData(
-      ["db", "edge", "details", edge.id, explorer],
-      edge
-    );
+    const request: EdgeDetailsRequest = {
+      edgeId: edge.id,
+    };
+    queryClient.setQueriesData(edgeDetailsQuery(request, explorer), edge);
   }
 }

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -8,6 +8,7 @@ import {
   RawQueryRequest,
   RawQueryResponse,
   SchemaResponse,
+  toMappedQueryResults,
   VertexDetailsRequest,
   VertexDetailsResponse,
 } from "./useGEFetchTypes";
@@ -59,7 +60,7 @@ export function searchQuery(
     queryKey: ["keyword-search", request, explorer, queryClient],
     queryFn: async ({ signal }): Promise<KeywordSearchResponse> => {
       if (!request) {
-        return { vertices: [], edges: [], scalars: [] };
+        return toMappedQueryResults({});
       }
       const results = await explorer.keywordSearch(request, { signal });
 

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.ts
@@ -1,6 +1,9 @@
 import groupBy from "lodash/groupBy";
 import { Edge, Vertex, VertexId } from "@/core";
-import type { NeighborsResponse } from "@/connector/useGEFetchTypes";
+import {
+  toMappedQueryResults,
+  type NeighborsResponse,
+} from "@/connector/useGEFetchTypes";
 import mapIncomingToEdge, {
   IncomingPredicate,
   isIncomingPredicate,
@@ -157,11 +160,10 @@ const fetchNeighbors = async (
     subjectsURIs
   );
 
-  return {
+  return toMappedQueryResults({
     vertices,
     edges: [...edges, ...bNodesEdges],
-    scalars: [],
-  };
+  });
 };
 
 export default fetchNeighbors;

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
@@ -1,4 +1,7 @@
-import { NeighborsResponse } from "@/connector/useGEFetchTypes";
+import {
+  NeighborsResponse,
+  toMappedQueryResults,
+} from "@/connector/useGEFetchTypes";
 import { BlankNodesMap, SPARQLNeighborsRequest } from "../types";
 
 /**
@@ -12,11 +15,7 @@ export const storedBlankNodeNeighborsRequest = (
   return new Promise<NeighborsResponse>(resolve => {
     const bNode = blankNodes.get(req.resourceURI);
     if (!bNode?.neighbors) {
-      resolve({
-        vertices: [],
-        edges: [],
-        scalars: [],
-      });
+      resolve(toMappedQueryResults({}));
       return;
     }
 
@@ -46,13 +45,14 @@ export const storedBlankNodeNeighborsRequest = (
       return true;
     });
 
-    resolve({
-      vertices: filteredVertices.slice(
-        req.offset ?? 0,
-        req.limit ? req.limit + (req.offset ?? 0) : undefined
-      ),
-      edges: bNode.neighbors.edges,
-      scalars: [],
-    });
+    resolve(
+      toMappedQueryResults({
+        vertices: filteredVertices.slice(
+          req.offset ?? 0,
+          req.limit ? req.limit + (req.offset ?? 0) : undefined
+        ),
+        edges: bNode.neighbors.edges,
+      })
+    );
   });
 };

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/index.ts
@@ -1,5 +1,9 @@
 import { logger } from "@/utils";
-import type { ErrorResponse, KeywordSearchResponse } from "@/connector";
+import {
+  toMappedQueryResults,
+  type ErrorResponse,
+  type KeywordSearchResponse,
+} from "@/connector";
 import isErrorResponse from "@/connector/utils/isErrorResponse";
 import mapRawResultToVertex from "../mappers/mapRawResultToVertex";
 import keywordSearchTemplate from "./keywordSearchTemplate";
@@ -62,11 +66,7 @@ const keywordSearch = async (
     return mapRawResultToVertex(result);
   });
 
-  return {
-    vertices,
-    edges: [],
-    scalars: [],
-  };
+  return toMappedQueryResults({ vertices });
 };
 
 export default keywordSearch;

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -1,7 +1,8 @@
-import type {
-  Criterion,
-  Explorer,
-  ExplorerRequestOptions,
+import {
+  toMappedQueryResults,
+  type Criterion,
+  type Explorer,
+  type ExplorerRequestOptions,
 } from "../useGEFetchTypes";
 import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
 import fetchBlankNodeNeighbors from "./fetchBlankNodeNeighbors";
@@ -137,7 +138,7 @@ export function createSparqlExplorer(
         request,
         response
       );
-      return { vertices, edges: response.edges, scalars: [] };
+      return toMappedQueryResults({ vertices, edges: response.edges });
     },
     async fetchNeighborsCount(req, options) {
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors count...");
@@ -205,7 +206,7 @@ export function createSparqlExplorer(
         response
       );
 
-      return { vertices, edges: [], scalars: [] };
+      return toMappedQueryResults({ vertices });
     },
     async vertexDetails(req, options) {
       remoteLogger.info("[SPARQL Explorer] Fetching vertex details...");

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -221,5 +221,10 @@ export function createSparqlExplorer(
         req
       );
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async rawQuery(_req, _options) {
+      remoteLogger.info("[SPARQL Explorer] Fetching raw query...");
+      throw new Error("Raw query functionality is not implemented for SPARQL");
+    },
   } satisfies Explorer;
 }

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -4,7 +4,6 @@ import {
   VertexTypeConfig,
 } from "@/core";
 import { ConnectionConfig } from "@shared/types";
-import { MappedQueryResults } from "./gremlin/mappers/mapResults";
 import { Edge, EdgeId, Vertex, VertexId } from "@/core";
 
 export type QueryOptions = RequestInit & {
@@ -74,6 +73,31 @@ export type Criterion = {
    */
   dataType?: "String" | "Number" | "Date";
 };
+
+export type ScalarValue = number | string | Date;
+
+/**
+ * Results from any query.
+ *
+ * Used by keyword search and raw query. Could potentially be used for other
+ * queries in the future.
+ */
+export type MappedQueryResults = {
+  vertices: Vertex[];
+  edges: Edge[];
+  scalars: ScalarValue[];
+};
+
+/** Constructs a `MappedQueryResults` instance without providing all values. */
+export function toMappedQueryResults(
+  value: Partial<MappedQueryResults>
+): MappedQueryResults {
+  return {
+    vertices: value.vertices ?? [],
+    edges: value.edges ?? [],
+    scalars: value.scalars ?? [],
+  };
+}
 
 export type NeighborsRequest = {
   /**

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -199,6 +199,12 @@ export type EdgeDetailsResponse = {
   edge: Edge | null;
 };
 
+export type RawQueryRequest = {
+  query: string;
+};
+
+export type RawQueryResponse = MappedQueryResults;
+
 /**
  * Abstracted interface to the common database queries used by
  * Graph Explorer.
@@ -230,4 +236,8 @@ export type Explorer = {
     req: EdgeDetailsRequest,
     options?: ExplorerRequestOptions
   ) => Promise<EdgeDetailsResponse>;
+  rawQuery: (
+    req: RawQueryRequest,
+    options?: ExplorerRequestOptions
+  ) => Promise<RawQueryResponse>;
 };

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -1,4 +1,4 @@
-import { Edge, EdgeId, getRawId, VertexId } from "@/core";
+import { Edge, EdgeId, getRawId, Vertex, VertexId } from "@/core";
 import { selector, selectorFamily, useRecoilValue } from "recoil";
 import { textTransformSelector } from "@/hooks";
 import {
@@ -37,6 +37,7 @@ type EdgeVertex = {
   id: VertexId;
   displayId: string;
   displayTypes: string;
+  types: Vertex["types"];
 };
 
 /** Maps all `Edge` instances in the graph canvas to `DisplayEdge` instances. */
@@ -151,11 +152,13 @@ const displayEdgeSelector = selectorFamily({
           id: edge.source,
           displayId: sourceDisplayId,
           displayTypes: sourceDisplayTypes,
+          types: edge.sourceTypes,
         },
         target: {
           id: edge.target,
           displayId: targetDisplayId,
           displayTypes: targetDisplayTypes,
+          types: edge.targetTypes,
         },
         attributes: sortedAttributes,
         // SPARQL does not have unique ID values for predicates, so the UI should hide them

--- a/packages/graph-explorer/src/core/StateProvider/useResetState.ts
+++ b/packages/graph-explorer/src/core/StateProvider/useResetState.ts
@@ -20,6 +20,8 @@ import {
   selectedVertexTypeAtom,
 } from "@/modules/SearchSidebar/useKeywordSearch";
 import { isRestorePreviousSessionAvailableAtom } from "./graphSession";
+import { selectedTabAtom } from "@/modules/SearchSidebar";
+import { queryTextAtom } from "@/modules/SearchSidebar/QuerySearchTabContent";
 
 export default function useResetState() {
   return useRecoilCallback(
@@ -44,6 +46,8 @@ export default function useResetState() {
         reset(selectedVertexTypeAtom);
         reset(selectedAttributeAtom);
         reset(partialMatchAtom);
+        reset(selectedTabAtom);
+        reset(queryTextAtom);
 
         // Previous session
         reset(isRestorePreviousSessionAvailableAtom);

--- a/packages/graph-explorer/src/hooks/index.ts
+++ b/packages/graph-explorer/src/hooks/index.ts
@@ -2,6 +2,7 @@ export { default as useDebounceValue } from "./useDebounceValue";
 export { default as useDeepMemo } from "./useDeepMemo";
 export { default as useExpandNode } from "./useExpandNode";
 export * from "./useAddToGraph";
+export * from "./useHasEdgeBeenAddedToGraph";
 export * from "./useHasVertexBeenAddedToGraph";
 export * from "./useRemoveFromGraph";
 export { default as useTextTransform } from "./useTextTransform";

--- a/packages/graph-explorer/src/hooks/useAddToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.ts
@@ -69,3 +69,9 @@ export function useAddVertexToGraph(vertex: Vertex) {
     [callback, vertex]
   );
 }
+
+/** Returns a callback the given edge to the graph. */
+export function useAddEdgeToGraph(edge: Edge) {
+  const callback = useAddToGraph();
+  return useCallback(() => callback({ edges: [edge] }), [callback, edge]);
+}

--- a/packages/graph-explorer/src/hooks/useHasEdgeBeenAddedToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useHasEdgeBeenAddedToGraph.ts
@@ -1,0 +1,7 @@
+import { EdgeId, edgesAtom } from "@/core";
+import { useRecoilValue } from "recoil";
+
+/** Returns true if the given edge has been added to the graph. */
+export function useHasEdgeBeenAddedToGraph(id: EdgeId) {
+  return useRecoilValue(edgesAtom).has(id);
+}

--- a/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useHasVertexBeenAddedToGraph.ts
@@ -1,5 +1,4 @@
-import { VertexId } from "@/core";
-import { nodesAtom } from "@/core";
+import { nodesAtom, VertexId } from "@/core";
 import { useRecoilValue } from "recoil";
 
 /** Returns true if the given vertex has been added to the graph. */

--- a/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
@@ -80,7 +80,12 @@ const EdgeDetail = ({ edge }: EdgeDetailProps) => {
 
   return (
     <div className={styleWithTheme(defaultStyles(style.lineColor))}>
-      <EdgeRow edge={edge} className="px-3 py-3" />
+      <EdgeRow
+        edge={edge}
+        source={sourceVertex}
+        target={targetVertex}
+        className="px-3 py-3"
+      />
       <div className={cn("source-vertex")}>
         <div className={cn("start-line", `line-${style.lineStyle || "solid"}`)}>
           {style.sourceArrowStyle === "triangle" && (

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -1,15 +1,22 @@
-import { useDisplayVertexFromVertex, Vertex } from "@/core";
+import {
+  DisplayEdge,
+  DisplayVertex,
+  Edge,
+  useDisplayEdgeFromEdge,
+  useDisplayVertexFromVertex,
+  Vertex,
+} from "@/core";
 import {
   Button,
+  EdgeRow,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  VertexRow,
 } from "@/components";
 import {
-  useAddVertexToGraph,
-  useHasVertexBeenAddedToGraph,
-  useRemoveNodeFromGraph,
+  useAddEdgeToGraph,
+  useHasEdgeBeenAddedToGraph,
+  useRemoveEdgeFromGraph,
 } from "@/hooks";
 import { cn } from "@/utils";
 import {
@@ -20,13 +27,15 @@ import {
 import { useState } from "react";
 import EntityAttribute from "../EntityDetails/EntityAttribute";
 
-export function NodeSearchResult({ node }: { node: Vertex }) {
+export function EdgeSearchResult({ edge }: { edge: Edge }) {
   const [expanded, setExpanded] = useState(false);
-  const displayNode = useDisplayVertexFromVertex(node);
+  const displayEdge = useDisplayEdgeFromEdge(edge);
+  const sourceVertex = useDisplayForEdgeVertex(displayEdge.source);
+  const targetVertex = useDisplayForEdgeVertex(displayEdge.target);
 
-  const addToGraph = useAddVertexToGraph(node);
-  const removeFromGraph = useRemoveNodeFromGraph(node.id);
-  const hasBeenAdded = useHasVertexBeenAddedToGraph(node.id);
+  const addToGraph = useAddEdgeToGraph(edge);
+  const removeFromGraph = useRemoveEdgeFromGraph(edge.id);
+  const hasBeenAdded = useHasEdgeBeenAddedToGraph(edge.id);
 
   return (
     <div
@@ -42,7 +51,12 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
         <div>
           <ChevronRightIcon className="text-primary-dark/50 size-5 transition-transform duration-200 ease-in-out group-data-[expanded=true]:rotate-90" />
         </div>
-        <VertexRow vertex={displayNode} className="grow" />
+        <EdgeRow
+          edge={displayEdge}
+          source={sourceVertex}
+          target={targetVertex}
+          className="grow"
+        />
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="flex size-8 shrink-0 items-center justify-center">
@@ -52,7 +66,7 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
                   variant="text"
                   onPress={removeFromGraph}
                 >
-                  <span className="sr-only">Remove node from view</span>
+                  <span className="sr-only">Remove edge from view</span>
                 </Button>
               ) : (
                 <Button
@@ -60,19 +74,19 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
                   variant="text"
                   onPress={addToGraph}
                 >
-                  <span className="sr-only">Add node to view</span>
+                  <span className="sr-only">Add edge to view</span>
                 </Button>
               )}
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            {hasBeenAdded ? "Remove node from view" : "Add node to view"}
+            {hasBeenAdded ? "Remove edge from view" : "Add edge to view"}
           </TooltipContent>
         </Tooltip>
       </div>
       <div className="border-background-secondary px-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
         <ul>
-          {displayNode.attributes.map(attr => (
+          {displayEdge.attributes.map(attr => (
             <EntityAttribute
               key={attr.name}
               attribute={attr}
@@ -83,4 +97,29 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
       </div>
     </div>
   );
+}
+
+/**
+ * Creates a fragment vertex in order to get a DisplayVertex instance for the
+ * edge vertex.
+ *
+ * NOTE: This should be replaced by logic that fetches the full vertex details.
+ */
+function useDisplayForEdgeVertex(
+  edgeVertex: DisplayEdge["source"]
+): DisplayVertex {
+  // TODO: Fetch the vertex details to display the proper display name in the EdgeRow
+  const fragment: Vertex = {
+    entityType: "vertex",
+    id: edgeVertex.id,
+    type: edgeVertex.types[0] ?? "",
+    types: edgeVertex.types,
+    attributes: {},
+    __isFragment: true,
+  };
+  const result = useDisplayVertexFromVertex(fragment);
+  return {
+    ...result,
+    displayName: edgeVertex.displayId,
+  };
 }

--- a/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
@@ -1,23 +1,113 @@
-import { Button, FormItem, Label, TextArea } from "@/components";
+import {
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  Label,
+  TextArea,
+} from "@/components";
+import { rawQueryQuery } from "@/connector";
+import { useExplorer, useUpdateSchemaFromEntities } from "@/core";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CornerDownRightIcon } from "lucide-react";
+import { SearchResultsList } from "./SearchResultsList";
+import { useCallback, useDeferredValue } from "react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { logger } from "@/utils";
+import { atom, useRecoilState } from "recoil";
+
+const formDataSchema = z.object({
+  query: z.string().default(""),
+});
+
+type FormData = z.infer<typeof formDataSchema>;
+
+export const queryTextAtom = atom({ key: "queryText", default: "" });
 
 export function QuerySearchTabContent() {
+  const [queryText, setQueryText] = useRecoilState(queryTextAtom);
+  const form = useForm<FormData>({
+    resolver: zodResolver(formDataSchema),
+    defaultValues: {
+      query: queryText,
+    },
+  });
+
+  const query = useQuerySearch(queryText);
+
+  const executeQuery = useCallback(
+    (data: FormData) => {
+      logger.debug("Executing query", data);
+      if (data.query !== queryText) {
+        setQueryText(data.query);
+      } else {
+        query.refetch();
+      }
+    },
+    [query, queryText, setQueryText]
+  );
+
   return (
     <div className="bg-background-default flex h-full flex-col">
-      <div className="border-divider flex flex-col gap-3 border-b p-3">
-        <FormItem>
-          <Label htmlFor="query" className="sr-only">
-            Query
-          </Label>
-          <TextArea name="query" />
-        </FormItem>
-        <div className="flex gap-6">
-          <Button className="w-full" variant="filled">
-            <CornerDownRightIcon />
-            Run query
-          </Button>
-        </div>
-      </div>
+      <Form {...form}>
+        <form
+          className="border-divider flex shrink-0 flex-col gap-3 border-b p-3"
+          onSubmit={form.handleSubmit(executeQuery)}
+        >
+          <FormField
+            control={form.control}
+            name="query"
+            render={({ field }) => (
+              <FormItem>
+                <Label htmlFor="query" className="sr-only">
+                  Query
+                </Label>
+                <FormControl>
+                  <TextArea
+                    {...field}
+                    aria-label="Query"
+                    className="h-full w-full"
+                    onKeyDown={e => {
+                      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                        e.preventDefault();
+                        form.handleSubmit(executeQuery)();
+                      }
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <div className="flex gap-6">
+            <Button className="w-full" variant="filled" type="submit">
+              <CornerDownRightIcon />
+              Run query
+            </Button>
+          </div>
+        </form>
+      </Form>
+
+      <SearchResultsList query={query} />
     </div>
   );
+}
+
+function useQuerySearch(query: string) {
+  const explorer = useExplorer();
+  const queryClient = useQueryClient();
+  const updateSchema = useUpdateSchemaFromEntities();
+  const delayedQuery = useDeferredValue(query);
+
+  return useQuery({
+    ...rawQueryQuery(
+      { query: delayedQuery },
+      updateSchema,
+      explorer,
+      queryClient
+    ),
+    staleTime: 0,
+  });
 }

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -1,0 +1,63 @@
+import { ScalarValue } from "@/connector";
+import { cn } from "@/utils";
+import { CalendarIcon, HashIcon, QuoteIcon } from "lucide-react";
+import { ComponentPropsWithoutRef } from "react";
+
+function getDisplayValue(scalar: ScalarValue) {
+  if (typeof scalar === "string") {
+    return scalar;
+  } else if (typeof scalar === "number") {
+    return new Intl.NumberFormat().format(scalar);
+  } else if (scalar instanceof Date) {
+    return new Intl.DateTimeFormat().format(scalar);
+  }
+}
+
+function getIcon(scalar: ScalarValue) {
+  if (typeof scalar === "string") {
+    return <QuoteIcon className="size-5" />;
+  } else if (typeof scalar === "number") {
+    return <HashIcon className="size-5" />;
+  } else if (scalar instanceof Date) {
+    return <CalendarIcon className="size-5" />;
+  }
+}
+
+export function ScalarSearchResult({ scalar }: { scalar: ScalarValue }) {
+  const displayValue = getDisplayValue(scalar);
+  const Icon = getIcon(scalar);
+
+  return (
+    <div
+      className={cn(
+        "bg-background-default w-full overflow-hidden transition-all"
+      )}
+    >
+      <div className="flex w-full flex-row items-center gap-2 p-3 text-left ring-0">
+        <div className="flex grow flex-row items-center gap-3">
+          <ScalarSymbol>{Icon}</ScalarSymbol>
+          <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
+            <div className="font-bold">{displayValue}</div>
+            <div className="text-text-secondary/90 line-clamp-2">
+              Scalar value
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+export function ScalarSymbol({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "text-primary-main bg-primary-main/20 grid size-[36px] shrink-0 place-content-center rounded-lg p-2 text-[2em]",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -13,6 +13,8 @@ import { NodeSearchResult } from "./NodeSearchResult";
 import { useAddToGraph } from "@/hooks/useAddToGraph";
 import { MappedQueryResults } from "@/connector/gremlin/mappers/mapResults";
 import { PlusCircleIcon } from "lucide-react";
+import { EdgeSearchResult } from "./EdgeSearchResult";
+import { ScalarSearchResult } from "./ScalarSearchResult";
 
 export function SearchResultsList({
   query,
@@ -73,14 +75,30 @@ function LoadedResults({ vertices, edges, scalars }: MappedQueryResults) {
 
   return (
     <>
-      <div className="bg-background-contrast/35 grow p-3">
+      <div className="bg-background-contrast/35 flex grow flex-col p-3">
         <ul className="border-divider flex flex-col overflow-hidden rounded-xl border shadow">
           {vertices.map(entity => (
             <li
               key={`node:${entity.type}:${entity.id}`}
-              className="border-divider border-b last:border-0"
+              className="border-divider content-auto intrinsic-size-16 border-b last:border-0"
             >
               <NodeSearchResult node={entity} />
+            </li>
+          ))}
+          {edges.map(entity => (
+            <li
+              key={`edge:${entity.type}:${entity.id}`}
+              className="border-divider content-auto intrinsic-size-16 border-b last:border-0"
+            >
+              <EdgeSearchResult edge={entity} />
+            </li>
+          ))}
+          {scalars.map((entity, index) => (
+            <li
+              key={`scalar:${String(entity)}:${index}`}
+              className="border-divider content-auto intrinsic-size-16 border-b last:border-0"
+            >
+              <ScalarSearchResult scalar={entity} />
             </li>
           ))}
         </ul>

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -6,12 +6,11 @@ import {
   Button,
   PanelFooter,
 } from "@/components";
-import { KeywordSearchResponse } from "@/connector";
+import { KeywordSearchResponse, MappedQueryResults } from "@/connector";
 import { UseQueryResult } from "@tanstack/react-query";
 import { useCancelKeywordSearch } from "./useKeywordSearchQuery";
 import { NodeSearchResult } from "./NodeSearchResult";
 import { useAddToGraph } from "@/hooks/useAddToGraph";
-import { MappedQueryResults } from "@/connector/gremlin/mappers/mapResults";
 import { PlusCircleIcon } from "lucide-react";
 import { EdgeSearchResult } from "./EdgeSearchResult";
 import { ScalarSearchResult } from "./ScalarSearchResult";

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchSidebar.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchSidebar.tsx
@@ -16,11 +16,18 @@ import {
 } from "@/components/SidebarTabs";
 import { QuerySearchTabContent } from "./QuerySearchTabContent";
 import { CodeIcon, ListFilterIcon } from "lucide-react";
+import { atom, useRecoilState } from "recoil";
 import { cn } from "@/utils";
+
+export const selectedTabAtom = atom({
+  key: "search-sidebar-selected-tab",
+  default: "filter",
+});
 
 export function SearchSidebarPanel() {
   const queryEngine = useQueryEngine();
   const featureFlags = useFeatureFlags();
+  const [selectedTab, setSelectedTab] = useRecoilState(selectedTabAtom);
 
   // Hide tabs when not gremlin or the query editor feature is turned off
   if (queryEngine !== "gremlin" || !featureFlags.showQueryEditor) {
@@ -33,7 +40,7 @@ export function SearchSidebarPanel() {
 
   return (
     <Layout>
-      <SidebarTabs defaultValue="filter">
+      <SidebarTabs defaultValue={selectedTab} onValueChange={setSelectedTab}>
         <SidebarTabsList>
           <SidebarTabsTrigger value="filter">
             <ListFilterIcon /> Filter

--- a/packages/graph-explorer/src/utils/testing/createMockExplorer.ts
+++ b/packages/graph-explorer/src/utils/testing/createMockExplorer.ts
@@ -11,5 +11,6 @@ export function createMockExplorer(): Explorer {
     fetchSchema: vi.fn(),
     edgeDetails: vi.fn(),
     vertexDetails: vi.fn(),
+    rawQuery: vi.fn(),
   };
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds basic query functionality for Gremlin.

- Can type query in to query text area
- Can use [CMD + Enter] or [CTRL + Enter] to execute query from keyboard
- Results of query are not cached directly (individual vertices and edges are add to the cache)
- Can use the "Add All" button to add all results (vertices and edges) to the graph
- Errors are shown in search results area

### Limitations

- Adding an edge to the graph does nothing on its own since an edge can not exist without both source and target vertices
- Edge search result uses ID value as source and target vertex display names since we don't have the full vertex object with all its properties
- No cancellation of long running queries

## Validation

- Verified with Neptune

### Example Queries Used

Simple vertex list

```
g.V().range(0, 10)
```

Complex rendered graph (air routes)

```
g.V().as("departure")
    .has("country", eq("US")).outE().as("route")
    .otherV().as("destination")
    .has("country", eq("UK"))
    .union(select("departure"), select("route"), select("destination"))
```

Example from G.V() website (air routes)

```
g.V().hasLabel("airport")
    .limit(15)
    .outE("route")
    .order().by("dist")
    .limit(global, 300)
```

Mix of vertices and scalar values

```
g.V().hasLabel("airport")
    .range(0,10)
    .union(values("code"), identity())
```

## Related Issues

- Resolves #807
- Resolves #808

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
