### PR TITLE
Rename labels in connection detail for properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@
   [#1024](https://github.com/aws/graph-explorer/pull/1024))
 - **Added** close button to table view
   ([#1026](https://github.com/aws/graph-explorer/pull/1026))
+- **Updated** label for properties count in connection detail
+  ([#1030](https://github.com/aws/graph-explorer/pull/1030))
 - **Updated** dependencies to latest versions and some minor refactorings
   ([#1014](https://github.com/aws/graph-explorer/pull/1014),
   [#1023](https://github.com/aws/graph-explorer/pull/1023),

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -10,7 +10,11 @@ import {
   useSearchItems,
   VertexIcon,
 } from "@/components";
-import { DisplayVertexTypeConfig, useDisplayVertexTypeConfigs } from "@/core";
+import {
+  DisplayVertexTypeConfig,
+  useDisplayVertexTypeConfigs,
+  useQueryEngine,
+} from "@/core";
 import useTranslations from "@/hooks/useTranslations";
 import { Virtuoso } from "react-virtuoso";
 import { ComponentPropsWithoutRef } from "react";
@@ -98,6 +102,16 @@ function VertexTypeList({
 }
 
 function Row({ config }: { config: DisplayVertexTypeConfig }) {
+  const queryEngine = useQueryEngine();
+  const unit =
+    config.attributes.length === 1
+      ? queryEngine === "sparql"
+        ? "predicate"
+        : "property"
+      : queryEngine === "sparql"
+        ? "predicates"
+        : "properties";
+
   return (
     <Link to={`/data-explorer/${encodeURIComponent(config.type)}`}>
       <div className="flex min-h-12 items-center gap-4 px-4 py-2 hover:cursor-pointer">
@@ -105,7 +119,7 @@ function Row({ config }: { config: DisplayVertexTypeConfig }) {
         <ListRowContent>
           <ListRowTitle>{config.displayLabel}</ListRowTitle>
           <ListRowSubtitle>
-            {config.attributes.length} attributes
+            {config.attributes.length} {unit}
           </ListRowSubtitle>
         </ListRowContent>
         <ChevronRightIcon className="text-text-secondary size-5" />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Renamed the label from "attributes" to "properties" or "predicates" depending on connection type.

## Validation

![CleanShot 2025-06-19 at 19 24 10@2x](https://github.com/user-attachments/assets/61e5fcc9-774f-4610-86e1-fca4e0ab67f2)

![CleanShot 2025-06-19 at 19 34 10@2x](https://github.com/user-attachments/assets/4cde089a-2b81-4c21-9533-1d7c4259bb49)


## Related Issues

- Resolves #1029

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
