### PR TITLE
Fix RDF neighbor expansion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,8 @@
   ([#828](https://github.com/aws/graph-explorer/pull/828))
 - **Updated** namespaces sidebar to use tabs instead of dropdown
   ([#830](https://github.com/aws/graph-explorer/pull/830))
+- **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF
+  databases ([#870](https://github.com/aws/graph-explorer/pull/870))
 - **Fixed** issue with table exports
   ([#860](https://github.com/aws/graph-explorer/pull/860))
 - **Fixed** issue with long node titles or descriptions pushing the "add to

--- a/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/edgeDetails.ts
@@ -1,7 +1,6 @@
 import { createEdge } from "@/core";
 import { EdgeDetailsRequest, EdgeDetailsResponse } from "../useGEFetchTypes";
 import {
-  parseEdgeId,
   SparqlFetch,
   sparqlResponseSchema,
   sparqlUriValueSchema,
@@ -10,6 +9,7 @@ import { logger, query } from "@/utils";
 import { z } from "zod";
 import isErrorResponse from "../utils/isErrorResponse";
 import { idParam } from "./idParam";
+import { parseEdgeId } from "./parseEdgeId";
 
 const responseSchema = sparqlResponseSchema(
   z.object({

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.test.ts
@@ -1,0 +1,62 @@
+import { query } from "@/utils";
+import { getFilters, getSubjectClasses } from "./helpers";
+import { normalizeWithNewlines as normalize } from "@/utils/testing";
+
+describe("getSubjectClasses", () => {
+  it("should return empty string if no subject classes", () => {
+    const result = getSubjectClasses([]);
+    expect(result).toEqual("");
+  });
+
+  it("should create values with one class", () => {
+    const result = getSubjectClasses(["http://example.org/class"]);
+    expect(result).toEqual(
+      `VALUES ?subjectClass { <http://example.org/class> }`
+    );
+  });
+
+  it("should create values with multiple classes", () => {
+    const result = getSubjectClasses([
+      "http://example.org/class1",
+      "http://example.org/class2",
+    ]);
+    expect(result).toEqual(
+      `VALUES ?subjectClass { <http://example.org/class1> <http://example.org/class2> }`
+    );
+  });
+});
+
+describe("getFilters", () => {
+  it("should return empty string if no filters", () => {
+    const result = getFilters([]);
+    expect(normalize(result)).toEqual("");
+  });
+
+  it("should create filter with one criteria", () => {
+    const result = getFilters([
+      { predicate: "http://example.org/predicate", object: "value" },
+    ]);
+    expect(normalize(result)).toEqual(
+      normalize(query`
+        FILTER (
+          (?sPred=<http://example.org/predicate> && regex(str(?sValue), "value", "i"))
+        )
+      `)
+    );
+  });
+
+  it("should create filter with multiple criteria", () => {
+    const result = getFilters([
+      { predicate: "http://example.org/predicate", object: "value" },
+      { predicate: "http://example.org/predicate2", object: "value2" },
+    ]);
+    expect(normalize(result)).toEqual(
+      normalize(query`
+        FILTER (
+          (?sPred=<http://example.org/predicate> && regex(str(?sValue), "value", "i")) ||
+          (?sPred=<http://example.org/predicate2> && regex(str(?sValue), "value2", "i"))
+        )
+      `)
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
@@ -1,6 +1,5 @@
-import dedent from "dedent";
 import { SPARQLCriterion } from "../types";
-import { indentLinesBeyondFirst } from "@/utils";
+import { query } from "@/utils";
 
 export const getSubjectClasses = (subjectClasses: string[]) => {
   if (!subjectClasses?.length) {
@@ -27,9 +26,9 @@ export const getFilters = (filterCriteria: SPARQLCriterion[]) => {
     )
     .join(" ||\n");
 
-  return dedent`
+  return query`
   FILTER (
-    ${indentLinesBeyondFirst(filtersTemplate, "    ")}
+    ${filtersTemplate}
   )`;
 };
 

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
@@ -1,4 +1,6 @@
+import dedent from "dedent";
 import { SPARQLCriterion } from "../types";
+import { indentLinesBeyondFirst } from "@/utils";
 
 export const getSubjectClasses = (subjectClasses: string[]) => {
   if (!subjectClasses?.length) {
@@ -18,16 +20,17 @@ export const getFilters = (filterCriteria: SPARQLCriterion[]) => {
     return "";
   }
 
-  let filter = "FILTER(";
-  filterCriteria.forEach((criterion, cI) => {
-    filter += `(?sPred=<${criterion.predicate}> && regex(str(?sValue), "${criterion.object}", "i"))`;
+  const filtersTemplate = filterCriteria
+    .map(
+      c =>
+        `(?sPred=<${c.predicate}> && regex(str(?sValue), "${c.object}", "i"))`
+    )
+    .join(" ||\n");
 
-    if (cI < filterCriteria.length - 1) {
-      filter += " || ";
-    }
-  });
-  filter += ")";
-  return filter;
+  return dedent`
+  FILTER (
+    ${indentLinesBeyondFirst(filtersTemplate, "    ")}
+  )`;
 };
 
 export const getLimit = (limit?: number, offset?: number) => {

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
@@ -32,10 +32,3 @@ export function getFilters(filterCriteria: SPARQLCriterion[]) {
     )
   `;
 }
-
-export const getLimit = (limit?: number, offset?: number) => {
-  if (limit === 0) {
-    return "";
-  }
-  return `LIMIT ${limit} OFFSET ${offset}`;
-};

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/helpers.ts
@@ -1,7 +1,7 @@
 import { SPARQLCriterion } from "../types";
 import { query } from "@/utils";
 
-export const getSubjectClasses = (subjectClasses: string[]) => {
+export function getSubjectClasses(subjectClasses: string[]) {
   if (!subjectClasses?.length) {
     return "";
   }
@@ -12,9 +12,9 @@ export const getSubjectClasses = (subjectClasses: string[]) => {
   });
   classesValues += " }";
   return classesValues;
-};
+}
 
-export const getFilters = (filterCriteria: SPARQLCriterion[]) => {
+export function getFilters(filterCriteria: SPARQLCriterion[]) {
   if (!filterCriteria?.length) {
     return "";
   }
@@ -27,10 +27,11 @@ export const getFilters = (filterCriteria: SPARQLCriterion[]) => {
     .join(" ||\n");
 
   return query`
-  FILTER (
-    ${filtersTemplate}
-  )`;
-};
+    FILTER (
+      ${filtersTemplate}
+    )
+  `;
+}
 
 export const getLimit = (limit?: number, offset?: number) => {
   if (limit === 0) {

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.ts
@@ -1,134 +1,12 @@
-import groupBy from "lodash/groupBy";
-import { Edge, Vertex, VertexId } from "@/core";
 import {
   toMappedQueryResults,
   type NeighborsResponse,
 } from "@/connector/useGEFetchTypes";
-import mapIncomingToEdge, {
-  IncomingPredicate,
-  isIncomingPredicate,
-} from "../mappers/mapIncomingToEdge";
-import mapOutgoingToEdge, {
-  OutgoingPredicate,
-} from "../mappers/mapOutgoingToEdge";
-import mapRawResultToVertex from "../mappers/mapRawResultToVertex";
-import oneHopNeighborsTemplate from "./oneHopNeighborsTemplate";
-import subjectPredicatesTemplate from "./subjectPredicatesTemplate";
-import {
-  RawResult,
-  RawValue,
-  SparqlFetch,
-  SPARQLNeighborsRequest,
-} from "../types";
+import { oneHopNeighborsTemplate } from "./oneHopNeighborsTemplate";
+
+import { SparqlFetch, SPARQLNeighborsRequest } from "../types";
 import { logger } from "@/utils";
-
-type RawOneHopNeighborsResponse = {
-  results: {
-    bindings: Array<{
-      subject: RawValue;
-      pred: RawValue;
-      value: RawValue;
-      subjectClass: RawValue;
-      pToSubject?: RawValue;
-      pFromSubject?: RawValue;
-    }>;
-  };
-};
-
-type RawNeighborsPredicatesResponse = {
-  results: {
-    bindings: Array<OutgoingPredicate | IncomingPredicate>;
-  };
-};
-
-const isBlank = (result: RawValue) => {
-  return result.type === "bnode";
-};
-
-const fetchOneHopNeighbors = async (
-  sparqlFetch: SparqlFetch,
-  req: SPARQLNeighborsRequest
-) => {
-  const oneHopTemplate = oneHopNeighborsTemplate(req);
-  logger.log("[SPARQL Explorer] Fetching oneHopNeighbors...", req);
-  const data = await sparqlFetch<RawOneHopNeighborsResponse>(oneHopTemplate);
-
-  const groupBySubject = groupBy(
-    data.results.bindings,
-    result => result.subject.value
-  );
-
-  const mappedResults: Record<string, RawResult> = {};
-  const bNodesEdges: Edge[] = [];
-
-  Object.entries(groupBySubject).forEach(([uri, result]) => {
-    // Create outgoing predicates to blank nodes
-    if (isBlank(result[0].subject) && result[0].pToSubject) {
-      const edge = mapOutgoingToEdge(req.resourceURI, req.resourceClasses, {
-        subject: result[0].subject,
-        subjectClass: result[0].subjectClass,
-        predToSubject: result[0].pToSubject,
-      });
-      bNodesEdges.push(edge);
-    }
-
-    // Create incoming predicates from blank nodes
-    if (isBlank(result[0].subject) && result[0].pFromSubject) {
-      const edge = mapIncomingToEdge(req.resourceURI, req.resourceClasses, {
-        subject: result[0].subject,
-        subjectClass: result[0].subjectClass,
-        predFromSubject: result[0].pFromSubject,
-      });
-      bNodesEdges.push(edge);
-    }
-
-    mappedResults[uri] = {
-      uri: uri,
-      class: result[0].subjectClass.value,
-      isBlank: isBlank(result[0].subject),
-      attributes: {},
-    };
-
-    result.forEach(attr => {
-      mappedResults[uri].attributes[attr.pred.value] = attr.value.value;
-    });
-  });
-
-  const vertices = Object.values(mappedResults).map(result => {
-    return mapRawResultToVertex(result);
-  });
-
-  return {
-    vertices,
-    bNodesEdges,
-  };
-};
-
-export const fetchNeighborsPredicates = async (
-  sparqlFetch: SparqlFetch,
-  resourceURI: VertexId,
-  resourceClasses: Vertex["types"],
-  subjectURIs: VertexId[]
-) => {
-  const template = subjectPredicatesTemplate({
-    resourceURI,
-    subjectURIs,
-  });
-
-  logger.log("[SPARQL Explorer] Fetching neighbor predicates...", {
-    resourceURI,
-    resourceClasses,
-    subjectURIs,
-  });
-  const response = await sparqlFetch<RawNeighborsPredicatesResponse>(template);
-  return response.results.bindings.map(result => {
-    if (isIncomingPredicate(result)) {
-      return mapIncomingToEdge(resourceURI, resourceClasses, result);
-    }
-
-    return mapOutgoingToEdge(resourceURI, resourceClasses, result);
-  });
-};
+import { mapToResults, RawOneHopNeighborsResponse } from "./mapToResults";
 
 /**
  * Given a subject URI, it returns a set of subjects (with their properties)
@@ -144,26 +22,20 @@ export const fetchNeighborsPredicates = async (
  *
  * It does not return neighbors counts.
  */
-const fetchNeighbors = async (
+export default async function fetchNeighbors(
   sparqlFetch: SparqlFetch,
   req: SPARQLNeighborsRequest
-): Promise<NeighborsResponse> => {
-  const { vertices, bNodesEdges } = await fetchOneHopNeighbors(
-    sparqlFetch,
-    req
-  );
-  const subjectsURIs = vertices.map(v => v.id);
-  const edges = await fetchNeighborsPredicates(
-    sparqlFetch,
-    req.resourceURI,
-    req.resourceClasses,
-    subjectsURIs
-  );
+): Promise<NeighborsResponse> {
+  const oneHopTemplate = oneHopNeighborsTemplate(req);
+  logger.log("[SPARQL Explorer] Fetching oneHopNeighbors...", req);
+  const data = await sparqlFetch<RawOneHopNeighborsResponse>(oneHopTemplate);
+  logger.log("[SPARQL Explorer] Fetched oneHopNeighbors", data);
+
+  const results = mapToResults(data.results.bindings);
 
   return toMappedQueryResults({
-    vertices,
-    edges: [...edges, ...bNodesEdges],
+    // Filter out the source vertex since it is already in the graph and this one is missing the attributes
+    vertices: results.vertices.filter(v => v.id !== req.resourceURI),
+    edges: results.edges,
   });
-};
-
-export default fetchNeighbors;
+}

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.test.ts
@@ -1,0 +1,139 @@
+import { toMappedQueryResults } from "@/connector";
+import { mapToResults } from "./mapToResults";
+import { Edge, Vertex } from "@/core";
+import {
+  createRandomEdgeForRdf,
+  createRandomEntitiesForRdf,
+  createRandomVertexForRdf,
+} from "@/utils/testing";
+import { rdfTypeUri } from "../types";
+
+describe("mapToResults", () => {
+  it("should map empty data to empty results", () => {
+    const result = mapToResults([]);
+    expect(result).toEqual(toMappedQueryResults({}));
+  });
+  it("should map vertices to results", () => {
+    const entities = createRandomEntitiesForRdf();
+    const bindings = createBindings(
+      entities.nodes.values().toArray(),
+      entities.edges.values().toArray()
+    );
+    const result = mapToResults(bindings);
+    expect(result.vertices).toEqual(entities.nodes.values().toArray());
+    expect(result.edges).toEqual(entities.edges.values().toArray());
+  });
+  it("should map blank nodes to results", () => {
+    const vertex = createRandomVertexForRdf();
+    vertex.__isBlank = true;
+
+    const bindings = createBindings([vertex], []);
+    const result = mapToResults(bindings);
+    expect(result.vertices).toEqual([vertex]);
+    expect(result.vertices[0].__isBlank).toBe(true);
+  });
+  it("should map blank nodes and edges to results", () => {
+    const node1 = createRandomVertexForRdf();
+    const node2 = createRandomVertexForRdf();
+    node1.__isBlank = true;
+    node2.__isBlank = true;
+
+    const vertices = [node1, node2];
+    const edges = [createRandomEdgeForRdf(node1, node2)];
+    const bindings = createBindings(vertices, edges);
+    const result = mapToResults(bindings);
+
+    expect(result.vertices).toEqual(vertices);
+    expect(result.edges).toEqual(edges);
+  });
+});
+
+const rdfValue = {
+  uri(value: string) {
+    return { type: "uri", value };
+  },
+  blank(value: string) {
+    return { type: "bnode", value };
+  },
+  literal(value: string | number) {
+    if (typeof value === "number") {
+      return {
+        type: "literal",
+        datatype: "http://www.w3.org/2001/XMLSchema#integer",
+        value: String(value),
+      };
+    }
+    return { type: "literal", value };
+  },
+};
+
+function createBindings(vertices: Vertex[], edges: Edge[]) {
+  return [
+    ...vertices.flatMap(createBindingForVertex),
+    ...edges
+      .map(edge => {
+        // Gets the vertices to see if they are blank nodes
+        const source = vertices.find(v => v.id === edge.source);
+        const target = vertices.find(v => v.id === edge.target);
+        return {
+          edge,
+          source,
+          target,
+        };
+      })
+      .flatMap(createBindingsForEdge),
+  ];
+}
+
+function createBindingForVertex(vertex: Vertex) {
+  return [
+    // Vertex types
+    ...vertex.types.map(type => ({
+      subject: rdfValue.uri(String(vertex.id)),
+      p: rdfValue.uri(rdfTypeUri),
+      value: rdfValue.uri(type),
+    })),
+    // Vertex properties
+    ...Object.entries(vertex.attributes).map(([key, value]) => ({
+      subject: rdfValue.uri(String(vertex.id)),
+      p: rdfValue.uri(key),
+      value: rdfValue.literal(value),
+    })),
+  ].map(binding =>
+    // Modify bindings to represent blank nodes
+    vertex.__isBlank
+      ? {
+          ...binding,
+          subject: {
+            ...binding.subject,
+            type: "bnode",
+          },
+        }
+      : binding
+  );
+}
+
+function createBindingsForEdge({
+  edge,
+  source,
+  target,
+}: {
+  edge: Edge;
+  source?: Vertex;
+  target?: Vertex;
+}) {
+  const isSourceBlank = source?.__isBlank ?? false;
+  const isTargetBlank = target?.__isBlank ?? false;
+  return [
+    // Relationship between resources
+    {
+      subject: isSourceBlank
+        ? rdfValue.blank(String(edge.source))
+        : rdfValue.uri(String(edge.source)),
+      p: rdfValue.uri(edge.type),
+      value: isTargetBlank
+        ? rdfValue.blank(String(edge.target))
+        : rdfValue.uri(String(edge.target)),
+    },
+  ];
+}

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.ts
@@ -97,9 +97,12 @@ export function mapToResults(bindings: Bindings): MappedQueryResults {
   // Get edge related triples
   const edges = bindings
     .values()
-    .filter(triple => triple.p.value !== rdfTypeUri)
-    .filter(triple => ["uri", "bnode"].includes(triple.subject.type))
-    .filter(triple => ["uri", "bnode"].includes(triple.value.type))
+    .filter(
+      triple =>
+        triple.p.value !== rdfTypeUri &&
+        (triple.subject.type === "uri" || triple.subject.type === "bnode") &&
+        (triple.value.type === "uri" || triple.value.type === "bnode")
+    )
     .map(
       triple =>
         ({

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/mapToResults.ts
@@ -1,0 +1,148 @@
+import {
+  MappedQueryResults,
+  toMappedQueryResults,
+} from "@/connector/useGEFetchTypes";
+import { RawValue, rdfTypeUri } from "../types";
+import { createEdge, createVertex } from "@/core";
+import { createRdfEdgeId } from "../createRdfEdgeId";
+
+export type RawOneHopNeighborsResponse = {
+  results: {
+    bindings: Array<{
+      subject: RawValue;
+      p: RawValue;
+      value: RawValue;
+    }>;
+  };
+};
+type Bindings = RawOneHopNeighborsResponse["results"]["bindings"];
+
+type DraftRdfNode = {
+  uri: string;
+  classes?: string[];
+  isBlankNode?: boolean;
+  attributes?: { predicate: string; value: string | number }[];
+};
+
+type DraftRdfEdge = {
+  uri: string;
+  source?: string;
+  sourceClasses?: string[];
+  target?: string;
+  targetClasses?: string[];
+};
+
+export function mapToResults(bindings: Bindings): MappedQueryResults {
+  // Get types map
+  const typesMap = getTypesMap(bindings);
+
+  // Get node related triples
+  const drafts = bindings
+    .values()
+    .filter(triple => triple.p.value !== rdfTypeUri)
+    .reduce((draftsMap, current) => {
+      const updated = new Map(draftsMap);
+      const uri = current.subject.value;
+      const classes = typesMap.get(uri);
+      const isBlankNode = current.subject.type === "bnode";
+      const attribute =
+        current.value.type === "literal"
+          ? {
+              predicate: current.p.value,
+              value:
+                current.value.datatype ===
+                "http://www.w3.org/2001/XMLSchema#integer"
+                  ? Number(current.value.value)
+                  : current.value.value,
+            }
+          : null;
+
+      const existingDraft = updated.get(uri);
+
+      const draft: DraftRdfNode = {
+        ...existingDraft,
+        uri,
+        classes,
+        isBlankNode,
+        attributes: [
+          ...(existingDraft?.attributes ?? []),
+          ...(attribute ? [attribute] : []),
+        ],
+      };
+
+      updated.set(uri, draft);
+      return updated;
+    }, new Map<string, DraftRdfNode>());
+
+  const vertices = drafts
+    .values()
+    .map(draft => {
+      if (!draft.classes?.length) {
+        return null;
+      }
+      const attributes: Record<string, string | number> = {};
+      for (const attribute of draft.attributes ?? []) {
+        attributes[attribute.predicate] = attribute.value;
+      }
+      return createVertex({
+        id: draft.uri,
+        types: draft.classes,
+        isBlankNode: draft.isBlankNode,
+        attributes: attributes,
+      });
+    })
+    .filter(raw => raw != null)
+    .toArray();
+
+  // Get edge related triples
+  const edges = bindings
+    .values()
+    .filter(triple => triple.p.value !== rdfTypeUri)
+    .filter(triple => ["uri", "bnode"].includes(triple.subject.type))
+    .filter(triple => ["uri", "bnode"].includes(triple.value.type))
+    .map(
+      triple =>
+        ({
+          uri: triple.p.value,
+          source: triple.subject.value,
+          target: triple.value.value,
+          sourceClasses: typesMap.get(triple.subject.value),
+          targetClasses: typesMap.get(triple.value.value),
+        }) satisfies DraftRdfEdge
+    )
+    .map(draft => {
+      if (!draft.sourceClasses?.length || !draft.targetClasses?.length) {
+        return null;
+      }
+      return createEdge({
+        id: createRdfEdgeId(draft.source, draft.uri, draft.target),
+        source: createVertex({
+          id: draft.source,
+          types: draft.sourceClasses,
+        }),
+        target: createVertex({
+          id: draft.target,
+          types: draft.targetClasses,
+        }),
+        type: draft.uri,
+        attributes: {},
+      });
+    })
+    .filter(edge => edge != null)
+    .toArray();
+
+  return toMappedQueryResults({ vertices, edges });
+}
+
+function getTypesMap(bindings: Bindings) {
+  const typesMap = Map.groupBy(
+    bindings.filter(item => item.p.value === rdfTypeUri),
+    item => item.subject.value
+  );
+
+  return new Map(
+    typesMap
+      .entries()
+      .map(([key, value]) => [key, value.map(v => v.value.value)])
+  );
+}

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
@@ -1,7 +1,8 @@
 import { query } from "@/utils";
 import { SPARQLNeighborsRequest } from "../types";
-import { getFilters, getLimit, getSubjectClasses } from "./helpers";
+import { getFilters, getSubjectClasses } from "./helpers";
 import { idParam } from "../idParam";
+import { getLimit } from "../getLimit";
 
 /**
  * Generate a template with the same constraints that oneHopNeighborsTemplate

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -1,0 +1,156 @@
+import { oneHopNeighborsTemplate } from "./oneHopNeighborsTemplate";
+import { createVertexId } from "@/core";
+import { query } from "@/utils";
+import { normalizeWithNewlines as normalize } from "@/utils/testing";
+
+describe("oneHopNeighborsTemplate", () => {
+  it("should produce documentation example", () => {
+    // This represents the filter criteria used in the example documentation
+    const template = oneHopNeighborsTemplate({
+      resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
+      resourceClasses: [],
+      subjectClasses: ["http://www.example.com/soccer/ontology/Team"],
+      filterCriteria: [
+        {
+          predicate: "http://www.example.com/soccer/ontology/teamName",
+          object: "Arsenal",
+        },
+        {
+          predicate: "http://www.example.com/soccer/ontology/nickname",
+          object: "Gunners",
+        },
+      ],
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?p ?value
+        WHERE {
+          {
+            SELECT DISTINCT ?neighbor
+            WHERE {
+              BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+              VALUES ?class { <http://www.example.com/soccer/ontology/Team> }
+              {
+                ?neighbor ?pIncoming ?source .
+              }
+              UNION
+              {
+                ?source ?pOutgoing ?neighbor .
+              }
+              ?neighbor a ?class .
+              ?neighbor ?pValue ?value .
+              FILTER(
+                isLiteral(?value) && (
+                  (?pValue=<http://www.example.com/soccer/ontology/teamName> && regex(str(?value), "Arsenal", "i")) ||
+                  (?pValue=<http://www.example.com/soccer/ontology/nickname> && regex(str(?value), "Gunners", "i"))
+                )
+              )
+              FILTER NOT EXISTS {
+                ?anySubject a ?neighbor .
+              }
+            }
+            ORDER BY ?neighbor
+            LIMIT 2 OFFSET 0
+          }
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?neighbor ?pToSource ?source
+            BIND(?neighbor as ?subject)
+            BIND(?pToSource as ?p)
+            BIND(?source as ?value)
+          }
+          UNION
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?source ?pFromSource ?neighbor
+            BIND(?neighbor as ?value)
+            BIND(?pFromSource as ?p)
+            BIND(?source as ?subject)
+          }
+          UNION
+          {
+            ?neighbor ?p ?value
+            FILTER(isLiteral(?value) || ?p = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+            BIND(?neighbor as ?subject)
+          }
+          UNION
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?source ?p ?value
+            FILTER(?p = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+            BIND(?source as ?subject)
+          }
+        }
+        ORDER BY ?subject
+      `)
+    );
+  });
+
+  it("should produce query for resource", () => {
+    // This represents the filter criteria used in the example documentation
+    const template = oneHopNeighborsTemplate({
+      resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
+      resourceClasses: [],
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?p ?value
+        WHERE {
+          {
+            SELECT DISTINCT ?neighbor
+            WHERE {
+              BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+              {
+                ?neighbor ?pIncoming ?source .
+              }
+              UNION
+              {
+                ?source ?pOutgoing ?neighbor .
+              }
+              FILTER NOT EXISTS {
+                ?anySubject a ?neighbor .
+              }
+            }
+            ORDER BY ?neighbor
+            LIMIT 10 OFFSET 0
+          }
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?neighbor ?pToSource ?source
+            BIND(?neighbor as ?subject)
+            BIND(?pToSource as ?p)
+            BIND(?source as ?value)
+          }
+          UNION
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?source ?pFromSource ?neighbor
+            BIND(?neighbor as ?value)
+            BIND(?pFromSource as ?p)
+            BIND(?source as ?subject)
+          }
+          UNION
+          {
+            ?neighbor ?p ?value
+            FILTER(isLiteral(?value) || ?p = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+            BIND(?neighbor as ?subject)
+          }
+          UNION
+          {
+            BIND(<http://www.example.com/soccer/resource#EPL> AS ?source)
+            ?source ?p ?value
+            FILTER(?p = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+            BIND(?source as ?subject)
+          }
+        }
+        ORDER BY ?subject
+      `)
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -53,7 +53,7 @@ describe("oneHopNeighborsTemplate", () => {
               }
             }
             ORDER BY ?neighbor
-            LIMIT 2 OFFSET 0
+            LIMIT 2
           }
           ${commonPartOfQuery("http://www.example.com/soccer/resource#EPL")}
         }
@@ -90,7 +90,7 @@ describe("oneHopNeighborsTemplate", () => {
               }
             }
             ORDER BY ?neighbor
-            LIMIT 10 OFFSET 0
+            LIMIT 10
           }
           ${commonPartOfQuery("http://www.example.com/soccer/resource#EPL")}
         }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -1,7 +1,7 @@
 import { query } from "@/utils";
 import { idParam } from "../idParam";
 import { rdfTypeUri, SPARQLNeighborsRequest } from "../types";
-import { getLimit } from "./helpers";
+import { getLimit } from "../getLimit";
 
 /**
  * Fetch all neighbors and their predicates, values, and classes.

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -1,4 +1,4 @@
-import { indentLinesBeyondFirst, query } from "@/utils";
+import { query } from "@/utils";
 import { idParam } from "../idParam";
 import { rdfTypeUri, SPARQLNeighborsRequest } from "../types";
 import { getLimit } from "./helpers";
@@ -95,7 +95,7 @@ export function oneHopNeighborsTemplate({
       c =>
         `(?pValue=${idParam(c.predicate)} && regex(str(?value), "${c.object}", "i"))`
     )
-    .join(" ||\n            ");
+    .join(" ||\n");
   const filterTemplate = hasFilters
     ? query`
         FILTER(
@@ -138,7 +138,7 @@ export function oneHopNeighborsTemplate({
           }
           ${classBindingTemplate}
           ${valueBindingTemplate}
-          ${indentLinesBeyondFirst(filterTemplate, "          ")}
+          ${filterTemplate}
           # Remove any classes from the list of neighbors
           FILTER NOT EXISTS {
             ?anySubject a ?neighbor .

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -1,7 +1,7 @@
+import { indentLinesBeyondFirst, query } from "@/utils";
 import { idParam } from "../idParam";
-import { SPARQLNeighborsRequest } from "../types";
-import { getFilters, getLimit, getSubjectClasses } from "./helpers";
-import { query } from "@/utils";
+import { rdfTypeUri, SPARQLNeighborsRequest } from "../types";
+import { getLimit } from "./helpers";
 
 /**
  * Fetch all neighbors and their predicates, values, and classes.
@@ -52,38 +52,117 @@ import { query } from "@/utils";
  *   FILTER(isLiteral(?value))
  * }
  */
-export default function oneHopNeighborsTemplate({
+
+export function oneHopNeighborsTemplate({
   resourceURI,
   subjectClasses = [],
   filterCriteria = [],
   limit = 0,
   offset = 0,
 }: SPARQLNeighborsRequest): string {
+  const resourceTemplate = idParam(resourceURI);
+
+  // templates for filtering by value
+  const hasFilters = filterCriteria.length > 0;
+  const filterCriteriaTemplate = filterCriteria
+    .map(
+      c =>
+        `(?pValue=${idParam(c.predicate)} && regex(str(?value), "${c.object}", "i"))`
+    )
+    .join(" ||\n            ");
+  const filterTemplate = hasFilters
+    ? query`
+        FILTER(
+          isLiteral(?value) && (
+            ${filterCriteriaTemplate}
+          )
+        )
+      `
+    : "";
+  const valueBindingTemplate = hasFilters ? `?neighbor ?pValue ?value .` : "";
+
+  // templates for filtering by class
+  const subjectClassesTemplate = subjectClasses.length
+    ? `VALUES ?class { ${subjectClasses.map(idParam).join(" ")} }`
+    : "";
+  const classBindingTemplate = subjectClasses.length
+    ? `?neighbor a ?class .`
+    : "";
+
+  const limitTemplate = getLimit(limit, offset);
+  const rdfTypeUriTemplate = idParam(rdfTypeUri);
+
   return query`
-    # Fetch all neighbors and their predicates, values, and classes
-    SELECT ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
-      ?subject a     ?subjectClass;
-               ?pred ?value {
-        SELECT DISTINCT ?subject ?pToSubject ?pFromSubject {
-          BIND(${idParam(resourceURI)} AS ?argument)
-          ${getSubjectClasses(subjectClasses)}
+    SELECT DISTINCT ?subject ?p ?value
+    WHERE {
+      {
+        # This sub-query will give us all unique neighbors within the given limit
+        SELECT DISTINCT ?neighbor
+        WHERE {
+          BIND(${resourceTemplate} AS ?source)
+          ${subjectClassesTemplate}
           {
-            ?argument ?pToSubject ?subject.
-            ?subject a         ?subjectClass;
-                     ?sPred    ?sValue .
-            ${getFilters(filterCriteria)}
+            # Incoming neighbors
+            ?neighbor ?pIncoming ?source .
           }
           UNION
           {
-            ?subject ?pFromSubject ?argument;
-                     a         ?subjectClass;
-                     ?sPred    ?sValue .
-           ${getFilters(filterCriteria)}
+            # Outgoing neighbors
+            ?source ?pOutgoing ?neighbor .
+          }
+          ${classBindingTemplate}
+          ${valueBindingTemplate}
+          ${indentLinesBeyondFirst(filterTemplate, "          ")}
+          # Remove any classes from the list of neighbors
+          FILTER NOT EXISTS {
+            ?anySubject a ?neighbor .
           }
         }
-        ${getLimit(limit, offset)}
+        ORDER BY ?neighbor
+        ${limitTemplate}
       }
-      FILTER(isLiteral(?value))
+
+      # Using the ?neighbor gathered above we can start getting
+      # the information we are really interested in
+      #
+      # - predicate to source from neighbor
+      # - predicate from source to neighbor
+      # - neighbor class
+      # - neighbor values
+
+      {
+        # Incoming connection predicate
+        BIND(${resourceTemplate} AS ?source)
+        ?neighbor ?pToSource ?source
+        BIND(?neighbor as ?subject)
+        BIND(?pToSource as ?p)
+        BIND(?source as ?value)
+      }
+      UNION
+      {
+        # Outgoing connection predicate
+        BIND(${resourceTemplate} AS ?source)
+        ?source ?pFromSource ?neighbor
+        BIND(?neighbor as ?value)
+        BIND(?pFromSource as ?p)
+        BIND(?source as ?subject)
+      }
+      UNION
+      {
+        # Values and types
+        ?neighbor ?p ?value
+        FILTER(isLiteral(?value) || ?p = ${rdfTypeUriTemplate})
+        BIND(?neighbor as ?subject)
+      }
+      UNION
+      {
+        # Source types
+        BIND(${resourceTemplate} AS ?source)
+        ?source ?p ?value
+        FILTER(?p = ${rdfTypeUriTemplate})
+        BIND(?source as ?subject)
+      }
     }
+    ORDER BY ?subject
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
@@ -1,0 +1,41 @@
+import { createVertexId } from "@/core";
+import neighborsCountTemplate from "./neighborsCountTemplate";
+import { normalizeWithNewlines as normalize } from "@/utils/testing";
+import { query } from "@/utils";
+
+describe("neighborsCountTemplate", () => {
+  it("should return a valid query", () => {
+    const template = neighborsCountTemplate({
+      resourceURI: createVertexId(
+        "http://kelvinlawrence.net/air-routes/resource/2018"
+      ),
+      limit: 10,
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT ?class (COUNT(?neighbor) as ?count) {
+          SELECT DISTINCT ?class ?neighbor
+          WHERE {
+            BIND(<http://kelvinlawrence.net/air-routes/resource/2018> AS ?source)
+            {
+              # Incoming neighbors
+              ?neighbor ?pIncoming ?source . 
+            }
+            UNION
+            { 
+              # Outgoing neighbors
+              ?source ?pOutgoing ?neighbor . 
+            }
+            ?neighbor a ?class .
+            FILTER NOT EXISTS {
+              ?anySubject a ?neighbor .
+            }
+          }
+          LIMIT 10
+        }
+        GROUP BY ?class
+      `)
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
@@ -4,7 +4,38 @@ import { normalizeWithNewlines as normalize } from "@/utils/testing";
 import { query } from "@/utils";
 
 describe("neighborsCountTemplate", () => {
-  it("should return a valid query", () => {
+  it("should return query with no limit", () => {
+    const template = neighborsCountTemplate({
+      resourceURI: createVertexId(
+        "http://kelvinlawrence.net/air-routes/resource/2018"
+      ),
+    });
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT ?class (COUNT(?neighbor) as ?count) {
+          SELECT DISTINCT ?class ?neighbor
+          WHERE {
+            BIND(<http://kelvinlawrence.net/air-routes/resource/2018> AS ?source)
+            {
+              ?neighbor ?pIncoming ?source . 
+            }
+            UNION
+            {
+              ?source ?pOutgoing ?neighbor . 
+            }
+            ?neighbor a ?class .
+            FILTER NOT EXISTS {
+              ?anySubject a ?neighbor .
+            }
+          }
+        }
+        GROUP BY ?class
+      `)
+    );
+  });
+
+  it("should return a valid query with a limit", () => {
     const template = neighborsCountTemplate({
       resourceURI: createVertexId(
         "http://kelvinlawrence.net/air-routes/resource/2018"

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.test.ts
@@ -54,7 +54,7 @@ describe("neighborsCountTemplate", () => {
               ?neighbor ?pIncoming ?source . 
             }
             UNION
-            { 
+            {
               # Outgoing neighbors
               ?source ?pOutgoing ?neighbor . 
             }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
@@ -1,6 +1,7 @@
 import { query } from "@/utils";
 import { SPARQLNeighborsCountRequest } from "../types";
 import { idParam } from "../idParam";
+import { getLimit } from "../getLimit";
 
 /**
  * Count neighbors by class which are related with the given subject URI.
@@ -36,7 +37,6 @@ export default function neighborsCountTemplate({
   limit,
 }: SPARQLNeighborsCountRequest) {
   const resourceTemplate = idParam(resourceURI);
-  const limitTemplate = limit ? `LIMIT ${limit}` : "";
 
   return query`
     # Count neighbors by class which are related with the given subject URI
@@ -61,7 +61,7 @@ export default function neighborsCountTemplate({
           ?anySubject a ?neighbor .
         }
       }
-      ${limitTemplate}
+      ${getLimit(limit)}
     }
     GROUP BY ?class
   `;

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
@@ -49,7 +49,7 @@ export default function neighborsCountTemplate({
           ?neighbor ?pIncoming ?source . 
         }
         UNION
-        { 
+        {
           # Outgoing neighbors
           ?source ?pOutgoing ?neighbor . 
         }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
@@ -29,27 +29,29 @@ export default function neighborsCountTemplate({
 
   return query`
     # Count neighbors by class which are related with the given subject URI
-    SELECT ?class (COUNT(DISTINCT ?neighbor) as ?count)
-    WHERE {
-      BIND(${resourceTemplate} AS ?source)
-      {
-        # Incoming neighbors
-        ?neighbor ?pIncoming ?source . 
-      }
-      UNION
-      { 
-        # Outgoing neighbors
-        ?source ?pOutgoing ?neighbor . 
-      }
+    SELECT ?class (COUNT(?neighbor) as ?count) {
+      SELECT DISTINCT ?class ?neighbor
+      WHERE {
+        BIND(${resourceTemplate} AS ?source)
+        {
+          # Incoming neighbors
+          ?neighbor ?pIncoming ?source . 
+        }
+        UNION
+        { 
+          # Outgoing neighbors
+          ?source ?pOutgoing ?neighbor . 
+        }
 
-      ?neighbor a ?class .
+        ?neighbor a ?class .
 
-      # Remove any classes from the list of neighbors
-      FILTER NOT EXISTS {
-        ?anySubject a ?neighbor .
+        # Remove any classes from the list of neighbors
+        FILTER NOT EXISTS {
+          ?anySubject a ?neighbor .
+        }
       }
+      ${limitTemplate}
     }
     GROUP BY ?class
-    ${limitTemplate}
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighborsCount/neighborsCountTemplate.ts
@@ -9,12 +9,23 @@ import { idParam } from "../idParam";
  * resourceURI = "http://kelvinlawrence.net/air-routes/resource/2018"
  * limit = 10
  *
- * SELECT ?class (COUNT(?class) AS ?count) {
- *   SELECT DISTINCT ?subject ?class {
- *     ?subject a ?class .
- *     { ?subject ?p <http://kelvinlawrence.net/air-routes/resource/2018> }
+ * SELECT ?class (COUNT(?neighbor) as ?count) {
+ *   SELECT DISTINCT ?class ?neighbor
+ *   WHERE {
+ *     BIND(<http://kelvinlawrence.net/air-routes/resource/2018> AS ?source)
+ *     {
+ *       # Incoming neighbors
+ *       ?neighbor ?pIncoming ?source .
+ *     }
  *     UNION
- *     { <http://kelvinlawrence.net/air-routes/resource/2018> ?p ?subject }
+ *     {
+ *       # Outgoing neighbors
+ *       ?source ?pOutgoing ?neighbor .
+ *     }
+ *     ?neighbor a ?class .
+ *     FILTER NOT EXISTS {
+ *       ?anySubject a ?neighbor .
+ *     }
  *   }
  *   LIMIT 10
  * }

--- a/packages/graph-explorer/src/connector/sparql/getLimit.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/getLimit.test.ts
@@ -1,0 +1,38 @@
+import { getLimit } from "./getLimit";
+
+describe("getLimit", () => {
+  it("should return empty string if no offset", () => {
+    const result = getLimit();
+    expect(result).toEqual("");
+  });
+
+  it("should return empty string if no limit", () => {
+    const result = getLimit(undefined);
+    expect(result).toEqual("");
+  });
+
+  it("should return empty string if limit is 0", () => {
+    const result = getLimit(0);
+    expect(result).toEqual("");
+  });
+
+  it("should return limit", () => {
+    const result = getLimit(10);
+    expect(result).toEqual("LIMIT 10");
+  });
+
+  it("should return limit with no offset when zero", () => {
+    const result = getLimit(10, 0);
+    expect(result).toEqual("LIMIT 10");
+  });
+
+  it("should return limit with offset", () => {
+    const result = getLimit(10, 5);
+    expect(result).toEqual("LIMIT 10 OFFSET 5");
+  });
+
+  it("should return offset only when limit is zero", () => {
+    const result = getLimit(0, 5);
+    expect(result).toEqual("OFFSET 5");
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/getLimit.ts
+++ b/packages/graph-explorer/src/connector/sparql/getLimit.ts
@@ -1,0 +1,7 @@
+export function getLimit(limit?: number, offset?: number) {
+  const limitTemplate = limit ? `LIMIT ${limit}` : null;
+  const offsetTemplate = offset ? `OFFSET ${offset}` : null;
+
+  // Combine the parts that exist with a space
+  return [limitTemplate, offsetTemplate].filter(Boolean).join(" ");
+}

--- a/packages/graph-explorer/src/connector/sparql/idParam.ts
+++ b/packages/graph-explorer/src/connector/sparql/idParam.ts
@@ -1,10 +1,9 @@
-import { EdgeId, getRawId, VertexId } from "@/core";
+import { EdgeId, VertexId } from "@/core";
 
 /** Formats the ID parameter for a sparql query based on the ID type. */
-export function idParam(id: VertexId | EdgeId) {
-  const rawId = getRawId(id);
-  if (typeof rawId !== "string") {
+export function idParam(id: VertexId | EdgeId | string) {
+  if (typeof id !== "string") {
     throw new Error("ID must be a URI");
   }
-  return `<${rawId}>`;
+  return `<${id}>`;
 }

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
@@ -5,6 +5,7 @@ import {
   getFilterPredicates,
   getSubjectClasses,
 } from "./helpers";
+import { getLimit } from "../getLimit";
 
 /**
  * This generates a template to get all blank nodes ids from
@@ -31,7 +32,7 @@ export default function keywordSearchBlankNodesIdsTemplate({
             ${getSubjectClasses(subjectClasses)}
             ${getFilterObject(exactMatch, searchTerm)}
         }
-        ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""}
+        ${getLimit(limit, offset)}
       }
       FILTER(isLiteral(?value))
       FILTER(isBlank(?bNode))

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
@@ -52,7 +52,7 @@ describe("SPARQL > keywordSearchTemplate", () => {
             SELECT DISTINCT ?subject ?class { 
               ?subject a ?class ; ?predicate ?value . 
             } 
-            LIMIT 10 OFFSET 0 
+            LIMIT 10
           } 
           FILTER(isLiteral(?value)) 
         }

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.ts
@@ -5,6 +5,7 @@ import {
   getFilterPredicates,
   getSubjectClasses,
 } from "./helpers";
+import { getLimit } from "../getLimit";
 
 /**
  * Fetch nodes matching the given search parameters
@@ -57,7 +58,7 @@ export default function keywordSearchTemplate({
             ${getSubjectClasses(subjectClasses)}
             ${getFilterObject(exactMatch, searchTerm)}
         }
-        ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""}
+        ${getLimit(limit, offset)}
       }
       FILTER(isLiteral(?value))
     }

--- a/packages/graph-explorer/src/connector/sparql/parseEdgeId.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/parseEdgeId.test.ts
@@ -1,5 +1,5 @@
 import { createEdgeId, createVertexId } from "@/core";
-import { parseEdgeId } from "./types";
+import { parseEdgeId } from "./parseEdgeId";
 
 test("parseEdgeId", () => {
   const edgeId = createEdgeId(

--- a/packages/graph-explorer/src/connector/sparql/parseEdgeId.ts
+++ b/packages/graph-explorer/src/connector/sparql/parseEdgeId.ts
@@ -1,0 +1,47 @@
+import { EdgeId, VertexId, getRawId, createVertexId } from "@/core";
+import { logger } from "@/utils";
+
+/**
+ * Parses out the source, target, and predicate from the edge ID.
+ *
+ * @param edgeId a synthetic id created using <source URI>-[predicate]-><target URI>
+ */
+export function parseEdgeId(edgeId: EdgeId): {
+  source: VertexId;
+  target: VertexId;
+  predicate: string;
+} {
+  const rawEdgeId = getRawId(edgeId);
+  if (typeof rawEdgeId !== "string") {
+    logger.error("SPARQL EdgeId values must be of type string");
+    throw new Error("SPARQL EdgeId values must be of type string");
+  }
+
+  const result = parseRdfEdgeIdString(rawEdgeId);
+
+  if (!result) {
+    logger.error("Couldn't parse SPARQL edge ID", edgeId);
+    throw new Error("Invalid RDF edge ID");
+  }
+
+  return {
+    source: createVertexId(result.source),
+    predicate: result.predicate,
+    target: createVertexId(result.target),
+  };
+}
+
+export function parseRdfEdgeIdString(value: string) {
+  const regex = /^(.*?)-\[(.*?)\]->(.*)$/;
+  const match = value.match(regex);
+
+  if (!match || match.length !== 4) {
+    return null;
+  }
+
+  const source = match[1].trim();
+  const predicate = match[2].trim();
+  const target = match[3].trim();
+
+  return { source, predicate, target };
+}

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -1,14 +1,6 @@
-import {
-  createVertexId,
-  Edge,
-  EdgeId,
-  getRawId,
-  Vertex,
-  VertexId,
-} from "@/core";
+import { Edge, Vertex, VertexId } from "@/core";
 import type { NeighborsCountResponse } from "../useGEFetchTypes";
 import { z } from "zod";
-import { logger } from "@/utils";
 
 export type SparqlFetch = <TResult = any>(
   queryTemplate: string
@@ -228,49 +220,4 @@ export function sparqlResponseSchema<T extends z.ZodTypeAny>(
       bindings: z.array(bindingsSchema),
     }),
   });
-}
-
-/**
- * Parses out the source, target, and predicate from the edge ID.
- *
- * @param edgeId a synthetic id created using <source URI>-[predicate]-><target URI>
- */
-export function parseEdgeId(edgeId: EdgeId): {
-  source: VertexId;
-  target: VertexId;
-  predicate: string;
-} {
-  const rawEdgeId = getRawId(edgeId);
-  if (typeof rawEdgeId !== "string") {
-    logger.error("SPARQL EdgeId values must be of type string");
-    throw new Error("SPARQL EdgeId values must be of type string");
-  }
-
-  const result = parseRdfEdgeIdString(rawEdgeId);
-
-  if (!result) {
-    logger.error("Couldn't parse SPARQL edge ID", edgeId);
-    throw new Error("Invalid RDF edge ID");
-  }
-
-  return {
-    source: createVertexId(result.source),
-    predicate: result.predicate,
-    target: createVertexId(result.target),
-  };
-}
-
-export function parseRdfEdgeIdString(value: string) {
-  const regex = /^(.*?)-\[(.*?)\]->(.*)$/;
-  const match = value.match(regex);
-
-  if (!match || match.length !== 4) {
-    return null;
-  }
-
-  const source = match[1].trim();
-  const predicate = match[2].trim();
-  const target = match[3].trim();
-
-  return { source, predicate, target };
 }

--- a/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/exportedGraph.ts
@@ -1,4 +1,4 @@
-import { parseRdfEdgeIdString } from "@/connector/sparql/types";
+import { parseRdfEdgeIdString } from "@/connector/sparql/parseEdgeId";
 import { createEdgeId, createVertexId, EdgeId, VertexId } from "@/core";
 import { APP_NAME, escapeString, logger } from "@/utils";
 import {

--- a/packages/graph-explorer/src/utils/sanitizeQuery.test.ts
+++ b/packages/graph-explorer/src/utils/sanitizeQuery.test.ts
@@ -1,0 +1,50 @@
+import { query } from "./sanitizeQuery";
+
+describe("sanitizeQuery", () => {
+  it("should remove leading space evenly across all lines and remove empty lines", () => {
+    const value = query`
+      SELECT ?subject ?pred ?value
+      WHERE {
+        ?subject a ?subjectClass;
+                 ?pred ?value .
+      }
+      ${"LIMIT 10"}
+    `;
+
+    expect(value).toEqual(
+      `SELECT ?subject ?pred ?value\n` +
+        `WHERE {\n` +
+        `  ?subject a ?subjectClass;\n` +
+        `           ?pred ?value .\n` +
+        `}\n` +
+        `LIMIT 10`
+    );
+  });
+
+  it("should handle parameters with multiple lines", () => {
+    const value = query`
+      SELECT ?subject ?pred ?value
+      WHERE {
+        ?subject a ?subjectClass;
+                 ?pred ?value .
+        ${'FILTER (\n  ?subject = <http://example.org/subject>\n  && ?pred = <http://example.org/predicate>\n  && ?value = "value"\n)'}
+      }
+      ${"LIMIT 10\nOFFSET 10"}
+    `;
+
+    expect(value).toEqual(
+      `SELECT ?subject ?pred ?value\n` +
+        `WHERE {\n` +
+        `  ?subject a ?subjectClass;\n` +
+        `           ?pred ?value .\n` +
+        `  FILTER (\n` +
+        `    ?subject = <http://example.org/subject>\n` +
+        `    && ?pred = <http://example.org/predicate>\n` +
+        `    && ?value = "value"\n` +
+        `  )\n` +
+        `}\n` +
+        `LIMIT 10\n` +
+        `OFFSET 10`
+    );
+  });
+});

--- a/packages/graph-explorer/src/utils/sanitizeQuery.ts
+++ b/packages/graph-explorer/src/utils/sanitizeQuery.ts
@@ -5,10 +5,16 @@ export function query(
   literals: TemplateStringsArray,
   ...placeholders: string[]
 ) {
-  // First make sure any parameters are properly indented
+  // Ensure any parameters are properly indented
   const indented = indentTemplate(literals, ...placeholders);
-  // Then remove leading space and empty lines
-  return dedent(indented).replace(/^\s*\n/gm, "");
+  return (
+    // Remove leading space
+    dedent(indented)
+      // Remove empty lines
+      .replace(/^\s*\n/gm, "")
+      // Remove trailing whitespace
+      .replace(/\s+$/gm, "")
+  );
 }
 
 /** Ensures that all multi-line template values match the indentation of the line where they are used. */

--- a/packages/graph-explorer/src/utils/sanitizeQuery.ts
+++ b/packages/graph-explorer/src/utils/sanitizeQuery.ts
@@ -7,3 +7,10 @@ export function query(
 ) {
   return dedent(literals, ...placeholders).replace(/^\s*\n/gm, "");
 }
+
+export function indentLinesBeyondFirst(str: string, indent: string) {
+  return str
+    .split("\n")
+    .map((line, index) => (index > 0 ? indent + line : line))
+    .join("\n");
+}

--- a/packages/graph-explorer/src/utils/testing/normalize.ts
+++ b/packages/graph-explorer/src/utils/testing/normalize.ts
@@ -23,3 +23,22 @@ export function normalize(str: string) {
 export function normalizeWithNoSpace(str: string) {
   return str.replace(/\s+/g, "");
 }
+
+/**
+ * Reduces all whitespace in a string to a single space and normalizes line endings.
+ * @param str The string to be normalized.
+ * @returns A whitespace and newline normalized string.
+ */
+export function normalizeWithNewlines(str: string) {
+  return (
+    str
+      // Remove any line beginning with `#` with or without whitespace in front
+      .replace(/^\s*#.*$/gm, "")
+      // Replace any line ending with a normalized line ending
+      .replace(/\r\n|\r|\n/g, "\n")
+      // Removes any empty lines
+      .replace(/^\s*\n/gm, "")
+      // Trim leading and trailing whitespace
+      .trim()
+  );
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes issues with neighbor expansion in RDF databases. It uses a single query to retrieve the following information using subqueries and unions:

- Distinct neighbors of source
  - Filter by class
  - Filter by property value
  - Limit results
- Edges between neighbor and source in both directions
- Neighbor properties and classes
- Resource classes of source

### Fixes issues

- Property value filter not working
- Neighbor counts inconsistent (only sometimes correct)
- Limit properly applied to neighbor list before getting to edges

### Does not fix

- [Remaining neighbor count issues with multi-label](#746)
- RDF handling of multi-label in other queries
  - I don't think multi-label in RDF was ever officially supported

### Other changes

- Moved `parseEdgeId` function out of `types.ts` file
- Update `idParam` to accept a plain string param

## Validation

- Verified with air routes in Neptune
- Verified with premiere league in Neptune (includes blank nodes)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
- Resolves #344
- Resolves #324 
- Resolves #871
- Part of #747 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
