### PR TITLE
Add ability to cancel schema sync

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@
   [#840](https://github.com/aws/graph-explorer/pull/840))
 - **Added** ability to see full error details from errors in the UI
   ([#858](https://github.com/aws/graph-explorer/pull/858))
+- **Added** ability to cancel a long running schema sync
+  ([#869](https://github.com/aws/graph-explorer/pull/869))
 - **Updated** graph manipulation logic to lay foundations for query editor
   ([#864](https://github.com/aws/graph-explorer/pull/864),
   [#848](https://github.com/aws/graph-explorer/pull/848),

--- a/packages/graph-explorer/src/connector/queries.ts
+++ b/packages/graph-explorer/src/connector/queries.ts
@@ -24,8 +24,8 @@ export function schemaSyncQuery(
 ) {
   return queryOptions({
     queryKey: ["schema", explorer],
-    queryFn: async () => {
-      let schema = await explorer.fetchSchema();
+    queryFn: async ({ signal }) => {
+      let schema = await explorer.fetchSchema({ signal });
 
       // Update the prefixes for sparql connections
       schema = updateSchemaPrefixes(schema);

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -1,12 +1,22 @@
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useResolvedConfig } from "@/core/ConfigurationProvider";
 import { useExplorer } from "@/core/connector";
 import useUpdateSchema from "./useUpdateSchema";
-import { useIsFetching, useQuery } from "@tanstack/react-query";
+import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
 import { schemaSyncQuery } from "@/connector";
 
 export function useIsSyncing() {
   return useIsFetching({ queryKey: ["schema"] }) > 0;
+}
+
+export function useCancelSchemaSync() {
+  const queryClient = useQueryClient();
+  const { replaceSchema } = useUpdateSchema();
+  const explorer = useExplorer();
+  return useCallback(
+    () => queryClient.cancelQueries(schemaSyncQuery(replaceSchema, explorer)),
+    [replaceSchema, queryClient, explorer]
+  );
 }
 
 export function useSchemaSync() {

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -32,7 +32,11 @@ import {
   showDebugActionsAtom,
 } from "@/core";
 
-import { useIsSyncing, useSchemaSync } from "@/hooks/useSchemaSync";
+import {
+  useCancelSchemaSync,
+  useIsSyncing,
+  useSchemaSync,
+} from "@/hooks/useSchemaSync";
 import useTranslations from "@/hooks/useTranslations";
 import {
   formatDate,
@@ -178,6 +182,7 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
 /** Shows the vertex list, loading, or error state. */
 function MainContentLayout() {
   const schemaSyncQuery = useSchemaSync();
+  const cancel = useCancelSchemaSync();
 
   if (schemaSyncQuery.isFetching) {
     return (
@@ -187,6 +192,8 @@ function MainContentLayout() {
         title="Synchronizing..."
         subtitle="The connection is being synchronized."
         className="p-6"
+        onAction={() => cancel()}
+        actionLabel="Cancel Sync"
       />
     );
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds cancel button for long running schema sync.

## Validation

![Cancel schema sync](https://github.com/user-attachments/assets/5c535919-87df-4998-8064-08e2308b5015)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
