### PR TITLE
Add ability to wrap component with spinner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,10 @@
 - **Added** support for openCypher in the query editor
   ([#1016](https://github.com/aws/graph-explorer/pull/1016),
   [#1024](https://github.com/aws/graph-explorer/pull/1024))
-- **Updated** dependencies to latest versions
+- **Updated** dependencies to latest versions and some minor refactorings
   ([#1014](https://github.com/aws/graph-explorer/pull/1014),
-  [#1023](https://github.com/aws/graph-explorer/pull/1023))
+  [#1023](https://github.com/aws/graph-explorer/pull/1023),
+  [#1025](https://github.com/aws/graph-explorer/pull/1025))
 
 ## Release v2.0
 

--- a/packages/graph-explorer/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/graph-explorer/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/utils";
-import type { ReactNode } from "react";
+import type { PropsWithChildren, ReactNode } from "react";
 import { useWithTheme } from "@/core";
 import { LoaderIcon } from "@/components/icons";
 
@@ -33,9 +33,34 @@ export const LoadingSpinner = ({
   );
 };
 
+interface SpinnerProps extends PropsWithChildren<IconBaseProps> {
+  loading?: boolean;
+}
+
 /** Basic spinner */
-export function Spinner({ className, ...props }: IconBaseProps) {
-  return <LoaderIcon className={cn(className, "animate-spin")} {...props} />;
+export function Spinner({
+  className,
+  loading,
+  children,
+  ...props
+}: SpinnerProps) {
+  if (!children) {
+    return <LoaderIcon className={cn(className, "animate-spin")} {...props} />;
+  }
+
+  return (
+    <span className="stack">
+      <LoaderIcon
+        className={cn(
+          "invisible",
+          loading && "visible animate-spin",
+          className
+        )}
+        {...props}
+      />
+      <span className={cn("visible", loading && "invisible")}>{children}</span>
+    </span>
+  );
 }
 
 export default LoadingSpinner;

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -88,6 +88,8 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
       : config.connection.url
     : MISSING_DISPLAY_VALUE;
 
+  const isSyncing = useIsSyncing();
+
   return (
     <Panel>
       <PanelHeader>
@@ -145,7 +147,9 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
           <EdgeCounts />
           <InfoItem>
             <InfoItemIcon>
-              <ClockIcon />
+              <Spinner loading={isSyncing}>
+                <ClockIcon />
+              </Spinner>
             </InfoItemIcon>
             <InfoItemContent>
               <InfoItemLabel>Last Synchronization</InfoItemLabel>
@@ -210,12 +214,7 @@ function LastSyncInfo({ config }: { config: ConfigurationContextProps }) {
   const { refetch: syncSchema } = useSchemaSync();
 
   if (isSyncing) {
-    return (
-      <InfoItemValue>
-        <Spinner />
-        Synchronizing...
-      </InfoItemValue>
-    );
+    return <InfoItemValue>Synchronizing...</InfoItemValue>;
   }
 
   const lastSyncFail = config.schema?.lastSyncFail === true;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I saw this pattern and knew it would be easy to implement and could be useful.

The spinner component can now wrap another component. When the `loading` flag is true the spinner is shown instead of the wrapped component. No layout shift will occur.

My inspiration came from [Radix UI](https://www.radix-ui.com/blog/themes-3#spinner).

## Validation

- Changed the sync icon in the connection details to use this style to verify it works propeerly
- Tested other uses of spinner to make sure they still work correctly

## Related Issues

- None

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.