### PR TITLE
Fix auto sync on connection change

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,9 @@
   ([#896](https://github.com/aws/graph-explorer/pull/896))
 - **Updated** to use the React Compiler to improve performance and simplify code
   ([#916](https://github.com/aws/graph-explorer/pull/916))
+- **Fixed** issue where a schema sync would not automatically run when a
+  connection was changed
+  ([#919](https://github.com/aws/graph-explorer/pull/919))
 
 ## Release v1.15.0
 

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_NODE_EXPAND_LIMIT,
 } from "@/utils/constants";
 import { useAtomCallback } from "jotai/utils";
+import { useQueryClient } from "@tanstack/react-query";
 
 type ConnectionForm = {
   name?: string;
@@ -85,6 +86,7 @@ const CreateConnection = ({
   onClose,
 }: CreateConnectionProps) => {
   const styleWithTheme = useWithTheme();
+  const queryClient = useQueryClient();
 
   const configId = existingConfig?.id;
   const initialData: ConnectionForm | undefined = existingConfig
@@ -158,6 +160,8 @@ const CreateConnection = ({
             updatedGraphs.delete(configId);
             return updatedGraphs;
           });
+
+          await queryClient.resetQueries();
         }
       },
       [
@@ -165,6 +169,7 @@ const CreateConnection = ({
         initialData?.url,
         initialData?.graphDbUrl,
         initialData?.queryEngine,
+        queryClient,
       ]
     )
   );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When certain parts of the connection config changes, we should dump all the cached values in TanStack Query. This will cause a schema sync to automatically fire.

## Validation

- Tested by updating existing connection changing query engine, URL, or DB URL
- Tested by updating existing connection changing any other property
- Tested by creating a new connection

## Related Issues

- Resolves #914 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
