### PR TITLE
Fix brittleness of tests

### DIFF
--- a/packages/graph-explorer/src/core/fetchEntityDetails.test.ts
+++ b/packages/graph-explorer/src/core/fetchEntityDetails.test.ts
@@ -35,8 +35,8 @@ describe("createCompletionNotification", () => {
 
   it("should create a completion notification when some nodes and edges were not found", () => {
     const fetchResult = createRandomFetchEntityDetailsResult();
-    fetchResult.counts.notFound.vertices = createRandomInteger();
-    fetchResult.counts.notFound.edges = createRandomInteger();
+    fetchResult.counts.notFound.vertices = createRandomInteger({ min: 2 });
+    fetchResult.counts.notFound.edges = createRandomInteger({ min: 2 });
     fetchResult.counts.notFound.total =
       fetchResult.counts.notFound.vertices + fetchResult.counts.notFound.edges;
     const nodeCount = fetchResult.counts.notFound.vertices.toLocaleString();
@@ -87,8 +87,8 @@ describe("createCompletionNotification", () => {
     const fetchResult = createRandomFetchEntityDetailsResult();
     fetchResult.entities.vertices = [];
     fetchResult.entities.edges = [];
-    fetchResult.counts.notFound.vertices = createRandomInteger();
-    fetchResult.counts.notFound.edges = createRandomInteger();
+    fetchResult.counts.notFound.vertices = createRandomInteger({ min: 2 });
+    fetchResult.counts.notFound.edges = createRandomInteger({ min: 2 });
     fetchResult.counts.notFound.total =
       fetchResult.counts.notFound.vertices + fetchResult.counts.notFound.edges;
     const nodeCount = fetchResult.counts.notFound.vertices.toLocaleString();

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -453,7 +453,7 @@ export function createRandomEdgePreferences(): EdgePreferences {
   const lineColor = randomlyUndefined(createRandomColor());
   const labelColor = randomlyUndefined(createRandomColor());
   const labelBorderColor = randomlyUndefined(createRandomColor());
-  const lineThickness = randomlyUndefined(createRandomInteger(25));
+  const lineThickness = randomlyUndefined(createRandomInteger({ max: 25 }));
   return {
     type: createRandomName("EdgeType"),
     ...(displayLabel && { displayLabel }),

--- a/packages/shared/src/utils/testing/randomData.ts
+++ b/packages/shared/src/utils/testing/randomData.ts
@@ -33,11 +33,19 @@ export function createRandomBoolean(): boolean {
 
 /**
  * Creates a random integer.
- * @param max The maximum value the random integer can have. Defaults to 100,000.
+ * @param options The options for the random integer.
+ * @param options.min The minimum value the random integer can have (inclusive). Defaults to 0.
+ * @param options.max The maximum value the random integer can have (inclusive). Defaults to 100000.
  * @returns A random integer value from 0 to the max.
  */
-export function createRandomInteger(max: number = 100000): number {
-  return Math.floor(Math.random() * max);
+export function createRandomInteger(options?: {
+  min?: number;
+  max?: number;
+}): number {
+  const min = options?.min ?? 0;
+  const max = options?.max ?? 100000;
+
+  return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 /**
@@ -74,7 +82,10 @@ export function createRandomColor(): string {
 export function createRandomUrlString(): string {
   const scheme = pickRandomElement(["http", "https"]);
   const host = createRandomName("host");
-  const port = pickRandomElement(["", `:${createRandomInteger(30000)}`]);
+  const port = pickRandomElement([
+    "",
+    `:${createRandomInteger({ max: 30000 })}`,
+  ]);
   const path = pickRandomElement(["", `/${createRandomName("path")}`]);
   return `${scheme}://${host}${port}${path}`;
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The tests were failing because the string being generated is different when the input number has a value of 1. Since the input number was random, it would randomly fail (1:100,000 chance).

I have added a `min` option to the random generator so that these tests can generate a number larger than 2, avoiding the special case.

## Validation

- Unit tests

## Related Issues

- Resolves #1069 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
