### PR TITLE
Add configurable path for .env and defaultConnection.json files

### DIFF
--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -22,15 +22,16 @@ const EnvironmentValuesSchema = z.object({
   CONFIGURATION_FOLDER_PATH: z.coerce.string().default(clientRoot),
 });
 
-const defaultConnectionFolderPath = process.env.CONFIGURATION_FOLDER_PATH ?
-  process.env.CONFIGURATION_FOLDER_PATH : clientRoot
+const defaultConnectionFolderPath = process.env.CONFIGURATION_FOLDER_PATH
+  ? process.env.CONFIGURATION_FOLDER_PATH
+  : clientRoot;
 
 // Load environment variables from .env file.
 dotenv.config({
   path: [
     path.join(clientRoot, ".env.local"),
     path.join(clientRoot, ".env"),
-    path.join(defaultConnectionFolderPath, ".env")
+    path.join(defaultConnectionFolderPath, ".env"),
   ],
 });
 

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -19,11 +19,19 @@ const EnvironmentValuesSchema = z.object({
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("debug"),
   LOG_STYLE: z.enum(["cloudwatch", "default"]).default("default"),
+  CONFIGURATION_FOLDER_PATH: z.coerce.string().default(clientRoot),
 });
+
+const defaultConnectionFolderPath = process.env.CONFIGURATION_FOLDER_PATH ?
+  process.env.CONFIGURATION_FOLDER_PATH : clientRoot
 
 // Load environment variables from .env file.
 dotenv.config({
-  path: [path.join(clientRoot, ".env.local"), path.join(clientRoot, ".env")],
+  path: [
+    path.join(clientRoot, ".env.local"),
+    path.join(clientRoot, ".env"),
+    path.join(defaultConnectionFolderPath, ".env")
+  ],
 });
 
 // Parse the environment values from the process

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -163,8 +163,9 @@ async function fetchData(
   }
 }
 
-const defaultConnectionFolderPath = env.CONFIGURATION_FOLDER_PATH ?
-  env.CONFIGURATION_FOLDER_PATH : clientRoot
+const defaultConnectionFolderPath = env.CONFIGURATION_FOLDER_PATH
+  ? env.CONFIGURATION_FOLDER_PATH
+  : clientRoot;
 
 app.use(compression()); // Use compression middleware
 app.use(cors());
@@ -172,7 +173,9 @@ app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 app.use(
   "/defaultConnection",
-  express.static(path.join(defaultConnectionFolderPath, "defaultConnection.json"))
+  express.static(
+    path.join(defaultConnectionFolderPath, "defaultConnection.json")
+  )
 );
 
 // Host the Graph Explorer UI static files

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -163,13 +163,16 @@ async function fetchData(
   }
 }
 
+const defaultConnectionFolderPath = env.CONFIGURATION_FOLDER_PATH ?
+  env.CONFIGURATION_FOLDER_PATH : clientRoot
+
 app.use(compression()); // Use compression middleware
 app.use(cors());
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 app.use(
   "/defaultConnection",
-  express.static(path.join(clientRoot, "defaultConnection.json"))
+  express.static(path.join(defaultConnectionFolderPath, "defaultConnection.json"))
 );
 
 // Host the Graph Explorer UI static files

--- a/process-environment.sh
+++ b/process-environment.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+CONFIGURATION_FOLDER_PATH=${CONFIGURATION_FOLDER_PATH:-"./packages/graph-explorer/"}
+
 if [ -f "./config.json" ]; then
 
     json=$(cat ./config.json)
@@ -17,61 +19,61 @@ if [ -f "./config.json" ]; then
 fi
 
 if [ -n "$NEPTUNE_NOTEBOOK" ]; then
-    echo -e "\nNEPTUNE_NOTEBOOK=${NEPTUNE_NOTEBOOK}" >> ./packages/graph-explorer/.env
+    echo -e "\nNEPTUNE_NOTEBOOK=${NEPTUNE_NOTEBOOK}" >> $CONFIGURATION_FOLDER_PATH/.env
     if [ "$NEPTUNE_NOTEBOOK" == "true" ]; then
       # Override Proxy SSL setting if Neptune notebook
       PROXY_SERVER_HTTPS_CONNECTION="false"
       GRAPH_EXP_HTTPS_CONNECTION="false"
     fi
 else
-    echo -e "\nNEPTUNE_NOTEBOOK=false" >> ./packages/graph-explorer/.env
+    echo -e "\nNEPTUNE_NOTEBOOK=false" >> $CONFIGURATION_FOLDER_PATH/.env
 fi
 
 if [ -n "$PROXY_SERVER_HTTPS_CONNECTION" ]; then
-  echo -e "\nPROXY_SERVER_HTTPS_CONNECTION=${PROXY_SERVER_HTTPS_CONNECTION}" >> ./packages/graph-explorer/.env
+  echo -e "\nPROXY_SERVER_HTTPS_CONNECTION=${PROXY_SERVER_HTTPS_CONNECTION}" >> $CONFIGURATION_FOLDER_PATH/.env
 else
