### PR TITLE
Migrate vitest workspaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,5 @@
 {
-  "[html]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "vitest.workspaceConfig": "vitest.workspace.ts",

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,8 @@
 - **Updated** dependencies to latest versions and some minor refactorings
   ([#1014](https://github.com/aws/graph-explorer/pull/1014),
   [#1023](https://github.com/aws/graph-explorer/pull/1023),
-  [#1025](https://github.com/aws/graph-explorer/pull/1025))
+  [#1025](https://github.com/aws/graph-explorer/pull/1025),
+  [#1027](https://github.com/aws/graph-explorer/pull/1027))
 
 ## Release v2.0
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check:types": "tsc --build --force",
     "checks": "pnpm run '/^check:.*/'",
     "start": "pnpm --filter \"graph-explorer-proxy-server\" run start",
-    "clean": "pnpm --stream -r run clean",
+    "clean": "tsc --build --clean && pnpm --stream -r run clean",
     "clean:dep": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",
     "build": "pnpm --stream -r run build",
     "dev": "pnpm --stream -r run dev"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
-    "check:types": "tsc --build --force",
+    "check:types": "tsc --build",
     "checks": "pnpm run '/^check:.*/'",
     "start": "pnpm --filter \"graph-explorer-proxy-server\" run start",
     "clean": "tsc --build --clean && pnpm --stream -r run clean",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -5,7 +5,7 @@
   "main": "dist/node-server.js",
   "type": "module",
   "scripts": {
-    "clean": "tsc --build tsconfig.build.json --clean && rimraf dist coverage",
+    "clean": "rimraf dist coverage",
     "build": "tsc --build tsconfig.build.json",
     "dev": "tsx watch src/node-server.ts",
     "start": "NODE_ENV=production node dist/node-server.js"

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --force",
-    "clean": "tsc --build --clean && rimraf dist coverage",
+    "clean": "rimraf dist coverage",
     "vite-build": "NODE_OPTIONS=--max_old_space_size=6144 vite build",
     "build": "pnpm vite-build -- --mode production"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.base.json",
   "files": [],
   "references": [
+    { "path": "./tsconfig.root.json" },
     { "path": "packages/shared" },
     { "path": "packages/graph-explorer" },
     { "path": "packages/graph-explorer-proxy-server" }

--- a/tsconfig.root.json
+++ b/tsconfig.root.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": true,
+    "noEmit": true
   },
-  "files": ["./vitest.config.ts"],
+  "files": ["./vitest.config.ts"]
 }

--- a/tsconfig.root.json
+++ b/tsconfig.root.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+  },
+  "files": ["./vitest.config.ts"],
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: ["packages/*"],
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,0 @@
-export default ["packages/**/vite.config.ts", "packages/**/vitest.config.ts"];


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I removed the old `vitest.workspaces.ts` and added a `vitest.config.ts`. This change is documented in the [Vitest documentation](https://vitest.dev/guide/projects).

### Other changes

- Added `vitest.config.ts` to TypeScript type checking by adding a new `tsconfig.root.json`
- Moved the TypeScript cleaning to the root so that the new root level typescript config build info will be cleaned up properly
- Changed `check:types` to use incremental building for the performance wins
  - If this becomes an issue we can always go back to `--force`
  - If needed, `pnpm clean && pnpm check:types` is the same as `--force`
- Make Prettier the default formatter for all files in VS Code

## Validation

- Tested checking types
- Tested running tests
- Tested building
- Tested cleaning

## Related Issues

- Resolves #1018 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
