### PR TITLE
Use react-colorful for ColorInput

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,7 +28,8 @@
   ([#919](https://github.com/aws/graph-explorer/pull/919))
 - **Updated** dependencies and minor refactoring of code
   ([#922](https://github.com/aws/graph-explorer/pull/922),
-  [#926](https://github.com/aws/graph-explorer/pull/926))
+  [#926](https://github.com/aws/graph-explorer/pull/926),
+  [#931](https://github.com/aws/graph-explorer/pull/931))
 
 ## Release v1.15.0
 

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -70,6 +70,7 @@
     "papaparse": "^5.5.2",
     "re-resizable": "^6.11.2",
     "react": "^19.1.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^19.1.0",
     "react-error-boundary": "^6.0.0",
     "react-hook-form": "^7.56.3",

--- a/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
+++ b/packages/graph-explorer/src/components/ColorInput/ColorInput.tsx
@@ -1,49 +1,29 @@
 import { cn } from "@/utils";
-import { ColorPicker, ColorPickerProps } from "@mantine/core";
-import { useEffect, useState } from "react";
+import { ComponentPropsWithoutRef } from "react";
 import {
   InputField,
   InputFieldProps,
+  inputStyles,
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components";
-
-const validHexColorRegex = /^#([0-9a-f]{3}){1,2}$/i;
+import { HexColorPicker, HexColorInput } from "react-colorful";
 
 export interface ColorInputProps
   extends Pick<InputFieldProps, "label" | "labelPlacement">,
-    ColorPickerProps {
-  startColor?: string;
-  onChange(color: string): void;
-}
+    ComponentPropsWithoutRef<typeof HexColorPicker> {}
+
+const DEFAULT_COLOR = "#128ee5";
 
 function ColorInput({
   className,
-  startColor = "#128ee5",
+  color = DEFAULT_COLOR,
   onChange,
   label,
   labelPlacement,
   ...props
 }: ColorInputProps) {
-  const [lastColor, setLastColor] = useState<string>(startColor);
-  const [color, setColor] = useState<string>(startColor);
-
-  if (lastColor !== startColor) {
-    setLastColor(startColor);
-    setColor(startColor);
-  }
-
-  useEffect(() => {
-    if (
-      startColor !== color &&
-      lastColor === startColor &&
-      validHexColorRegex.test(color)
-    ) {
-      onChange(color);
-    }
-  }, [startColor, color, lastColor, onChange]);
-
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -54,22 +34,24 @@ function ColorInput({
             aria-label="color-input"
             type="text"
             value={color}
-            onChange={(newColor: string) => setColor(newColor)}
+            isReadOnly
           />
           <div
             className="pointer-events-none absolute inset-y-2 right-2 aspect-square rounded"
             style={{
-              backgroundColor: startColor,
+              backgroundColor: color,
             }}
           />
         </div>
       </PopoverTrigger>
-      <PopoverContent side="bottom" align="start">
-        <ColorPicker
-          onChange={(newColor: string) => setColor(newColor)}
-          value={color}
-          {...props}
+      <PopoverContent side="bottom" align="start" className="space-y-4">
+        <HexColorInput
+          color={color}
+          onChange={onChange}
+          className={cn(inputStyles())}
+          autoFocus
         />
+        <HexColorPicker onChange={onChange} color={color} {...props} />
       </PopoverContent>
     </Popover>
   );

--- a/packages/graph-explorer/src/components/Input.tsx
+++ b/packages/graph-explorer/src/components/Input.tsx
@@ -1,18 +1,26 @@
 import * as React from "react";
-
 import { cn } from "@/utils";
+import { cva } from "cva";
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+/*
+ * DEV NOTE: There's not a set of variants here, but I wanted a consistent way
+ * to share the input styles.
+ *
+ * This style is used for color input from react-colorful.
+ */
+
+export const inputStyles = cva({
+  base: "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+});
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
-          className
-        )}
+        className={cn(inputStyles(), className)}
         ref={ref}
         {...props}
       />

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -106,7 +106,7 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.labelColor || "#17457b"}
+            color={edgePreferences?.labelColor || "#17457b"}
             onChange={(color: string) =>
               onUserPrefsChange({ labelColor: color })
             }
@@ -130,7 +130,7 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Border Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.labelBorderColor || "#17457b"}
+            color={edgePreferences?.labelBorderColor || "#17457b"}
             onChange={(color: string) =>
               onUserPrefsChange({ labelBorderColor: color })
             }
@@ -162,7 +162,7 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            startColor={edgePreferences?.lineColor || "#b3b3b3"}
+            color={edgePreferences?.lineColor || "#b3b3b3"}
             onChange={(color: string) =>
               onUserPrefsChange({ lineColor: color })
             }

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -200,7 +200,7 @@ function Content({ vertexType }: { vertexType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            startColor={nodePreferences?.color || "#17457b"}
+            color={nodePreferences?.color || "#17457b"}
             onChange={(color: string) => onUserPrefsChange({ color })}
           />
           <InputField
@@ -222,7 +222,7 @@ function Content({ vertexType }: { vertexType: string }) {
           <ColorInput
             label="Border Color"
             labelPlacement="inner"
-            startColor={nodePreferences?.borderColor || "#17457b"}
+            color={nodePreferences?.borderColor || "#17457b"}
             onChange={(color: string) =>
               onUserPrefsChange({ borderColor: color })
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.1.0
+      react-colorful:
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -4898,6 +4901,12 @@ packages:
     peerDependencies:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
@@ -11004,6 +11013,11 @@ snapshots:
       strip-json-comments: 2.0.1
 
   re-resizable@6.11.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  react-colorful@5.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Continuing the slow process of removing Mantine. This change uses [react-colorful](https://omgovich.github.io/react-colorful/), a very popular library for picking colors.

I considered using the browser's built in color picker, but browser support and OS support is still a little spotty.

The library offers a HEX input that handles all the validation logic, so the existing logic was removed.

You'll also notice that there is an input inside the popover. This is because the old color input had dueling focus issues. You'd click on the input to type, then the popover would show up and steal the focus. So you'd have to click again to dismiss the popover in order to type in the input.

So, to make the UX better (but the UI a little worse), I added the input in to the popover and made the outer input readonly. An alternative idea was to make the color swatch a button and be the only way to show the popover, which would allow the input to just be an input. But I felt like this was not discoverable enough.

## Validation

- Tested that no non-hex characters can be put in the input through typing or copy paste
- Tested performance while dragging the color loop in the picker
- Tested focus on the input

| Old | New |
| --- | --- |
| ![CleanShot 2025-05-19 at 09 34 29@2x](https://github.com/user-attachments/assets/7a1aee3f-2ca8-4937-bc8d-aae6b5b1e76b) | ![CleanShot 2025-05-19 at 09 34 09@2x](https://github.com/user-attachments/assets/6cda79e4-afbb-45c1-813b-3f7e52d61241) |


## Related Issues

- Resolves #704

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