-  echo -e "\nPROXY_SERVER_HTTPS_CONNECTION=true" >> ./packages/graph-explorer/.env
+  echo -e "\nPROXY_SERVER_HTTPS_CONNECTION=true" >> $CONFIGURATION_FOLDER_PATH/.env
 fi
 
 if [ -n "$GRAPH_EXP_HTTPS_CONNECTION" ]; then
-  echo -e "\nGRAPH_EXP_HTTPS_CONNECTION=${GRAPH_EXP_HTTPS_CONNECTION}" >> ./packages/graph-explorer/.env
+  echo -e "\nGRAPH_EXP_HTTPS_CONNECTION=${GRAPH_EXP_HTTPS_CONNECTION}" >> $CONFIGURATION_FOLDER_PATH/.env
 else
-  echo -e "\nGRAPH_EXP_HTTPS_CONNECTION=true" >> ./packages/graph-explorer/.env
+  echo -e "\nGRAPH_EXP_HTTPS_CONNECTION=true" >> $CONFIGURATION_FOLDER_PATH/.env
 fi
 
 # Update the default connection file with the configuration values
 if [ -n "$PUBLIC_OR_PROXY_ENDPOINT" ]; then 
     # Overwrite existing file with an empty string
-    echo "" > ./packages/graph-explorer/defaultConnection.json
+    echo "" > $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     
-    echo -e "{\n\"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT\":\"${PUBLIC_OR_PROXY_ENDPOINT}\"," >> ./packages/graph-explorer/defaultConnection.json
+    echo -e "{\n\"GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT\":\"${PUBLIC_OR_PROXY_ENDPOINT}\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
 
     if [ -n "$SERVICE_TYPE" ]; then
-        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"${SERVICE_TYPE}\"," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"${SERVICE_TYPE}\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     else
-        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"neptune-db\"," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_SERVICE_TYPE\":\"neptune-db\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     fi
 
     if [ -n "$GRAPH_TYPE" ]; then 
-        echo "\"GRAPH_EXP_GRAPH_TYPE\":\"${GRAPH_TYPE}\"," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_GRAPH_TYPE\":\"${GRAPH_TYPE}\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     else
       if [ "$SERVICE_TYPE" == "neptune-graph" ]; then
-        echo "\"GRAPH_EXP_GRAPH_TYPE\":\"openCypher\"," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_GRAPH_TYPE\":\"openCypher\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
       fi
     fi
     
     if [ -n "$USING_PROXY_SERVER" ]; then 
-        echo "\"GRAPH_EXP_USING_PROXY_SERVER\":${USING_PROXY_SERVER}," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_USING_PROXY_SERVER\":${USING_PROXY_SERVER}," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     else 
-        echo "\"GRAPH_EXP_USING_PROXY_SERVER\":false," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_USING_PROXY_SERVER\":false," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     fi 
 
     if [ -n "$IAM" ]; then 
-        echo "\"GRAPH_EXP_IAM\":${IAM}," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_IAM\":${IAM}," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     else 
-        echo "\"GRAPH_EXP_IAM\":false," >> ./packages/graph-explorer/defaultConnection.json
+        echo "\"GRAPH_EXP_IAM\":false," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
     fi
 
-    echo "\"GRAPH_EXP_CONNECTION_URL\":\"${GRAPH_CONNECTION_URL}\"," >> ./packages/graph-explorer/defaultConnection.json
-    echo -e "\"GRAPH_EXP_AWS_REGION\":\"${AWS_REGION}\"\n}" >> ./packages/graph-explorer/defaultConnection.json
+    echo "\"GRAPH_EXP_CONNECTION_URL\":\"${GRAPH_CONNECTION_URL}\"," >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
+    echo -e "\"GRAPH_EXP_AWS_REGION\":\"${AWS_REGION}\"\n}" >> $CONFIGURATION_FOLDER_PATH/defaultConnection.json
 fi


### PR DESCRIPTION
## Description
This MR adds support for configuring the folder path where the .env and defaultConnection.json files are read from and written to. This solves an issue when Graph Explorer is deployed in ECS with read-only root volume enabled, by allowing these configuration files to be stored in a writable location.

The changes introduce a new environment variable `CONFIGURATION_FOLDER_PATH` that specifies where these configuration files should be located. If not specified, the system falls back to the default client root path.

## Validation
The changes have been tested by:

Setting the CONFIGURATION_FOLDER_PATH environment variable to different locations
Verifying that the application correctly reads the .env and defaultConnection.json files from the specified location
Confirming that the application still works correctly when the variable is not set (using default paths)

## Related Issues
Fixes issue with ECS deployments using read-only root volumes where configuration files cannot be written to the default location.