### PR TITLE
Improve the no results message for the query editor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,8 @@
 
 - **Added** support for openCypher in the query editor
   ([#1016](https://github.com/aws/graph-explorer/pull/1016),
-  [#1024](https://github.com/aws/graph-explorer/pull/1024))
+  [#1024](https://github.com/aws/graph-explorer/pull/1024),
+  [#1035](https://github.com/aws/graph-explorer/pull/1035))
 - **Added** close button to table view
   ([#1026](https://github.com/aws/graph-explorer/pull/1026))
 - **Updated** dependencies to latest versions and some minor refactorings

--- a/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
@@ -8,7 +8,6 @@ import {
   LoadingSpinner,
   PanelEmptyState,
   PanelError,
-  SearchSadIcon,
   TextArea,
   Tooltip,
   TooltipContent,
@@ -24,7 +23,7 @@ import {
   useMutationState,
   useQueryClient,
 } from "@tanstack/react-query";
-import { SendHorizonalIcon } from "lucide-react";
+import { ListIcon, SendHorizonalIcon } from "lucide-react";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -237,8 +236,8 @@ function QueryTabNoResults() {
   return (
     <PanelEmptyState
       title="No Results"
-      subtitle="Your query does not produce any results"
-      icon={<SearchSadIcon />}
+      subtitle="Your query executed successfully, but no results were included in the response."
+      icon={<ListIcon />}
       className="p-8"
     />
   );

--- a/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
@@ -235,8 +235,8 @@ function QueryTabEmptyState() {
 function QueryTabNoResults() {
   return (
     <PanelEmptyState
-      title="No Results"
-      subtitle="Your query executed successfully, but no results were included in the response."
+      title="Empty Results"
+      subtitle="Your query executed successfully, but the result was empty."
       icon={<ListIcon />}
       className="p-8"
     />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The no results message can be a bit confusing when executing mutations that would not have any results returned. So I modified the message to show that the query succeeded.

## Validation

![CleanShot 2025-06-20 at 18 49 23@2x](https://github.com/user-attachments/assets/d50821c7-5fa1-40fe-abd2-7ee05c4f7a03)


## Related Issues

- Resolves #1032

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have added an entry in the `Changelog.md`.
