### PR TITLE
Ensure edge details are materialized

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,8 @@
   ([#949](https://github.com/aws/graph-explorer/pull/949),
   [#947](https://github.com/aws/graph-explorer/pull/947),
   [#956](https://github.com/aws/graph-explorer/pull/956),
-  [#957](https://github.com/aws/graph-explorer/pull/957))
+  [#957](https://github.com/aws/graph-explorer/pull/957),
+  [#974](https://github.com/aws/graph-explorer/pull/974))
 
 ### Other changes
 

--- a/packages/graph-explorer/src/hooks/useMaterializeEdges.test.ts
+++ b/packages/graph-explorer/src/hooks/useMaterializeEdges.test.ts
@@ -1,0 +1,52 @@
+import {
+  createMockExplorer,
+  createRandomEdge,
+  createRandomVertex,
+  renderHookWithJotai,
+} from "@/utils/testing";
+import { explorerForTestingAtom, toEdgeMap } from "@/core";
+import { useMaterializeEdges } from "./useMaterializeEdges";
+import { cloneDeep } from "lodash";
+
+test("should return edge when already materialized", async () => {
+  const explorer = createMockExplorer();
+  const { result } = renderHookWithJotai(
+    () => useMaterializeEdges(),
+    snapshot => {
+      snapshot.set(explorerForTestingAtom, explorer);
+    }
+  );
+
+  const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+  edge.__isFragment = false;
+  const edgeMap = toEdgeMap([edge]);
+
+  const actual = await result.current(edgeMap);
+
+  expect(actual).toEqual(edgeMap);
+});
+
+test("should fetch edge details when fragment", async () => {
+  const explorer = createMockExplorer();
+  const { result } = renderHookWithJotai(
+    () => useMaterializeEdges(),
+    snapshot => {
+      snapshot.set(explorerForTestingAtom, explorer);
+    }
+  );
+
+  const edge = createRandomEdge(createRandomVertex(), createRandomVertex());
+  const expectedEdge = cloneDeep(edge);
+
+  edge.__isFragment = true;
+  edge.attributes = {};
+
+  vi.mocked(explorer.edgeDetails).mockResolvedValue({
+    edge: expectedEdge,
+  });
+
+  const actual = await result.current(toEdgeMap([edge]));
+
+  expect(actual).toEqual(toEdgeMap([expectedEdge]));
+  expect(explorer.edgeDetails).toBeCalledTimes(1);
+});

--- a/packages/graph-explorer/src/hooks/useMaterializeEdges.ts
+++ b/packages/graph-explorer/src/hooks/useMaterializeEdges.ts
@@ -1,0 +1,28 @@
+import { EdgeDetailsRequest, edgeDetailsQuery } from "@/connector";
+import { useExplorer, Edge, toEdgeMap, EdgeId } from "@/core";
+import { useQueryClient } from "@tanstack/react-query";
+
+/** Fetch the details if the edge is a fragment */
+export function useMaterializeEdges() {
+  const queryClient = useQueryClient();
+  const explorer = useExplorer();
+
+  return async (edges: Map<EdgeId, Edge>) => {
+    const responses = await Promise.all(
+      edges.values().map(async edge => {
+        if (!edge.__isFragment) {
+          return edge;
+        }
+
+        const request: EdgeDetailsRequest = {
+          edgeId: edge.id,
+        };
+        const response = await queryClient.ensureQueryData(
+          edgeDetailsQuery(request, explorer)
+        );
+        return response.edge;
+      })
+    );
+    return toEdgeMap(responses.filter(edge => edge != null));
+  };
+}

--- a/packages/graph-explorer/src/hooks/useMaterializeVertices.test.ts
+++ b/packages/graph-explorer/src/hooks/useMaterializeVertices.test.ts
@@ -1,0 +1,52 @@
+import {
+  createMockExplorer,
+  createRandomVertex,
+  renderHookWithJotai,
+} from "@/utils/testing";
+import { explorerForTestingAtom, toNodeMap } from "@/core";
+import { useMaterializeVertices } from "./useMaterializeVertices";
+import { cloneDeep } from "lodash";
+
+test("should return vertex when already materialized", async () => {
+  const explorer = createMockExplorer();
+  const { result } = renderHookWithJotai(
+    () => useMaterializeVertices(),
+    snapshot => {
+      snapshot.set(explorerForTestingAtom, explorer);
+    }
+  );
+
+  const vertex = createRandomVertex();
+  vertex.__isFragment = false;
+  const nodeMap = toNodeMap([vertex]);
+
+  const actual = await result.current(nodeMap);
+
+  expect(actual).toEqual(nodeMap);
+  expect(explorer.vertexDetails).not.toBeCalled();
+});
+
+test("should fetch vertex details when fragment", async () => {
+  const explorer = createMockExplorer();
+  const { result } = renderHookWithJotai(
+    () => useMaterializeVertices(),
+    snapshot => {
+      snapshot.set(explorerForTestingAtom, explorer);
+    }
+  );
+
+  const vertex = createRandomVertex();
+  const expectedVertex = cloneDeep(vertex);
+
+  vertex.__isFragment = true;
+  vertex.attributes = {};
+
+  vi.mocked(explorer.vertexDetails).mockResolvedValue({
+    vertex: expectedVertex,
+  });
+
+  const actual = await result.current(toNodeMap([vertex]));
+
+  expect(actual).toEqual(toNodeMap([expectedVertex]));
+  expect(explorer.vertexDetails).toBeCalledTimes(1);
+});

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -9,6 +9,7 @@ import {
 import {
   useAddToGraphMutation,
   useDisplayVertexFromFragment,
+  useEdgeDetailsQuery,
   useHasEdgeBeenAddedToGraph,
   useRemoveEdgeFromGraph,
 } from "@/hooks";
@@ -23,7 +24,13 @@ import EntityAttribute from "../EntityDetails/EntityAttribute";
 
 export function EdgeSearchResult({ edge }: { edge: Edge }) {
   const [expanded, setExpanded] = useState(false);
-  const displayEdge = useDisplayEdgeFromEdge(edge);
+
+  // Ensure the edge is fully materialized
+  const { data: detailsResponse } = useEdgeDetailsQuery(edge.id);
+  const preferredEdge = detailsResponse?.edge ?? edge;
+  const displayEdge = useDisplayEdgeFromEdge(preferredEdge);
+
+  // Get the display vertices
   const source = useDisplayVertexFromFragment(
     displayEdge.source.id,
     displayEdge.source.types

--- a/packages/graph-explorer/src/utils/testing/index.ts
+++ b/packages/graph-explorer/src/utils/testing/index.ts
@@ -1,3 +1,4 @@
+export * from "./createMockExplorer";
 export * from "./DbState";
 export * from "./graphsonHelpers";
 export * from "./normalize";


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When a query returns a path with an edge, the edge is a fragment. While we are correctly materializing vertices, we were not materializing edges.

This change is basically a copy of what we are doing with vertices.

## Validation

- Tested using query in #971 

## Related Issues

- Resolves #971 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
