### PR TITLE
Exclude metadata types from schema sync

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,9 @@ And as always, there are many additional small fixes and improvements.
   ([#892](https://github.com/aws/graph-explorer/pull/892))
 - **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF
   databases ([#870](https://github.com/aws/graph-explorer/pull/870))
+- **Fixed** issue representing metadata classes as valid instance types during
+  schema sync in RDF databases
+  ([#903](https://github.com/aws/graph-explorer/pull/903))
 - **Fixed** issue where double click expansion was inconsistent
   ([#841](https://github.com/aws/graph-explorer/pull/841))
 - **Fixed** issue with table exports


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Exclude RDF metadata types from class list during schema sync.

## Validation

- Validated with RDF database in Neptune that includes OWL metadata classes
- Validated with Air Routes in Neptune (no metadata classes)

## Related Issues

- Resolves #902

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
