### PR TITLE
Fix handling null values in OC and Gremlin

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -1,3 +1,4 @@
+import { MISSING_DISPLAY_VALUE } from "@/utils";
 import { GAnyValue } from "../types";
 import mapApiEdge from "./mapApiEdge";
 import mapApiVertex from "./mapApiVertex";
@@ -14,6 +15,8 @@ function mapAnyValue(data: GAnyValue): MapValueResult[] {
     return [{ scalar: data }];
   } else if (typeof data === "boolean") {
     return [{ scalar: data }];
+  } else if (data === null) {
+    return [{ scalar: MISSING_DISPLAY_VALUE }];
   } else if (
     data["@type"] === "g:Int32" ||
     data["@type"] === "g:Int64" ||

--- a/packages/graph-explorer/src/connector/gremlin/mappers/parseProperty.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/parseProperty.ts
@@ -1,5 +1,6 @@
 import { EntityPropertyValue } from "@/core";
 import type { GProperty, GVertexProperty } from "../types";
+import { MISSING_DISPLAY_VALUE } from "@/utils";
 
 export default function parseProperty(
   property: GVertexProperty | GProperty
@@ -10,6 +11,10 @@ export default function parseProperty(
 
   if (typeof property["@value"].value === "boolean") {
     return property["@value"].value;
+  }
+
+  if (property["@value"].value === null) {
+    return MISSING_DISPLAY_VALUE;
   }
 
   return property["@value"].value["@value"];

--- a/packages/graph-explorer/src/connector/gremlin/types.ts
+++ b/packages/graph-explorer/src/connector/gremlin/types.ts
@@ -110,7 +110,15 @@ export type GEntityList = {
   "@value": Array<GVertex | GEdge>;
 };
 
-export type GAnyValue = GList | GMap | GSet | GPath | GVertex | GEdge | GScalar;
+export type GAnyValue =
+  | GList
+  | GMap
+  | GSet
+  | GPath
+  | GVertex
+  | GEdge
+  | GScalar
+  | null;
 
 export type GremlinFetch = <TResult = any>(
   queryTemplate: string

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
@@ -3,6 +3,7 @@ import { mapResults } from "./mapResults";
 import { createRandomEdge, createRandomVertex } from "@/utils/testing";
 import { createRandomInteger } from "@shared/utils/testing";
 import { OCEdge, OCVertex } from "../types";
+import { MISSING_DISPLAY_VALUE } from "@/utils";
 
 describe("mapResults", () => {
   it("should map empty results", () => {
@@ -58,14 +59,16 @@ describe("mapResults", () => {
           total: expectedValue,
           name: "total",
           list: [expectedValue],
+          nullValue: null,
         },
       ],
     });
 
-    expect(result.scalars).toHaveLength(3);
+    expect(result.scalars).toHaveLength(4);
     expect(result.scalars[0]).toEqual(expectedValue);
     expect(result.scalars[1]).toEqual("total");
     expect(result.scalars[2]).toEqual(expectedValue);
+    expect(result.scalars[3]).toEqual(MISSING_DISPLAY_VALUE);
   });
 
   it("should map vertex in array", () => {

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/utils";
+import { logger, MISSING_DISPLAY_VALUE } from "@/utils";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 import mapApiVertex from "./mapApiVertex";
@@ -6,7 +6,12 @@ import mapApiEdge from "./mapApiEdge";
 import { MapValueResult, mapValuesToQueryResults } from "@/connector/mapping";
 import { OCEdge, OCVertex } from "../types";
 
-const cypherScalarValueSchema = z.union([z.number(), z.string(), z.boolean()]);
+const cypherScalarValueSchema = z.union([
+  z.number(),
+  z.string(),
+  z.boolean(),
+  z.null(),
+]);
 
 const cypherNodeSchema: z.ZodType<OCVertex> = z.object({
   "~entityType": z.literal("node"),
@@ -89,6 +94,11 @@ function mapValue(value: CypherValue): MapValueResult[] {
 
   if (Array.isArray(value)) {
     return value.flatMap(mapValue);
+  }
+
+  // Skip nulls
+  if (value === null) {
+    return [{ scalar: MISSING_DISPLAY_VALUE }];
   }
 
   // Map record types

--- a/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
+++ b/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
@@ -48,6 +48,11 @@ export function createGMap<Value extends EntityPropertyValue | GAnyValue>(
 ): GMap {
   const mapItems: GAnyValue[] = [];
   for (const [key, value] of Object.entries(values)) {
+    // Skip any null values, since that's how Gremlin behaves
+    if (value === null) {
+      continue;
+    }
+
     mapItems.push(key);
     if (
       typeof value === "boolean" ||


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Null values were not being handled properly in the mapping logic for both Gremlin and openCypher.

## Gremlin

Gremlin will ignore null properties when returning vertices, edges, or maps. But if you inject `null`, Graph Explorer breaks.

```gremlin
g.inject(null)
```

### openCypher

Similar to Gremlin, openCypher will skip null properties. But you can force it to return null values in a sparse result.

```cypher
# Create sample data with nulls
MERGE (v1:Person {name: 'John', age: 30, email: null})
MERGE (v2:Person {name: 'Jane', age: 28, email: 'jane@example.com'})
RETURN v1, v2

# Select data in sparse results
MATCH (p:Person)
WHERE p.name = 'John' OR p.name = 'Jane'
RETURN p.name, p.email
```

## Validation

- Tested in Neptune with Gremlin and openCypher
- Added unit tests

## Related Issues

- Resolves #1067

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
