### PR TITLE
Fix row separator in search results

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,8 @@
   ([#988](https://github.com/aws/graph-explorer/pull/988))
 - **Updated** too many requests error message for accuracy
   ([#990](https://github.com/aws/graph-explorer/pull/990))
+- **Fixed** search result row separators to ensure they are always rendered
+  properly ([#997](https://github.com/aws/graph-explorer/pull/997))
 
 ### Other changes
 

--- a/packages/graph-explorer/src/components/Label.tsx
+++ b/packages/graph-explorer/src/components/Label.tsx
@@ -9,7 +9,7 @@ const Label = React.forwardRef<
   <LabelPrimitive.Root
     ref={ref}
     className={cn(
-      "text-text-secondary inline-flex items-center gap-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      "text-text-secondary font-base inline-flex items-center gap-2 text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
       className
     )}
     {...props}

--- a/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EdgeDetail.tsx
@@ -79,9 +79,9 @@ const EdgeDetail = ({ edge }: EdgeDetailProps) => {
   ];
 
   return (
-    <div className="space-y-6 p-3">
+    <div className="divide-border divide-y">
       {/* Uses a grid with the first column width matching the size of the edge icon */}
-      <div className="grid grid-cols-[2.75rem_1fr] gap-3">
+      <div className="grid grid-cols-[2.75rem_1fr] gap-3 p-3">
         <EdgeRow
           edge={edge}
           source={sourceVertex}
@@ -108,7 +108,7 @@ const EdgeDetail = ({ edge }: EdgeDetailProps) => {
         <VertexRow vertex={sourceVertex} />
         <VertexRow vertex={targetVertex} />
       </div>
-      <div className="space-y-[1.125rem]">
+      <div className="space-y-[1.125rem] p-3">
         <div className="text-lg font-bold">Properties</div>
         <ul className="space-y-[1.125rem]">
           {allAttributes.map(attribute => (

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -82,7 +82,8 @@ const NodeExpandFilters = ({
   };
 
   return (
-    <div className="flex grow flex-col gap-6 px-3 py-4">
+    <div className="grow space-y-6 p-3">
+      <h1 className="text-lg font-bold">Neighbor Expansion Options</h1>
       <Section>
         <SectionTitle>{t("node-expand.neighbors-of-type")}</SectionTitle>
         <SelectField
@@ -168,12 +169,12 @@ const NodeExpandFilters = ({
 };
 
 function Section({ children }: PropsWithChildren) {
-  return <div className="space-y-3">{children}</div>;
+  return <div className="space-y-[1.125rem]">{children}</div>;
 }
 
 function SectionTitle({ children }: PropsWithChildren) {
   return (
-    <div className="text-text-primary flex justify-between gap-2 text-base font-bold">
+    <div className="text-text-primary flex justify-between gap-2 text-base font-medium">
       {children}
     </div>
   );

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -62,13 +62,13 @@ export function EdgeSearchResult({ edge }: { edge: Edge }) {
         />
         <AddOrRemoveButton edge={edge} />
       </div>
-      <div className="border-background-secondary px-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
-        <ul>
+      <div className="border-border pl-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
+        <ul className="divide-y divide-gray-200">
           {displayEdge.attributes.map(attr => (
             <EntityAttribute
               key={attr.name}
               attribute={attr}
-              className="border-b border-gray-200 px-3 py-2 last:border-0"
+              className="px-3 py-2"
             />
           ))}
         </ul>

--- a/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/NodeSearchResult.tsx
@@ -42,13 +42,13 @@ export function NodeSearchResult({ node }: { node: Vertex }) {
         <VertexRow vertex={displayNode} className="grow" />
         <AddOrRemoveButton vertex={preferredNode} />
       </div>
-      <div className="border-background-secondary px-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
-        <ul>
+      <div className="border-border pl-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
+        <ul className="divide-y divide-gray-200">
           {displayNode.attributes.map(attr => (
             <EntityAttribute
               key={attr.name}
               attribute={attr}
-              className="border-b border-gray-200 px-3 py-2 last:border-0"
+              className="px-3 py-2"
             />
           ))}
         </ul>

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -40,12 +40,9 @@ export function SearchResultsList(results: MappedQueryResults) {
   return (
     <>
       <div className="bg-background-contrast/35 flex grow flex-col p-3">
-        <ul className="border-divider flex flex-col overflow-hidden rounded-xl border shadow">
+        <ul className="border-divider divide-border flex flex-col divide-y overflow-hidden rounded-xl border shadow">
           {currentPageRows.map(row => (
-            <li
-              key={row.key}
-              className="border-divider content-auto intrinsic-size-16 border-b last:border-0"
-            >
+            <li key={row.key} className="content-auto intrinsic-size-16">
               {row.render()}
             </li>
           ))}

--- a/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
+++ b/packages/graph-explorer/src/modules/common/NeighborsList/NeighborsList.tsx
@@ -36,11 +36,11 @@ export default function NeighborsList({
 
   return (
     <div
-      className={cn("flex flex-col gap-3 border-b p-3", className)}
+      className={cn("space-y-[1.125rem] border-b p-3", className)}
       {...props}
     >
-      <div className="font-bold">Neighbors ({neighbors.all})</div>
-      <ul className="flex flex-col gap-3">
+      <div className="text-lg font-bold">Neighbors ({neighbors.all})</div>
+      <ul className="space-y-3">
         {neighborsOptions
           .slice(0, showMore ? undefined : MAX_NEIGHBOR_TYPE_ROWS)
           .map(op => (


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The use of borders at the bottom of rows was not rendering properly sometimes. My theory is that some overlapping of elements was occurring. Instead, we use the Tailwind standard way of applying separators, using `divide-y divide-{color}`. This seems to render properly in all cases.

### Other Changes

- Added separator in edge detail panel between edge representation and properties
- Tweaked spacing and style of neighbor list header
- Tweaked spacing of neighbor expansion options
- Added title to neighbor expansion options section
- In search results that expand to show attributes (node and edge) I allow the attribute to stretch to the right edge, only indenting on the left
- Tweaked `Label` to reduce font weight to baseline since medium was looking a bit heavy

## Validation

![CleanShot 2025-06-12 at 11 07 46@2x](https://github.com/user-attachments/assets/5cb799ee-154d-44d5-870d-b51797e04963)
![CleanShot 2025-06-12 at 11 14 43@2x](https://github.com/user-attachments/assets/217759bf-879a-4209-962e-f83091affba1)
![CleanShot 2025-06-12 at 11 07 32@2x](https://github.com/user-attachments/assets/51d53a63-63e3-4c92-a037-0c28d0e7d4b6)
![CleanShot 2025-06-12 at 11 07 16@2x](https://github.com/user-attachments/assets/7447fa10-6358-4cf0-b139-885658079be3)

## Related Issues

- Resolves #994 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
