### PR TITLE
Use internal FileButton instead of Mantine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,7 +29,8 @@
 - **Updated** dependencies and minor refactoring of code
   ([#922](https://github.com/aws/graph-explorer/pull/922),
   [#926](https://github.com/aws/graph-explorer/pull/926),
-  [#931](https://github.com/aws/graph-explorer/pull/931))
+  [#931](https://github.com/aws/graph-explorer/pull/931),
+  [#932](https://github.com/aws/graph-explorer/pull/932))
 
 ## Release v1.15.0
 

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -1,4 +1,4 @@
-import { FileButton, Modal } from "@mantine/core";
+import { Modal } from "@mantine/core";
 import {
   AddIcon,
   PanelHeaderActionButton,
@@ -9,6 +9,7 @@ import {
   PanelHeaderDivider,
   Panel,
   PanelContent,
+  FileButton,
 } from "@/components";
 import {
   activeConfigurationAtom,
@@ -44,15 +45,13 @@ const AvailableConnections = ({
           <FileButton
             onChange={payload => payload && importConnectionFile(payload)}
             accept="application/json"
+            asChild
           >
-            {props => (
-              <PanelHeaderActionButton
-                label="Import Connection"
-                isDisabled={isSync}
-                onActionClick={props.onClick}
-                icon={<TrayArrowIcon style={{ transform: "rotate(180deg)" }} />}
-              />
-            )}
+            <PanelHeaderActionButton
+              label="Import Connection"
+              isDisabled={isSync}
+              icon={<TrayArrowIcon style={{ transform: "rotate(180deg)" }} />}
+            />
           </FileButton>
           <PanelHeaderDivider />
           <PanelHeaderActionButton

--- a/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
@@ -27,7 +27,7 @@ export function ImportGraphButton() {
 
   return (
     <FileButton
-      onChange={payload => payload && importGraph.mutate(payload[0])}
+      onChange={payload => payload && importGraph.mutate(payload)}
       accept="application/json"
       asChild
     >

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -1,6 +1,7 @@
-import { FileButton, Modal } from "@mantine/core";
+import { Modal } from "@mantine/core";
 import {
   Button,
+  FileButton,
   IconButton,
   InputField,
   SelectField,
@@ -171,26 +172,24 @@ function Content({ vertexType }: { vertexType: string }) {
             onChange={file => {
               file && convertImageToBase64AndSetNewIcon(file);
             }}
+            asChild
           >
-            {props => (
-              <IconButton
-                variant="filled"
-                className="text-text-primary hover:text-text-primary group rounded-full border-0 bg-transparent p-0 hover:cursor-pointer hover:bg-gray-200"
-                icon={
-                  <>
-                    <div className="hidden group-hover:flex">
-                      <UploadIcon />
-                    </div>
-                    <VertexSymbol
-                      vertexStyle={displayConfig.style}
-                      className="size-full group-hover:hidden"
-                    />
-                  </>
-                }
-                tooltipText="Upload New Icon"
-                onClick={props.onClick}
-              />
-            )}
+            <IconButton
+              variant="filled"
+              className="text-text-primary hover:text-text-primary group rounded-full border-0 bg-transparent p-0 hover:cursor-pointer hover:bg-gray-200"
+              icon={
+                <>
+                  <div className="hidden group-hover:flex">
+                    <UploadIcon />
+                  </div>
+                  <VertexSymbol
+                    vertexStyle={displayConfig.style}
+                    className="size-full group-hover:hidden"
+                  />
+                </>
+              }
+              tooltipText="Upload New Icon"
+            />
           </FileButton>
         </div>
       </div>

--- a/packages/graph-explorer/src/workspaces/Settings/LoadConfigButton.tsx
+++ b/packages/graph-explorer/src/workspaces/Settings/LoadConfigButton.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils";
-import { FileButton, Modal } from "@mantine/core";
+import { Modal } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import localforage from "localforage";
@@ -11,6 +11,8 @@ import {
   LoaderIcon,
   Button,
   CheckIcon,
+  FileButton,
+  FileButtonHandle,
 } from "@/components";
 import {
   readBackupDataFromFile,
@@ -23,7 +25,7 @@ import { FolderOpenIcon } from "lucide-react";
 
 export default function LoadConfigButton() {
   const [file, setFile] = useState<File | null>(null);
-  const resetRef = useRef<() => void>(null);
+  const resetRef = useRef<FileButtonHandle | null>(null);
 
   const backupFileQuery = useQuery({
     queryKey: ["backup", "file", file],
@@ -34,7 +36,7 @@ export default function LoadConfigButton() {
 
   const clearFile = () => {
     setFile(null);
-    resetRef.current?.();
+    resetRef.current?.reset();
   };
 
   const load = useMutation({
@@ -56,12 +58,11 @@ export default function LoadConfigButton() {
         onChange={file => setFile(file)}
         accept="application/json"
         disabled={load.isPending}
+        asChild
       >
-        {props => (
-          <Button icon={<FolderOpenIcon />} className="min-w-28" {...props}>
-            Load
-          </Button>
-        )}
+        <Button icon={<FolderOpenIcon />} className="min-w-28">
+          Load
+        </Button>
       </FileButton>
       <ConfirmationModal
         backupData={backupFileQuery.data}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Use internal `FileButton` component rather than the Mantine provided one.

- Add `resetRef` to allow clearing the file input state imperatively
- Updated `onChange` to be specific to multiple or single files
- Use the HTML standard `disabled` instead of the React Aria `isDisabled` 
- Update usages of `FileButton` to use the slightly updated API

## Validation

- For reviewing, you should ignore whitespace
- Tested all file buttons in the app
- No UI or behavior change

## Related Issues

- Resolves #729

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
