### PR TITLE
Allow resizing the sidebar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 
 - **Added** ability to customize default neighbor expansion limit
   ([#925](https://github.com/aws/graph-explorer/pull/925))
+- **Added** ability to resize the sidebar
+  ([#938](https://github.com/aws/graph-explorer/pull/938))
 - **Improved** Improved connection details by moving the sync button near the
   last sync timestamp (thanks @enumura1,
   [#901](https://github.com/aws/graph-explorer/pull/901),

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBar.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBar.tsx
@@ -1,8 +1,15 @@
 import { cn } from "@/utils";
-import type { PropsWithChildren, ReactElement } from "react";
+import { useState, type PropsWithChildren, type ReactElement } from "react";
 import getChildOfType from "@/utils/getChildOfType";
 import getChildrenOfType from "@/utils/getChildrenOfType";
 import WorkspaceSideBarContent from "./WorkspaceSideBarContent";
+import { Resizable } from "re-resizable";
+import {
+  CLOSED_SIDEBAR_WIDTH,
+  DEFAULT_SIDEBAR_WIDTH,
+  useSidebar,
+  useSidebarSize,
+} from "@/core";
 
 interface WorkspaceSideBarComposition {
   Content: typeof WorkspaceSideBarContent;
@@ -27,19 +34,44 @@ const WorkspaceSideBar = ({
     true
   );
 
+  const { isSidebarOpen } = useSidebar();
+  const [sidebarWidth, setSidebarWidth] = useSidebarSize();
+
+  // The transition animation used for opening and closing sidebar animation
+  // does not play well with the resizing behavior of the Resizable component.
+  // If the animation is not disabled, the resize will feel jerky.
+  const [enableAnimation, setEnableAnimation] = useState(true);
+
   return (
-    <div
+    <Resizable
+      size={{ width: isSidebarOpen ? sidebarWidth : CLOSED_SIDEBAR_WIDTH }}
+      minWidth={isSidebarOpen ? DEFAULT_SIDEBAR_WIDTH : CLOSED_SIDEBAR_WIDTH}
+      defaultSize={{
+        width: isSidebarOpen ? DEFAULT_SIDEBAR_WIDTH : CLOSED_SIDEBAR_WIDTH,
+      }}
+      enable={{ left: isSidebarOpen }}
+      onResizeStart={() => setEnableAnimation(false)}
+      onResizeStop={(_e, _direction, _ref, delta) => {
+        setEnableAnimation(true);
+        setSidebarWidth(delta.width);
+      }}
       className={cn(
-        "shadow-left bg-background-default flex",
-        direction === "row" && "flex-row",
-        direction === "row-reverse" && "flex-row-reverse"
+        enableAnimation && "transition-width transform duration-200 ease-in-out"
       )}
     >
-      <div className="bg-background-secondary-subtle text-primary-dark dark:text-brand-100 shadow-primary-dark/20 flex flex-col gap-2 p-2 shadow dark:bg-gray-900">
-        {sidebarActions}
+      <div
+        className={cn(
+          "shadow-left bg-background-default flex h-full",
+          direction === "row" && "flex-row",
+          direction === "row-reverse" && "flex-row-reverse"
+        )}
+      >
+        <div className="bg-background-secondary-subtle text-primary-dark dark:text-brand-100 shadow-primary-dark/20 flex flex-col gap-2 p-2 shadow dark:bg-gray-900">
+          {sidebarActions}
+        </div>
+        {sidebarContent}
       </div>
-      {sidebarContent}
-    </div>
+    </Resizable>
   );
 };
 

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
@@ -9,12 +9,7 @@ const WorkspaceSideBarContent = ({
   className,
   ...props
 }: ComponentPropsWithRef<"div">) => {
-  return (
-    <div
-      className={cn("h-full w-full overflow-x-hidden", className)}
-      {...props}
-    />
-  );
+  return <div className={cn("h-full w-full", className)} {...props} />;
 };
 
 WorkspaceSideBarContent.displayName = "WorkspaceSideBarContent";

--- a/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
+++ b/packages/graph-explorer/src/components/Workspace/components/WorkspaceSideBarContent.tsx
@@ -1,30 +1,19 @@
 import { cn } from "@/utils";
-import type { PropsWithChildren } from "react";
+import type { ComponentPropsWithRef } from "react";
 
 export type WorkspaceSideBarContentProps = {
   className?: string;
-  isOpen?: boolean;
-  defaultWidth?: number | string;
 };
 
 const WorkspaceSideBarContent = ({
   className,
-  children,
-  isOpen,
-  defaultWidth = 350,
-}: PropsWithChildren<WorkspaceSideBarContentProps>) => {
+  ...props
+}: ComponentPropsWithRef<"div">) => {
   return (
     <div
-      className={cn(
-        "transition-width h-full overflow-x-hidden duration-200 ease-in-out",
-        className
-      )}
-      style={{
-        width: isOpen ? defaultWidth : 0,
-      }}
-    >
-      {children}
-    </div>
+      className={cn("h-full w-full overflow-x-hidden", className)}
+      {...props}
+    />
   );
 };
 

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
@@ -1,0 +1,87 @@
+import { DbState, renderHookWithJotai } from "@/utils/testing";
+import { userLayoutAtom, useSidebar } from "./userLayout";
+import { act } from "react";
+
+describe("useSidebar", () => {
+  it("should default to sidebar open", () => {
+    const { result } = renderHookWithJotai(() => useSidebar());
+
+    expect(result.current.isSidebarOpen).toBe(true);
+  });
+
+  it("should change to the give sidebar item", async () => {
+    const { result } = renderHookWithJotai(() => useSidebar());
+
+    await act(() => result.current.toggleSidebar("details"));
+    expect(result.current.isSidebarOpen).toBe(true);
+    expect(result.current.activeSidebarItem).toBe("details");
+
+    await act(() => result.current.toggleSidebar("search"));
+    expect(result.current.isSidebarOpen).toBe(true);
+    expect(result.current.activeSidebarItem).toBe("search");
+  });
+
+  it("should close the sidebar if toggling to the same item", async () => {
+    const { result } = renderHookWithJotai(
+      () => useSidebar(),
+      snapshot =>
+        snapshot.set(userLayoutAtom, {
+          activeSidebarItem: "details",
+          activeToggles: new Set<string>(),
+        })
+    );
+
+    await act(() => result.current.toggleSidebar("details"));
+
+    expect(result.current.isSidebarOpen).toBe(false);
+    expect(result.current.activeSidebarItem).toBeNull();
+  });
+
+  it("should close the sidebar", async () => {
+    const { result } = renderHookWithJotai(() => useSidebar());
+
+    await act(() => result.current.closeSidebar());
+
+    expect(result.current.isSidebarOpen).toBe(false);
+  });
+
+  it("should show namespaces when the connection is a SPARQL connection", () => {
+    const dbState = new DbState();
+    dbState.activeConfig.connection!.queryEngine = "sparql";
+
+    const { result } = renderHookWithJotai(
+      () => useSidebar(),
+      snapshot => {
+        dbState.applyTo(snapshot);
+        snapshot.set(userLayoutAtom, {
+          activeSidebarItem: "namespaces",
+          activeToggles: new Set<string>(),
+        });
+      }
+    );
+
+    expect(result.current.isSidebarOpen).toBe(true);
+    expect(result.current.activeSidebarItem).toBe("namespaces");
+    expect(result.current.shouldShowNamespaces).toBe(true);
+  });
+
+  it("should be closed when active item is namespaces but connection is not RDF", () => {
+    const dbState = new DbState();
+    dbState.activeConfig.connection!.queryEngine = "gremlin";
+
+    const { result } = renderHookWithJotai(
+      () => useSidebar(),
+      snapshot => {
+        dbState.applyTo(snapshot);
+        snapshot.set(userLayoutAtom, {
+          activeSidebarItem: "namespaces",
+          activeToggles: new Set<string>(),
+        });
+      }
+    );
+
+    expect(result.current.isSidebarOpen).toBe(false);
+    expect(result.current.activeSidebarItem).toBeNull();
+    expect(result.current.shouldShowNamespaces).toBe(false);
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.ts
@@ -40,15 +40,16 @@ export function useSidebar() {
   const [userLayout, setUserLayout] = useAtom(userLayoutAtom);
   const queryEngine = useQueryEngine();
 
-  // If the sidebar item is namespaces, but we are not in a RDF connection, the sidebar should be closed
+  // The namespace sidebar panel is hidden for property graph connections
+  const shouldShowNamespaces = queryEngine === "sparql";
+
+  // If the namespace panel is hidden and the active item is namespaces, the sidebar should be closed
   const activeSidebarItem =
-    userLayout.activeSidebarItem === "namespaces" && queryEngine !== "sparql"
+    userLayout.activeSidebarItem === "namespaces" && !shouldShowNamespaces
       ? null
       : userLayout.activeSidebarItem;
 
   const isSidebarOpen = activeSidebarItem !== null;
-
-  const shouldShowNamespaces = queryEngine === "sparql";
 
   /** Closes the sidebar */
   const closeSidebar = () =>

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.ts
@@ -16,6 +16,9 @@ type UserLayout = {
   tableView?: {
     height: number;
   };
+  sidebar?: {
+    width: number;
+  };
   detailsAutoOpenOnSelection?: boolean;
 };
 
@@ -78,4 +81,30 @@ export function useSidebar() {
     toggleSidebar,
     shouldShowNamespaces,
   };
+}
+
+export const DEFAULT_SIDEBAR_WIDTH = 400;
+export const CLOSED_SIDEBAR_WIDTH = 50;
+
+export function useSidebarSize() {
+  const [userLayout, setUserLayout] = useAtom(userLayoutAtom);
+
+  const sidebarWidth = userLayout.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
+
+  /** Sets the sidebar width to the current with + the given delta */
+  const setSidebarWidth = (deltaWidth: number) => {
+    setUserLayout(async prevPromise => {
+      const prev = await prevPromise;
+      const prevWidth = prev.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
+      return {
+        ...prev,
+        sidebar: {
+          ...prev.sidebar,
+          width: prevWidth + deltaWidth,
+        },
+      };
+    });
+  };
+
+  return [sidebarWidth, setSidebarWidth] as const;
 }

--- a/packages/graph-explorer/src/modules/SidebarCloseButton.tsx
+++ b/packages/graph-explorer/src/modules/SidebarCloseButton.tsx
@@ -1,8 +1,8 @@
 import { PanelHeaderCloseButton } from "@/components";
-import { useCloseSidebar } from "@/core";
+import { useSidebar } from "@/core";
 
 export function SidebarCloseButton() {
-  const closeSidebar = useCloseSidebar();
+  const { closeSidebar } = useSidebar();
 
   return <PanelHeaderCloseButton onClose={closeSidebar} />;
 }

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/icons";
 import GridIcon from "@/components/icons/GridIcon";
 import Workspace, { SidebarButton } from "@/components/Workspace";
-import { SidebarItems, useConfiguration, userLayoutAtom } from "@/core";
+import { useConfiguration, userLayoutAtom, useSidebar } from "@/core";
 import { totalFilteredCount } from "@/core/StateProvider/filterCount";
 import useTranslations from "@/hooks/useTranslations";
 import EdgesStyling from "@/modules/EdgesStyling/EdgesStyling";
@@ -50,27 +50,12 @@ const RESIZE_ENABLE_TOP = {
 const GraphExplorer = () => {
   const config = useConfiguration();
   const t = useTranslations();
-  const hasNamespaces = config?.connection?.queryEngine === "sparql";
   const [userLayout, setUserLayout] = useAtom(userLayoutAtom);
 
   const filteredEntitiesCount = useAtomValue(totalFilteredCount);
 
-  const toggleSidebar = (item: SidebarItems) => async () => {
-    await setUserLayout(async prev => {
-      const prevValue = await prev;
-      if (prevValue.activeSidebarItem === item) {
-        return {
-          ...prevValue,
-          activeSidebarItem: null,
-        };
-      }
-
-      return {
-        ...prevValue,
-        activeSidebarItem: item,
-      };
-    });
-  };
+  const { activeSidebarItem, toggleSidebar, shouldShowNamespaces } =
+    useSidebar();
 
   const toggleView = (item: string) => async () => {
     await setUserLayout(async prev => {
@@ -179,63 +164,57 @@ const GraphExplorer = () => {
         <SidebarButton
           title="Search"
           icon={<SearchIcon />}
-          onPressedChange={toggleSidebar("search")}
-          pressed={userLayout.activeSidebarItem === "search"}
+          onPressedChange={() => toggleSidebar("search")}
+          pressed={activeSidebarItem === "search"}
         />
         <SidebarButton
           title="Details"
           icon={<DetailsIcon />}
-          onPressedChange={toggleSidebar("details")}
-          pressed={userLayout.activeSidebarItem === "details"}
+          onPressedChange={() => toggleSidebar("details")}
+          pressed={activeSidebarItem === "details"}
         />
         <SidebarButton
           title="Filters"
           icon={<FilterIcon />}
-          onPressedChange={toggleSidebar("filters")}
+          onPressedChange={() => toggleSidebar("filters")}
           badge={filteredEntitiesCount > 0}
-          pressed={userLayout.activeSidebarItem === "filters"}
+          pressed={activeSidebarItem === "filters"}
         />
         <SidebarButton
           title="Expand"
           icon={<ExpandGraphIcon />}
-          onPressedChange={toggleSidebar("expand")}
-          pressed={userLayout.activeSidebarItem === "expand"}
+          onPressedChange={() => toggleSidebar("expand")}
+          pressed={activeSidebarItem === "expand"}
         />
         <SidebarButton
           title={t("nodes-styling.title")}
           icon={<GraphIcon />}
-          onPressedChange={toggleSidebar("nodes-styling")}
-          pressed={userLayout.activeSidebarItem === "nodes-styling"}
+          onPressedChange={() => toggleSidebar("nodes-styling")}
+          pressed={activeSidebarItem === "nodes-styling"}
         />
         <SidebarButton
           title={t("edges-styling.title")}
           icon={<EdgeIcon />}
-          onPressedChange={toggleSidebar("edges-styling")}
-          pressed={userLayout.activeSidebarItem === "edges-styling"}
+          onPressedChange={() => toggleSidebar("edges-styling")}
+          pressed={activeSidebarItem === "edges-styling"}
         />
-        {hasNamespaces && (
+        {shouldShowNamespaces && (
           <SidebarButton
             title="Namespaces"
             icon={<NamespaceIcon />}
-            onPressedChange={toggleSidebar("namespaces")}
-            pressed={userLayout.activeSidebarItem === "namespaces"}
+            onPressedChange={() => toggleSidebar("namespaces")}
+            pressed={activeSidebarItem === "namespaces"}
           />
         )}
 
-        <Workspace.SideBar.Content
-          isOpen={
-            !hasNamespaces && userLayout.activeSidebarItem === "namespaces"
-              ? false
-              : userLayout.activeSidebarItem !== null
-          }
-        >
-          {userLayout.activeSidebarItem === "search" && <SearchSidebarPanel />}
-          {userLayout.activeSidebarItem === "details" && <EntityDetails />}
-          {userLayout.activeSidebarItem === "expand" && <NodeExpand />}
-          {userLayout.activeSidebarItem === "filters" && <EntitiesFilter />}
-          {userLayout.activeSidebarItem === "nodes-styling" && <NodesStyling />}
-          {userLayout.activeSidebarItem === "edges-styling" && <EdgesStyling />}
-          {userLayout.activeSidebarItem === "namespaces" && <Namespaces />}
+        <Workspace.SideBar.Content>
+          {activeSidebarItem === "search" && <SearchSidebarPanel />}
+          {activeSidebarItem === "details" && <EntityDetails />}
+          {activeSidebarItem === "expand" && <NodeExpand />}
+          {activeSidebarItem === "filters" && <EntitiesFilter />}
+          {activeSidebarItem === "nodes-styling" && <NodesStyling />}
+          {activeSidebarItem === "edges-styling" && <EdgesStyling />}
+          {activeSidebarItem === "namespaces" && <Namespaces />}
         </Workspace.SideBar.Content>
       </Workspace.SideBar>
     </Workspace>

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -151,19 +151,13 @@ const GraphExplorer = () => {
 
       <Workspace.Content>
         {toggles.size === 0 && (
-          <div style={{ width: "100%", flexGrow: 1 }}>
-            <PanelEmptyState
-              icon={<EmptyWidgetIcon />}
-              title="No active views"
-              subtitle="Use toggles in the top-right corner to show/hide views"
-            />
-          </div>
+          <PanelEmptyState
+            icon={<EmptyWidgetIcon />}
+            title="No active views"
+            subtitle="Use toggles in the top-right corner to show/hide views"
+          />
         )}
-        {toggles.has("graph-viewer") && (
-          <div className="relative w-full grow">
-            <GraphViewer />
-          </div>
-        )}
+        {toggles.has("graph-viewer") && <GraphViewer />}
         {toggles.has("table-view") && (
           <Resizable
             enable={RESIZE_ENABLE_TOP}
@@ -176,9 +170,7 @@ const GraphExplorer = () => {
             minHeight={300}
             onResizeStop={onTableViewResizeStop}
           >
-            <div style={{ width: "100%", height: "100%", flexGrow: 1 }}>
-              <EntitiesTabular />
-            </div>
+            <EntitiesTabular />
           </Resizable>
         )}
       </Workspace.Content>

--- a/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/workspaces/GraphExplorer/GraphExplorer.tsx
@@ -159,15 +159,6 @@ const GraphExplorer = () => {
             />
           </div>
         )}
-        {toggles.size === 0 && (
-          <div style={{ width: "100%", flexGrow: 1 }}>
-            <PanelEmptyState
-              icon={<EmptyWidgetIcon />}
-              title="No active views"
-              subtitle="Use toggles in the top-right corner to show/hide views"
-            />
-          </div>
-        )}
         {toggles.has("graph-viewer") && (
           <div className="relative w-full grow">
             <GraphViewer />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds the ability to resize the sidebar using a gripper on the left side.

* Disable resizing when sidebar is closed
* Persist size in user layout preferences
* Disable transition animation when resizing since it makes the resize feel laggy

## Validation

- Tested in Arc (chrome) and Safari

https://github.com/user-attachments/assets/e8563758-5e11-4829-8b09-7b118816edf2


## Related Issues

- Resolves #937 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
