### PR TITLE
Make tests less fragile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,8 @@
   ([#847](https://github.com/aws/graph-explorer/pull/847),
   [#832](https://github.com/aws/graph-explorer/pull/832),
   [#834](https://github.com/aws/graph-explorer/pull/834))
+- **Updated** tests to be less fragile
+  ([865](https://github.com/aws/graph-explorer/pull/865))
 - **Updated** HMR behavior to ignore test files
   ([#835](https://github.com/aws/graph-explorer/pull/835))
 - **Fix** Docker build by not removing gzip

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -1,12 +1,11 @@
-import globalMockFetch from "@/connector/testUtils/globalMockFetch";
+import { globalMockFetch } from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighbors from ".";
 import { createEdge, createVertex, createVertexId } from "@/core";
 
 describe("Gremlin > fetchNeighbors", () => {
-  beforeEach(globalMockFetch);
-
   it("Should return all neighbors from node 2018", async () => {
+    globalMockFetch("should-return-all-neighbors-from-node-2018.json");
     const expectedVertices = [
       createVertex({
         id: "486",
@@ -189,6 +188,7 @@ describe("Gremlin > fetchNeighbors", () => {
   });
 
   it("Should return filtered neighbors from node 2018", async () => {
+    globalMockFetch("should-return-filtered-neighbors-from-node-2018.json");
     const expectedVertices = [
       createVertex({
         id: "486",

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighborsCount/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighborsCount/index.test.ts
@@ -1,12 +1,11 @@
-import globalMockFetch from "@/connector/testUtils/globalMockFetch";
+import { globalMockFetch } from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchNeighborsCount from ".";
 import { createVertexId } from "@/core";
 
 describe("Gremlin > fetchNeighborsCount", () => {
-  beforeEach(globalMockFetch);
-
   it("Should return neighbors counts for node 2018", async () => {
+    globalMockFetch("should-return-neighbors-counts-for-node-123.json");
     const response = await fetchNeighborsCount(mockGremlinFetch(), {
       vertexId: createVertexId("123"),
     });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/index.test.ts
@@ -1,12 +1,16 @@
-import globalMockFetch from "@/connector/testUtils/globalMockFetch";
+import { globalMockFetch } from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import fetchSchema from ".";
 import { ClientLoggerConnector } from "@/connector/LoggerConnector";
 
 describe("Gremlin > fetchSchema", () => {
-  beforeEach(globalMockFetch);
-
   it("Should return an inferred schema", async () => {
+    globalMockFetch(
+      "vertices-labels-and-counts.json",
+      "vertices-schema.json",
+      "edges-labels-and-counts.json",
+      "edges-schema.json"
+    );
     const schemaResponse = await fetchSchema(
       mockGremlinFetch(),
       new ClientLoggerConnector()

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/index.test.ts
@@ -1,12 +1,11 @@
-import globalMockFetch from "@/connector/testUtils/globalMockFetch";
+import { globalMockFetch } from "@/connector/testUtils/globalMockFetch";
 import mockGremlinFetch from "@/connector/testUtils/mockGremlinFetch";
 import keywordSearch from ".";
 import { createVertexId } from "@/core";
 
 describe("Gremlin > keywordSearch", () => {
-  beforeEach(globalMockFetch);
-
   it("Should return 1 random node", async () => {
+    globalMockFetch("should-return-1-random-node.json");
     const keywordResponse = await keywordSearch(mockGremlinFetch(), {
       limit: 1,
     });
@@ -37,6 +36,7 @@ describe("Gremlin > keywordSearch", () => {
   });
 
   it("Should return airports whose code matches with SFA", async () => {
+    globalMockFetch("should-return-airports-whose-code-matches-with-SFA.json");
     const keywordResponse = await keywordSearch(mockGremlinFetch(), {
       searchTerm: "SFA",
       vertexTypes: ["airport"],

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 
 const GREMLIN = "../gremlin/__mock";
-const RESPONSES_FILES_MAP_NEW = {
+const RESPONSES_FILES_MAP = {
   "vertices-schema.json": `${GREMLIN}/vertices-schema.json`,
   "vertices-labels-and-counts.json": `${GREMLIN}/vertices-labels-and-counts.json`,
   "edges-schema.json": `${GREMLIN}/edges-schema.json`,
@@ -14,7 +14,7 @@ const RESPONSES_FILES_MAP_NEW = {
   "should-return-filtered-neighbors-from-node-2018-counts.json": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018-counts.json`,
   "should-return-neighbors-counts-for-node-123.json": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
 };
-type FileName = keyof typeof RESPONSES_FILES_MAP_NEW;
+type FileName = keyof typeof RESPONSES_FILES_MAP;
 
 /**
  * Stubs out the fetch function and returns the contents of the given file or files.
@@ -27,7 +27,7 @@ export function globalMockFetch(...fileNames: FileName[]) {
   // Add a response for each file given
   for (const fileName of fileNames) {
     // Respond with the contents of the file
-    const filePath = RESPONSES_FILES_MAP_NEW[fileName];
+    const filePath = RESPONSES_FILES_MAP[fileName];
 
     // Only respond once with this response
     mockFetch.mockImplementationOnce(async () => {

--- a/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
+++ b/packages/graph-explorer/src/connector/testUtils/globalMockFetch.ts
@@ -1,39 +1,44 @@
 import { vi } from "vitest";
-import { shortHash } from "./shortHash";
 
 const GREMLIN = "../gremlin/__mock";
-const RESPONSES_FILES_MAP: Record<string, string> = {
-  "6281d1a5": `${GREMLIN}/vertices-schema.json`,
-  "186857e1": `${GREMLIN}/vertices-labels-and-counts.json`,
-  "2c38e2dd": `${GREMLIN}/edges-schema.json`,
-  "7062d2e": `${GREMLIN}/edges-labels-and-counts.json`,
-  "35be2501": `${GREMLIN}/should-return-1-random-node.json`,
-  "4b332677": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
-  "1559ced5": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
-  "37e14b1": `${GREMLIN}/should-return-all-neighbors-from-node-2018-counts.json`,
-  "7afef36": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
-  "40a4690b": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018-counts.json`,
-  "59bc2d43": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
+const RESPONSES_FILES_MAP_NEW = {
+  "vertices-schema.json": `${GREMLIN}/vertices-schema.json`,
+  "vertices-labels-and-counts.json": `${GREMLIN}/vertices-labels-and-counts.json`,
+  "edges-schema.json": `${GREMLIN}/edges-schema.json`,
+  "edges-labels-and-counts.json": `${GREMLIN}/edges-labels-and-counts.json`,
+  "should-return-1-random-node.json": `${GREMLIN}/should-return-1-random-node.json`,
+  "should-return-airports-whose-code-matches-with-SFA.json": `${GREMLIN}/should-return-airports-whose-code-matches-with-SFA.json`,
+  "should-return-all-neighbors-from-node-2018.json": `${GREMLIN}/should-return-all-neighbors-from-node-2018.json`,
+  "should-return-all-neighbors-from-node-2018-counts.json": `${GREMLIN}/should-return-all-neighbors-from-node-2018-counts.json`,
+  "should-return-filtered-neighbors-from-node-2018.json": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018.json`,
+  "should-return-filtered-neighbors-from-node-2018-counts.json": `${GREMLIN}/should-return-filtered-neighbors-from-node-2018-counts.json`,
+  "should-return-neighbors-counts-for-node-123.json": `${GREMLIN}/should-return-neighbors-counts-for-node-123.json`,
 };
+type FileName = keyof typeof RESPONSES_FILES_MAP_NEW;
 
-export default function globalMockFetch() {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (url: string) => {
-      const key = shortHash(url);
-      const filePath = RESPONSES_FILES_MAP[key];
-      if (!filePath) {
-        throw new Error(
-          `Failed to find a response file in the map for key '${key}' and URL '${url}'`,
-          { cause: { url } }
-        );
-      }
+/**
+ * Stubs out the fetch function and returns the contents of the given file or files.
+ *
+ * @param fileNames The file to use for a response. The order of files corresponds to the order of calls to the mock.
+ */
+export function globalMockFetch(...fileNames: FileName[]) {
+  const mockFetch = vi.fn();
+
+  // Add a response for each file given
+  for (const fileName of fileNames) {
+    // Respond with the contents of the file
+    const filePath = RESPONSES_FILES_MAP_NEW[fileName];
+
+    // Only respond once with this response
+    mockFetch.mockImplementationOnce(async () => {
       const response = await import(filePath);
       return Promise.resolve({
         json: () => {
           return Promise.resolve(response);
         },
       });
-    })
-  );
+    });
+  }
+
+  vi.stubGlobal("fetch", mockFetch);
 }

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -19,15 +19,24 @@ beforeEach(() => {
   vi.stubEnv("PROD", false);
 });
 
-beforeAll(() => {
-  // Mock localforage
-  vi.mock("localforage", () => {
-    return {
-      default: {
-        config: vi.fn(),
-        getItem: vi.fn(),
-        setItem: vi.fn(),
-      },
-    };
-  });
+// Mock logger
+vi.mock("@/utils/logger", () => ({
+  default: {
+    debug: vi.fn(),
+    log: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// Mock localforage
+vi.mock("localforage", () => {
+  return {
+    default: {
+      config: vi.fn(),
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    },
+  };
 });

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -12,6 +12,7 @@ expect.extend(matchers);
 afterEach(() => {
   cleanup();
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 beforeEach(() => {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

- Makes `globalMockFetch` helper in to an explicit stub of specific response files
  - The old code used a generated hash of the query string being submitted to find the file to use as the response. This was extremely fragile because any single character change in the query would cause these tests to break. It was then very difficult to determine which hash code to update to "fix" the tests.
- Ensure all global stubs are reset after each test
- Move `localforage` mock out of `beforeEach` since Vitest hoists that code to the global scope no matter where it is placed.
- Add global mock for `logger` so that when running tests nothing is printed to the standard out, making the test results much easier to comprehend

## Validation

- All tests pass
- No log statements are produced in test output


https://github.com/user-attachments/assets/8ec22322-76a5-409f-ad81-2b4a80059b6d



## Related Issues

- Part of #462
- Tech debt

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
