### PR TITLE
Fix saving entity preferences

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,7 +20,8 @@
   ([#909](https://github.com/aws/graph-explorer/pull/909))
 - **Updated** the state management layer to use Jotai instead of Recoil
   ([#896](https://github.com/aws/graph-explorer/pull/896),
-  [#920](https://github.com/aws/graph-explorer/pull/920))
+  [#920](https://github.com/aws/graph-explorer/pull/920),
+  [#934](https://github.com/aws/graph-explorer/pull/934))
 - **Updated** to use the React Compiler to improve performance and simplify code
   ([#916](https://github.com/aws/graph-explorer/pull/916))
 - **Fixed** issue where a schema sync would not automatically run when a

--- a/packages/graph-explorer/src/core/StateProvider/StateProvider.tsx
+++ b/packages/graph-explorer/src/core/StateProvider/StateProvider.tsx
@@ -7,7 +7,8 @@ import { showDebugActionsAtom, allowLoggingDbQueryAtom } from "../featureFlags";
 import { activeConfigurationAtom, configurationAtom } from "./configuration";
 import { allGraphSessionsAtom } from "./graphSession";
 import { schemaAtom } from "./schema";
-import { userStylingAtom, userLayoutAtom } from "./userPreferences";
+import { userStylingAtom } from "./userPreferences";
+import { userLayoutAtom } from "./userLayout";
 
 export default function StateProvider({
   children,

--- a/packages/graph-explorer/src/core/StateProvider/index.ts
+++ b/packages/graph-explorer/src/core/StateProvider/index.ts
@@ -9,3 +9,4 @@ export * from "./nodes";
 export * from "./userPreferences";
 export * from "./schema";
 export * from "./graphSession";
+export * from "./userLayout";

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.ts
@@ -1,0 +1,43 @@
+import { useSetAtom } from "jotai";
+import { atomWithLocalForage } from "./localForageEffect";
+
+type UserLayout = {
+  activeToggles: Set<string>;
+  activeSidebarItem:
+    | "search"
+    | "details"
+    | "filters"
+    | "expand"
+    | "nodes-styling"
+    | "edges-styling"
+    | "namespaces"
+    | null;
+  tableView?: {
+    height: number;
+  };
+  detailsAutoOpenOnSelection?: boolean;
+};
+
+export type SidebarItems = UserLayout["activeSidebarItem"];
+
+export const userLayoutAtom = atomWithLocalForage<UserLayout>(
+  {
+    activeToggles: new Set(["graph-viewer", "table-view"]),
+    activeSidebarItem: "search",
+    detailsAutoOpenOnSelection: true,
+    tableView: {
+      height: 300,
+    },
+  },
+  "user-layout"
+);
+
+export function useCloseSidebar() {
+  const setUserLayout = useSetAtom(userLayoutAtom);
+  return () => {
+    setUserLayout(prev => ({
+      ...prev,
+      activeSidebarItem: null,
+    }));
+  };
+}

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -1,0 +1,141 @@
+import { DbState, renderHookWithJotai } from "@/utils/testing";
+import { useEdgeStyling, useVertexStyling } from "./userPreferences";
+import { act } from "react";
+
+describe("useVertexStyling", () => {
+  it("should return undefined when the style does not exist", () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.vertexStyle).toBeUndefined();
+  });
+
+  it("should return the vertex style when it exists", () => {
+    const dbState = new DbState();
+    const style = dbState.addVertexStyle("test", { color: "red" });
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.vertexStyle).toEqual(style);
+  });
+
+  it("should insert the vertex style when none exist", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setVertexStyle({ color: "red" }));
+
+    expect(result.current.vertexStyle).toEqual({ type: "test", color: "red" });
+  });
+
+  it("should update the existing style, merging new styles", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() =>
+      result.current.setVertexStyle({ color: "red", borderColor: "green" })
+    );
+    await act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+
+    expect(result.current.vertexStyle).toEqual({
+      type: "test",
+      color: "red",
+      borderColor: "blue",
+    });
+  });
+
+  it("should reset the vertex style", async () => {
+    const dbState = new DbState();
+    dbState.addVertexStyle("test", { borderColor: "blue" });
+
+    const { result } = renderHookWithJotai(
+      () => useVertexStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.resetVertexStyle());
+
+    expect(result.current.vertexStyle).toBeUndefined();
+  });
+});
+
+describe("useEdgeStyling", () => {
+  it("should return undefined when the style does not exist", () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.edgeStyle).toBeUndefined();
+  });
+
+  it("should return the edge style when it exists", () => {
+    const dbState = new DbState();
+    const style = dbState.addEdgeStyle("test", { lineColor: "red" });
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    expect(result.current.edgeStyle).toEqual(style);
+  });
+
+  it("should insert the edge style when none exist", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setEdgeStyle({ lineColor: "red" }));
+
+    expect(result.current.edgeStyle).toEqual({
+      type: "test",
+      lineColor: "red",
+    });
+  });
+
+  it("should update the existing style, merging new styles", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() =>
+      result.current.setEdgeStyle({ lineColor: "red", labelColor: "green" })
+    );
+    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+
+    expect(result.current.edgeStyle).toEqual({
+      type: "test",
+      lineColor: "red",
+      labelColor: "blue",
+    });
+  });
+
+  it("should reset the edge style", async () => {
+    const dbState = new DbState();
+    const { result } = renderHookWithJotai(
+      () => useEdgeStyling("test"),
+      snapshot => dbState.applyTo(snapshot)
+    );
+
+    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+    await act(() => result.current.resetEdgeStyle());
+
+    expect(result.current.edgeStyle).toBeUndefined();
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -1,5 +1,5 @@
 import { atomWithLocalForage } from "./localForageEffect";
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import { clone } from "lodash";
 
 export type ShapeStyle =
@@ -95,27 +95,6 @@ export type UserStyling = {
   vertices?: Array<VertexPreferences>;
   edges?: Array<EdgePreferences>;
 };
-
-export type UserPreferences = {
-  layout: {
-    activeToggles: Set<string>;
-    activeSidebarItem:
-      | "search"
-      | "details"
-      | "filters"
-      | "expand"
-      | "nodes-styling"
-      | "edges-styling"
-      | "namespaces"
-      | null;
-    tableView?: {
-      height: number;
-    };
-    detailsAutoOpenOnSelection?: boolean;
-  };
-  styling: UserStyling;
-};
-export type SidebarItems = UserPreferences["layout"]["activeSidebarItem"];
 
 export const userStylingAtom = atomWithLocalForage<UserStyling>(
   {},
@@ -231,27 +210,5 @@ export function useEdgeStyling(type: string) {
     edgeStyle,
     setEdgeStyle,
     resetEdgeStyle,
-  };
-}
-
-export const userLayoutAtom = atomWithLocalForage<UserPreferences["layout"]>(
-  {
-    activeToggles: new Set(["graph-viewer", "table-view"]),
-    activeSidebarItem: "search",
-    detailsAutoOpenOnSelection: true,
-    tableView: {
-      height: 300,
-    },
-  },
-  "user-layout"
-);
-
-export function useCloseSidebar() {
-  const setUserLayout = useSetAtom(userLayoutAtom);
-  return () => {
-    setUserLayout(prev => ({
-      ...prev,
-      activeSidebarItem: null,
-    }));
   };
 }

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -4,9 +4,8 @@ import ColorInput from "@/components/ColorInput/ColorInput";
 import { useDisplayEdgeTypeConfig, useWithTheme } from "@/core";
 import {
   ArrowStyle,
-  EdgePreferences,
   LineStyle,
-  userStylingEdgeAtom,
+  useEdgeStyling,
 } from "@/core/StateProvider/userPreferences";
 import useTranslations from "@/hooks/useTranslations";
 import {
@@ -17,7 +16,6 @@ import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import modalDefaultStyles from "./SingleEdgeStylingModal.style";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
 import { atom, useAtom } from "jotai";
-import { useResetAtom } from "jotai/utils";
 
 export const customizeEdgeTypeAtom = atom<string | undefined>(undefined);
 
@@ -60,9 +58,7 @@ function Content({ edgeType }: { edgeType: string }) {
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
   const t = useTranslations();
 
-  const [edgePreferences, setEdgePreferences] = useAtom(
-    userStylingEdgeAtom(edgeType)
-  );
+  const { edgeStyle, setEdgeStyle, resetEdgeStyle } = useEdgeStyling(edgeType);
 
   const selectOptions = (() => {
     const options = displayConfig.attributes.map(attr => ({
@@ -78,12 +74,6 @@ function Content({ edgeType }: { edgeType: string }) {
     return options;
   })();
 
-  const onUserPrefsChange = (prefs: Omit<EdgePreferences, "type">) => {
-    setEdgePreferences({ type: edgeType, ...prefs });
-  };
-
-  const onUserPrefsReset = useResetAtom(userStylingEdgeAtom(edgeType));
-
   return (
     <div className="modal-container">
       <div>
@@ -94,7 +84,7 @@ function Content({ edgeType }: { edgeType: string }) {
             labelPlacement="inner"
             value={displayConfig.displayNameAttribute}
             onValueChange={value =>
-              onUserPrefsChange({ displayNameAttribute: value })
+              setEdgeStyle({ displayNameAttribute: value })
             }
             options={selectOptions}
           />
@@ -106,10 +96,8 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            color={edgePreferences?.labelColor || "#17457b"}
-            onChange={(color: string) =>
-              onUserPrefsChange({ labelColor: color })
-            }
+            color={edgeStyle?.labelColor || "#17457b"}
+            onChange={(color: string) => setEdgeStyle({ labelColor: color })}
           />
           <InputField
             label="Background Opacity"
@@ -118,9 +106,9 @@ function Content({ edgeType }: { edgeType: string }) {
             min={0}
             max={1}
             step={0.1}
-            value={edgePreferences?.labelBackgroundOpacity ?? 0.7}
+            value={edgeStyle?.labelBackgroundOpacity ?? 0.7}
             onChange={(value: number) =>
-              onUserPrefsChange({ labelBackgroundOpacity: value })
+              setEdgeStyle({ labelBackgroundOpacity: value })
             }
           />
         </div>
@@ -130,9 +118,9 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Border Color"
             labelPlacement="inner"
-            color={edgePreferences?.labelBorderColor || "#17457b"}
+            color={edgeStyle?.labelBorderColor || "#17457b"}
             onChange={(color: string) =>
-              onUserPrefsChange({ labelBorderColor: color })
+              setEdgeStyle({ labelBorderColor: color })
             }
           />
           <InputField
@@ -140,17 +128,17 @@ function Content({ edgeType }: { edgeType: string }) {
             labelPlacement="inner"
             type="number"
             min={0}
-            value={edgePreferences?.labelBorderWidth ?? 0}
+            value={edgeStyle?.labelBorderWidth ?? 0}
             onChange={(value: number) =>
-              onUserPrefsChange({ labelBorderWidth: value })
+              setEdgeStyle({ labelBorderWidth: value })
             }
           />
           <SelectField
             label="Border Style"
             labelPlacement="inner"
-            value={edgePreferences?.labelBorderStyle || "solid"}
+            value={edgeStyle?.labelBorderStyle || "solid"}
             onValueChange={value =>
-              onUserPrefsChange({ labelBorderStyle: value as LineStyle })
+              setEdgeStyle({ labelBorderStyle: value as LineStyle })
             }
             options={LINE_STYLE_OPTIONS}
           />
@@ -162,27 +150,23 @@ function Content({ edgeType }: { edgeType: string }) {
           <ColorInput
             label="Color"
             labelPlacement="inner"
-            color={edgePreferences?.lineColor || "#b3b3b3"}
-            onChange={(color: string) =>
-              onUserPrefsChange({ lineColor: color })
-            }
+            color={edgeStyle?.lineColor || "#b3b3b3"}
+            onChange={(color: string) => setEdgeStyle({ lineColor: color })}
           />
           <InputField
             label="Thickness"
             labelPlacement="inner"
             type="number"
             min={1}
-            value={edgePreferences?.lineThickness || 2}
-            onChange={(value: number) =>
-              onUserPrefsChange({ lineThickness: value })
-            }
+            value={edgeStyle?.lineThickness || 2}
+            onChange={(value: number) => setEdgeStyle({ lineThickness: value })}
           />
           <SelectField
             label="Style"
             labelPlacement="inner"
-            value={edgePreferences?.lineStyle || "solid"}
+            value={edgeStyle?.lineStyle || "solid"}
             onValueChange={value =>
-              onUserPrefsChange({ lineStyle: value as LineStyle })
+              setEdgeStyle({ lineStyle: value as LineStyle })
             }
             options={LINE_STYLE_OPTIONS}
           />
@@ -194,25 +178,25 @@ function Content({ edgeType }: { edgeType: string }) {
           <SelectField
             label="Source"
             labelPlacement="inner"
-            value={edgePreferences?.sourceArrowStyle || "none"}
+            value={edgeStyle?.sourceArrowStyle || "none"}
             onValueChange={value =>
-              onUserPrefsChange({ sourceArrowStyle: value as ArrowStyle })
+              setEdgeStyle({ sourceArrowStyle: value as ArrowStyle })
             }
             options={SOURCE_ARROW_STYLE_OPTIONS}
           />
           <SelectField
             label="Target"
             labelPlacement="inner"
-            value={edgePreferences?.targetArrowStyle || "triangle"}
+            value={edgeStyle?.targetArrowStyle || "triangle"}
             onValueChange={value =>
-              onUserPrefsChange({ targetArrowStyle: value as ArrowStyle })
+              setEdgeStyle({ targetArrowStyle: value as ArrowStyle })
             }
             options={TARGET_ARROW_STYLE_OPTIONS}
           />
         </div>
       </div>
       <div className="actions">
-        <Button onPress={onUserPrefsReset}>Reset to Default</Button>
+        <Button onClick={resetEdgeStyle}>Reset to Default</Button>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -1,10 +1,7 @@
-import { ComponentPropsWithRef, useCallback, useEffect, useState } from "react";
+import { ComponentPropsWithRef, useEffect, useState } from "react";
 import { Button, FormItem, InputField, Label, StylingIcon } from "@/components";
 import { useDisplayEdgeTypeConfig } from "@/core";
-import {
-  EdgePreferences,
-  userStylingEdgeAtom,
-} from "@/core/StateProvider/userPreferences";
+import { useEdgeStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { MISSING_DISPLAY_TYPE } from "@/utils";
 import { customizeEdgeTypeAtom } from "./EdgeStyleDialog";
@@ -16,21 +13,13 @@ export type SingleEdgeStylingProps = {
 
 export default function SingleEdgeStyling({
   edgeType,
-
   ...rest
 }: SingleEdgeStylingProps) {
-  const setEdgePreferences = useSetAtom(userStylingEdgeAtom(edgeType));
+  const { setEdgeStyle } = useEdgeStyling(edgeType);
   const setCustomizeEdgeType = useSetAtom(customizeEdgeTypeAtom);
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
-
-  const onUserPrefsChange = useCallback(
-    (prefs: Omit<EdgePreferences, "type">) => {
-      setEdgePreferences({ type: edgeType, ...prefs });
-    },
-    [edgeType, setEdgePreferences]
-  );
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -40,8 +29,8 @@ export default function SingleEdgeStyling({
     if (prevDisplayAs === null || prevDisplayAs === debouncedDisplayAs) {
       return;
     }
-    onUserPrefsChange({ displayLabel: debouncedDisplayAs });
-  }, [debouncedDisplayAs, prevDisplayAs, onUserPrefsChange]);
+    void setEdgeStyle({ displayLabel: debouncedDisplayAs });
+  }, [debouncedDisplayAs, prevDisplayAs, setEdgeStyle]);
 
   return (
     <FormItem {...rest}>

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityDetails.tsx
@@ -10,10 +10,13 @@ import {
 } from "@/components";
 import GraphIcon from "@/components/icons/GraphIcon";
 import PanelEmptyState from "@/components/PanelEmptyState/PanelEmptyState";
-import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
 import EdgeDetail from "./EdgeDetail";
 import NodeDetail from "./NodeDetail";
-import { useSelectedDisplayEdges, useSelectedDisplayVertices } from "@/core";
+import {
+  userLayoutAtom,
+  useSelectedDisplayEdges,
+  useSelectedDisplayVertices,
+} from "@/core";
 import { SidebarCloseButton } from "../SidebarCloseButton";
 import { useAtom } from "jotai";
 

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -18,13 +18,11 @@ import {
   useDisplayVerticesInCanvas,
   EdgeId,
   VertexId,
+  userLayoutAtom,
+  SidebarItems,
 } from "@/core";
 import { edgesSelectedIdsAtom } from "@/core/StateProvider/edges";
 import { nodesSelectedIdsAtom } from "@/core/StateProvider/nodes";
-import {
-  SidebarItems,
-  userLayoutAtom,
-} from "@/core/StateProvider/userPreferences";
 import { useClearGraph, useRemoveFromGraph, useTranslations } from "@/hooks";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import {

--- a/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.ts
@@ -1,4 +1,4 @@
-import { userLayoutAtom } from "@/core/StateProvider/userPreferences";
+import { userLayoutAtom } from "@/core";
 import { useAtomCallback } from "jotai/utils";
 import { useCallback } from "react";
 

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -52,7 +52,6 @@ export default function SingleNodeStyling({
         <Button
           icon={<StylingIcon />}
           variant="text"
-          // disabled={pending}
           onClick={() => setCustomizeNodeType(vertexType)}
         >
           Customize

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -1,10 +1,7 @@
-import { ComponentPropsWithRef, useCallback, useEffect, useState } from "react";
+import { ComponentPropsWithRef, useEffect, useState } from "react";
 import { Button, FormItem, InputField, Label, StylingIcon } from "@/components";
 import { useDisplayVertexTypeConfig } from "@/core";
-import {
-  userStylingNodeAtom,
-  VertexPreferences,
-} from "@/core/StateProvider/userPreferences";
+import { useVertexStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { MISSING_DISPLAY_TYPE } from "@/utils/constants";
 import { customizeNodeTypeAtom } from "./NodeStyleDialog";
@@ -16,22 +13,14 @@ export type SingleNodeStylingProps = {
 
 export default function SingleNodeStyling({
   vertexType,
-
   ...rest
 }: SingleNodeStylingProps) {
-  const setNodePreferences = useSetAtom(userStylingNodeAtom(vertexType));
+  const { setVertexStyle } = useVertexStyling(vertexType);
   const displayConfig = useDisplayVertexTypeConfig(vertexType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
 
   const setCustomizeNodeType = useSetAtom(customizeNodeTypeAtom);
-
-  const onUserPrefsChange = useCallback(
-    (prefs: Omit<VertexPreferences, "type">) => {
-      setNodePreferences({ type: vertexType, ...prefs });
-    },
-    [setNodePreferences, vertexType]
-  );
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -41,8 +30,8 @@ export default function SingleNodeStyling({
     if (prevDisplayAs === null || prevDisplayAs === debouncedDisplayAs) {
       return;
     }
-    onUserPrefsChange({ displayLabel: debouncedDisplayAs });
-  }, [debouncedDisplayAs, prevDisplayAs, onUserPrefsChange]);
+    void setVertexStyle({ displayLabel: debouncedDisplayAs });
+  }, [debouncedDisplayAs, prevDisplayAs, setVertexStyle]);
 
   return (
     <FormItem {...rest}>
@@ -63,6 +52,7 @@ export default function SingleNodeStyling({
         <Button
           icon={<StylingIcon />}
           variant="text"
+          // disabled={pending}
           onClick={() => setCustomizeNodeType(vertexType)}
         >
           Customize

--- a/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/DataExplorer/DataExplorer.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/utils";
-import clone from "lodash/clone";
 import { useRef } from "react";
 import {
   keepPreviousData,
@@ -41,10 +40,7 @@ import Tabular from "@/components/Tabular/Tabular";
 import Workspace from "@/components/Workspace/Workspace";
 import { KeywordSearchRequest, searchQuery } from "@/connector";
 import { useExplorer } from "@/core/connector";
-import {
-  userStylingAtom,
-  VertexPreferences,
-} from "@/core/StateProvider/userPreferences";
+import { useVertexStyling } from "@/core/StateProvider/userPreferences";
 import { useAddVertexToGraph, useHasVertexBeenAddedToGraph } from "@/hooks";
 import useTranslations from "@/hooks/useTranslations";
 import useUpdateVertexTypeCounts from "@/hooks/useUpdateVertexTypeCounts";
@@ -55,7 +51,6 @@ import {
   RESERVED_ID_PROPERTY,
   RESERVED_TYPES_PROPERTY,
 } from "@/utils/constants";
-import { useSetAtom } from "jotai";
 
 export type ConnectionsProps = {
   vertexType: string;
@@ -200,34 +195,16 @@ function DisplayNameAndDescriptionOptions({
     return options;
   })();
 
-  const setUserStyling = useSetAtom(userStylingAtom);
+  const { setVertexStyle: setPreferences } = useVertexStyling(vertexType);
   const onDisplayNameChange =
     (field: "name" | "longName") => async (value: string | string[]) => {
-      await setUserStyling(async prevStyling => {
-        const prevValue = await prevStyling;
-        const vtItem =
-          clone(prevValue.vertices?.find(v => v.type === vertexType)) ||
-          ({} as VertexPreferences);
+      if (field === "name") {
+        await setPreferences({ displayNameAttribute: value as string });
+      }
 
-        if (field === "name") {
-          vtItem.displayNameAttribute = value as string;
-        }
-
-        if (field === "longName") {
-          vtItem.longDisplayNameAttribute = value as string;
-        }
-
-        return {
-          ...prevValue,
-          vertices: [
-            ...(prevValue.vertices || []).filter(v => v.type !== vertexType),
-            {
-              ...(vtItem || {}),
-              type: vertexType,
-            },
-          ],
-        };
-      });
+      if (field === "longName") {
+        await setPreferences({ longDisplayNameAttribute: value as string });
+      }
     };
 
   return (

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -20,12 +20,8 @@ import {
 } from "@/components/icons";
 import GridIcon from "@/components/icons/GridIcon";
 import Workspace, { SidebarButton } from "@/components/Workspace";
-import { useConfiguration } from "@/core";
+import { SidebarItems, useConfiguration, userLayoutAtom } from "@/core";
 import { totalFilteredCount } from "@/core/StateProvider/filterCount";
-import {
-  SidebarItems,
-  userLayoutAtom,
-} from "@/core/StateProvider/userPreferences";
 import useTranslations from "@/hooks/useTranslations";
 import EdgesStyling from "@/modules/EdgesStyling/EdgesStyling";
 import EntitiesFilter from "@/modules/EntitiesFilter";


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes a bug in the saving logic for node & edge preferences.

Before the fix, the user-styling storage would be overwritten with a single node or edge preference, rather than updating the list of node and edge preferences.

After finding the bug, I moved all logic related to updating the user preferences in to `userPreferences.ts` and added some tests.

## Validation

- Tested setting styles in sidebar (node & edge)
- Tested setting style in Data Explorer

## Related Issues

- Resolves #935

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
