### PR TITLE
Add ability to see full error message

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@
 - **Added** ability to restore the graph from the previous session
   ([#826](https://github.com/aws/graph-explorer/pull/826),
   [#840](https://github.com/aws/graph-explorer/pull/840))
+- **Added** ability to see full error details from errors in the UI
+  ([#858](https://github.com/aws/graph-explorer/pull/858))
 - **Added** query editor for Gremlin connections
   ([#853](https://github.com/aws/graph-explorer/pull/853),
   [#850](https://github.com/aws/graph-explorer/pull/850),

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -23,6 +23,7 @@
     "@mantine/emotion": "^7.17.1",
     "@mantine/hooks": "^7.17.1",
     "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-form": "^0.1.2",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",

--- a/packages/graph-explorer/src/components/Dialog.tsx
+++ b/packages/graph-explorer/src/components/Dialog.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@/utils";
+import { XIcon } from "lucide-react";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <div className="fixed inset-0 z-50 flex h-full w-full items-center justify-center p-20">
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "bg-background-default data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid max-h-full max-w-lg overflow-y-auto duration-200 sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-4 top-4 rounded-sm p-2 opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+          <XIcon className="h-5 w-5" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </div>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 p-6 pb-3 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogBody = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col gap-5 p-6 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+DialogBody.displayName = "DialogBody";
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse bg-gray-100 p-6 sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-bold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogBody,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/packages/graph-explorer/src/components/PanelError.tsx
+++ b/packages/graph-explorer/src/components/PanelError.tsx
@@ -1,6 +1,27 @@
 import { createDisplayError } from "@/utils/createDisplayError";
-import { PanelEmptyState } from "./PanelEmptyState";
 import { GraphIcon } from "./icons";
+import { Button } from "./Button";
+import {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateContent,
+  EmptyStateTitle,
+  EmptyStateDescription,
+  EmptyStateActions,
+} from "./EmptyState";
+import { InfoIcon, RotateCcwIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./Dialog";
+import { Label } from "./Label";
+import { FormField, FormItem } from "./Form";
 
 export default function PanelError({
   error,
@@ -13,14 +34,57 @@ export default function PanelError({
 }) {
   const displayError = createDisplayError(error);
   return (
-    <PanelEmptyState
-      variant="error"
-      icon={<GraphIcon />}
-      title={displayError.title}
-      subtitle={displayError.message}
-      onAction={onRetry}
-      actionLabel={onRetry ? "Retry" : undefined}
-      className={className}
-    />
+    <EmptyState className={className}>
+      <EmptyStateIcon variant="error">
+        <GraphIcon />
+      </EmptyStateIcon>
+      <EmptyStateContent>
+        <EmptyStateTitle>{displayError.title}</EmptyStateTitle>
+        <EmptyStateDescription>{displayError.message}</EmptyStateDescription>
+
+        <EmptyStateActions>
+          <ErrorDetailsButton error={error} />
+          {onRetry ? (
+            <Button onPress={onRetry}>
+              <RotateCcwIcon />
+              Retry
+            </Button>
+          ) : null}
+        </EmptyStateActions>
+      </EmptyStateContent>
+    </EmptyState>
+  );
+}
+
+function ErrorDetailsButton({ error }: { error: Error }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>
+          <InfoIcon />
+          Error Details
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Error Details</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          <FormItem>
+            <Label>Error name</Label>
+            <div>{error.name}</div>
+          </FormItem>
+          <FormItem>
+            <Label>Error message</Label>
+            <div>{error.message}</div>
+          </FormItem>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="filled">Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/graph-explorer/src/components/PanelError.tsx
+++ b/packages/graph-explorer/src/components/PanelError.tsx
@@ -21,7 +21,7 @@ import {
   DialogTrigger,
 } from "./Dialog";
 import { Label } from "./Label";
-import { FormField, FormItem } from "./Form";
+import { FormItem } from "./Form";
 
 export default function PanelError({
   error,
@@ -72,11 +72,15 @@ function ErrorDetailsButton({ error }: { error: Error }) {
         <DialogBody>
           <FormItem>
             <Label>Error name</Label>
-            <div>{error.name}</div>
+            <div className="text-pretty text-base leading-snug [word-break:break-word]">
+              {error.name}
+            </div>
           </FormItem>
           <FormItem>
             <Label>Error message</Label>
-            <div>{error.message}</div>
+            <div className="text-pretty text-base leading-snug [word-break:break-word]">
+              {error.message}
+            </div>
           </FormItem>
         </DialogBody>
         <DialogFooter>

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -14,6 +14,7 @@ export { PanelEmptyState } from "./PanelEmptyState";
 export * from "./PanelEmptyState";
 export { default as PanelError } from "./PanelError";
 
+export * from "./Dialog";
 export { default as Divider } from "./Divider";
 
 export * from "./EdgeRow";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.1.4
         version: 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.6
+        version: 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-form':
         specifier: ^0.1.2
         version: 0.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1882,6 +1885,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.6':
+    resolution: {integrity: sha512-/IVhJV5AceX620DUJ4uYVMymzsipdKBzo3edo+omeskCKGm9FRHM0ebIdbPnlQVJqyuHbuBltQUOG2mOTq2IYw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.0':
@@ -7703,6 +7719,28 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.18
+
+  '@radix-ui/react-dialog@1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.3(@types/react@18.3.18)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
   '@radix-ui/react-direction@1.1.0(@types/react@18.3.18)(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a new "Error Details" button to error panels to open a dialog with the full message from the error.

### Other changes

- Convert `PanelError` to use basic `EmptyState` components
- Add radix dialog component and styles (this is part of #701)

## Validation

![CleanShot 2025-03-28 at 17 12 03@2x](https://github.com/user-attachments/assets/3c319f13-1a08-44bc-b9e1-3bec2cdb67af)
![CleanShot 2025-03-28 at 17 12 08@2x](https://github.com/user-attachments/assets/4d2fb1ca-9711-4798-8e06-b8325e686532)

## Related Issues

- Part of #701 
- Resolves #856 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
