### PR TITLE
Create entity functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,8 @@
   ([#826](https://github.com/aws/graph-explorer/pull/826),
   [#840](https://github.com/aws/graph-explorer/pull/840))
 - **Added** query editor for Gremlin connections
-  ([#850](https://github.com/aws/graph-explorer/pull/850),
+  ([#853](https://github.com/aws/graph-explorer/pull/853),
+  [#850](https://github.com/aws/graph-explorer/pull/850),
   [#843](https://github.com/aws/graph-explorer/pull/843),
   [#842](https://github.com/aws/graph-explorer/pull/842),
   [#839](https://github.com/aws/graph-explorer/pull/839),

--- a/packages/graph-explorer/src/connector/gremlin/edgeDetails.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/edgeDetails.test.ts
@@ -5,7 +5,6 @@ import { Edge } from "@/core";
 describe("edgeDetails", () => {
   it("should return the correct edge details", async () => {
     const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
-    edge.__isFragment = false;
     const response = createGremlinResponseFromEdge(edge);
     const mockFetch = vi
       .fn()

--- a/packages/graph-explorer/src/connector/gremlin/edgeDetails.ts
+++ b/packages/graph-explorer/src/connector/gremlin/edgeDetails.ts
@@ -43,7 +43,10 @@ export async function edgeDetails(
   const edge = entities.edges.length > 0 ? entities.edges[0] : null;
   if (!edge) {
     logger.warn("Edge not found", request.edgeId);
+    return { edge: null };
   }
 
+  // Always false for edgeDetails query, even if the edge has no properties
+  edge.__isFragment = false;
   return { edge };
 }

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -1,17 +1,15 @@
 import globalMockFetch from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighbors from ".";
-import { createEdgeId, createVertexId, Edge, Vertex } from "@/core";
+import { createEdgeId, createVertex, createVertexId, Edge } from "@/core";
 
 describe("Gremlin > fetchNeighbors", () => {
   beforeEach(globalMockFetch);
 
   it("Should return all neighbors from node 2018", async () => {
-    const expectedVertices: Vertex[] = [
-      {
-        entityType: "vertex",
-        id: createVertexId("486"),
-        type: "airport",
+    const expectedVertices = [
+      createVertex({
+        id: "486",
         types: ["airport"],
         attributes: {
           country: "ES",
@@ -27,11 +25,9 @@ describe("Gremlin > fetchNeighbors", () => {
           lat: 28.044500351,
           desc: "Tenerife South Airport",
         },
-      },
-      {
-        entityType: "vertex",
-        id: createVertexId("228"),
-        type: "airport",
+      }),
+      createVertex({
+        id: "228",
         types: ["airport"],
         attributes: {
           country: "ES",
@@ -47,11 +43,9 @@ describe("Gremlin > fetchNeighbors", () => {
           lat: 27.9319000244141,
           desc: "Gran Canaria Airport",
         },
-      },
-      {
-        entityType: "vertex",
-        id: createVertexId("124"),
-        type: "airport",
+      }),
+      createVertex({
+        id: "124",
         types: ["airport"],
         attributes: {
           country: "ES",
@@ -67,21 +61,17 @@ describe("Gremlin > fetchNeighbors", () => {
           lat: 28.4827003479,
           desc: "Tenerife Norte Airport",
         },
-      },
-      {
-        entityType: "vertex",
-        id: createVertexId("3741"),
-        type: "continent",
+      }),
+      createVertex({
+        id: "3741",
         types: ["continent"],
         attributes: { code: "EU", type: "continent", desc: "Europe" },
-      },
-      {
-        entityType: "vertex",
-        id: createVertexId("3701"),
-        type: "country",
+      }),
+      createVertex({
+        id: "3701",
         types: ["country"],
         attributes: { code: "ES", type: "country", desc: "Spain" },
-      },
+      }),
     ];
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
@@ -177,11 +167,9 @@ describe("Gremlin > fetchNeighbors", () => {
   });
 
   it("Should return filtered neighbors from node 2018", async () => {
-    const expectedVertices: Vertex[] = [
-      {
-        entityType: "vertex",
-        id: createVertexId("486"),
-        type: "airport",
+    const expectedVertices = [
+      createVertex({
+        id: "486",
         types: ["airport"],
         attributes: {
           country: "ES",
@@ -197,11 +185,9 @@ describe("Gremlin > fetchNeighbors", () => {
           lat: 28.044500351,
           desc: "Tenerife South Airport",
         },
-      },
-      {
-        entityType: "vertex",
-        id: createVertexId("124"),
-        type: "airport",
+      }),
+      createVertex({
+        id: "124",
         types: ["airport"],
         attributes: {
           country: "ES",
@@ -217,7 +203,7 @@ describe("Gremlin > fetchNeighbors", () => {
           lat: 28.4827003479,
           desc: "Tenerife Norte Airport",
         },
-      },
+      }),
     ];
 
     const response = await fetchNeighbors(mockGremlinFetch(), {

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -1,7 +1,7 @@
 import globalMockFetch from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighbors from ".";
-import { createEdgeId, createVertex, createVertexId, Edge } from "@/core";
+import { createEdge, createVertex, createVertexId } from "@/core";
 
 describe("Gremlin > fetchNeighbors", () => {
   beforeEach(globalMockFetch);
@@ -82,87 +82,109 @@ describe("Gremlin > fetchNeighbors", () => {
     expect(response).toMatchObject({
       vertices: expectedVertices,
       edges: [
-        {
-          entityType: "edge",
-          id: createEdgeId("49540"),
+        createEdge({
+          id: "49540",
           type: "route",
-          source: createVertexId("2018"),
-          sourceTypes: ["airport"],
-          target: createVertexId("486"),
-          targetTypes: ["airport"],
+          source: {
+            id: "2018",
+            types: ["airport"],
+          },
+          target: {
+            id: "486",
+            types: ["airport"],
+          },
           attributes: { dist: 82 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("33133"),
+        }),
+        createEdge({
+          id: "33133",
           type: "route",
-          source: createVertexId("486"),
-          sourceTypes: ["airport"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
+          source: {
+            id: "486",
+            types: ["airport"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
           attributes: { dist: 82 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("49539"),
+        }),
+        createEdge({
+          id: "49539",
           type: "route",
-          source: createVertexId("2018"),
-          sourceTypes: ["airport"],
-          target: createVertexId("228"),
-          targetTypes: ["airport"],
+          source: {
+            id: "2018",
+            types: ["airport"],
+          },
+          target: {
+            id: "228",
+            types: ["airport"],
+          },
           attributes: { dist: 153 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("24860"),
+        }),
+        createEdge({
+          id: "24860",
           type: "route",
-          source: createVertexId("228"),
-          sourceTypes: ["airport"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
+          source: {
+            id: "228",
+            types: ["airport"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
           attributes: { dist: 153 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("49538"),
+        }),
+        createEdge({
+          id: "49538",
           type: "route",
-          source: createVertexId("2018"),
-          sourceTypes: ["airport"],
-          target: createVertexId("124"),
-          targetTypes: ["airport"],
+          source: {
+            id: "2018",
+            types: ["airport"],
+          },
+          target: {
+            id: "124",
+            types: ["airport"],
+          },
           attributes: { dist: 105 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("18665"),
+        }),
+        createEdge({
+          id: "18665",
           type: "route",
-          source: createVertexId("124"),
-          sourceTypes: ["airport"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
+          source: {
+            id: "124",
+            types: ["airport"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
           attributes: { dist: 105 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("59800"),
+        }),
+        createEdge({
+          id: "59800",
           type: "contains",
-          source: createVertexId("3741"),
-          sourceTypes: ["continent"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
-          attributes: {},
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("56297"),
+          source: {
+            id: "3741",
+            types: ["continent"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
+        }),
+        createEdge({
+          id: "56297",
           type: "contains",
-          source: createVertexId("3701"),
-          sourceTypes: ["country"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
-          attributes: {},
-        },
-      ] satisfies Edge[],
+          source: {
+            id: "3701",
+            types: ["country"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
+        }),
+      ],
     });
   });
 
@@ -216,47 +238,59 @@ describe("Gremlin > fetchNeighbors", () => {
     expect(response).toMatchObject({
       vertices: expectedVertices,
       edges: [
-        {
-          entityType: "edge",
-          id: createEdgeId("49540"),
+        createEdge({
+          id: "49540",
           type: "route",
-          source: createVertexId("2018"),
-          sourceTypes: ["airport"],
-          target: createVertexId("486"),
-          targetTypes: ["airport"],
+          source: {
+            id: "2018",
+            types: ["airport"],
+          },
+          target: {
+            id: "486",
+            types: ["airport"],
+          },
           attributes: { dist: 82 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("33133"),
+        }),
+        createEdge({
+          id: "33133",
           type: "route",
-          source: createVertexId("486"),
-          sourceTypes: ["airport"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
+          source: {
+            id: "486",
+            types: ["airport"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
           attributes: { dist: 82 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("49538"),
+        }),
+        createEdge({
+          id: "49538",
           type: "route",
-          source: createVertexId("2018"),
-          sourceTypes: ["airport"],
-          target: createVertexId("124"),
-          targetTypes: ["airport"],
+          source: {
+            id: "2018",
+            types: ["airport"],
+          },
+          target: {
+            id: "124",
+            types: ["airport"],
+          },
           attributes: { dist: 105 },
-        },
-        {
-          entityType: "edge",
-          id: createEdgeId("18665"),
+        }),
+        createEdge({
+          id: "18665",
           type: "route",
-          source: createVertexId("124"),
-          sourceTypes: ["airport"],
-          target: createVertexId("2018"),
-          targetTypes: ["airport"],
+          source: {
+            id: "124",
+            types: ["airport"],
+          },
+          target: {
+            id: "2018",
+            types: ["airport"],
+          },
           attributes: { dist: 105 },
-        },
-      ] satisfies Edge[],
+        }),
+      ],
     });
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.test.ts
@@ -4,7 +4,6 @@ import mapApiVertex from "./mapApiVertex";
 describe("mapApiVertex", () => {
   it("should map a graphSON vertex to a vertex", () => {
     const vertex = createRandomVertex();
-    vertex.__isFragment = false;
     const gVertex = createGVertex(vertex);
 
     const mappedVertex = mapApiVertex(gVertex);
@@ -26,7 +25,6 @@ describe("mapApiVertex", () => {
 
   it("should map a graphSON vertex without labels", () => {
     const vertex = createRandomVertex();
-    vertex.__isFragment = false;
     vertex.type = "";
     vertex.types = [];
     const gVertex = createGVertex(vertex);

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -1,24 +1,22 @@
-import { createVertexId, type Vertex } from "@/core";
+import { createVertex } from "@/core";
 import type { GVertex } from "../types";
 import parsePropertiesValues from "./parsePropertiesValues";
 import { extractRawId } from "./extractRawId";
 
-const mapApiVertex = (apiVertex: GVertex): Vertex => {
+const mapApiVertex = (apiVertex: GVertex) => {
   // Split multi-label from Neptune and filter out empty strings
-  const labels = apiVertex["@value"].label.split("::").filter(Boolean);
+  const types = apiVertex["@value"].label.split("::").filter(Boolean);
 
-  // Check for empty labels, which is possible with some databases
-  const vt = labels[0] ?? "";
-  const isFragment = apiVertex["@value"].properties == null;
+  // If the properties are null then the vertex is a fragment
+  const attributes = apiVertex["@value"].properties
+    ? parsePropertiesValues(apiVertex["@value"].properties)
+    : undefined;
 
-  return {
-    entityType: "vertex",
-    id: createVertexId(extractRawId(apiVertex["@value"].id)),
-    type: vt,
-    types: labels,
-    attributes: parsePropertiesValues(apiVertex["@value"].properties ?? {}),
-    __isFragment: isFragment,
-  };
+  return createVertex({
+    id: extractRawId(apiVertex["@value"].id),
+    types,
+    attributes,
+  });
 };
 
 export default mapApiVertex;

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -1,4 +1,4 @@
-import { createEdgeId, createVertex, createVertexId } from "@/core";
+import { createEdge, createVertex } from "@/core";
 import { mapResults } from "./mapResults";
 import {
   createGEdge,
@@ -79,7 +79,6 @@ describe("mapResults", () => {
 
   it("should remove duplicate vertices", () => {
     const vertex = createRandomVertex();
-    vertex.__isFragment = false;
     const gVertex = createGVertex(vertex);
     const gList = createGList([gVertex, gVertex]);
     const results = mapResults(gList);
@@ -92,7 +91,6 @@ describe("mapResults", () => {
 
   it("should remove duplicate vertices", () => {
     const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
-    edge.__isFragment = false;
     const gEdge = createGEdge(edge);
     const gList = createGList([gEdge, gEdge]);
     const results = mapResults(gList);
@@ -135,19 +133,21 @@ describe("mapResults", () => {
     expect(results).toEqual(
       toMappedQueryResults({
         edges: [
-          {
-            entityType: "edge",
-            id: createEdgeId("3"),
+          createEdge({
+            id: "3",
             type: "knows",
-            source: createVertexId("2"),
-            target: createVertexId("1"),
-            sourceTypes: ["Person"],
-            targetTypes: ["Person"],
+            source: {
+              id: "2",
+              types: ["Person"],
+            },
+            target: {
+              id: "1",
+              types: ["Person"],
+            },
             attributes: {
               since: 20200101,
             },
-            __isFragment: false,
-          },
+          }),
         ],
       })
     );

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -152,4 +152,21 @@ describe("mapResults", () => {
       })
     );
   });
+
+  it("should be fragment when no properties exist", () => {
+    const vertex = createRandomVertex();
+    vertex.__isFragment = true;
+    vertex.attributes = {};
+    const gVertex = createGVertex(vertex);
+    const result = mapResults(gVertex);
+    expect(result).toEqual(toMappedQueryResults({ vertices: [vertex] }));
+  });
+
+  it("should not be fragment when some properties exist", () => {
+    const vertex = createRandomVertex();
+    vertex.__isFragment = false;
+    const gVertex = createGVertex(vertex);
+    const result = mapResults(gVertex);
+    expect(result).toEqual(toMappedQueryResults({ vertices: [vertex] }));
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -1,4 +1,4 @@
-import { createEdgeId, createVertexId } from "@/core";
+import { createEdgeId, createVertex, createVertexId } from "@/core";
 import { mapResults } from "./mapResults";
 import {
   createGEdge,
@@ -65,16 +65,13 @@ describe("mapResults", () => {
     expect(results).toEqual(
       toMappedQueryResults({
         vertices: [
-          {
-            entityType: "vertex",
-            id: createVertexId("1"),
-            type: "Person",
+          createVertex({
+            id: "1",
             types: ["Person"],
             attributes: {
               name: "Alice",
             },
-            __isFragment: false,
-          },
+          }),
         ],
       })
     );

--- a/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
@@ -7,11 +7,6 @@ import { vertexDetails } from "./vertexDetails";
 describe("vertexDetails", () => {
   it("should return the correct vertex details", async () => {
     const vertex = createRandomVertex();
-
-    // Align with the gremlin mapper
-    vertex.types = [vertex.type];
-    vertex.__isFragment = false;
-
     const response = createGremlinResponseFromVertex(vertex);
     const mockFetch = vi
       .fn()

--- a/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/vertexDetails.test.ts
@@ -18,4 +18,20 @@ describe("vertexDetails", () => {
 
     expect(result.vertex).toEqual(vertex);
   });
+
+  it("should not be fragment if the response does not include the properties", async () => {
+    const vertex = createRandomVertex();
+    vertex.attributes = {};
+    vertex.__isFragment = true;
+    const response = createGremlinResponseFromVertex(vertex);
+    const mockFetch = vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(response));
+
+    const result = await vertexDetails(mockFetch, {
+      vertexId: vertex.id,
+    });
+
+    expect(result.vertex?.__isFragment).toBe(false);
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/vertexDetails.ts
+++ b/packages/graph-explorer/src/connector/gremlin/vertexDetails.ts
@@ -42,7 +42,10 @@ export async function vertexDetails(
   const vertex = entities.vertices.length > 0 ? entities.vertices[0] : null;
   if (!vertex) {
     logger.warn("Vertex not found", request.vertexId);
+    return { vertex: null };
   }
 
+  // Always false for vertexDetails query, even if the vertex has no properties
+  vertex.__isFragment = false;
   return { vertex };
 }

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiEdge.ts
@@ -1,21 +1,22 @@
-import { createEdgeId, createVertexId, Vertex, type Edge } from "@/core";
+import { createEdge, Vertex } from "@/core";
 import type { OCEdge } from "../types";
 
-const mapApiEdge = (
+export default function mapApiEdge(
   apiEdge: OCEdge,
   sourceTypes: Vertex["types"],
   targetTypes: Vertex["types"]
-): Edge => {
-  return {
-    entityType: "edge",
-    id: createEdgeId(apiEdge["~id"]),
+) {
+  return createEdge({
+    id: apiEdge["~id"],
     type: apiEdge["~type"],
-    source: createVertexId(apiEdge["~start"]),
-    sourceTypes: sourceTypes,
-    target: createVertexId(apiEdge["~end"]),
-    targetTypes: targetTypes,
+    source: {
+      id: apiEdge["~start"],
+      types: sourceTypes,
+    },
+    target: {
+      id: apiEdge["~end"],
+      types: targetTypes,
+    },
     attributes: apiEdge["~properties"] || {},
-  };
-};
-
-export default mapApiEdge;
+  });
+}

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.test.ts
@@ -1,5 +1,5 @@
 import mapApiVertex from "./mapApiVertex";
-import { createVertexId, Vertex } from "@/core";
+import { createVertex } from "@/core";
 
 test("maps empty vertex", () => {
   const input = {
@@ -10,13 +10,13 @@ test("maps empty vertex", () => {
   };
   const result = mapApiVertex(input);
 
-  expect(result).toEqual({
-    entityType: "vertex",
-    id: createVertexId(""),
-    type: "",
-    types: [],
-    attributes: {},
-  } satisfies Vertex);
+  expect(result).toEqual(
+    createVertex({
+      id: "",
+      types: [],
+      attributes: {},
+    })
+  );
 });
 
 test("maps airport node", () => {
@@ -42,24 +42,24 @@ test("maps airport node", () => {
 
   const result = mapApiVertex(input);
 
-  expect(result).toEqual({
-    entityType: "vertex",
-    id: createVertexId("1"),
-    type: "airport",
-    types: ["airport"],
-    attributes: {
-      city: "Atlanta",
-      code: "ATL",
-      country: "US",
-      desc: "Hartsfield - Jackson Atlanta International Airport",
-      elev: 1026,
-      icao: "KATL",
-      lat: 33.6366996765137,
-      lon: -84.4281005859375,
-      longest: 12390,
-      region: "US-GA",
-      runways: 5,
-      type: "airport",
-    },
-  } satisfies Vertex);
+  expect(result).toEqual(
+    createVertex({
+      id: "1",
+      types: ["airport"],
+      attributes: {
+        city: "Atlanta",
+        code: "ATL",
+        country: "US",
+        desc: "Hartsfield - Jackson Atlanta International Airport",
+        elev: 1026,
+        icao: "KATL",
+        lat: 33.6366996765137,
+        lon: -84.4281005859375,
+        longest: 12390,
+        region: "US-GA",
+        runways: 5,
+        type: "airport",
+      },
+    })
+  );
 });

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapApiVertex.ts
@@ -1,17 +1,12 @@
-import { createVertexId, type Vertex } from "@/core";
+import { createVertex } from "@/core";
 import type { OCVertex } from "../types";
 
-export default function mapApiVertex(apiVertex: OCVertex): Vertex {
+export default function mapApiVertex(apiVertex: OCVertex) {
   const labels = apiVertex["~labels"];
 
-  // Check for empty labels, which is possible with some databases
-  const vt = labels[0] ?? "";
-
-  return {
-    entityType: "vertex",
-    id: createVertexId(apiVertex["~id"]),
-    type: vt,
+  return createVertex({
+    id: apiVertex["~id"],
     types: labels,
     attributes: apiVertex["~properties"],
-  };
+  });
 }

--- a/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
@@ -1,4 +1,4 @@
-import { Edge } from "@/core";
+import { createEdge } from "@/core";
 import { EdgeDetailsRequest, EdgeDetailsResponse } from "../useGEFetchTypes";
 import {
   parseEdgeId,
@@ -78,15 +78,19 @@ export async function edgeDetails(
     throw new Error("Edge type not found in bindings");
   }
 
-  const edge: Edge = {
-    entityType: "edge",
+  const edge = createEdge({
     id: request.edgeId,
     type: predicate,
-    source,
-    sourceTypes,
-    target,
-    targetTypes,
+    source: {
+      id: source,
+      types: sourceTypes,
+    },
+    target: {
+      id: target,
+      types: targetTypes,
+    },
+    // Ensure this edge is not a fragment since SPARQL edges can not have attributes
     attributes: {},
-  };
+  });
   return { edge };
 }

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapIncomingToEdge.ts
@@ -1,4 +1,4 @@
-import { createVertexId, Edge, Vertex, VertexId } from "@/core";
+import { createEdge, Vertex, VertexId } from "@/core";
 import { RawValue } from "../types";
 import { createRdfEdgeId } from "../createRdfEdgeId";
 
@@ -8,30 +8,30 @@ export type IncomingPredicate = {
   predFromSubject: RawValue;
 };
 
-const mapIncomingToEdge = (
+export default function mapIncomingToEdge(
   resourceURI: VertexId,
   resourceClasses: Vertex["types"],
   result: IncomingPredicate
-): Edge => {
+) {
   const sourceUri = result.subject.value;
   const predicate = result.predFromSubject.value;
 
-  return {
-    entityType: "edge",
+  return createEdge({
     id: createRdfEdgeId(sourceUri, predicate, resourceURI),
     type: predicate,
-    source: createVertexId(sourceUri),
-    sourceTypes: [result.subjectClass.value],
-    target: resourceURI,
-    targetTypes: resourceClasses,
+    source: {
+      id: sourceUri,
+      types: [result.subjectClass.value],
+    },
+    target: {
+      id: resourceURI,
+      types: resourceClasses,
+    },
+    // Ensure this edge is not a fragment since SPARQL edges can not have attributes
     attributes: {},
-  };
-};
+  });
+}
 
-export default mapIncomingToEdge;
-
-export const isIncomingPredicate = (
-  result: any
-): result is IncomingPredicate => {
+export function isIncomingPredicate(result: any): result is IncomingPredicate {
   return !!result.predFromSubject;
-};
+}

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapOutgoingToEdge.ts
@@ -1,4 +1,4 @@
-import { createVertexId, Edge, Vertex, VertexId } from "@/core";
+import { createEdge, Vertex, VertexId } from "@/core";
 import { RawValue } from "../types";
 import { createRdfEdgeId } from "../createRdfEdgeId";
 
@@ -8,23 +8,25 @@ export type OutgoingPredicate = {
   predToSubject: RawValue;
 };
 
-const mapOutgoingToEdge = (
+export default function mapOutgoingToEdge(
   resourceURI: VertexId,
   resourceClasses: Vertex["types"],
   result: OutgoingPredicate
-): Edge => {
+) {
   const targetUri = result.subject.value;
   const predicate = result.predToSubject.value;
-  return {
-    entityType: "edge",
+  return createEdge({
     id: createRdfEdgeId(resourceURI, predicate, targetUri),
     type: predicate,
-    source: resourceURI,
-    sourceTypes: resourceClasses,
-    target: createVertexId(targetUri),
-    targetTypes: [result.subjectClass.value],
+    source: {
+      id: resourceURI,
+      types: resourceClasses,
+    },
+    target: {
+      id: targetUri,
+      types: [result.subjectClass.value],
+    },
+    // Ensure this edge is not a fragment since SPARQL edges can not have attributes
     attributes: {},
-  };
-};
-
-export default mapOutgoingToEdge;
+  });
+}

--- a/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
+++ b/packages/graph-explorer/src/connector/sparql/mappers/mapRawResultToVertex.ts
@@ -1,15 +1,13 @@
-import { createVertexId, Vertex } from "@/core";
+import { createVertex } from "@/core";
 import { RawResult } from "../types";
 
-const mapRawResultToVertex = (rawResult: RawResult): Vertex => {
-  return {
-    entityType: "vertex",
-    id: createVertexId(rawResult.uri),
-    type: rawResult.class,
+const mapRawResultToVertex = (rawResult: RawResult) => {
+  return createVertex({
+    id: rawResult.uri,
     types: [rawResult.class],
     attributes: rawResult.attributes,
-    __isBlank: rawResult.isBlank,
-  };
+    isBlankNode: rawResult.isBlank,
+  });
 };
 
 export default mapRawResultToVertex;

--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
@@ -12,7 +12,7 @@ import {
   SparqlValue,
 } from "./types";
 import { z } from "zod";
-import { Vertex, VertexId } from "@/core";
+import { createVertex, VertexId } from "@/core";
 import isErrorResponse from "../utils/isErrorResponse";
 import { idParam } from "./idParam";
 
@@ -85,34 +85,27 @@ export async function vertexDetails(
   return { vertex };
 }
 
-function mapToVertex(
-  id: VertexId,
-  detailsBinding: VertexDetailsBinding[]
-): Vertex {
-  const typeUri: string[] = [];
+function mapToVertex(id: VertexId, detailsBinding: VertexDetailsBinding[]) {
+  const types: string[] = [];
   const attributes: Record<string, string | number> = {};
 
   for (const result of detailsBinding) {
     if (result.label.value === rdfTypeUri) {
-      typeUri.push(result.value.value);
+      types.push(result.value.value);
     } else {
       attributes[result.label.value] = mapToValue(result.value);
     }
   }
 
-  if (!typeUri.length) {
+  if (!types.length) {
     throw new Error("Vertex type not found in bindings");
   }
 
-  const result: Vertex = {
-    entityType: "vertex",
+  return createVertex({
     id,
-    type: typeUri[0],
-    types: typeUri,
+    types,
     attributes,
-  };
-
-  return result;
+  });
 }
 
 function mapToValue(value: SparqlValue): string | number {

--- a/packages/graph-explorer/src/core/createEntities.test.ts
+++ b/packages/graph-explorer/src/core/createEntities.test.ts
@@ -1,0 +1,334 @@
+import { createEdge, createVertex } from "./createEntities";
+
+describe("createVertex", () => {
+  it("should create a vertex with a single type", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person"],
+      attributes: {
+        name: "Alice",
+      },
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person"],
+      attributes: {
+        name: "Alice",
+      },
+      __isFragment: false,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with multiple types", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person", "Worker"],
+      attributes: {
+        name: "Alice",
+      },
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person", "Worker"],
+      attributes: {
+        name: "Alice",
+      },
+      __isFragment: false,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with no types", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: [],
+      attributes: {
+        name: "Alice",
+      },
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "",
+      types: [],
+      attributes: {
+        name: "Alice",
+      },
+      __isFragment: false,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with missing attributes", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person"],
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person"],
+      attributes: {},
+      __isFragment: true,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with no attributes", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person"],
+      attributes: {},
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person"],
+      attributes: {},
+      __isFragment: false,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with attributes as a map", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person"],
+      attributes: new Map<string, string | number>([
+        ["name", "Alice"],
+        ["age", 30],
+      ]),
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person"],
+      attributes: {
+        name: "Alice",
+        age: 30,
+      },
+      __isFragment: false,
+      __isBlank: false,
+    });
+  });
+
+  it("should create a vertex with that is a blank node", () => {
+    const vertex = createVertex({
+      id: "1",
+      types: ["Person"],
+      attributes: {},
+      isBlankNode: true,
+    });
+
+    expect(vertex).toMatchObject({
+      entityType: "vertex",
+      id: "1",
+      type: "Person",
+      types: ["Person"],
+      attributes: {},
+      __isFragment: false,
+      __isBlank: true,
+    });
+  });
+});
+
+describe("createEdge", () => {
+  it("should create an edge where the nodes have a single type", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      attributes: {
+        since: "2020-01-01",
+      },
+      source: {
+        id: "1",
+        types: ["Person"],
+      },
+      target: {
+        id: "2",
+        types: ["Person"],
+      },
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: ["Person"],
+      target: "2",
+      targetTypes: ["Person"],
+      attributes: {
+        since: "2020-01-01",
+      },
+      __isFragment: false,
+    });
+  });
+
+  it("should create an edge where the nodes have multiple types", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      attributes: {
+        since: "2020-01-01",
+      },
+      source: {
+        id: "1",
+        types: ["Person", "Worker"],
+      },
+      target: {
+        id: "2",
+        types: ["Person", "Worker"],
+      },
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: ["Person", "Worker"],
+      target: "2",
+      targetTypes: ["Person", "Worker"],
+      attributes: {
+        since: "2020-01-01",
+      },
+      __isFragment: false,
+    });
+  });
+
+  it("should create an edge where the nodes have no types", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      attributes: {
+        since: "2020-01-01",
+      },
+      source: {
+        id: "1",
+        types: [],
+      },
+      target: {
+        id: "2",
+        types: [],
+      },
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: [],
+      target: "2",
+      targetTypes: [],
+      attributes: {
+        since: "2020-01-01",
+      },
+      __isFragment: false,
+    });
+  });
+
+  it("should create an edge with missing attributes", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      source: {
+        id: "1",
+        types: ["Person"],
+      },
+      target: {
+        id: "2",
+        types: ["Person"],
+      },
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: ["Person"],
+      target: "2",
+      targetTypes: ["Person"],
+      attributes: {},
+      __isFragment: true,
+    });
+  });
+
+  it("should create an edge with no attributes", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      source: {
+        id: "1",
+        types: ["Person"],
+      },
+      target: {
+        id: "2",
+        types: ["Person"],
+      },
+      attributes: {},
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: ["Person"],
+      target: "2",
+      targetTypes: ["Person"],
+      attributes: {},
+      __isFragment: false,
+    });
+  });
+
+  it("should create an edge with attributes as a map", () => {
+    const edge = createEdge({
+      id: "1",
+      type: "WORKS_WITH",
+      source: {
+        id: "1",
+        types: ["Person"],
+      },
+      target: {
+        id: "2",
+        types: ["Person"],
+      },
+      attributes: new Map<string, string | number>([
+        ["since", "2020-01-01"],
+        ["until", "2020-01-02"],
+      ]),
+    });
+
+    expect(edge).toMatchObject({
+      entityType: "edge",
+      id: "1",
+      type: "WORKS_WITH",
+      source: "1",
+      sourceTypes: ["Person"],
+      target: "2",
+      targetTypes: ["Person"],
+      attributes: {
+        since: "2020-01-01",
+        until: "2020-01-02",
+      },
+      __isFragment: false,
+    });
+  });
+});

--- a/packages/graph-explorer/src/core/createEntities.ts
+++ b/packages/graph-explorer/src/core/createEntities.ts
@@ -1,0 +1,67 @@
+import { Vertex, Edge } from "./entities";
+import { createVertexId, createEdgeId } from "./entityIdType";
+
+type CreateEntityAttributeOptions =
+  | Map<string, string | number>
+  | Record<string, string | number>;
+
+type CreateVertexOptions = {
+  id: string | number;
+  types: string[];
+  attributes?: CreateEntityAttributeOptions;
+  isBlankNode?: boolean;
+};
+
+/** Constructs a Vertex instance from the given values. */
+export function createVertex(options: CreateVertexOptions): Vertex {
+  return {
+    entityType: "vertex",
+    id: createVertexId(options.id),
+    type: options.types[0] ?? "",
+    types: options.types,
+    attributes:
+      options.attributes != null ? createAttributes(options.attributes) : {},
+    __isFragment: options.attributes == null,
+    __isBlank: options.isBlankNode ?? false,
+  };
+}
+
+/** Constructs an Edge instance from the given values. */
+export function createEdge(options: {
+  id: string | number;
+  type: string;
+  source: CreateVertexOptions;
+  target: CreateVertexOptions;
+  attributes?: CreateEntityAttributeOptions;
+}): Edge {
+  const source = createVertex(options.source);
+  const target = createVertex(options.target);
+  return {
+    entityType: "edge",
+    id: createEdgeId(options.id),
+    type: options.type,
+    source: source.id,
+    sourceTypes: source.types,
+    target: target.id,
+    targetTypes: target.types,
+    attributes:
+      options.attributes != null ? createAttributes(options.attributes) : {},
+    __isFragment: options.attributes == null,
+  };
+}
+
+function createAttributes(
+  attributes: CreateEntityAttributeOptions
+): Vertex["attributes"] {
+  if (attributes instanceof Map) {
+    return attributes.entries().reduce(
+      (prev, [key, value]) => {
+        prev[key] = value;
+        return prev;
+      },
+      {} as Vertex["attributes"]
+    );
+  }
+
+  return attributes;
+}

--- a/packages/graph-explorer/src/core/entities.ts
+++ b/packages/graph-explorer/src/core/entities.ts
@@ -44,7 +44,7 @@ export type Vertex = {
   /**
    * Internal flag to mark the resource as blank node in RDF.
    */
-  __isBlank?: boolean;
+  __isBlank: boolean;
 };
 
 export type Edge = {

--- a/packages/graph-explorer/src/core/entities.ts
+++ b/packages/graph-explorer/src/core/entities.ts
@@ -1,5 +1,4 @@
 import { Branded } from "@/utils";
-import { createEdgeId, createVertexId } from "./entityIdType";
 
 export type EdgeId = Branded<string | number, "EdgeId">;
 export type VertexId = Branded<string | number, "VertexId">;
@@ -99,66 +98,3 @@ export type Entities = {
   nodes: Map<VertexId, Vertex>;
   edges: Map<EdgeId, Edge>;
 };
-
-type CreateEntityAttributeOptions =
-  | Map<string, string | number>
-  | Record<string, string | number>;
-
-type CreateVertexOptions = {
-  id: string | number;
-  types: string[];
-  attributes?: CreateEntityAttributeOptions;
-  isBlankNode?: boolean;
-};
-
-export function createVertex(options: CreateVertexOptions): Vertex {
-  return {
-    entityType: "vertex",
-    id: createVertexId(options.id),
-    type: options.types[0] ?? "",
-    types: options.types,
-    attributes:
-      options.attributes != null ? createAttributes(options.attributes) : {},
-    __isFragment: options.attributes == null,
-    __isBlank: options.isBlankNode ?? false,
-  };
-}
-
-export function createEdge(options: {
-  id: string | number;
-  type: string;
-  source: CreateVertexOptions;
-  target: CreateVertexOptions;
-  attributes?: CreateEntityAttributeOptions;
-}): Edge {
-  const source = createVertex(options.source);
-  const target = createVertex(options.target);
-  return {
-    entityType: "edge",
-    id: createEdgeId(options.id),
-    type: options.type,
-    source: source.id,
-    sourceTypes: source.types,
-    target: target.id,
-    targetTypes: target.types,
-    attributes:
-      options.attributes != null ? createAttributes(options.attributes) : {},
-    __isFragment: options.attributes == null,
-  };
-}
-
-function createAttributes(
-  attributes: CreateEntityAttributeOptions
-): Vertex["attributes"] {
-  if (attributes instanceof Map) {
-    return attributes.entries().reduce(
-      (prev, [key, value]) => {
-        prev[key] = value;
-        return prev;
-      },
-      {} as Vertex["attributes"]
-    );
-  }
-
-  return attributes;
-}

--- a/packages/graph-explorer/src/core/entities.ts
+++ b/packages/graph-explorer/src/core/entities.ts
@@ -1,4 +1,5 @@
 import { Branded } from "@/utils";
+import { createVertexId } from "./entityIdType";
 
 export type EdgeId = Branded<string | number, "EdgeId">;
 export type VertexId = Branded<string | number, "VertexId">;
@@ -40,7 +41,7 @@ export type Vertex = {
    * Sometimes the vertex response does not include the properties, so this flag
    * indicates that another query must be executed to get the properties.
    */
-  __isFragment?: boolean;
+  __isFragment: boolean;
   /**
    * Internal flag to mark the resource as blank node in RDF.
    */
@@ -98,3 +99,37 @@ export type Entities = {
   nodes: Map<VertexId, Vertex>;
   edges: Map<EdgeId, Edge>;
 };
+
+export function createVertex(options: {
+  id: string | number;
+  types: string[];
+  attributes?: Map<string, string | number> | Record<string, string | number>;
+  isBlankNode?: boolean;
+}): Vertex {
+  return {
+    entityType: "vertex",
+    id: createVertexId(options.id),
+    type: options.types[0] ?? "",
+    types: options.types,
+    attributes:
+      options.attributes != null ? createAttributes(options.attributes) : {},
+    __isFragment: options.attributes == null,
+    __isBlank: options.isBlankNode ?? false,
+  };
+}
+
+function createAttributes(
+  attributes: Map<string, string | number> | Record<string, string | number>
+): Vertex["attributes"] {
+  if (attributes instanceof Map) {
+    return attributes.entries().reduce(
+      (prev, [key, value]) => {
+        prev[key] = value;
+        return prev;
+      },
+      {} as Vertex["attributes"]
+    );
+  }
+
+  return attributes;
+}

--- a/packages/graph-explorer/src/core/index.ts
+++ b/packages/graph-explorer/src/core/index.ts
@@ -3,6 +3,7 @@ export * from "./ThemeProvider";
 export * from "./featureFlags";
 export * from "./StateProvider";
 export * from "./connector";
+export * from "./createEntities";
 export * from "./entityIdType";
 export * from "./entities";
 export * from "./renderedEntities";

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -1,10 +1,10 @@
 import {
+  createVertex,
   DisplayEdge,
   DisplayVertex,
   Edge,
   useDisplayEdgeFromEdge,
   useDisplayVertexFromVertex,
-  Vertex,
 } from "@/core";
 import {
   Button,
@@ -110,14 +110,7 @@ function useDisplayForEdgeVertex(
   edgeVertex: DisplayEdge["source"]
 ): DisplayVertex {
   // TODO: Fetch the vertex details to display the proper display name in the EdgeRow
-  const fragment: Vertex = {
-    entityType: "vertex",
-    id: edgeVertex.id,
-    type: edgeVertex.types[0] ?? "",
-    types: edgeVertex.types,
-    attributes: {},
-    __isFragment: true,
-  };
+  const fragment = createVertex(edgeVertex);
   const result = useDisplayVertexFromVertex(fragment);
   return {
     ...result,

--- a/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
+++ b/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
@@ -43,7 +43,9 @@ export function createGVertex(vertex: Vertex): GVertex {
     "@value": {
       id,
       label: vertex.types.join("::"),
-      properties: createGVertexProperties(vertex.attributes),
+      properties: vertex.__isFragment
+        ? undefined
+        : createGVertexProperties(vertex.attributes),
     },
   };
 }
@@ -58,7 +60,9 @@ export function createGEdge(edge: Edge): GEdge {
       outVLabel: edge.sourceTypes.join("::"),
       inV: createIdValue(edge.target),
       outV: createIdValue(edge.source),
-      properties: createGProperties(edge.attributes),
+      properties: edge.__isFragment
+        ? undefined
+        : createGProperties(edge.attributes),
     },
   };
 }

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -2,11 +2,11 @@ import {
   ArrowStyle,
   AttributeConfig,
   ConnectionWithId,
+  createEdge,
   createEdgeId,
   createNewConfigurationId,
   createVertex,
   createVertexId,
-  Edge,
   EdgeId,
   EdgePreferences,
   EdgeTypeConfig,
@@ -218,31 +218,37 @@ export function createRandomVertexForRdf() {
  * Creates a random edge.
  * @returns A random Edge object.
  */
-export function createRandomEdge(source: Vertex, target: Vertex): Edge {
-  return {
-    entityType: "edge",
+export function createRandomEdge(source: Vertex, target: Vertex) {
+  return createEdge({
     id: createRandomEdgeId(),
     type: createRandomName("EdgeType"),
     attributes: createRecord(3, createRandomEntityAttribute),
-    source: source.id,
-    sourceTypes: source.types,
-    target: target.id,
-    targetTypes: target.types,
-  };
+    source: {
+      id: source.id,
+      types: source.types,
+    },
+    target: {
+      id: target.id,
+      types: target.types,
+    },
+  });
 }
 
-export function createRandomEdgeForRdf(source: Vertex, target: Vertex): Edge {
+export function createRandomEdgeForRdf(source: Vertex, target: Vertex) {
   const predicate = createRandomUrlString();
-  return {
-    entityType: "edge",
+  return createEdge({
     id: createRdfEdgeId(source.id, predicate, target.id),
     type: predicate,
     attributes: {},
-    source: source.id,
-    sourceTypes: source.types,
-    target: target.id,
-    targetTypes: target.types,
-  };
+    source: {
+      id: source.id,
+      types: source.types,
+    },
+    target: {
+      id: target.id,
+      types: target.types,
+    },
+  });
 }
 
 /**

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -4,6 +4,7 @@ import {
   ConnectionWithId,
   createEdgeId,
   createNewConfigurationId,
+  createVertex,
   createVertexId,
   Edge,
   EdgeId,
@@ -195,26 +196,22 @@ export function createRandomEdgeId(): EdgeId {
  * Creates a random vertex.
  * @returns A random Vertex object.
  */
-export function createRandomVertex(): Vertex {
+export function createRandomVertex() {
   const label = createRandomName("VertexType");
-  return {
-    entityType: "vertex",
+  return createVertex({
     id: createRandomVertexId(),
-    type: label,
     types: [label],
     attributes: createRecord(3, createRandomEntityAttribute),
-  };
+  });
 }
 
-export function createRandomVertexForRdf(): Vertex {
+export function createRandomVertexForRdf() {
   const label = createRandomUrlString();
-  return {
-    entityType: "vertex",
-    id: createVertexId(createRandomUrlString()),
-    type: label,
+  return createVertex({
+    id: createRandomUrlString(),
     types: [label],
     attributes: createRecord(3, createRandomEntityAttributeForRdf),
-  };
+  });
 }
 
 /**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Instead of creating `Vertex` or `Edge` instances from scratch, I've changed it to use a factory method. This abstracts the intricacies of the type in to the factory function, such as how the fragment flag is determined and how type vs types are handled.

This also allows easier modification of the `Vertex` and `Edge` type structures in the future.

- Adds `createVertex()` and `createEdge()` functions
- Updates all creation sites to use new functions
- Add tests to ensure `__isFragment` is set correctly
- Make `__isFragment` and `__isBlank` non-optional

## Validation

- Smoke tested all three query languages

## Related Issues

- Part of #845

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
