### PR TITLE
Use deep equal for atomFamily

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,7 +20,8 @@
   ([#909](https://github.com/aws/graph-explorer/pull/909))
 - **Updated** the state management layer to use Jotai instead of Recoil
   ([#896](https://github.com/aws/graph-explorer/pull/896),
-  [#920](https://github.com/aws/graph-explorer/pull/920))
+  [#920](https://github.com/aws/graph-explorer/pull/920),
+  [#921](https://github.com/aws/graph-explorer/pull/921))
 - **Updated** to use the React Compiler to improve performance and simplify code
   ([#916](https://github.com/aws/graph-explorer/pull/916))
 - **Fixed** issue where a schema sync would not automatically run when a

--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -8,6 +8,7 @@ import {
 import type { ConfigurationContextProps } from "./types";
 import { atomFamily } from "jotai/utils";
 import { atom, useAtomValue } from "jotai";
+import { isEqual } from "lodash";
 
 const assembledConfigSelector = atom(get => {
   const configuration = get(mergedConfigurationSelector);
@@ -44,22 +45,25 @@ export const vertexTypeAttributesSelector = atomFamily(
       );
 
       return attributesByNameMap.values().toArray();
-    })
+    }),
+  isEqual
 );
 
-export const edgeTypeAttributesSelector = atomFamily((edgeTypes: string[]) =>
-  atom(get => {
-    const attributesByNameMap = new Map(
-      edgeTypes
-        .values()
-        .map(et => get(edgeTypeConfigSelector(et)))
-        .filter(et => et != null)
-        .flatMap(et => et.attributes)
-        .map(attr => [attr.name, attr])
-    );
+export const edgeTypeAttributesSelector = atomFamily(
+  (edgeTypes: string[]) =>
+    atom(get => {
+      const attributesByNameMap = new Map(
+        edgeTypes
+          .values()
+          .map(et => get(edgeTypeConfigSelector(et)))
+          .filter(et => et != null)
+          .flatMap(et => et.attributes)
+          .map(attr => [attr.name, attr])
+      );
 
-    return attributesByNameMap.values().toArray();
-  })
+      return attributesByNameMap.values().toArray();
+    }),
+  isEqual
 );
 
 export const vertexTypeConfigSelector = atomFamily((vertexType: string) =>
@@ -75,16 +79,18 @@ export function useVertexTypeConfig(vertexType: string) {
   return useAtomValue(vertexTypeConfigSelector(vertexType));
 }
 
-const vertexTypeConfigsSelector = atomFamily((vertexTypes?: string[]) =>
-  atom(get => {
-    const allConfigs = get(allVertexTypeConfigsSelector);
-    if (!vertexTypes) {
-      return allConfigs.values().toArray();
-    }
-    return vertexTypes.map(
-      type => allConfigs.get(type) ?? getDefaultVertexTypeConfig(type)
-    );
-  })
+const vertexTypeConfigsSelector = atomFamily(
+  (vertexTypes?: string[]) =>
+    atom(get => {
+      const allConfigs = get(allVertexTypeConfigsSelector);
+      if (!vertexTypes) {
+        return allConfigs.values().toArray();
+      }
+      return vertexTypes.map(
+        type => allConfigs.get(type) ?? getDefaultVertexTypeConfig(type)
+      );
+    }),
+  isEqual
 );
 
 /** Gets the matching vertex type configs or the generated default values. */
@@ -105,16 +111,18 @@ export function useEdgeTypeConfig(edgeType: string) {
   return useAtomValue(edgeTypeConfigSelector(edgeType));
 }
 
-const edgeTypeConfigsSelector = atomFamily((edgeTypes?: string[]) =>
-  atom(get => {
-    const allConfigs = get(allEdgeTypeConfigsSelector);
-    if (!edgeTypes) {
-      return allConfigs.values().toArray();
-    }
-    return edgeTypes.map(
-      type => allConfigs.get(type) ?? getDefaultEdgeTypeConfig(type)
-    );
-  })
+const edgeTypeConfigsSelector = atomFamily(
+  (edgeTypes?: string[]) =>
+    atom(get => {
+      const allConfigs = get(allEdgeTypeConfigsSelector);
+      if (!edgeTypes) {
+        return allConfigs.values().toArray();
+      }
+      return edgeTypes.map(
+        type => allConfigs.get(type) ?? getDefaultEdgeTypeConfig(type)
+      );
+    }),
+  isEqual
 );
 
 /** Gets the matching edge type configs or the generated default values. */

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -1,5 +1,5 @@
 import { isEqual, uniq } from "lodash";
-import { atom } from "jotai";
+import { atom, useAtomValue } from "jotai";
 import { sanitizeText } from "@/utils";
 import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 import {
@@ -205,11 +205,17 @@ export const allVertexTypeConfigsSelector = atom(get => {
   const configuration = get(mergedConfigurationSelector);
   return new Map(configuration?.schema?.vertices.map(vt => [vt.type, vt]));
 });
+export function useAllVertexTypeConfigs() {
+  return useAtomValue(allVertexTypeConfigsSelector);
+}
 
 export const allEdgeTypeConfigsSelector = atom(get => {
   const configuration = get(mergedConfigurationSelector);
   return new Map(configuration?.schema?.edges.map(et => [et.type, et]));
 });
+export function useAllEdgeTypeConfigs() {
+  return useAtomValue(allEdgeTypeConfigsSelector);
+}
 
 export const vertexTypesSelector = atom(get => {
   const configuration = get(mergedConfigurationSelector);

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -7,7 +7,6 @@ import {
   DisplayVertexTypeConfig,
   displayVertexTypeConfigSelector,
   queryEngineSelector,
-  nodeSelector,
   getRawId,
   Vertex,
   VertexId,
@@ -64,9 +63,10 @@ export function useDisplayVerticesFromVertices(vertices: Vertex[]) {
 
 const selectedDisplayVerticesSelector = atom(get => {
   const selectedIds = get(nodesSelectedIdsAtom);
+  const nodes = get(nodesAtom);
   return selectedIds
     .values()
-    .map(id => get(nodeSelector(id)))
+    .map(id => nodes.get(id))
     .filter(n => n != null)
     .map(n => get(displayVertexSelector(n)))
     .filter(n => n != null)

--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -12,6 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { neighborsCountQuery } from "@/connector";
 import { useExplorer } from "../connector";
 import { useNotification } from "@/components/NotificationProvider";
+import { isEqual } from "lodash";
 
 export type NeighborCounts = {
   all: number;
@@ -252,8 +253,10 @@ export function useFetchedNeighborsCallback() {
     );
 }
 
-const allFetchedNeighborsSelector = atomFamily((ids: VertexId[]) =>
-  atom(get => {
-    return new Map(ids.map(id => [id, get(fetchedNeighborsSelector(id))]));
-  })
+const allFetchedNeighborsSelector = atomFamily(
+  (ids: VertexId[]) =>
+    atom(get => {
+      return new Map(ids.map(id => [id, get(fetchedNeighborsSelector(id))]));
+    }),
+  isEqual
 );

--- a/packages/graph-explorer/src/core/StateProvider/nodes.ts
+++ b/packages/graph-explorer/src/core/StateProvider/nodes.ts
@@ -1,5 +1,5 @@
 import { atom, useAtomValue, useSetAtom } from "jotai";
-import { atomFamily, atomWithReset, RESET } from "jotai/utils";
+import { atomWithReset, RESET } from "jotai/utils";
 import {
   createRenderedVertexId,
   getVertexIdFromRenderedVertexId,
@@ -13,10 +13,6 @@ export function toNodeMap(nodes: Vertex[]): Map<VertexId, Vertex> {
 }
 
 export const nodesAtom = atomWithReset(new Map<VertexId, Vertex>());
-
-export const nodeSelector = atomFamily((id: VertexId) =>
-  atom(get => get(nodesAtom).get(id) ?? null)
-);
 
 export const nodesSelectedIdsAtom = atomWithReset(new Set<VertexId>());
 

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -1,0 +1,118 @@
+import { DbState, renderHookWithJotai } from "@/utils/testing";
+import { useEdgeStyling, useVertexStyling } from "./userPreferences";
+import { act } from "react";
+
+describe("useVertexStyling", () => {
+  it("should return the vertex style if it exists", () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.vertexStyle).toBeUndefined();
+  });
+
+  it("should insert the vertex style when none exist", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setVertexStyle({ color: "red" }));
+
+    expect(result.current.vertexStyle).toEqual({ type: "test", color: "red" });
+  });
+
+  it("should update the existing style, merging new styles", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() =>
+      result.current.setVertexStyle({ color: "red", borderColor: "green" })
+    );
+    await act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+
+    expect(result.current.vertexStyle).toEqual({
+      type: "test",
+      color: "red",
+      borderColor: "blue",
+    });
+  });
+
+  it("should reset the vertex style", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+    await act(() => result.current.resetVertexStyle());
+
+    expect(result.current.vertexStyle).toBeUndefined();
+  });
+});
+
+describe("useEdgeStyling", () => {
+  it("should return the edge style if it exists", () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.edgeStyle).toBeUndefined();
+  });
+
+  it("should insert the edge style when none exist", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setEdgeStyle({ lineColor: "red" }));
+
+    expect(result.current.edgeStyle).toEqual({
+      type: "test",
+      lineColor: "red",
+    });
+  });
+
+  it("should update the existing style, merging new styles", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() =>
+      result.current.setEdgeStyle({ lineColor: "red", labelColor: "green" })
+    );
+    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+
+    expect(result.current.edgeStyle).toEqual({
+      type: "test",
+      lineColor: "red",
+      labelColor: "blue",
+    });
+  });
+
+  it("should reset the edge style", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+    await act(() => result.current.resetEdgeStyle());
+
+    expect(result.current.edgeStyle).toBeUndefined();
+  });
+});

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -4,9 +4,8 @@ import ColorInput from "@/components/ColorInput/ColorInput";
 import { useDisplayEdgeTypeConfig, useWithTheme } from "@/core";
 import {
   ArrowStyle,
-  EdgePreferences,
   LineStyle,
-  userStylingEdgeAtom,
+  useEdgeStyling,
 } from "@/core/StateProvider/userPreferences";
 import useTranslations from "@/hooks/useTranslations";
 import {
@@ -17,7 +16,6 @@ import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
 import { atom, useAtom } from "jotai";
-import { useResetAtom } from "jotai/utils";
 
 export const customizeEdgeTypeAtom = atom<string | undefined>(undefined);
 
@@ -60,9 +58,7 @@ function Content({ edgeType }: { edgeType: string }) {
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
   const t = useTranslations();
 
-  const [edgePreferences, setEdgePreferences] = useAtom(
-    userStylingEdgeAtom(edgeType)
-  );
+  const { edgeStyle, setEdgeStyle, resetEdgeStyle } = useEdgeStyling(edgeType);
 
   const selectOptions = (() => {
     const options = displayConfig.attributes.map(attr => ({
@@ -78,12 +74,6 @@ function Content({ edgeType }: { edgeType: string }) {
     return options;
   })();
 
-  const onUserPrefsChange = (prefs: Omit<EdgePreferences, "type">) => {
-    setEdgePreferences({ type: edgeType, ...prefs });
-  };
-
-  const onUserPrefsReset = useResetAtom(userStylingEdgeAtom(edgeType));
-
   return (
     <div className="modal-container">
       <div>
@@ -94,7 +84,7 @@ function Content({ edgeType }: { edgeType: string }) {
             labelPlacement="inner"
             value={displayConfig.displayNameAttribute}
             onValueChange={value =>
-              onUserPrefsChange({ displayNameAttribute: value })
+              setEdgeStyle({ displayNameAttribute: value })
             }
             options={selectOptions}
           />
@@ -106,10 +96,8 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.labelColor || "#17457b"}
-            onChange={(color: string) =>
-              onUserPrefsChange({ labelColor: color })
-            }
+            startColor={edgeStyle?.labelColor || "#17457b"}
+            onChange={(color: string) => setEdgeStyle({ labelColor: color })}
           />
           <InputField
             label="Background Opacity"
@@ -118,9 +106,9 @@ function Content({ edgeType }: { edgeType: string }) {
             min={0}
             max={1}
             step={0.1}
-            value={edgePreferences?.labelBackgroundOpacity ?? 0.7}
+            value={edgeStyle?.labelBackgroundOpacity ?? 0.7}
             onChange={(value: number) =>
-              onUserPrefsChange({ labelBackgroundOpacity: value })
+              setEdgeStyle({ labelBackgroundOpacity: value })
             }
           />
         </div>
@@ -130,9 +118,9 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Border Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.labelBorderColor || "#17457b"}
+            startColor={edgeStyle?.labelBorderColor || "#17457b"}
             onChange={(color: string) =>
-              onUserPrefsChange({ labelBorderColor: color })
+              setEdgeStyle({ labelBorderColor: color })
             }
           />
           <InputField
@@ -140,17 +128,17 @@ function Content({ edgeType }: { edgeType: string }) {
             labelPlacement="inner"
             type="number"
             min={0}
-            value={edgePreferences?.labelBorderWidth ?? 0}
+            value={edgeStyle?.labelBorderWidth ?? 0}
             onChange={(value: number) =>
-              onUserPrefsChange({ labelBorderWidth: value })
+              setEdgeStyle({ labelBorderWidth: value })
             }
           />
           <SelectField
             label="Border Style"
             labelPlacement="inner"
-            value={edgePreferences?.labelBorderStyle || "solid"}
+            value={edgeStyle?.labelBorderStyle || "solid"}
             onValueChange={value =>
-              onUserPrefsChange({ labelBorderStyle: value as LineStyle })
+              setEdgeStyle({ labelBorderStyle: value as LineStyle })
             }
             options={LINE_STYLE_OPTIONS}
           />
@@ -162,27 +150,23 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.lineColor || "#b3b3b3"}
-            onChange={(color: string) =>
-              onUserPrefsChange({ lineColor: color })
-            }
+            startColor={edgeStyle?.lineColor || "#b3b3b3"}
+            onChange={(color: string) => setEdgeStyle({ lineColor: color })}
           />
           <InputField
             label="Thickness"
             labelPlacement="inner"
             type="number"
             min={1}
-            value={edgePreferences?.lineThickness || 2}
-            onChange={(value: number) =>
-              onUserPrefsChange({ lineThickness: value })
-            }
+            value={edgeStyle?.lineThickness || 2}
+            onChange={(value: number) => setEdgeStyle({ lineThickness: value })}
           />
           <SelectField
             label="Style"
             labelPlacement="inner"
-            value={edgePreferences?.lineStyle || "solid"}
+            value={edgeStyle?.lineStyle || "solid"}
             onValueChange={value =>
-              onUserPrefsChange({ lineStyle: value as LineStyle })
+              setEdgeStyle({ lineStyle: value as LineStyle })
             }
             options={LINE_STYLE_OPTIONS}
           />
@@ -194,25 +178,25 @@ function Content({ edgeType }: { edgeType: string }) {
           <SelectField
             label="Source"
             labelPlacement="inner"
-            value={edgePreferences?.sourceArrowStyle || "none"}
+            value={edgeStyle?.sourceArrowStyle || "none"}
             onValueChange={value =>
-              onUserPrefsChange({ sourceArrowStyle: value as ArrowStyle })
+              setEdgeStyle({ sourceArrowStyle: value as ArrowStyle })
             }
             options={SOURCE_ARROW_STYLE_OPTIONS}
           />
           <SelectField
             label="Target"
             labelPlacement="inner"
-            value={edgePreferences?.targetArrowStyle || "triangle"}
+            value={edgeStyle?.targetArrowStyle || "triangle"}
             onValueChange={value =>
-              onUserPrefsChange({ targetArrowStyle: value as ArrowStyle })
+              setEdgeStyle({ targetArrowStyle: value as ArrowStyle })
             }
             options={TARGET_ARROW_STYLE_OPTIONS}
           />
         </div>
       </div>
       <div className="actions">
-        <Button onPress={onUserPrefsReset}>Reset to Default</Button>
+        <Button onPress={resetEdgeStyle}>Reset to Default</Button>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -1,10 +1,7 @@
-import { ComponentPropsWithRef, useCallback, useEffect, useState } from "react";
+import { ComponentPropsWithRef, useEffect, useState } from "react";
 import { Button, FormItem, InputField, Label, StylingIcon } from "@/components";
 import { useDisplayEdgeTypeConfig } from "@/core";
-import {
-  EdgePreferences,
-  userStylingEdgeAtom,
-} from "@/core/StateProvider/userPreferences";
+import { useEdgeStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { MISSING_DISPLAY_TYPE } from "@/utils";
 import { customizeEdgeTypeAtom } from "./EdgeStyleDialog";
@@ -16,21 +13,13 @@ export type SingleEdgeStylingProps = {
 
 export default function SingleEdgeStyling({
   edgeType,
-
   ...rest
 }: SingleEdgeStylingProps) {
-  const setEdgePreferences = useSetAtom(userStylingEdgeAtom(edgeType));
+  const { setEdgeStyle } = useEdgeStyling(edgeType);
   const setCustomizeEdgeType = useSetAtom(customizeEdgeTypeAtom);
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
-
-  const onUserPrefsChange = useCallback(
-    (prefs: Omit<EdgePreferences, "type">) => {
-      setEdgePreferences({ type: edgeType, ...prefs });
-    },
-    [edgeType, setEdgePreferences]
-  );
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -40,8 +29,8 @@ export default function SingleEdgeStyling({
     if (prevDisplayAs === null || prevDisplayAs === debouncedDisplayAs) {
       return;
     }
-    onUserPrefsChange({ displayLabel: debouncedDisplayAs });
-  }, [debouncedDisplayAs, prevDisplayAs, onUserPrefsChange]);
+    void setEdgeStyle({ displayLabel: debouncedDisplayAs });
+  }, [debouncedDisplayAs, prevDisplayAs, setEdgeStyle]);
 
   return (
     <FormItem {...rest}>

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -3,15 +3,13 @@ import { useEffect, useState } from "react";
 import {
   getEdgeIdFromRenderedEdgeId,
   RenderedEdgeId,
+  useAllEdgeTypeConfigs,
+  useAllVertexTypeConfigs,
   useDisplayEdgesInCanvas,
 } from "@/core";
 import type { GraphProps } from "@/components";
 import useTextTransform from "@/hooks/useTextTransform";
 import { renderNode } from "./renderNode";
-import {
-  useEdgeTypeConfigs,
-  useVertexTypeConfigs,
-} from "@/core/ConfigurationProvider/useConfiguration";
 import { MISSING_DISPLAY_VALUE } from "@/utils/constants";
 
 const LINE_PATTERN = {
@@ -21,8 +19,8 @@ const LINE_PATTERN = {
 };
 
 const useGraphStyles = () => {
-  const vtConfigs = useVertexTypeConfigs();
-  const etConfigs = useEdgeTypeConfigs();
+  const vtConfigs = useAllVertexTypeConfigs();
+  const etConfigs = useAllEdgeTypeConfigs();
   const textTransform = useTextTransform();
   const [styles, setStyles] = useState<GraphProps["styles"]>({});
   const displayEdges = useDisplayEdgesInCanvas();
@@ -31,7 +29,7 @@ const useGraphStyles = () => {
     (async () => {
       const styles: GraphProps["styles"] = {};
 
-      for (const vtConfig of vtConfigs) {
+      for (const vtConfig of vtConfigs.values()) {
         const vt = vtConfig.type;
 
         // Process the image data or SVG
@@ -51,7 +49,7 @@ const useGraphStyles = () => {
         };
       }
 
-      for (const etConfig of etConfigs) {
+      for (const etConfig of etConfigs.values()) {
         const et = etConfig?.type;
 
         let label = textTransform(et);

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -1,10 +1,7 @@
-import { ComponentPropsWithRef, useCallback, useEffect, useState } from "react";
+import { ComponentPropsWithRef, useEffect, useState } from "react";
 import { Button, FormItem, InputField, Label, StylingIcon } from "@/components";
 import { useDisplayVertexTypeConfig } from "@/core";
-import {
-  userStylingNodeAtom,
-  VertexPreferences,
-} from "@/core/StateProvider/userPreferences";
+import { useVertexStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { MISSING_DISPLAY_TYPE } from "@/utils/constants";
 import { customizeNodeTypeAtom } from "./NodeStyleDialog";
@@ -16,22 +13,14 @@ export type SingleNodeStylingProps = {
 
 export default function SingleNodeStyling({
   vertexType,
-
   ...rest
 }: SingleNodeStylingProps) {
-  const setNodePreferences = useSetAtom(userStylingNodeAtom(vertexType));
+  const { setVertexStyle } = useVertexStyling(vertexType);
   const displayConfig = useDisplayVertexTypeConfig(vertexType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
 
   const setCustomizeNodeType = useSetAtom(customizeNodeTypeAtom);
-
-  const onUserPrefsChange = useCallback(
-    (prefs: Omit<VertexPreferences, "type">) => {
-      setNodePreferences({ type: vertexType, ...prefs });
-    },
-    [setNodePreferences, vertexType]
-  );
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -41,8 +30,8 @@ export default function SingleNodeStyling({
     if (prevDisplayAs === null || prevDisplayAs === debouncedDisplayAs) {
       return;
     }
-    onUserPrefsChange({ displayLabel: debouncedDisplayAs });
-  }, [debouncedDisplayAs, prevDisplayAs, onUserPrefsChange]);
+    void setVertexStyle({ displayLabel: debouncedDisplayAs });
+  }, [debouncedDisplayAs, prevDisplayAs, setVertexStyle]);
 
   return (
     <FormItem {...rest}>
@@ -63,6 +52,7 @@ export default function SingleNodeStyling({
         <Button
           icon={<StylingIcon />}
           variant="text"
+          // disabled={pending}
           onClick={() => setCustomizeNodeType(vertexType)}
         >
           Customize


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Apparently Jotai and Recoil treat family instances a little bit differently. In order to make sure we are getting cached versions of the family atoms I've added a deep equals comparer to the atom from lodash. This is only needed for the `atomFamily` instances that use arrays or objects as the parameter.

This stems from [this bit of Jotai documentation](https://jotai.org/docs/utilities/family#usage):

> To reproduce behavior similar to [Recoil's atomFamily/selectorFamily](https://recoiljs.org/docs/api-reference/utils/atomFamily), specify a deepEqual function to `areEqual`.

## Validation

- Simple smoke test as this is just a memory optimization

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
