### PR TITLE
Fix performance issues in generatePrefixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -45,6 +45,9 @@ And as always, there are many additional small fixes and improvements.
   ([#828](https://github.com/aws/graph-explorer/pull/828))
 - **Updated** namespaces sidebar to use tabs instead of dropdown
   ([#830](https://github.com/aws/graph-explorer/pull/830))
+- **Fixed** rendering performance issues adding to the graph and showing the
+  entity filters or node & edge style sidebars
+  ([#892](https://github.com/aws/graph-explorer/pull/892))
 - **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF
   databases ([#870](https://github.com/aws/graph-explorer/pull/870))
 - **Fixed** issue where double click expansion was inconsistent

--- a/packages/graph-explorer/src/components/CheckboxList.tsx
+++ b/packages/graph-explorer/src/components/CheckboxList.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/utils";
-import { ReactNode } from "react";
-import Divider from "./Divider";
+import { ComponentPropsWithoutRef, PropsWithChildren, ReactNode } from "react";
 import { Label } from "./Label";
 import { Checkbox } from "./Checkbox";
+import { Virtuoso } from "react-virtuoso";
 
 export type CheckboxListItemProps = {
   id: string;
@@ -17,10 +17,6 @@ export type CheckboxListProps = {
    */
   className?: string;
   /**
-   * The content to display as element title.
-   */
-  title?: string;
-  /**
    * Checkboxes array to be displayed.
    */
   checkboxes: Array<CheckboxListItemProps>;
@@ -29,10 +25,6 @@ export type CheckboxListProps = {
    */
   selectedIds: Set<string>;
   /**
-   * If true <code>true</code> the component is disabled
-   */
-  isDisabled?: boolean;
-  /**
    * Callback fired when the state is changed
    */
   onChange(id: string, isSelected: boolean): void;
@@ -40,67 +32,89 @@ export type CheckboxListProps = {
    * Callback fired when the state of all checkboxes it wants to be changed.
    * If this method is not defined, the "all/none" Checkbox is removed.
    */
-  onChangeAll?(isSelected: boolean): void;
+  onChangeAll(isSelected: boolean): void;
 };
 
 export default function CheckboxList({
   className,
-  title,
   checkboxes,
-  isDisabled,
   selectedIds,
   onChange,
   onChangeAll,
 }: CheckboxListProps) {
   const numOfSelections = selectedIds.size;
   const totalCheckboxes = checkboxes.length;
-  const allDisabled = checkboxes.reduce(
-    (disabled, ch) => disabled && !!ch.isDisabled,
-    true
-  );
 
   return (
-    <div className={cn("space-y-2", className)}>
-      {title && <div className="text-base font-medium">{title}</div>}
-      <div className="border-divider flex flex-col gap-3 rounded-lg border py-3">
-        {checkboxes.map(checkbox => {
-          return (
-            <Label
-              key={checkbox.id}
-              className="w-full px-3 hover:cursor-pointer"
-            >
-              <Checkbox
-                aria-label={`checkbox for ${checkbox.id}`}
-                checked={selectedIds.has(checkbox.id)}
-                disabled={isDisabled || checkbox.isDisabled}
-                onCheckedChange={isSelected =>
-                  onChange(checkbox.id, Boolean(isSelected))
+    <div className={cn("flex h-full grow flex-col space-y-2", className)}>
+      <div className="flex h-full grow flex-col gap-3">
+        <Virtuoso
+          className="h-full grow"
+          data={checkboxes}
+          components={{
+            Header: () => (
+              <CheckboxRow
+                isTop={true}
+                isBottom={false}
+                aria-label="checkbox for all"
+                checked={
+                  numOfSelections > 0 && numOfSelections !== totalCheckboxes
+                    ? "indeterminate"
+                    : numOfSelections === totalCheckboxes
                 }
-              ></Checkbox>
+                onCheckedChange={isSelected => {
+                  onChangeAll(Boolean(isSelected));
+                }}
+                className="font-bold"
+              >
+                {numOfSelections} selected of {totalCheckboxes}
+              </CheckboxRow>
+            ),
+          }}
+          itemContent={(index, checkbox) => (
+            <CheckboxRow
+              isBottom={index === checkboxes.length - 1}
+              isTop={false}
+              aria-label={`checkbox for ${checkbox.id}`}
+              checked={selectedIds.has(checkbox.id)}
+              onCheckedChange={isSelected =>
+                onChange(checkbox.id, Boolean(isSelected))
+              }
+            >
               <div className="grow">{checkbox.text}</div>
               <div className="[&_svg]:size-5">{checkbox.endAdornment}</div>
-            </Label>
-          );
-        })}
-        <Divider />
-        {onChangeAll && (
-          <Label className="inline-flex items-center gap-2 px-3 tabular-nums hover:cursor-pointer">
-            <Checkbox
-              aria-label="checkbox for all"
-              checked={
-                numOfSelections > 0 && numOfSelections !== totalCheckboxes
-                  ? "indeterminate"
-                  : numOfSelections === totalCheckboxes
-              }
-              disabled={isDisabled || allDisabled}
-              onCheckedChange={isSelected => {
-                onChangeAll(Boolean(isSelected));
-              }}
-            />
-            {numOfSelections} selected of {totalCheckboxes}
-          </Label>
-        )}
+            </CheckboxRow>
+          )}
+        />
       </div>
+    </div>
+  );
+}
+
+function CheckboxRow({
+  isBottom,
+  isTop,
+  className,
+  children,
+  ...checkboxProps
+}: PropsWithChildren<
+  { isTop: boolean; isBottom: boolean } & ComponentPropsWithoutRef<
+    typeof Checkbox
+  >
+>) {
+  return (
+    <div className={cn("px-3", isTop && "pt-3", isBottom && "pb-3")}>
+      <Label
+        className={cn(
+          "text-text-primary w-full border-x border-b px-3 py-3 hover:cursor-pointer",
+          isTop && "bg-background-contrast/50 rounded-t-lg border-t",
+          isBottom && "rounded-b-lg",
+          className
+        )}
+      >
+        <Checkbox {...checkboxProps} />
+        {children}
+      </Label>
     </div>
   );
 }

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -159,11 +159,9 @@ export function updateSchemaPrefixes(schema: SchemaInference): SchemaInference {
   const existingPrefixes = schema.prefixes ?? [];
 
   // Get all the resource URIs from the vertex and edge type configs
-  const resourceUris = schema.vertices
-    .flatMap(v => [v.type, ...v.attributes.map(attr => attr.name)])
-    .concat(schema.edges.map(e => e.type));
+  const resourceUris = getResourceUris(schema);
 
-  if (resourceUris.length === 0) {
+  if (resourceUris.size === 0) {
     return schema;
   }
 
@@ -178,6 +176,23 @@ export function updateSchemaPrefixes(schema: SchemaInference): SchemaInference {
     ...schema,
     prefixes: genPrefixes,
   };
+}
+
+/** A performant way to construct the set of resource URIs from the schema. */
+function getResourceUris(schema: SchemaInference) {
+  const result = new Set<string>();
+
+  schema.vertices.forEach(v => {
+    result.add(v.type);
+    v.attributes.forEach(attr => {
+      result.add(attr.name);
+    });
+  });
+  schema.edges.forEach(e => {
+    result.add(e.type);
+  });
+
+  return result;
 }
 
 /** Updates the schema with any new vertex or edge types, any new attributes, and updates the generated prefixes for sparql connections. */

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -1,0 +1,230 @@
+import { Modal } from "@mantine/core";
+import { useCallback, useMemo } from "react";
+import { atom, useRecoilState, useResetRecoilState } from "recoil";
+import { Button, InputField, SelectField } from "@/components";
+import ColorInput from "@/components/ColorInput/ColorInput";
+import { useDisplayEdgeTypeConfig, useWithTheme } from "@/core";
+import {
+  ArrowStyle,
+  EdgePreferences,
+  LineStyle,
+  userStylingEdgeAtom,
+} from "@/core/StateProvider/userPreferences";
+import useTranslations from "@/hooks/useTranslations";
+import {
+  SOURCE_ARROW_STYLE_OPTIONS,
+  TARGET_ARROW_STYLE_OPTIONS,
+} from "./arrowsStyling";
+import { LINE_STYLE_OPTIONS } from "./lineStyling";
+import modalDefaultStyles from "./SingleEdgeStylingModal.style";
+import { RESERVED_TYPES_PROPERTY } from "@/utils";
+
+export const customizeEdgeTypeAtom = atom<string | undefined>({
+  key: "customize-edge-type",
+  default: undefined,
+});
+
+export type SingleEdgeStylingProps = {
+  edgeType: string;
+  opened: boolean;
+};
+
+export default function EdgeStyleDialog() {
+  const styleWithTheme = useWithTheme();
+
+  const [customizeEdgeType, setCustomizeEdgeType] = useRecoilState(
+    customizeEdgeTypeAtom
+  );
+
+  return (
+    <Modal
+      opened={Boolean(customizeEdgeType)}
+      onClose={() => setCustomizeEdgeType(undefined)}
+      centered={true}
+      size="auto"
+      title={
+        customizeEdgeType ? <DialogTitle edgeType={customizeEdgeType} /> : null
+      }
+      className={styleWithTheme(modalDefaultStyles)}
+      overlayProps={{
+        backgroundOpacity: 0.1,
+      }}
+    >
+      {customizeEdgeType ? <Content edgeType={customizeEdgeType} /> : null}
+    </Modal>
+  );
+}
+
+function DialogTitle({ edgeType }: { edgeType: string }) {
+  const displayConfig = useDisplayEdgeTypeConfig(edgeType);
+  return (
+    <div>
+      Customize <strong>{displayConfig.displayLabel}</strong>
+    </div>
+  );
+}
+
+function Content({ edgeType }: { edgeType: string }) {
+  const displayConfig = useDisplayEdgeTypeConfig(edgeType);
+  const t = useTranslations();
+
+  const [edgePreferences, setEdgePreferences] = useRecoilState(
+    userStylingEdgeAtom(edgeType)
+  );
+
+  const selectOptions = useMemo(() => {
+    const options = displayConfig.attributes.map(attr => ({
+      value: attr.name,
+      label: attr.displayLabel,
+    }));
+
+    options.unshift({
+      label: t("edges-styling.edge-type"),
+      value: RESERVED_TYPES_PROPERTY,
+    });
+
+    return options;
+  }, [displayConfig.attributes, t]);
+
+  const onUserPrefsChange = useCallback(
+    (prefs: Omit<EdgePreferences, "type">) => {
+      setEdgePreferences({ type: edgeType, ...prefs });
+    },
+    [edgeType, setEdgePreferences]
+  );
+
+  const onUserPrefsReset = useResetRecoilState(userStylingEdgeAtom(edgeType));
+
+  return (
+    <div className="modal-container">
+      <div>
+        <p>Display Attributes</p>
+        <div className="attrs-container">
+          <SelectField
+            label="Display Name Attribute"
+            labelPlacement="inner"
+            value={displayConfig.displayNameAttribute}
+            onValueChange={value =>
+              onUserPrefsChange({ displayNameAttribute: value })
+            }
+            options={selectOptions}
+          />
+        </div>
+      </div>
+      <div>
+        <p>Label Styling</p>
+        <div className="attrs-container">
+          <ColorInput
+            label="Color"
+            labelPlacement="inner"
+            startColor={edgePreferences?.labelColor || "#17457b"}
+            onChange={(color: string) =>
+              onUserPrefsChange({ labelColor: color })
+            }
+          />
+          <InputField
+            label="Background Opacity"
+            labelPlacement="inner"
+            type="number"
+            min={0}
+            max={1}
+            step={0.1}
+            value={edgePreferences?.labelBackgroundOpacity ?? 0.7}
+            onChange={(value: number) =>
+              onUserPrefsChange({ labelBackgroundOpacity: value })
+            }
+          />
+        </div>
+      </div>
+      <div>
+        <div className="attrs-container">
+          <ColorInput
+            label="Border Color"
+            labelPlacement="inner"
+            startColor={edgePreferences?.labelBorderColor || "#17457b"}
+            onChange={(color: string) =>
+              onUserPrefsChange({ labelBorderColor: color })
+            }
+          />
+          <InputField
+            label="Border Width"
+            labelPlacement="inner"
+            type="number"
+            min={0}
+            value={edgePreferences?.labelBorderWidth ?? 0}
+            onChange={(value: number) =>
+              onUserPrefsChange({ labelBorderWidth: value })
+            }
+          />
+          <SelectField
+            label="Border Style"
+            labelPlacement="inner"
+            value={edgePreferences?.labelBorderStyle || "solid"}
+            onValueChange={value =>
+              onUserPrefsChange({ labelBorderStyle: value as LineStyle })
+            }
+            options={LINE_STYLE_OPTIONS}
+          />
+        </div>
+      </div>
+      <div>
+        <p>Line Styling</p>
+        <div className="attrs-container">
+          <ColorInput
+            label="Color"
+            labelPlacement="inner"
+            startColor={edgePreferences?.lineColor || "#b3b3b3"}
+            onChange={(color: string) =>
+              onUserPrefsChange({ lineColor: color })
+            }
+          />
+          <InputField
+            label="Thickness"
+            labelPlacement="inner"
+            type="number"
+            min={1}
+            value={edgePreferences?.lineThickness || 2}
+            onChange={(value: number) =>
+              onUserPrefsChange({ lineThickness: value })
+            }
+          />
+          <SelectField
+            label="Style"
+            labelPlacement="inner"
+            value={edgePreferences?.lineStyle || "solid"}
+            onValueChange={value =>
+              onUserPrefsChange({ lineStyle: value as LineStyle })
+            }
+            options={LINE_STYLE_OPTIONS}
+          />
+        </div>
+      </div>
+      <div>
+        <p>Arrows Styling</p>
+        <div className="attrs-container">
+          <SelectField
+            label="Source"
+            labelPlacement="inner"
+            value={edgePreferences?.sourceArrowStyle || "none"}
+            onValueChange={value =>
+              onUserPrefsChange({ sourceArrowStyle: value as ArrowStyle })
+            }
+            options={SOURCE_ARROW_STYLE_OPTIONS}
+          />
+          <SelectField
+            label="Target"
+            labelPlacement="inner"
+            value={edgePreferences?.targetArrowStyle || "triangle"}
+            onValueChange={value =>
+              onUserPrefsChange({ targetArrowStyle: value as ArrowStyle })
+            }
+            options={TARGET_ARROW_STYLE_OPTIONS}
+          />
+        </div>
+      </div>
+      <div className="actions">
+        <Button onPress={onUserPrefsReset}>Reset to Default</Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -24,11 +24,6 @@ export const customizeEdgeTypeAtom = atom<string | undefined>({
   default: undefined,
 });
 
-export type SingleEdgeStylingProps = {
-  edgeType: string;
-  opened: boolean;
-};
-
 export default function EdgeStyleDialog() {
   const styleWithTheme = useWithTheme();
 

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
@@ -11,17 +11,16 @@ import { useDisplayEdgeTypeConfigs } from "@/core";
 import useTranslations from "@/hooks/useTranslations";
 import SingleEdgeStyling from "./SingleEdgeStyling";
 import { SidebarCloseButton } from "../SidebarCloseButton";
+import EdgeStyleDialog from "./EdgeStyleDialog";
+import { useMemo } from "react";
+import { Virtuoso } from "react-virtuoso";
 
-export type EdgesStylingProps = {
-  onEdgeCustomize(edgeType?: string): void;
-  customizeEdgeType?: string;
-};
-
-function EdgesStyling({
-  customizeEdgeType,
-  onEdgeCustomize,
-}: EdgesStylingProps) {
-  const etConfigs = useDisplayEdgeTypeConfigs().values().toArray();
+function EdgesStyling() {
+  const etConfigMap = useDisplayEdgeTypeConfigs();
+  const etConfigs = useMemo(
+    () => etConfigMap.values().toArray(),
+    [etConfigMap]
+  );
   const t = useTranslations();
 
   return (
@@ -33,21 +32,21 @@ function EdgesStyling({
         </PanelHeaderActions>
       </PanelHeader>
       <PanelContent className="flex flex-col gap-2">
-        {etConfigs.map((etConfig, index) => {
-          return (
+        <Virtuoso
+          className="h-full grow"
+          data={etConfigs}
+          itemContent={(index, etConfig) => (
             <Fragment key={etConfig.type}>
               {index !== 0 ? <Divider /> : null}
 
               <SingleEdgeStyling
                 edgeType={etConfig.type}
-                opened={customizeEdgeType === etConfig.type}
-                onOpen={() => onEdgeCustomize(etConfig.type)}
-                onClose={() => onEdgeCustomize(undefined)}
                 className="px-3 pb-3 pt-2"
               />
             </Fragment>
-          );
-        })}
+          )}
+        />
+        <EdgeStyleDialog />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -1,70 +1,36 @@
-import { Modal } from "@mantine/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRecoilState, useResetRecoilState } from "recoil";
+import { useCallback, useEffect, useState } from "react";
+import { useSetRecoilState } from "recoil";
 import {
   Button,
   ComponentBaseProps,
   FormItem,
   InputField,
   Label,
-  SelectField,
   StylingIcon,
 } from "@/components";
-import ColorInput from "@/components/ColorInput/ColorInput";
-import { useDisplayEdgeTypeConfig, useWithTheme } from "@/core";
+import { useDisplayEdgeTypeConfig } from "@/core";
 import {
-  ArrowStyle,
   EdgePreferences,
-  LineStyle,
   userStylingEdgeAtom,
 } from "@/core/StateProvider/userPreferences";
-import useTranslations from "@/hooks/useTranslations";
-import {
-  SOURCE_ARROW_STYLE_OPTIONS,
-  TARGET_ARROW_STYLE_OPTIONS,
-} from "./arrowsStyling";
-import { LINE_STYLE_OPTIONS } from "./lineStyling";
-import modalDefaultStyles from "./SingleEdgeStylingModal.style";
 import { useDebounceValue, usePrevious } from "@/hooks";
-import { MISSING_DISPLAY_TYPE, RESERVED_TYPES_PROPERTY } from "@/utils";
+import { MISSING_DISPLAY_TYPE } from "@/utils";
+import { customizeEdgeTypeAtom } from "./EdgeStyleDialog";
 
 export type SingleEdgeStylingProps = {
   edgeType: string;
-  opened: boolean;
-  onOpen(): void;
-  onClose(): void;
 } & ComponentBaseProps;
 
 export default function SingleEdgeStyling({
   edgeType,
-  opened,
-  onOpen,
-  onClose,
+
   ...rest
 }: SingleEdgeStylingProps) {
-  const t = useTranslations();
-  const styleWithTheme = useWithTheme();
-
-  const [edgePreferences, setEdgePreferences] = useRecoilState(
-    userStylingEdgeAtom(edgeType)
-  );
+  const setEdgePreferences = useSetRecoilState(userStylingEdgeAtom(edgeType));
+  const setCustomizeEdgeType = useSetRecoilState(customizeEdgeTypeAtom);
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
-
-  const selectOptions = useMemo(() => {
-    const options = displayConfig.attributes.map(attr => ({
-      value: attr.name,
-      label: attr.displayLabel,
-    }));
-
-    options.unshift({
-      label: t("edges-styling.edge-type"),
-      value: RESERVED_TYPES_PROPERTY,
-    });
-
-    return options;
-  }, [displayConfig.attributes, t]);
 
   const onUserPrefsChange = useCallback(
     (prefs: Omit<EdgePreferences, "type">) => {
@@ -72,8 +38,6 @@ export default function SingleEdgeStyling({
     },
     [edgeType, setEdgePreferences]
   );
-
-  const onUserPrefsReset = useResetRecoilState(userStylingEdgeAtom(edgeType));
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -101,156 +65,14 @@ export default function SingleEdgeStyling({
           value={displayAs}
           onChange={setDisplayAs}
         />
-        <Button icon={<StylingIcon />} variant="text" onClick={onOpen}>
+        <Button
+          icon={<StylingIcon />}
+          variant="text"
+          onClick={() => setCustomizeEdgeType(edgeType)}
+        >
           Customize
         </Button>
       </div>
-      <Modal
-        opened={opened}
-        onClose={onClose}
-        centered={true}
-        size="auto"
-        title={
-          <div>
-            Customize <strong>{displayConfig.displayLabel}</strong>
-          </div>
-        }
-        className={styleWithTheme(modalDefaultStyles)}
-        overlayProps={{
-          backgroundOpacity: 0.1,
-        }}
-      >
-        <div className="modal-container">
-          <div>
-            <p>Display Attributes</p>
-            <div className="attrs-container">
-              <SelectField
-                label="Display Name Attribute"
-                labelPlacement="inner"
-                value={displayConfig.displayNameAttribute}
-                onValueChange={value =>
-                  onUserPrefsChange({ displayNameAttribute: value })
-                }
-                options={selectOptions}
-              />
-            </div>
-          </div>
-          <div>
-            <p>Label Styling</p>
-            <div className="attrs-container">
-              <ColorInput
-                label="Color"
-                labelPlacement="inner"
-                startColor={edgePreferences?.labelColor || "#17457b"}
-                onChange={(color: string) =>
-                  onUserPrefsChange({ labelColor: color })
-                }
-              />
-              <InputField
-                label="Background Opacity"
-                labelPlacement="inner"
-                type="number"
-                min={0}
-                max={1}
-                step={0.1}
-                value={edgePreferences?.labelBackgroundOpacity ?? 0.7}
-                onChange={(value: number) =>
-                  onUserPrefsChange({ labelBackgroundOpacity: value })
-                }
-              />
-            </div>
-          </div>
-          <div>
-            <div className="attrs-container">
-              <ColorInput
-                label="Border Color"
-                labelPlacement="inner"
-                startColor={edgePreferences?.labelBorderColor || "#17457b"}
-                onChange={(color: string) =>
-                  onUserPrefsChange({ labelBorderColor: color })
-                }
-              />
-              <InputField
-                label="Border Width"
-                labelPlacement="inner"
-                type="number"
-                min={0}
-                value={edgePreferences?.labelBorderWidth ?? 0}
-                onChange={(value: number) =>
-                  onUserPrefsChange({ labelBorderWidth: value })
-                }
-              />
-              <SelectField
-                label="Border Style"
-                labelPlacement="inner"
-                value={edgePreferences?.labelBorderStyle || "solid"}
-                onValueChange={value =>
-                  onUserPrefsChange({ labelBorderStyle: value as LineStyle })
-                }
-                options={LINE_STYLE_OPTIONS}
-              />
-            </div>
-          </div>
-          <div>
-            <p>Line Styling</p>
-            <div className="attrs-container">
-              <ColorInput
-                label="Color"
-                labelPlacement="inner"
-                startColor={edgePreferences?.lineColor || "#b3b3b3"}
-                onChange={(color: string) =>
-                  onUserPrefsChange({ lineColor: color })
-                }
-              />
-              <InputField
-                label="Thickness"
-                labelPlacement="inner"
-                type="number"
-                min={1}
-                value={edgePreferences?.lineThickness || 2}
-                onChange={(value: number) =>
-                  onUserPrefsChange({ lineThickness: value })
-                }
-              />
-              <SelectField
-                label="Style"
-                labelPlacement="inner"
-                value={edgePreferences?.lineStyle || "solid"}
-                onValueChange={value =>
-                  onUserPrefsChange({ lineStyle: value as LineStyle })
-                }
-                options={LINE_STYLE_OPTIONS}
-              />
-            </div>
-          </div>
-          <div>
-            <p>Arrows Styling</p>
-            <div className="attrs-container">
-              <SelectField
-                label="Source"
-                labelPlacement="inner"
-                value={edgePreferences?.sourceArrowStyle || "none"}
-                onValueChange={value =>
-                  onUserPrefsChange({ sourceArrowStyle: value as ArrowStyle })
-                }
-                options={SOURCE_ARROW_STYLE_OPTIONS}
-              />
-              <SelectField
-                label="Target"
-                labelPlacement="inner"
-                value={edgePreferences?.targetArrowStyle || "triangle"}
-                onValueChange={value =>
-                  onUserPrefsChange({ targetArrowStyle: value as ArrowStyle })
-                }
-                options={TARGET_ARROW_STYLE_OPTIONS}
-              />
-            </div>
-          </div>
-          <div className="actions">
-            <Button onPress={onUserPrefsReset}>Reset to Default</Button>
-          </div>
-        </div>
-      </Modal>
     </FormItem>
   );
 }

--- a/packages/graph-explorer/src/modules/EdgesStyling/index.ts
+++ b/packages/graph-explorer/src/modules/EdgesStyling/index.ts
@@ -1,0 +1,2 @@
+export { default as EdgesStyling } from "./EdgesStyling";
+export * from "./EdgeStyleDialog";

--- a/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.tsx
+++ b/packages/graph-explorer/src/modules/EntitiesFilter/EntitiesFilter.tsx
@@ -1,30 +1,21 @@
 import {
   CheckboxList,
-  Divider,
   Panel,
   PanelContent,
   PanelHeader,
   PanelHeaderActions,
   PanelTitle,
+  SidebarTabs,
+  SidebarTabsContent,
+  SidebarTabsList,
+  SidebarTabsTrigger,
 } from "@/components";
-import useTranslations from "@/hooks/useTranslations";
 import useFiltersConfig from "./useFiltersConfig";
-import { PropsWithChildren } from "react";
 import { SidebarCloseButton } from "../SidebarCloseButton";
+import { useTranslations } from "@/hooks";
 
 function EntitiesFilter() {
   const t = useTranslations();
-
-  const {
-    selectedVertexTypes,
-    vertexTypes,
-    onChangeVertexTypes,
-    onChangeAllVertexTypes,
-    selectedConnectionTypes,
-    connectionTypes,
-    onChangeConnectionTypes,
-    onChangeAllConnectionTypes,
-  } = useFiltersConfig();
 
   return (
     <Panel variant="sidebar">
@@ -35,36 +26,61 @@ function EntitiesFilter() {
         </PanelHeaderActions>
       </PanelHeader>
       <PanelContent>
-        {connectionTypes.length > 0 && (
-          <CheckboxListContainer>
-            <CheckboxList
-              title={t("entities-filter.edge-types")}
-              selectedIds={selectedConnectionTypes}
-              checkboxes={connectionTypes}
-              onChange={onChangeConnectionTypes}
-              onChangeAll={onChangeAllConnectionTypes}
-            />
-          </CheckboxListContainer>
-        )}
-        <Divider />
-        {vertexTypes.length > 0 && (
-          <CheckboxListContainer>
-            <CheckboxList
-              title={t("entities-filter.node-types")}
-              selectedIds={selectedVertexTypes}
-              checkboxes={vertexTypes}
-              onChange={onChangeVertexTypes}
-              onChangeAll={onChangeAllVertexTypes}
-            />
-          </CheckboxListContainer>
-        )}
+        <SidebarTabs defaultValue="vertex">
+          <SidebarTabsList>
+            <SidebarTabsTrigger value="vertex">
+              {t("entities-filter.node-types")}
+            </SidebarTabsTrigger>
+            <SidebarTabsTrigger value="edge">
+              {t("entities-filter.edge-types")}
+            </SidebarTabsTrigger>
+          </SidebarTabsList>
+          <SidebarTabsContent value="vertex">
+            <VertexFiltersTabContent />
+          </SidebarTabsContent>
+          <SidebarTabsContent value="edge">
+            <EdgeFiltersTabContent />
+          </SidebarTabsContent>
+        </SidebarTabs>
       </PanelContent>
     </Panel>
   );
 }
 
-function CheckboxListContainer(props: PropsWithChildren) {
-  return <div className="w-full px-3 py-2">{props.children}</div>;
+function EdgeFiltersTabContent() {
+  const {
+    selectedConnectionTypes,
+    connectionTypes,
+    onChangeConnectionTypes,
+    onChangeAllConnectionTypes,
+  } = useFiltersConfig();
+
+  return (
+    <CheckboxList
+      selectedIds={selectedConnectionTypes}
+      checkboxes={connectionTypes}
+      onChange={onChangeConnectionTypes}
+      onChangeAll={onChangeAllConnectionTypes}
+    />
+  );
+}
+
+function VertexFiltersTabContent() {
+  const {
+    selectedVertexTypes,
+    vertexTypes,
+    onChangeVertexTypes,
+    onChangeAllVertexTypes,
+  } = useFiltersConfig();
+
+  return (
+    <CheckboxList
+      selectedIds={selectedVertexTypes}
+      checkboxes={vertexTypes}
+      onChange={onChangeVertexTypes}
+      onChangeAll={onChangeAllVertexTypes}
+    />
+  );
 }
 
 export default EntitiesFilter;

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -52,11 +52,6 @@ import {
   ZoomOutIcon,
 } from "lucide-react";
 
-export type GraphViewerProps = {
-  onNodeCustomize(nodeType?: string): void;
-  onEdgeCustomize(edgeType?: string): void;
-};
-
 const LAYOUT_OPTIONS = [
   {
     label: "Force Directed  (F0Cose)",
@@ -98,10 +93,7 @@ function onContextMenu(e: MouseEvent<HTMLDivElement>) {
   e.stopPropagation();
 }
 
-export default function GraphViewer({
-  onNodeCustomize,
-  onEdgeCustomize,
-}: GraphViewerProps) {
+export default function GraphViewer() {
   const graphRef = useRef<GraphRef | null>(null);
 
   const [nodesSelectedIds, setNodesSelectedIds] = useRecoilState(
@@ -259,8 +251,6 @@ export default function GraphViewer({
                   onClose={clearAllLayers}
                   affectedNodesIds={contextNodeId ? [contextNodeId] : []}
                   affectedEdgesIds={contextEdgeId ? [contextEdgeId] : []}
-                  onNodeCustomize={onNodeCustomize}
-                  onEdgeCustomize={onEdgeCustomize}
                 />
               </div>
             )}

--- a/packages/graph-explorer/src/modules/GraphViewer/index.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./GraphViewer";
-export type { GraphViewerProps } from "./GraphViewer";

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -29,14 +29,14 @@ import { useClearGraph, useRemoveFromGraph, useTranslations } from "@/hooks";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import { EdgeId, VertexId } from "@/core";
 import { MinusCircleIcon } from "lucide-react";
+import { customizeNodeTypeAtom } from "@/modules/NodesStyling";
+import { customizeEdgeTypeAtom } from "@/modules/EdgesStyling";
 
 export type ContextMenuProps = {
   affectedNodesIds?: VertexId[];
   affectedEdgesIds?: EdgeId[];
   graphRef: RefObject<GraphRef | null>;
   onClose?(): void;
-  onNodeCustomize(nodeType?: string): void;
-  onEdgeCustomize(edgeType?: string): void;
 };
 
 const ContextMenu = ({
@@ -44,8 +44,6 @@ const ContextMenu = ({
   affectedEdgesIds,
   graphRef,
   onClose,
-  onNodeCustomize,
-  onEdgeCustomize,
 }: ContextMenuProps) => {
   const t = useTranslations();
   const displayNodes = useDisplayVerticesInCanvas();
@@ -68,6 +66,9 @@ const ContextMenu = ({
   const nonEmptySelection =
     nodesSelectedIds.size >= 1 || edgesSelectedIds.size >= 1;
 
+  const setCustomizeNodeType = useSetRecoilState(customizeNodeTypeAtom);
+  const setCustomizeEdgeType = useSetRecoilState(customizeEdgeTypeAtom);
+
   const openSidebarPanel = useCallback(
     (
       panelName: SidebarItems,
@@ -87,20 +88,20 @@ const ContextMenu = ({
           setNodesSelectedIds(prev => (prev.size === 0 ? prev : new Set([])));
         }
 
-        props?.nodeType && onNodeCustomize(props.nodeType);
-        props?.edgeType && onEdgeCustomize(props.edgeType);
+        props?.nodeType && setCustomizeNodeType(props.nodeType);
+        props?.edgeType && setCustomizeEdgeType(props.edgeType);
 
         onClose?.();
       },
     [
-      affectedEdgesIds,
+      setUserLayout,
       affectedNodesIds,
+      affectedEdgesIds,
+      setCustomizeNodeType,
+      setCustomizeEdgeType,
       onClose,
-      onNodeCustomize,
-      onEdgeCustomize,
       setEdgesSelectedIds,
       setNodesSelectedIds,
-      setUserLayout,
     ]
   );
 

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -1,0 +1,265 @@
+import { FileButton, Modal } from "@mantine/core";
+import { useCallback, useMemo } from "react";
+import { atom, useRecoilState, useResetRecoilState } from "recoil";
+import {
+  Button,
+  IconButton,
+  InputField,
+  SelectField,
+  UploadIcon,
+  VertexSymbol,
+} from "@/components";
+import ColorInput from "@/components/ColorInput/ColorInput";
+import { useNotification } from "@/components/NotificationProvider";
+import { useDisplayVertexTypeConfig, useWithTheme } from "@/core";
+import {
+  LineStyle,
+  ShapeStyle,
+  userStylingNodeAtom,
+  VertexPreferences,
+} from "@/core/StateProvider/userPreferences";
+import useTranslations from "@/hooks/useTranslations";
+import { LINE_STYLE_OPTIONS } from "./lineStyling";
+import { NODE_SHAPE } from "./nodeShape";
+import modalDefaultStyles from "./SingleNodeStylingModal.style";
+import {
+  RESERVED_ID_PROPERTY,
+  RESERVED_TYPES_PROPERTY,
+} from "@/utils/constants";
+
+export const customizeNodeTypeAtom = atom<string | undefined>({
+  key: "customize-node-type",
+  default: undefined,
+});
+
+const file2Base64 = (file: File): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () =>
+      typeof reader.result === "string" ? resolve(reader.result) : resolve("");
+    reader.onerror = reject;
+  });
+};
+
+export default function NodeStyleDialog() {
+  const styleWithTheme = useWithTheme();
+
+  const [customizeNodeType, setCustomizeNodeType] = useRecoilState(
+    customizeNodeTypeAtom
+  );
+
+  return (
+    <Modal
+      opened={Boolean(customizeNodeType)}
+      onClose={() => setCustomizeNodeType(undefined)}
+      centered={true}
+      size="auto"
+      title={
+        customizeNodeType ? (
+          <DialogTitle vertexType={customizeNodeType} />
+        ) : null
+      }
+      className={styleWithTheme(modalDefaultStyles)}
+      overlayProps={{
+        backgroundOpacity: 0.1,
+      }}
+    >
+      {customizeNodeType ? <Content vertexType={customizeNodeType} /> : null}
+    </Modal>
+  );
+}
+
+function DialogTitle({ vertexType }: { vertexType: string }) {
+  const displayConfig = useDisplayVertexTypeConfig(vertexType);
+  return (
+    <div>
+      Customize <strong>{displayConfig.displayLabel}</strong>
+    </div>
+  );
+}
+
+function Content({ vertexType }: { vertexType: string }) {
+  const t = useTranslations();
+
+  const [nodePreferences, setNodePreferences] = useRecoilState(
+    userStylingNodeAtom(vertexType)
+  );
+  const displayConfig = useDisplayVertexTypeConfig(vertexType);
+
+  const selectOptions = useMemo(() => {
+    const options = displayConfig.attributes.map(attr => ({
+      label: attr.displayLabel,
+      value: attr.name,
+    }));
+
+    options.unshift({
+      label: t("nodes-styling.node-type"),
+      value: RESERVED_TYPES_PROPERTY,
+    });
+    options.unshift({
+      label: t("nodes-styling.node-id"),
+      value: RESERVED_ID_PROPERTY,
+    });
+
+    return options;
+  }, [displayConfig.attributes, t]);
+
+  const onUserPrefsChange = useCallback(
+    (prefs: Omit<VertexPreferences, "type">) => {
+      setNodePreferences({ type: vertexType, ...prefs });
+    },
+    [setNodePreferences, vertexType]
+  );
+
+  const reset = useResetRecoilState(userStylingNodeAtom(vertexType));
+
+  const { enqueueNotification } = useNotification();
+  const convertImageToBase64AndSetNewIcon = useCallback(
+    async (file: File) => {
+      if (file.size > 50 * 1024) {
+        enqueueNotification({
+          title: "Invalid file",
+          message: "File size too large. Maximum 50Kb",
+          type: "error",
+        });
+        return;
+      }
+      try {
+        const result = await file2Base64(file);
+        onUserPrefsChange({ iconUrl: result, iconImageType: file.type });
+      } catch (error) {
+        console.error("Unable to convert uploaded image to base64: ", error);
+      }
+    },
+    [enqueueNotification, onUserPrefsChange]
+  );
+
+  return (
+    <div className="modal-container">
+      <div>
+        <p>Display Attributes</p>
+        <div className="attrs-container">
+          <SelectField
+            label="Display Name Attribute"
+            labelPlacement="inner"
+            value={displayConfig.displayNameAttribute}
+            onValueChange={value => {
+              onUserPrefsChange({ displayNameAttribute: value });
+            }}
+            options={selectOptions}
+          />
+          <SelectField
+            label="Display Description Attribute"
+            labelPlacement="inner"
+            value={displayConfig.displayDescriptionAttribute}
+            onValueChange={value => {
+              onUserPrefsChange({
+                longDisplayNameAttribute: value,
+              });
+            }}
+            options={selectOptions}
+          />
+        </div>
+      </div>
+      <div>
+        <p>Shape and Icon</p>
+        <div className="flex flex-row items-center gap-2">
+          <SelectField
+            label="Style"
+            labelPlacement="inner"
+            value={nodePreferences?.shape || "ellipse"}
+            onValueChange={value =>
+              onUserPrefsChange({ shape: value as ShapeStyle })
+            }
+            options={NODE_SHAPE}
+            className="grow"
+          />
+          <FileButton
+            accept="image/*"
+            onChange={file => {
+              file && convertImageToBase64AndSetNewIcon(file);
+            }}
+          >
+            {props => (
+              <IconButton
+                variant="filled"
+                className="text-text-primary hover:text-text-primary group rounded-full border-0 bg-transparent p-0 hover:cursor-pointer hover:bg-gray-200"
+                icon={
+                  <>
+                    <div className="hidden group-hover:flex">
+                      <UploadIcon />
+                    </div>
+                    <VertexSymbol
+                      vertexStyle={displayConfig.style}
+                      className="size-full group-hover:hidden"
+                    />
+                  </>
+                }
+                tooltipText="Upload New Icon"
+                onClick={props.onClick}
+              />
+            )}
+          </FileButton>
+        </div>
+      </div>
+      <div>
+        <p>Shape Styling</p>
+        <div className="attrs-container">
+          <ColorInput
+            label="Color"
+            labelPlacement="inner"
+            startColor={nodePreferences?.color || "#17457b"}
+            onChange={(color: string) => onUserPrefsChange({ color })}
+          />
+          <InputField
+            label="Background Opacity"
+            labelPlacement="inner"
+            type="number"
+            min={0}
+            max={1}
+            step={0.1}
+            value={nodePreferences?.backgroundOpacity ?? 0.4}
+            onChange={(value: number) =>
+              onUserPrefsChange({ backgroundOpacity: value })
+            }
+          />
+        </div>
+      </div>
+      <div>
+        <div className="attrs-container">
+          <ColorInput
+            label="Border Color"
+            labelPlacement="inner"
+            startColor={nodePreferences?.borderColor || "#17457b"}
+            onChange={(color: string) =>
+              onUserPrefsChange({ borderColor: color })
+            }
+          />
+          <InputField
+            label="Border Width"
+            labelPlacement="inner"
+            type="number"
+            min={0}
+            value={nodePreferences?.borderWidth ?? 0}
+            onChange={(value: number) =>
+              onUserPrefsChange({ borderWidth: value })
+            }
+          />
+          <SelectField
+            label="Border Style"
+            labelPlacement="inner"
+            value={nodePreferences?.borderStyle || "solid"}
+            onValueChange={value =>
+              onUserPrefsChange({ borderStyle: value as LineStyle })
+            }
+            options={LINE_STYLE_OPTIONS}
+          />
+        </div>
+      </div>
+      <div className="actions">
+        <Button onPress={() => reset()}>Reset to Default</Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
@@ -11,16 +11,10 @@ import useTranslations from "@/hooks/useTranslations";
 import SingleNodeStyling from "./SingleNodeStyling";
 import { Fragment } from "react/jsx-runtime";
 import { SidebarCloseButton } from "../SidebarCloseButton";
+import { Virtuoso } from "react-virtuoso";
+import NodeStyleDialog from "./NodeStyleDialog";
 
-export type NodesStylingProps = {
-  onNodeCustomize(nodeType?: string): void;
-  customizeNodeType?: string;
-};
-
-function NodesStyling({
-  customizeNodeType,
-  onNodeCustomize,
-}: NodesStylingProps) {
+function NodesStyling() {
   const vtConfigs = useDisplayVertexTypeConfigs().values().toArray();
   const t = useTranslations();
 
@@ -33,21 +27,21 @@ function NodesStyling({
         </PanelHeaderActions>
       </PanelHeader>
       <PanelContent className="gap-2">
-        {vtConfigs.map((vtConfig, index) => {
-          return (
+        <Virtuoso
+          className="h-full grow"
+          data={vtConfigs}
+          itemContent={(index, vtConfig) => (
             <Fragment key={vtConfig.type}>
               {index !== 0 ? <Divider /> : null}
 
               <SingleNodeStyling
                 vertexType={vtConfig.type}
-                opened={customizeNodeType === vtConfig.type}
-                onOpen={() => onNodeCustomize(vtConfig.type)}
-                onClose={() => onNodeCustomize(undefined)}
                 className="px-3 pb-3 pt-2"
               />
             </Fragment>
-          );
-        })}
+          )}
+        />
+        <NodeStyleDialog />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -1,118 +1,43 @@
-import { FileButton, Modal } from "@mantine/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRecoilState, useResetRecoilState } from "recoil";
+import { useCallback, useEffect, useState } from "react";
+import { useSetRecoilState } from "recoil";
 import {
   Button,
   ComponentBaseProps,
   FormItem,
-  IconButton,
   InputField,
   Label,
-  SelectField,
   StylingIcon,
-  UploadIcon,
-  VertexSymbol,
 } from "@/components";
-import ColorInput from "@/components/ColorInput/ColorInput";
-import { useNotification } from "@/components/NotificationProvider";
-import { useDisplayVertexTypeConfig, useWithTheme } from "@/core";
+import { useDisplayVertexTypeConfig } from "@/core";
 import {
-  LineStyle,
-  ShapeStyle,
   userStylingNodeAtom,
   VertexPreferences,
 } from "@/core/StateProvider/userPreferences";
-import useTranslations from "@/hooks/useTranslations";
-import { LINE_STYLE_OPTIONS } from "./lineStyling";
-import { NODE_SHAPE } from "./nodeShape";
-import modalDefaultStyles from "./SingleNodeStylingModal.style";
 import { useDebounceValue, usePrevious } from "@/hooks";
-import {
-  MISSING_DISPLAY_TYPE,
-  RESERVED_ID_PROPERTY,
-  RESERVED_TYPES_PROPERTY,
-} from "@/utils/constants";
+import { MISSING_DISPLAY_TYPE } from "@/utils/constants";
+import { customizeNodeTypeAtom } from "./NodeStyleDialog";
 
 export type SingleNodeStylingProps = {
   vertexType: string;
-  opened: boolean;
-  onOpen(): void;
-  onClose(): void;
 } & ComponentBaseProps;
-
-const file2Base64 = (file: File): Promise<string> => {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = () =>
-      typeof reader.result === "string" ? resolve(reader.result) : resolve("");
-    reader.onerror = reject;
-  });
-};
 
 export default function SingleNodeStyling({
   vertexType,
-  opened,
-  onOpen,
-  onClose,
+
   ...rest
 }: SingleNodeStylingProps) {
-  const t = useTranslations();
-  const styleWithTheme = useWithTheme();
-
-  const [nodePreferences, setNodePreferences] = useRecoilState(
-    userStylingNodeAtom(vertexType)
-  );
+  const setNodePreferences = useSetRecoilState(userStylingNodeAtom(vertexType));
   const displayConfig = useDisplayVertexTypeConfig(vertexType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
 
-  const selectOptions = useMemo(() => {
-    const options = displayConfig.attributes.map(attr => ({
-      label: attr.displayLabel,
-      value: attr.name,
-    }));
-
-    options.unshift({
-      label: t("nodes-styling.node-type"),
-      value: RESERVED_TYPES_PROPERTY,
-    });
-    options.unshift({
-      label: t("nodes-styling.node-id"),
-      value: RESERVED_ID_PROPERTY,
-    });
-
-    return options;
-  }, [displayConfig.attributes, t]);
+  const setCustomizeNodeType = useSetRecoilState(customizeNodeTypeAtom);
 
   const onUserPrefsChange = useCallback(
     (prefs: Omit<VertexPreferences, "type">) => {
       setNodePreferences({ type: vertexType, ...prefs });
     },
     [setNodePreferences, vertexType]
-  );
-
-  const reset = useResetRecoilState(userStylingNodeAtom(vertexType));
-
-  const { enqueueNotification } = useNotification();
-  const convertImageToBase64AndSetNewIcon = useCallback(
-    async (file: File) => {
-      if (file.size > 50 * 1024) {
-        enqueueNotification({
-          title: "Invalid file",
-          message: "File size too large. Maximum 50Kb",
-          type: "error",
-        });
-        return;
-      }
-      try {
-        const result = await file2Base64(file);
-        onUserPrefsChange({ iconUrl: result, iconImageType: file.type });
-      } catch (error) {
-        console.error("Unable to convert uploaded image to base64: ", error);
-      }
-    },
-    [enqueueNotification, onUserPrefsChange]
   );
 
   // Delayed update of display name to prevent input lag
@@ -142,151 +67,14 @@ export default function SingleNodeStyling({
           value={displayAs}
           onChange={setDisplayAs}
         />
-        <Button icon={<StylingIcon />} variant="text" onClick={onOpen}>
+        <Button
+          icon={<StylingIcon />}
+          variant="text"
+          onClick={() => setCustomizeNodeType(vertexType)}
+        >
           Customize
         </Button>
       </div>
-      <Modal
-        opened={opened}
-        onClose={onClose}
-        centered={true}
-        size="auto"
-        title={
-          <div>
-            Customize <strong>{displayConfig.displayLabel}</strong>
-          </div>
-        }
-        className={styleWithTheme(modalDefaultStyles)}
-        overlayProps={{
-          backgroundOpacity: 0.1,
-        }}
-      >
-        <div className="modal-container">
-          <div>
-            <p>Display Attributes</p>
-            <div className="attrs-container">
-              <SelectField
-                label="Display Name Attribute"
-                labelPlacement="inner"
-                value={displayConfig.displayNameAttribute}
-                onValueChange={value => {
-                  onUserPrefsChange({ displayNameAttribute: value });
-                }}
-                options={selectOptions}
-              />
-              <SelectField
-                label="Display Description Attribute"
-                labelPlacement="inner"
-                value={displayConfig.displayDescriptionAttribute}
-                onValueChange={value => {
-                  onUserPrefsChange({
-                    longDisplayNameAttribute: value,
-                  });
-                }}
-                options={selectOptions}
-              />
-            </div>
-          </div>
-          <div>
-            <p>Shape and Icon</p>
-            <div className="flex flex-row items-center gap-2">
-              <SelectField
-                label="Style"
-                labelPlacement="inner"
-                value={nodePreferences?.shape || "ellipse"}
-                onValueChange={value =>
-                  onUserPrefsChange({ shape: value as ShapeStyle })
-                }
-                options={NODE_SHAPE}
-                className="grow"
-              />
-              <FileButton
-                accept="image/*"
-                onChange={file => {
-                  file && convertImageToBase64AndSetNewIcon(file);
-                }}
-              >
-                {props => (
-                  <IconButton
-                    variant="filled"
-                    className="text-text-primary hover:text-text-primary group rounded-full border-0 bg-transparent p-0 hover:cursor-pointer hover:bg-gray-200"
-                    icon={
-                      <>
-                        <div className="hidden group-hover:flex">
-                          <UploadIcon />
-                        </div>
-                        <VertexSymbol
-                          vertexStyle={displayConfig.style}
-                          className="size-full group-hover:hidden"
-                        />
-                      </>
-                    }
-                    tooltipText="Upload New Icon"
-                    onClick={props.onClick}
-                  />
-                )}
-              </FileButton>
-            </div>
-          </div>
-          <div>
-            <p>Shape Styling</p>
-            <div className="attrs-container">
-              <ColorInput
-                label="Color"
-                labelPlacement="inner"
-                startColor={nodePreferences?.color || "#17457b"}
-                onChange={(color: string) => onUserPrefsChange({ color })}
-              />
-              <InputField
-                label="Background Opacity"
-                labelPlacement="inner"
-                type="number"
-                min={0}
-                max={1}
-                step={0.1}
-                value={nodePreferences?.backgroundOpacity ?? 0.4}
-                onChange={(value: number) =>
-                  onUserPrefsChange({ backgroundOpacity: value })
-                }
-              />
-            </div>
-          </div>
-          <div>
-            <div className="attrs-container">
-              <ColorInput
-                label="Border Color"
-                labelPlacement="inner"
-                startColor={nodePreferences?.borderColor || "#17457b"}
-                onChange={(color: string) =>
-                  onUserPrefsChange({ borderColor: color })
-                }
-              />
-              <InputField
-                label="Border Width"
-                labelPlacement="inner"
-                type="number"
-                min={0}
-                value={nodePreferences?.borderWidth ?? 0}
-                onChange={(value: number) =>
-                  onUserPrefsChange({ borderWidth: value })
-                }
-              />
-              <SelectField
-                label="Border Style"
-                labelPlacement="inner"
-                value={nodePreferences?.borderStyle || "solid"}
-                onValueChange={value =>
-                  onUserPrefsChange({ borderStyle: value as LineStyle })
-                }
-                options={LINE_STYLE_OPTIONS}
-              />
-            </div>
-          </div>
-          <div className="actions">
-            <Button onPress={() => reset()}>Reset to Default</Button>
-          </div>
-        </div>
-      </Modal>
     </FormItem>
   );
 }

--- a/packages/graph-explorer/src/modules/NodesStyling/index.ts
+++ b/packages/graph-explorer/src/modules/NodesStyling/index.ts
@@ -1,0 +1,2 @@
+export { default as NodesStyling } from "./NodesStyling";
+export * from "./NodeStyleDialog";

--- a/packages/graph-explorer/src/utils/generatePrefixes.test.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.test.ts
@@ -4,6 +4,32 @@ import generatePrefixes, {
 } from "./generatePrefixes";
 
 describe("generatePrefixes", () => {
+  it("should return null when nothing is updated", () => {
+    const existing = [
+      {
+        prefix: "owl",
+        uri: "https://www.w3.org/2002/07/owl#",
+        __matches: new Set(["https://www.w3.org/2002/07/owl#ObjectProperty"]),
+      },
+      {
+        prefix: "rdf",
+        uri: "https://www.w3.org/2000/01/rdf-schema#",
+        __matches: new Set([
+          "https://www.w3.org/2000/01/rdf-schema#subClassOf",
+        ]),
+      },
+    ];
+
+    const uris = new Set([
+      "https://www.w3.org/2002/07/owl#ObjectProperty",
+      "https://www.w3.org/2000/01/rdf-schema#subClassOf",
+    ]);
+
+    const result = generatePrefixes(uris, existing);
+
+    expect(result).toBeNull();
+  });
+
   it("Should generate prefixes for URLs which contain a #", () => {
     const urisWithConfig = {
       "https://www.w3.org/2002/07/owl#ObjectProperty": {
@@ -76,14 +102,14 @@ describe("generatePrefixes", () => {
 
   it("Should generate only non-matching prefixes and update counts", () => {
     const updatedPrefixes = generatePrefixes(
-      [
+      new Set([
         "https://www.w3.org/2002/07/owl#ObjectProperty",
         "https://dbpedia.org/resource/Qualifying_Rounds",
         "http://www.example.com/soccer/ontology/League",
         "http://www.example.com/soccer/resource#EPL",
         "http://www.example.com/location/resource#London",
         "http://www.example.com/location/resource#Manchester",
-      ],
+      ]),
       [
         { prefix: "owl", uri: "https://www.w3.org/2002/07/owl#" },
         { prefix: "dbr", uri: "https://dbpedia.org/resource/" },
@@ -135,11 +161,11 @@ describe("generatePrefixes", () => {
 
   it("Should update existing prefixes when casing doesn't match", () => {
     const updatedPrefixes = generatePrefixes(
-      [
+      new Set([
         "http://SecretSpyOrg/entity/quantity",
         "http://SecretSpyOrg/entity/other",
         "http://SecretSpyOrg/data/hasText",
-      ],
+      ]),
       [
         {
           __inferred: true,

--- a/packages/graph-explorer/src/utils/generatePrefixes.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.ts
@@ -1,15 +1,57 @@
-import cloneDeep from "lodash/cloneDeep";
-import isEqual from "lodash/isEqual";
 import { PrefixTypeConfig } from "@/core";
 import commonPrefixes from "./common-prefixes.json";
 
-const cPrefixes: PrefixTypeConfig[] = Object.entries(commonPrefixes).map(
-  ([prefix, uri]) => ({ prefix, uri })
+// Create a map of the common prefixes
+const commonPrefixesMap = toPrefixTypeConfigMap(
+  Object.entries(commonPrefixes).map(([prefix, uri]) => ({ prefix, uri }))
 );
 
-export const generateHashPrefix = (
+/** Helper function to create a map of prefix configs from an array of configs. */
+function toPrefixTypeConfigMap(
+  configs: PrefixTypeConfig[]
+): Map<string, PrefixTypeConfig> {
+  return new Map(configs.map(config => [normalizeUri(config.uri), config]));
+}
+
+/** Converts URI to lowercase and trims leading and trailing whitespace. */
+function normalizeUri(uri: string) {
+  return uri.toLowerCase().trim();
+}
+
+/** Checks if the given string is a valid URL. */
+function isUrl(str: string) {
+  try {
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Creates a prefix config from the given URI. */
+function createPrefixTypeConfig(uri: string): PrefixTypeConfig | null {
+  // Create a new prefix entry
+  try {
+    const url = new URL(uri);
+    let newPrefix: PrefixTypeConfig;
+    if (url.hash) {
+      newPrefix = generateHashPrefix(url);
+    } else {
+      newPrefix = generatePrefix(url);
+    }
+
+    return {
+      ...newPrefix,
+      __matches: new Set([uri]),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function generateHashPrefix(
   url: URL
-): Omit<PrefixTypeConfig, "__count"> => {
+): Omit<PrefixTypeConfig, "__count"> {
   const paths = url.pathname.replace(/^\//, "").split("/");
   let prefix;
 
@@ -32,11 +74,13 @@ export const generateHashPrefix = (
     uri: url.href.replace(url.hash, "#"),
     prefix,
   };
-};
+}
 
-const prefixFromHost = (host: string) =>
-  host.replace(/^(www\.)*/, "").substring(0, 3);
-export const generatePrefix = (url: URL): Omit<PrefixTypeConfig, "__count"> => {
+function prefixFromHost(host: string) {
+  return host.replace(/^(www\.)*/, "").substring(0, 3);
+}
+
+export function generatePrefix(url: URL): Omit<PrefixTypeConfig, "__count"> {
   const paths = url.pathname.replace(/^\//, "").split("/");
 
   if (paths.length === 1) {
@@ -86,54 +130,49 @@ export const generatePrefix = (url: URL): Omit<PrefixTypeConfig, "__count"> => {
     uri: uriChunks.join("/") + "/",
     prefix: filteredPaths[0].substring(0, 3),
   };
-};
+}
 
-const generatePrefixes = (
-  uris: string[],
-  currentPrefixes: PrefixTypeConfig[] = []
-) => {
-  const updatedPrefixes: PrefixTypeConfig[] = cloneDeep(currentPrefixes);
-  uris.forEach(uri => {
-    const existInCommon = cPrefixes.some(prefixConfig => {
-      return !!uri.match(new RegExp(`^${prefixConfig.uri}`, "i"));
-    });
-    if (existInCommon) {
-      return;
-    }
+function generatePrefixes(
+  uris: Set<string>,
+  currentPrefixes: PrefixTypeConfig[]
+) {
+  const updatedPrefixes = toPrefixTypeConfigMap(currentPrefixes);
+  let hasBeenUpdated = false;
+  uris
+    .values()
+    // Filter out non-URLs
+    .filter(isUrl)
+    // Create prefix config
+    .map(uri => createPrefixTypeConfig(uri))
+    // Filter out prefix configs that failed to be created
+    .filter(newPrefix => newPrefix != null)
+    // Filter out common prefixes
+    .filter(prefix => !commonPrefixesMap.has(normalizeUri(prefix.uri)))
+    // Update the map of prefixes
+    .forEach(newPrefix => {
+      const existingPrefix = updatedPrefixes.get(newPrefix.uri);
+      const normalizedUri = normalizeUri(newPrefix.uri);
 
-    const existPrefixIndex = updatedPrefixes.findIndex(prefixConfig => {
-      return !!uri.match(new RegExp(`^${prefixConfig.uri}`, "i"));
-    });
-
-    if (existPrefixIndex === -1) {
-      // Create a new prefix entry
-      try {
-        const url = new URL(uri);
-        let newPrefix: PrefixTypeConfig;
-        if (url.hash) {
-          newPrefix = generateHashPrefix(url);
-        } else {
-          newPrefix = generatePrefix(url);
+      if (!existingPrefix) {
+        // Create a new prefix entry
+        updatedPrefixes.set(normalizedUri, newPrefix);
+        hasBeenUpdated = true;
+      } else {
+        const set = existingPrefix.__matches ?? new Set();
+        const matches = newPrefix.__matches ?? new Set();
+        if (set.isDisjointFrom(matches)) {
+          existingPrefix.__matches = set.union(matches);
+          hasBeenUpdated = true;
         }
-
-        updatedPrefixes.push({ ...newPrefix, __matches: new Set([uri]) });
-      } catch {
-        // Catching wrong URLs and skip them
       }
-    } else {
-      // Update existing prefix entry
-      if (!updatedPrefixes[existPrefixIndex].__matches) {
-        updatedPrefixes[existPrefixIndex].__matches = new Set();
-      }
-      updatedPrefixes[existPrefixIndex].__matches?.add(uri);
-    }
-  });
+    });
 
-  if (isEqual(currentPrefixes, updatedPrefixes)) {
-    return;
+  // If nothing was updated, return null
+  if (!hasBeenUpdated) {
+    return null;
   }
 
-  return updatedPrefixes;
-};
+  return updatedPrefixes.values().toArray();
+}
 
 export default generatePrefixes;

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/utils";
 import { Resizable } from "re-resizable";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { Link } from "react-router";
 import { useRecoilState, useRecoilValue } from "recoil";
 import {
@@ -35,7 +35,7 @@ import EntityDetails from "@/modules/EntityDetails";
 import GraphViewer from "@/modules/GraphViewer";
 import Namespaces from "@/modules/Namespaces/Namespaces";
 import NodeExpand from "@/modules/NodeExpand";
-import NodesStyling from "@/modules/NodesStyling/NodesStyling";
+import { NodesStyling } from "@/modules/NodesStyling";
 import defaultStyles from "./GraphExplorer.styles";
 import { APP_NAME } from "@/utils/constants";
 import { SearchSidebarPanel } from "@/modules/SearchSidebar";
@@ -114,12 +114,6 @@ const GraphExplorer = () => {
   );
 
   const toggles = userLayout.activeToggles;
-  const [customizeNodeType, setCustomizeNodeType] = useState<
-    string | undefined
-  >();
-  const [customizeEdgeType, setCustomizeEdgeType] = useState<
-    string | undefined
-  >();
 
   return (
     <Workspace className={cn(styleWithTheme(defaultStyles), "graph-explorer")}>
@@ -182,10 +176,7 @@ const GraphExplorer = () => {
         )}
         {toggles.has("graph-viewer") && (
           <div className="relative w-full grow">
-            <GraphViewer
-              onNodeCustomize={setCustomizeNodeType}
-              onEdgeCustomize={setCustomizeEdgeType}
-            />
+            <GraphViewer />
           </div>
         )}
         {toggles.has("table-view") && (
@@ -265,18 +256,8 @@ const GraphExplorer = () => {
           {userLayout.activeSidebarItem === "details" && <EntityDetails />}
           {userLayout.activeSidebarItem === "expand" && <NodeExpand />}
           {userLayout.activeSidebarItem === "filters" && <EntitiesFilter />}
-          {userLayout.activeSidebarItem === "nodes-styling" && (
-            <NodesStyling
-              customizeNodeType={customizeNodeType}
-              onNodeCustomize={setCustomizeNodeType}
-            />
-          )}
-          {userLayout.activeSidebarItem === "edges-styling" && (
-            <EdgesStyling
-              customizeEdgeType={customizeEdgeType}
-              onEdgeCustomize={setCustomizeEdgeType}
-            />
-          )}
+          {userLayout.activeSidebarItem === "nodes-styling" && <NodesStyling />}
+          {userLayout.activeSidebarItem === "edges-styling" && <EdgesStyling />}
           {userLayout.activeSidebarItem === "namespaces" && <Namespaces />}
         </Workspace.SideBar.Content>
       </Workspace.SideBar>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

* Adding and expanding nodes
  * The issue was updating prefixes doing too much work
  * Optimized now to nearly be instant
* Entity styles
  * Two issues: large list rendering & duplicate dialog instances
  * Large list is now virtualized
  * Dialog is now condensed to a single instance that changes based on the selected vertex types
  * Moved dialog open state in to Recoil
* Entity filters
  * The issue is large list rendering
  * Split vertex and edges in to separate tabs
  * Large list is now virtualized
  * Required tweaking the UI a bit to allow for virtualization

## Validation

- Used browser's CPU throttling at 4x and 6x for testing
- Used dataset with 500 node labels

## Related Issues

- Resolves #886

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
