### PR TITLE
Use a normalized connection type to reduce optionals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@
 - **Fixed** issue where a schema sync would not automatically run when a
   connection was changed
   ([#919](https://github.com/aws/graph-explorer/pull/919))
+- **Updated** dependencies and minor refactoring of code
+  ([#922](https://github.com/aws/graph-explorer/pull/922))
 
 ## Release v1.15.0
 

--- a/packages/graph-explorer/babel.config.js
+++ b/packages/graph-explorer/babel.config.js
@@ -11,4 +11,12 @@ module.exports = {
     "@babel/preset-react",
     "@babel/preset-typescript",
   ],
+  plugins: [
+    [
+      "babel-plugin-react-compiler",
+      {
+        target: "18", // '17' | '18' | '19'
+      },
+    ],
+  ],
 };

--- a/packages/graph-explorer/src/connector/emptyExplorer.ts
+++ b/packages/graph-explorer/src/connector/emptyExplorer.ts
@@ -7,6 +7,7 @@ import { Explorer, toMappedQueryResults } from "./useGEFetchTypes";
 export const emptyExplorer: Explorer = {
   connection: {
     url: "",
+    graphDbUrl: "",
     queryEngine: "gremlin",
     proxyConnection: false,
     awsAuthEnabled: false,

--- a/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
+++ b/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
@@ -1,7 +1,6 @@
-import { type ConnectionConfig } from "@shared/types";
 import { DEFAULT_SERVICE_TYPE } from "@/utils/constants";
 import { anySignal } from "./utils/anySignal";
-import { FeatureFlags } from "@/core";
+import { FeatureFlags, NormalizedConnection } from "@/core";
 import { z } from "zod";
 import { logger, NetworkError } from "@/utils";
 
@@ -57,18 +56,18 @@ async function decodeErrorSafely(response: Response): Promise<any> {
 
 // Construct the request headers based on the connection settings
 function getAuthHeaders(
-  connection: ConnectionConfig | undefined,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   typeHeaders: HeadersInit | undefined
 ) {
   const headers: HeadersInit = {};
-  if (connection?.proxyConnection) {
+  if (connection.proxyConnection) {
     headers["graph-db-connection-url"] = connection.graphDbUrl || "";
     headers["db-query-logging-enabled"] = String(
       featureFlags.allowLoggingDbQuery
     );
   }
-  if (connection?.awsAuthEnabled) {
+  if (connection.awsAuthEnabled) {
     headers["aws-neptune-region"] = connection.awsRegion || "";
     headers["service-type"] = connection.serviceType || DEFAULT_SERVICE_TYPE;
   }
@@ -77,8 +76,8 @@ function getAuthHeaders(
 }
 
 // Construct an AbortSignal for the fetch timeout if configured
-function getFetchTimeoutSignal(connection: ConnectionConfig | undefined) {
-  if (!connection?.fetchTimeoutMs) {
+function getFetchTimeoutSignal(connection: NormalizedConnection) {
+  if (!connection.fetchTimeoutMs) {
     return null;
   }
 
@@ -90,7 +89,7 @@ function getFetchTimeoutSignal(connection: ConnectionConfig | undefined) {
 }
 
 export async function fetchDatabaseRequest(
-  connection: ConnectionConfig | undefined,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   uri: URL | RequestInfo,
   options: RequestInit

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -1,4 +1,3 @@
-import { ConnectionConfig } from "@shared/types";
 import fetchNeighbors from "./fetchNeighbors";
 import fetchNeighborsCount from "./fetchNeighborsCount";
 import fetchSchema from "./fetchSchema";
@@ -10,12 +9,12 @@ import { v4 } from "uuid";
 import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
-import { FeatureFlags } from "@/core";
+import { FeatureFlags, NormalizedConnection } from "@/core";
 import { vertexDetails } from "./vertexDetails";
 import { edgeDetails } from "./edgeDetails";
 
 function _gremlinFetch(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: ExplorerRequestOptions
 ): GremlinFetch {
@@ -45,7 +44,7 @@ function _gremlinFetch(
 }
 
 async function fetchSummary(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: RequestInit
 ) {
@@ -69,7 +68,7 @@ async function fetchSummary(
 }
 
 export function createGremlinExplorer(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags
 ): Explorer {
   const remoteLogger = createLoggerFromConnection(connection);

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -5,17 +5,16 @@ import keywordSearch from "./keywordSearch";
 import fetchSchema from "./fetchSchema";
 import { GraphSummary } from "./types";
 import { fetchDatabaseRequest } from "../fetchDatabaseRequest";
-import { ConnectionConfig } from "@shared/types";
 import { DEFAULT_SERVICE_TYPE } from "@/utils/constants";
 import { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import { env, logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
-import { FeatureFlags } from "@/core";
+import { FeatureFlags, NormalizedConnection } from "@/core";
 import { vertexDetails } from "./vertexDetails";
 import { edgeDetails } from "./edgeDetails";
 
 function _openCypherFetch(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: ExplorerRequestOptions
 ) {
@@ -38,13 +37,13 @@ function _openCypherFetch(
 }
 
 export function createOpenCypherExplorer(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags
 ): Explorer {
   const remoteLogger = createLoggerFromConnection(connection);
   const serviceType = connection.serviceType || DEFAULT_SERVICE_TYPE;
   return {
-    connection: connection,
+    connection,
     async fetchSchema(options) {
       remoteLogger.info("[openCypher Explorer] Fetching schema...");
       const summary = await fetchSummary(
@@ -108,7 +107,7 @@ export function createOpenCypherExplorer(
 
 async function fetchSummary(
   serviceType: string,
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: RequestInit
 ) {

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -17,11 +17,10 @@ import {
   SPARQLKeywordSearchRequest,
   SPARQLNeighborsRequest,
 } from "./types";
-import { ConnectionConfig } from "@shared/types";
 import { v4 } from "uuid";
 import { env, logger } from "@/utils";
 import { createLoggerFromConnection } from "@/core/connector";
-import { FeatureFlags } from "@/core";
+import { FeatureFlags, NormalizedConnection } from "@/core";
 import { replaceBlankNodeFromNeighbors } from "./fetchNeighbors/replaceBlankNodeFromNeighbors";
 import { storedBlankNodeNeighborsRequest } from "./fetchNeighbors/storedBlankNodeNeighborsRequest";
 import { replaceBlankNodeFromSearch } from "./keywordSearch/replaceBlankNodeFromSearch";
@@ -29,7 +28,7 @@ import { vertexDetails } from "./vertexDetails";
 import { edgeDetails } from "./edgeDetails";
 
 function _sparqlFetch(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: ExplorerRequestOptions
 ) {
@@ -63,7 +62,7 @@ function _sparqlFetch(
 }
 
 async function fetchSummary(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   options?: RequestInit
 ) {
@@ -87,7 +86,7 @@ async function fetchSummary(
 }
 
 export function createSparqlExplorer(
-  connection: ConnectionConfig,
+  connection: NormalizedConnection,
   featureFlags: FeatureFlags,
   blankNodes: BlankNodesMap
 ): Explorer {

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -6,8 +6,8 @@ import {
   EdgeId,
   Vertex,
   VertexId,
+  NormalizedConnection,
 } from "@/core";
-import { ConnectionConfig } from "@shared/types";
 
 export type QueryOptions = RequestInit & {
   queryId?: string;
@@ -239,7 +239,7 @@ export type EdgeDetailsResponse = {
  * Graph Explorer.
  */
 export type Explorer = {
-  connection: ConnectionConfig;
+  connection: NormalizedConnection;
   fetchSchema: (options?: ExplorerRequestOptions) => Promise<SchemaResponse>;
   fetchVertexCountsByType: (
     req: CountsByTypeRequest,

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -10,6 +10,7 @@ import {
   defaultEdgeTypeConfig,
   defaultVertexTypeConfig,
   mergeConfiguration,
+  NormalizedConnection,
 } from "./configuration";
 import { RawConfiguration, VertexTypeConfig } from "../ConfigurationProvider";
 import { SchemaInference } from "./schema";
@@ -17,17 +18,22 @@ import { UserStyling } from "./userPreferences";
 import { createRandomName } from "@shared/utils/testing";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
 
+/** The default empty connection values when no value is provided. */
+const defaultEmptyConnection: NormalizedConnection = {
+  url: "",
+  graphDbUrl: "",
+  queryEngine: "gremlin",
+  proxyConnection: false,
+  awsAuthEnabled: false,
+};
+
 describe("mergedConfiguration", () => {
   it("should produce empty defaults when empty object is passed", () => {
     const config = {} as RawConfiguration;
     const result = mergeConfiguration(null, config, {});
 
     expect(result).toEqual({
-      connection: {
-        graphDbUrl: "",
-        queryEngine: "gremlin",
-        url: "",
-      },
+      connection: defaultEmptyConnection,
       schema: {
         edges: [],
         vertices: [],
@@ -44,8 +50,7 @@ describe("mergedConfiguration", () => {
     expect(result).toEqual({
       ...config,
       connection: {
-        url: "",
-        graphDbUrl: "",
+        ...defaultEmptyConnection,
         ...config.connection,
       },
       schema: {
@@ -84,6 +89,7 @@ describe("mergedConfiguration", () => {
     expect(result).toEqual({
       ...config,
       connection: {
+        ...defaultEmptyConnection,
         ...config.connection,
         url: config.connection?.url ?? "",
         graphDbUrl: config.connection?.graphDbUrl ?? "",
@@ -135,6 +141,7 @@ describe("mergedConfiguration", () => {
     expect(result).toEqual({
       ...config,
       connection: {
+        ...defaultEmptyConnection,
         ...config.connection,
         url: config.connection?.url ?? "",
         graphDbUrl: config.connection?.graphDbUrl ?? "",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The original `ConnectionConfig` type has many fields that are marked as optional. But once the app is using the connection it has been transformed to not have so many optional fields. But since the type is defined as optional, the code had to deal with those optionals.

So I'm adding a new type `NormalizedConnection` that does not have all the optionals.

## Validation

- Smoke test

## Related Issues

- Part of #572

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
