### PR TITLE
Use fetchQuery instead of ensureQueryData

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/neighbors.ts
+++ b/packages/graph-explorer/src/core/StateProvider/neighbors.ts
@@ -43,7 +43,7 @@ export function useNeighborsCallback() {
     useCallback(
       async (get, _set, vertexId: VertexId) => {
         const fetchedNeighbors = get(fetchedNeighborsSelector(vertexId));
-        const response = await queryClient.ensureQueryData(
+        const response = await queryClient.fetchQuery(
           neighborsCountQuery({ vertexId })
         );
 

--- a/packages/graph-explorer/src/core/fetchEntityDetails.ts
+++ b/packages/graph-explorer/src/core/fetchEntityDetails.ts
@@ -16,12 +16,10 @@ export async function fetchEntityDetails(
   queryClient: QueryClient
 ) {
   const vertexResults = await Promise.allSettled(
-    vertices
-      .values()
-      .map(id => queryClient.ensureQueryData(vertexDetailsQuery(id)))
+    vertices.values().map(id => queryClient.fetchQuery(vertexDetailsQuery(id)))
   );
   const edgeResults = await Promise.allSettled(
-    edges.values().map(id => queryClient.ensureQueryData(edgeDetailsQuery(id)))
+    edges.values().map(id => queryClient.fetchQuery(edgeDetailsQuery(id)))
   );
 
   const vertexDetails = vertexResults

--- a/packages/graph-explorer/src/hooks/useMaterializeEdges.ts
+++ b/packages/graph-explorer/src/hooks/useMaterializeEdges.ts
@@ -13,7 +13,7 @@ export function useMaterializeEdges() {
           return edge;
         }
 
-        const response = await queryClient.ensureQueryData(
+        const response = await queryClient.fetchQuery(
           edgeDetailsQuery(edge.id)
         );
         return response.edge;

--- a/packages/graph-explorer/src/hooks/useMaterializeVertices.ts
+++ b/packages/graph-explorer/src/hooks/useMaterializeVertices.ts
@@ -13,7 +13,7 @@ export function useMaterializeVertices() {
           return vertex;
         }
 
-        const response = await queryClient.ensureQueryData(
+        const response = await queryClient.fetchQuery(
           vertexDetailsQuery(vertex.id)
         );
         return response.vertex;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

I was using the `ensureQueryData` function to fetch query data imperatively. This will not use cached data if it exists and will always fetch new data.

Instead, we should use `fetchQuery` so that if there is valid cached data it will be used.

## Validation

Smoke tested

## Related Issues

- N/A

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
