### PR TITLE
Fix server side error when a query is cancelled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,8 @@
   ([#824](https://github.com/aws/graph-explorer/pull/824))
 - **Fixed** issue representing an edge connecting nodes with multiple labels
   ([#839](https://github.com/aws/graph-explorer/pull/839))
+- **Fixed** proxy server error when a request is aborted mid-stream
+  ([#873](https://github.com/aws/graph-explorer/pull/873))
 - **Updated** styling of buttons, input, textarea, and select fields
   ([#847](https://github.com/aws/graph-explorer/pull/847),
   [#832](https://github.com/aws/graph-explorer/pull/832),

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -149,11 +149,10 @@ async function fetchData(
 
     // Pipe the raw fetch response body directly to the client response
     if (response.body) {
-      // TODO: this doesn't seem to work right with cancelling requests
       pipeline(response.body, res, err => {
         if (err) {
-          console.error("Pipeline failed", err);
-          res.status(500).send("Stream error");
+          // Log the error as a warning, but otherwise ignore it
+          proxyLogger.warn("Pipeline error %o", err);
         }
       });
     } else {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

If a request to the proxy server is interrupted in the middle of piping the database response back, then we will fire the pipeline error handler. This was attempting to set the response status on a closed stream, which results in an error.

Instead, I now just log the error as a warning since the error doesn't actually cause any true harm. It no longer attempts to modify the response at all.

## Validation

- Verified locally with a query that is aborted milliseconds after the request is created

## Related Issues

- Resolves #861

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
