### PR TITLE
Update search result UI

### DIFF
--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -23,6 +23,7 @@
     "@mantine/emotion": "^8.1.0",
     "@mantine/hooks": "^8.1.0",
     "@radix-ui/react-checkbox": "^1.3.2",
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-form": "^0.1.7",
     "@radix-ui/react-label": "^2.1.7",

--- a/packages/graph-explorer/src/components/Collapsible.tsx
+++ b/packages/graph-explorer/src/components/Collapsible.tsx
@@ -25,7 +25,10 @@ function CollapsibleContent({
   return (
     <CollapsiblePrimitive.CollapsibleContent
       data-slot="collapsible-content"
-      className={cn("CollapsibleContent", className)}
+      className={cn(
+        "group-data-open:animate-expand group-data-closed:animate-collapse overflow-hidden",
+        className
+      )}
       {...props}
     />
   );

--- a/packages/graph-explorer/src/components/Collapsible.tsx
+++ b/packages/graph-explorer/src/components/Collapsible.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/utils";
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      className={cn("CollapsibleContent", className)}
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/packages/graph-explorer/src/components/EdgeRow.tsx
+++ b/packages/graph-explorer/src/components/EdgeRow.tsx
@@ -2,6 +2,7 @@ import { DisplayEdge, DisplayVertex } from "@/core";
 import { ComponentPropsWithoutRef } from "react";
 import { EdgeSymbol } from "./EdgeSymbol";
 import { cn } from "@/utils";
+import { SearchResultSubtitle, SearchResultTitle } from "./SearchResult";
 
 /**
  * Visually represents an edge from the graph database.
@@ -29,12 +30,12 @@ export function EdgeRow({
       className={cn("flex flex-row items-center gap-3", className)}
       {...props}
     >
-      <EdgeSymbol className="size-11 p-[8px]" />
-      <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
-        <div className="line-clamp-3 font-bold">{title}</div>
-        <div className="text-text-secondary/90 line-clamp-3">
+      <EdgeSymbol />
+      <div>
+        <SearchResultTitle>{title}</SearchResultTitle>
+        <SearchResultSubtitle>
           {source.displayName}&nbsp;&rarr; {target.displayName}
-        </div>
+        </SearchResultSubtitle>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/components/EdgeSymbol.tsx
+++ b/packages/graph-explorer/src/components/EdgeSymbol.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils";
 import { EdgeIcon } from "./icons";
 import { ComponentPropsWithoutRef } from "react";
+import { SearchResultSymbol } from "./SearchResult";
 
 /** Icon representing an edge in the graph. */
 export function EdgeSymbol({
@@ -8,14 +9,11 @@ export function EdgeSymbol({
   ...props
 }: ComponentPropsWithoutRef<"div">) {
   return (
-    <div
-      className={cn(
-        "text-primary-main bg-primary-main/20 grid size-[36px] shrink-0 place-content-center rounded-full p-2 text-[2em]",
-        className
-      )}
+    <SearchResultSymbol
+      className={cn("text-primary-main bg-primary-main/20", className)}
       {...props}
     >
       <EdgeIcon className="size-full" />
-    </div>
+    </SearchResultSymbol>
   );
 }

--- a/packages/graph-explorer/src/components/Input.tsx
+++ b/packages/graph-explorer/src/components/Input.tsx
@@ -12,7 +12,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
  */
 
 export const inputStyles = cva({
-  base: "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main border-input flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+  base: "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring bg-input-background invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main border-input flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
 });
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/packages/graph-explorer/src/components/Input.tsx
+++ b/packages/graph-explorer/src/components/Input.tsx
@@ -12,7 +12,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
  */
 
 export const inputStyles = cva({
-  base: "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+  base: "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring bg-input-background hover:bg-input-hover invalid:ring-error-main aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main border-input flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
 });
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -12,7 +12,7 @@ export function SearchResult({
     <div
       {...props}
       className={cn(
-        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow-sm",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border shadow-sm",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}
@@ -29,7 +29,7 @@ export function SearchResultCollapsible({
     <Collapsible
       {...props}
       className={cn(
-        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow-sm",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border shadow-sm",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -109,7 +109,7 @@ export function SearchResultAttribute({
       {...props}
       className={cn(
         "flex w-full flex-wrap justify-between gap-2 rounded-xl border px-4 py-2 shadow-sm",
-        level % 2 === 0 ? "bg-default" : "bg-gray-50",
+        isEven(level) ? "bg-default" : "bg-gray-50",
         className
       )}
     />

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -12,7 +12,7 @@ export function SearchResult({
     <div
       {...props}
       className={cn(
-        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow-sm",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}
@@ -29,7 +29,7 @@ export function SearchResultCollapsible({
     <Collapsible
       {...props}
       className={cn(
-        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow-sm",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -12,7 +12,7 @@ export function SearchResult({
     <div
       {...props}
       className={cn(
-        "group rounded-xl border border-gray-200 shadow",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}
@@ -29,7 +29,7 @@ export function SearchResultCollapsible({
     <Collapsible
       {...props}
       className={cn(
-        "group rounded-xl border border-gray-200 shadow",
+        "content-auto intrinsic-size-[4.75rem] rounded-xl border border-gray-200 shadow",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -1,0 +1,78 @@
+import { cn } from "@/utils";
+import { ChevronRightIcon } from "lucide-react";
+import { ComponentPropsWithRef } from "react";
+
+export function SearchResult({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "bg-background-default group w-full overflow-hidden transition-all",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultTitle({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "text-text-primary line-clamp-3 text-pretty text-base font-bold leading-snug [word-break:break-word]",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultSubtitle({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "text-text-secondary/90 line-clamp-3 text-pretty text-base leading-snug [word-break:break-word]",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultSymbol({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "grid size-[36px] shrink-0 place-content-center rounded-full p-2 text-[2em]",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SearchResultExpandChevron({
+  className,
+  ...props
+}: ComponentPropsWithRef<typeof ChevronRightIcon>) {
+  return (
+    <ChevronRightIcon
+      className={cn(
+        "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[expanded=true]:rotate-90",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -1,16 +1,36 @@
-import { cn } from "@/utils";
+import { cn, isEven } from "@/utils";
 import { ChevronRightIcon } from "lucide-react";
 import { ComponentPropsWithRef } from "react";
+import { Collapsible } from "./Collapsible";
 
 export function SearchResult({
   className,
+  level = 0,
   ...props
-}: ComponentPropsWithRef<"div">) {
+}: ComponentPropsWithRef<"div"> & { level?: number }) {
   return (
     <div
       {...props}
       className={cn(
-        "bg-background-default group w-full overflow-hidden transition-all",
+        "group rounded-xl border border-gray-200 shadow",
+        isEven(level) ? "bg-gray-50" : "bg-default",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultCollapsible({
+  className,
+  level = 0,
+  ...props
+}: ComponentPropsWithRef<typeof Collapsible> & { level?: number }) {
+  return (
+    <Collapsible
+      {...props}
+      className={cn(
+        "group rounded-xl border border-gray-200 shadow",
+        isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}
     />
@@ -25,7 +45,7 @@ export function SearchResultTitle({
     <div
       {...props}
       className={cn(
-        "text-text-primary line-clamp-3 text-pretty text-base font-bold leading-snug [word-break:break-word]",
+        "text-text-primary line-clamp-2 text-pretty break-words text-base font-bold leading-normal [word-break:break-word]",
         className
       )}
     />
@@ -40,7 +60,7 @@ export function SearchResultSubtitle({
     <div
       {...props}
       className={cn(
-        "text-text-secondary/90 line-clamp-3 text-pretty text-base leading-snug [word-break:break-word]",
+        "text-text-secondary line-clamp-2 min-w-0 text-pretty break-words text-base leading-snug [word-break:break-word]",
         className
       )}
     />
@@ -64,15 +84,64 @@ export function SearchResultSymbol({
 
 export function SearchResultExpandChevron({
   className,
+  open,
   ...props
-}: ComponentPropsWithRef<typeof ChevronRightIcon>) {
+}: ComponentPropsWithRef<typeof ChevronRightIcon> & { open: boolean }) {
   return (
     <ChevronRightIcon
       className={cn(
-        "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[expanded=true]:rotate-90",
+        "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out",
+        open && "rotate-90",
         className
       )}
       {...props}
+    />
+  );
+}
+
+export function SearchResultAttribute({
+  level = 0,
+  className,
+  ...props
+}: ComponentPropsWithRef<"div"> & { level?: number }) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "flex w-full flex-wrap justify-between gap-2 rounded-xl border border-gray-200 px-4 py-2 shadow-sm",
+        level % 2 === 0 ? "bg-default" : "bg-gray-50",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultAttributeName({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "text-secondary flex-[1 1 150px] text-pretty text-base leading-snug [word-break:break-word]",
+        className
+      )}
+    />
+  );
+}
+
+export function SearchResultAttributeValue({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "text-text-primary flex-[2 1 150px] text-pretty text-base leading-snug [word-break:break-word]",
+        className
+      )}
     />
   );
 }

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -45,7 +45,7 @@ export function SearchResultTitle({
     <div
       {...props}
       className={cn(
-        "text-text-primary line-clamp-2 text-pretty break-words text-base font-bold leading-snug [word-break:break-word]",
+        "text-text-primary line-clamp-2 min-w-0 text-pretty break-words text-base font-bold leading-snug [word-break:break-word]",
         className
       )}
     />

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -108,7 +108,7 @@ export function SearchResultAttribute({
     <div
       {...props}
       className={cn(
-        "flex w-full flex-wrap justify-between gap-2 rounded-xl border border-gray-200 px-4 py-2 shadow-sm",
+        "flex w-full flex-wrap justify-between gap-2 rounded-xl border px-4 py-2 shadow-sm",
         level % 2 === 0 ? "bg-default" : "bg-gray-50",
         className
       )}
@@ -124,7 +124,7 @@ export function SearchResultAttributeName({
     <div
       {...props}
       className={cn(
-        "text-secondary flex-[1 1 150px] text-pretty text-base leading-snug [word-break:break-word]",
+        "text-secondary flex-[1 1 150px] min-w-0 text-pretty break-words text-base leading-snug [word-break:break-word]",
         className
       )}
     />
@@ -139,7 +139,7 @@ export function SearchResultAttributeValue({
     <div
       {...props}
       className={cn(
-        "text-text-primary flex-[2 1 150px] text-pretty text-base leading-snug [word-break:break-word]",
+        "text-text-primary flex-[2 1 150px] min-w-0 text-pretty break-words text-base leading-snug [word-break:break-word]",
         className
       )}
     />

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -29,7 +29,7 @@ export function SearchResultCollapsible({
     <Collapsible
       {...props}
       className={cn(
-        "content-auto intrinsic-size-[4.75rem] rounded-xl border shadow-sm",
+        "content-auto intrinsic-size-[4.75rem] group rounded-xl border shadow-sm",
         isEven(level) ? "bg-gray-50" : "bg-default",
         className
       )}
@@ -84,14 +84,12 @@ export function SearchResultSymbol({
 
 export function SearchResultExpandChevron({
   className,
-  open,
   ...props
-}: ComponentPropsWithRef<typeof ChevronRightIcon> & { open: boolean }) {
+}: ComponentPropsWithRef<typeof ChevronRightIcon>) {
   return (
     <ChevronRightIcon
       className={cn(
-        "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out",
-        open && "rotate-90",
+        "text-primary-dark/50 group-data-open:rotate-90 group-data-closed:rotate-0 size-5 shrink-0 transition-transform duration-200 ease-in-out",
         className
       )}
       {...props}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -45,7 +45,7 @@ export function SearchResultTitle({
     <div
       {...props}
       className={cn(
-        "text-text-primary line-clamp-2 text-pretty break-words text-base font-bold leading-normal [word-break:break-word]",
+        "text-text-primary line-clamp-2 text-pretty break-words text-base font-bold leading-snug [word-break:break-word]",
         className
       )}
     />

--- a/packages/graph-explorer/src/components/Select.tsx
+++ b/packages/graph-explorer/src/components/Select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background placeholder:text-text-secondary focus:ring-ring text-text-primary border-divider bg-input-background hover:bg-input-hover flex h-10 w-full items-center justify-between whitespace-nowrap rounded-md border px-3 py-2 text-sm transition-colors duration-100 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "ring-offset-background placeholder:text-text-secondary focus:ring-ring text-text-primary bg-input-background hover:bg-input-hover border-input flex h-10 w-full items-center justify-between whitespace-nowrap rounded-md border px-3 py-2 text-sm shadow-sm transition-colors duration-100 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/packages/graph-explorer/src/components/Select.tsx
+++ b/packages/graph-explorer/src/components/Select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "ring-offset-background placeholder:text-text-secondary focus:ring-ring text-text-primary bg-input-background hover:bg-input-hover border-input flex h-10 w-full items-center justify-between whitespace-nowrap rounded-md border px-3 py-2 text-sm shadow-sm transition-colors duration-100 focus:outline-none focus:ring-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "ring-offset-background placeholder:text-text-secondary focus:ring-ring text-text-primary bg-input-background border-input data-open:ring-1 flex h-10 w-full items-center justify-between whitespace-nowrap rounded-md border px-3 py-2 text-sm shadow-sm transition-colors duration-100 focus:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/packages/graph-explorer/src/components/TextArea.tsx
+++ b/packages/graph-explorer/src/components/TextArea.tsx
@@ -8,7 +8,7 @@ export function TextArea({
   return (
     <textarea
       className={cn(
-        "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background hover:bg-input-hover aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
+        "placeholder:text-text-secondary text-text-primary focus-visible:ring-ring border-divider bg-input-background aria-invalid:ring-error-main aria-invalid:border-error-main invalid:border-error-main flex w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/packages/graph-explorer/src/components/VertexIcon.tsx
+++ b/packages/graph-explorer/src/components/VertexIcon.tsx
@@ -1,6 +1,7 @@
 import { DisplayVertexStyle, fade } from "@/core";
 import SVG from "react-inlinesvg";
 import { cn } from "@/utils";
+import { SearchResultSymbol } from "./SearchResult";
 
 interface Props {
   vertexStyle: DisplayVertexStyle;
@@ -35,17 +36,14 @@ export function VertexSymbol({
   className?: string;
 }) {
   return (
-    <div
-      className={cn(
-        "text-primary-main bg-primary-main/20 grid size-[36px] shrink-0 place-content-center rounded-full p-2 text-[2em]",
-        className
-      )}
+    <SearchResultSymbol
+      className={cn("text-primary-main bg-primary-main/20", className)}
       style={{
         background: fade(vertexStyle.color, 0.2),
       }}
     >
       <VertexIcon vertexStyle={vertexStyle} className="size-full" />
-    </div>
+    </SearchResultSymbol>
   );
 }
 

--- a/packages/graph-explorer/src/components/VertexRow.tsx
+++ b/packages/graph-explorer/src/components/VertexRow.tsx
@@ -1,5 +1,5 @@
 import { DisplayVertex } from "@/core";
-import { VertexSymbol } from ".";
+import { SearchResultSubtitle, SearchResultTitle, VertexSymbol } from ".";
 import { ComponentPropsWithoutRef } from "react";
 import { cn } from "@/utils";
 
@@ -13,17 +13,12 @@ export function VertexRow({
       className={cn("flex flex-row items-center gap-3", className)}
       {...props}
     >
-      <VertexSymbol
-        vertexStyle={vertex.typeConfig.style}
-        className="size-11 p-[8px]"
-      />
-      <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
-        <div className="line-clamp-3 font-bold">
+      <VertexSymbol vertexStyle={vertex.typeConfig.style} />
+      <div>
+        <SearchResultTitle>
           {vertex.displayTypes}&nbsp;&rsaquo; {vertex.displayName}
-        </div>
-        <div className="text-text-secondary/90 line-clamp-3">
-          {vertex.displayDescription}
-        </div>
+        </SearchResultTitle>
+        <SearchResultSubtitle>{vertex.displayDescription}</SearchResultSubtitle>
       </div>
     </div>
   );

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -8,6 +8,8 @@ export * from "./CheckboxList";
 export { default as Chip } from "./Chip";
 export * from "./Chip";
 
+export * from "./Collapsible";
+
 export * from "./CommonAnimationProps";
 
 export * from "./DefaultQueryErrorBoundary";

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -61,6 +61,8 @@ export { default as NotInProduction } from "./NotInProduction";
 export { default as SearchBar } from "./SearchBar";
 export * from "./SearchBar";
 
+export * from "./SearchResult";
+
 export * from "./Select";
 export { default as SelectField } from "./SelectField";
 export * from "./SelectField";

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/index.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/index.ts
@@ -107,11 +107,12 @@ const fetchVertexLabels = async (
 };
 
 const TYPE_MAP = {
-  "g:Date": "Date",
-  "g:Int32": "Number",
-  "g:Int64": "Number",
-  "g:Double": "Number",
-  "g:Float": "Number",
+  "g:Date": "Date" as const,
+  "g:Int32": "Number" as const,
+  "g:Int64": "Number" as const,
+  "g:Double": "Number" as const,
+  "g:Float": "Number" as const,
+  "g:T": "String" as const,
 };
 
 const fetchVerticesAttributes = async (

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -216,16 +216,16 @@ describe("mapResults", () => {
     );
   });
 
-  it("should handle g:Map with non-string keys (no names)", () => {
+  it("should handle g:Map with non-string keys", () => {
     const results = mapResults({
       "@type": "g:Map",
-      "@value": [createGInt32(1), "value1", createGInt32(2), "value2"],
+      "@value": [createGInt32(1), "value1", createGType("ID"), "value2"],
     });
     expect(results).toEqual(
       toMappedQueryResults({
         scalars: [
-          createScalar({ value: "value1" }), // No name since key is not a string
-          createScalar({ value: "value2" }), // No name since key is not a string
+          createScalar({ value: "value1", name: "1" }),
+          createScalar({ value: "value2", name: "ID" }),
         ],
       })
     );

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.test.ts
@@ -187,7 +187,7 @@ describe("mapResults", () => {
     const results = mapResults(createGList([null]));
     expect(results).toEqual(
       toMappedQueryResults({
-        scalars: [createScalar(null)],
+        scalars: [createScalar({ value: null })],
       })
     );
   });
@@ -204,10 +204,13 @@ describe("mapResults", () => {
     expect(results).toEqual(
       toMappedQueryResults({
         scalars: [
-          createScalar(42, "count"),
-          createScalar("John", "name"),
-          createScalar(true, "active"),
-          createScalar(new Date("2020-01-01T00:00:00.000Z"), "time"),
+          createScalar({ value: 42, name: "count" }),
+          createScalar({ value: "John", name: "name" }),
+          createScalar({ value: true, name: "active" }),
+          createScalar({
+            value: new Date("2020-01-01T00:00:00.000Z"),
+            name: "time",
+          }),
         ],
       })
     );
@@ -221,8 +224,8 @@ describe("mapResults", () => {
     expect(results).toEqual(
       toMappedQueryResults({
         scalars: [
-          createScalar("value1"), // No name since key is not a string
-          createScalar("value2"), // No name since key is not a string
+          createScalar({ value: "value1" }), // No name since key is not a string
+          createScalar({ value: "value2" }), // No name since key is not a string
         ],
       })
     );
@@ -240,8 +243,8 @@ describe("mapResults", () => {
     expect(results).toEqual(
       toMappedQueryResults({
         scalars: [
-          createScalar(100, "total"),
-          createScalar("success", "message"),
+          createScalar({ value: 100, name: "total" }),
+          createScalar({ value: "success", name: "message" }),
         ],
       })
     );
@@ -254,7 +257,10 @@ describe("mapResults", () => {
     });
     expect(results).toEqual(
       toMappedQueryResults({
-        scalars: [createScalar(null, "data"), createScalar(5, "count")],
+        scalars: [
+          createScalar({ value: null, name: "data" }),
+          createScalar({ value: 5, name: "count" }),
+        ],
       })
     );
   });
@@ -266,7 +272,10 @@ describe("mapResults", () => {
     });
     expect(results).toEqual(
       toMappedQueryResults({
-        scalars: [createScalar("1", "id"), createScalar("Foo::Bar", "label")],
+        scalars: [
+          createScalar({ value: "1", name: "id" }),
+          createScalar({ value: "Foo::Bar", name: "label" }),
+        ],
       })
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -1,8 +1,8 @@
 import { GAnyValue } from "../types";
 import mapApiEdge from "./mapApiEdge";
 import mapApiVertex from "./mapApiVertex";
-import { MapValueResult, mapValuesToQueryResults } from "@/connector/mapping";
-import { createScalar } from "@/core";
+import { mapValuesToQueryResults } from "@/connector/mapping";
+import { createScalar, Entity } from "@/core";
 
 export function mapResults(data: GAnyValue) {
   const values = mapAnyValue(data);
@@ -10,26 +10,48 @@ export function mapResults(data: GAnyValue) {
   return mapValuesToQueryResults(values);
 }
 
-function mapAnyValue(data: GAnyValue): MapValueResult[] {
+function mapAnyValue(data: GAnyValue, name?: string): Entity[] {
   if (typeof data === "string" || typeof data === "boolean" || data === null) {
-    return [createScalar(data)];
+    return [createScalar(data, name)];
   } else if (
     data["@type"] === "g:Int32" ||
     data["@type"] === "g:Int64" ||
-    data["@type"] === "g:Double"
+    data["@type"] === "g:Double" ||
+    data["@type"] === "g:T"
   ) {
-    return [createScalar(data["@value"])];
+    return [createScalar(data["@value"], name)];
+  } else if (data["@type"] === "g:Date") {
+    return [createScalar(new Date(data["@value"]), name)];
   } else if (data["@type"] === "g:Edge") {
     return [mapApiEdge(data)];
   } else if (data["@type"] === "g:Vertex") {
     return [mapApiVertex(data)];
   } else if (data["@type"] === "g:Path") {
     return mapAnyValue(data["@value"].objects);
-  } else if (
-    data["@type"] === "g:List" ||
-    data["@type"] === "g:Map" ||
-    data["@type"] === "g:Set"
-  ) {
+  } else if (data["@type"] === "g:Map") {
+    // Handle Maps specially to extract key-value pairs for scalar naming
+    const results: Entity[] = [];
+    for (let i = 0; i < data["@value"].length; i += 2) {
+      const key = data["@value"][i];
+      const value = data["@value"][i + 1];
+
+      if (key !== undefined && value !== undefined) {
+        // Use the key as the name if it can be parsed to a string
+        const scalarName = (() => {
+          // Try mapping and see if it comes out as a scalar
+          const mapped = mapAnyValue(key);
+          const firstScalar = mapped.filter(m => m.entityType === "scalar")[0];
+          // Only use string scalar values as name
+          return firstScalar && firstScalar.type === "string"
+            ? firstScalar.value
+            : undefined;
+        })();
+
+        results.push(...mapAnyValue(value, scalarName));
+      }
+    }
+    return results;
+  } else if (data["@type"] === "g:List" || data["@type"] === "g:Set") {
     return data["@value"].flatMap((item: GAnyValue) => mapAnyValue(item));
   }
 

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -12,16 +12,16 @@ export function mapResults(data: GAnyValue) {
 
 function mapAnyValue(data: GAnyValue, name?: string): Entity[] {
   if (typeof data === "string" || typeof data === "boolean" || data === null) {
-    return [createScalar(data, name)];
+    return [createScalar({ value: data, name })];
   } else if (
     data["@type"] === "g:Int32" ||
     data["@type"] === "g:Int64" ||
     data["@type"] === "g:Double" ||
     data["@type"] === "g:T"
   ) {
-    return [createScalar(data["@value"], name)];
+    return [createScalar({ value: data["@value"], name })];
   } else if (data["@type"] === "g:Date") {
-    return [createScalar(new Date(data["@value"]), name)];
+    return [createScalar({ value: new Date(data["@value"]), name })];
   } else if (data["@type"] === "g:Edge") {
     return [mapApiEdge(data)];
   } else if (data["@type"] === "g:Vertex") {

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -2,7 +2,7 @@ import { GAnyValue } from "../types";
 import mapApiEdge from "./mapApiEdge";
 import mapApiVertex from "./mapApiVertex";
 import { mapValuesToQueryResults } from "@/connector/mapping";
-import { createScalar, Entity } from "@/core";
+import { createScalar, Entity, getDisplayValueForScalar } from "@/core";
 
 export function mapResults(data: GAnyValue) {
   const values = mapAnyValue(data);
@@ -41,10 +41,11 @@ function mapAnyValue(data: GAnyValue, name?: string): Entity[] {
           // Try mapping and see if it comes out as a scalar
           const mapped = mapAnyValue(key);
           const firstScalar = mapped.filter(m => m.entityType === "scalar")[0];
-          // Only use string scalar values as name
-          return firstScalar && firstScalar.type === "string"
-            ? firstScalar.value
+          const displayValue = firstScalar
+            ? getDisplayValueForScalar(firstScalar)
             : undefined;
+          // Only use string scalar values as name
+          return displayValue;
         })();
 
         results.push(...mapAnyValue(value, scalarName));

--- a/packages/graph-explorer/src/connector/gremlin/types.ts
+++ b/packages/graph-explorer/src/connector/gremlin/types.ts
@@ -18,7 +18,14 @@ export type GDate = {
   "@value": number;
 };
 
-export type GScalar = GInt32 | GInt64 | GDouble | GDate | string | boolean;
+export type GScalar =
+  | GInt32
+  | GInt64
+  | GDouble
+  | GType
+  | GDate
+  | string
+  | boolean;
 
 export type JanusID = {
   "@type": "janusgraph:RelationIdentifier";
@@ -110,6 +117,11 @@ export type GEntityList = {
   "@value": Array<GVertex | GEdge>;
 };
 
+export type GType = {
+  "@type": "g:T";
+  "@value": string;
+};
+
 export type GAnyValue =
   | GList
   | GMap
@@ -118,6 +130,7 @@ export type GAnyValue =
   | GVertex
   | GEdge
   | GScalar
+  | GType
   | null;
 
 export type GremlinFetch = <TResult = any>(

--- a/packages/graph-explorer/src/connector/mapping.ts
+++ b/packages/graph-explorer/src/connector/mapping.ts
@@ -1,16 +1,7 @@
-import {
-  createVertex,
-  Edge,
-  Scalar,
-  toEdgeMap,
-  toNodeMap,
-  Vertex,
-} from "@/core";
+import { createVertex, Entity, toEdgeMap, toNodeMap } from "@/core";
 import { toMappedQueryResults } from "./useGEFetchTypes";
 
-export type MapValueResult = Vertex | Edge | Scalar;
-
-export function mapValuesToQueryResults(values: MapValueResult[]) {
+export function mapValuesToQueryResults(values: Entity[]) {
   // Use maps to deduplicate vertices and edges
   const vertexMap = toNodeMap(values.filter(v => v.entityType === "vertex"));
 

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
@@ -13,7 +13,6 @@ describe("mapResults", () => {
     expect(result.vertices).toHaveLength(0);
     expect(result.edges).toHaveLength(0);
     expect(result.scalars).toHaveLength(0);
-    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map vertex value", () => {
@@ -30,7 +29,6 @@ describe("mapResults", () => {
     expect(result.vertices[0]).toEqual(vertex);
     expect(result.edges).toHaveLength(0);
     expect(result.scalars).toHaveLength(0);
-    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map edge value", () => {
@@ -53,7 +51,6 @@ describe("mapResults", () => {
     } satisfies Edge);
     expect(result.vertices).toHaveLength(2);
     expect(result.scalars).toHaveLength(0);
-    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map scalar value", () => {
@@ -71,13 +68,20 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(4);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "total"));
-    expect(result.scalars[1]).toEqual(createScalar("total", "name"));
-    expect(result.scalars[2]).toEqual(createScalar(expectedValue, "list")); // Array values don't get names
-    expect(result.scalars[3]).toEqual(createScalar(null, "nullValue"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: expectedValue, name: "total" })
+    );
+    expect(result.scalars[1]).toEqual(
+      createScalar({ value: "total", name: "name" })
+    );
+    expect(result.scalars[2]).toEqual(
+      createScalar({ value: expectedValue, name: "list" })
+    ); // Array values don't get names
+    expect(result.scalars[3]).toEqual(
+      createScalar({ value: null, name: "nullValue" })
+    );
     expect(result.vertices).toHaveLength(0);
     expect(result.edges).toHaveLength(0);
-    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map vertex in array", () => {
@@ -94,7 +98,6 @@ describe("mapResults", () => {
     expect(result.vertices[0]).toEqual(vertex);
     expect(result.edges).toHaveLength(0);
     expect(result.scalars).toHaveLength(0);
-    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map edge in array", () => {
@@ -129,7 +132,9 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "n"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: expectedValue, name: "n" })
+    );
   });
 
   it("should map nested objects", () => {
@@ -260,7 +265,9 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "collect"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: expectedValue, name: "collect" })
+    );
   });
 
   it("should map collect with array of records", () => {
@@ -275,7 +282,9 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "values"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: expectedValue, name: "values" })
+    );
   });
 
   it("should preserve scalar names from top-level keys", () => {
@@ -291,10 +300,18 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(4);
-    expect(result.scalars[0]).toEqual(createScalar(42, "count"));
-    expect(result.scalars[1]).toEqual(createScalar("hello", "message"));
-    expect(result.scalars[2]).toEqual(createScalar(true, "isActive"));
-    expect(result.scalars[3]).toEqual(createScalar(null, "data"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: 42, name: "count" })
+    );
+    expect(result.scalars[1]).toEqual(
+      createScalar({ value: "hello", name: "message" })
+    );
+    expect(result.scalars[2]).toEqual(
+      createScalar({ value: true, name: "isActive" })
+    );
+    expect(result.scalars[3]).toEqual(
+      createScalar({ value: null, name: "data" })
+    );
   });
 
   it("should preserve names for scalars in nested objects", () => {
@@ -311,8 +328,10 @@ describe("mapResults", () => {
 
     expect(result.scalars).toHaveLength(2);
     // Scalars from nested objects don't get names since they're flattened
-    expect(result.scalars[0]).toEqual(createScalar("John", "name"));
-    expect(result.scalars[1]).toEqual(createScalar(30, "age"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: "John", name: "name" })
+    );
+    expect(result.scalars[1]).toEqual(createScalar({ value: 30, name: "age" }));
   });
 
   it("should preserve names for scalars in arrays", () => {
@@ -327,11 +346,21 @@ describe("mapResults", () => {
 
     expect(result.scalars).toHaveLength(5);
     // Array elements don't get names
-    expect(result.scalars[0]).toEqual(createScalar(1, "numbers"));
-    expect(result.scalars[1]).toEqual(createScalar(2, "numbers"));
-    expect(result.scalars[2]).toEqual(createScalar(3, "numbers"));
-    expect(result.scalars[3]).toEqual(createScalar("a", "strings"));
-    expect(result.scalars[4]).toEqual(createScalar("b", "strings"));
+    expect(result.scalars[0]).toEqual(
+      createScalar({ value: 1, name: "numbers" })
+    );
+    expect(result.scalars[1]).toEqual(
+      createScalar({ value: 2, name: "numbers" })
+    );
+    expect(result.scalars[2]).toEqual(
+      createScalar({ value: 3, name: "numbers" })
+    );
+    expect(result.scalars[3]).toEqual(
+      createScalar({ value: "a", name: "strings" })
+    );
+    expect(result.scalars[4]).toEqual(
+      createScalar({ value: "b", name: "strings" })
+    );
   });
 });
 

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
@@ -76,7 +76,7 @@ describe("mapResults", () => {
     );
     expect(result.scalars[2]).toEqual(
       createScalar({ value: expectedValue, name: "list" })
-    ); // Array values don't get names
+    );
     expect(result.scalars[3]).toEqual(
       createScalar({ value: null, name: "nullValue" })
     );
@@ -327,7 +327,6 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(2);
-    // Scalars from nested objects don't get names since they're flattened
     expect(result.scalars[0]).toEqual(
       createScalar({ value: "John", name: "name" })
     );

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
@@ -344,7 +344,6 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(5);
-    // Array elements don't get names
     expect(result.scalars[0]).toEqual(
       createScalar({ value: 1, name: "numbers" })
     );

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.test.ts
@@ -12,6 +12,8 @@ describe("mapResults", () => {
 
     expect(result.vertices).toHaveLength(0);
     expect(result.edges).toHaveLength(0);
+    expect(result.scalars).toHaveLength(0);
+    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map vertex value", () => {
@@ -26,6 +28,9 @@ describe("mapResults", () => {
 
     expect(result.vertices).toHaveLength(1);
     expect(result.vertices[0]).toEqual(vertex);
+    expect(result.edges).toHaveLength(0);
+    expect(result.scalars).toHaveLength(0);
+    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map edge value", () => {
@@ -47,6 +52,8 @@ describe("mapResults", () => {
       targetTypes: [],
     } satisfies Edge);
     expect(result.vertices).toHaveLength(2);
+    expect(result.scalars).toHaveLength(0);
+    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map scalar value", () => {
@@ -64,10 +71,13 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(4);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue));
-    expect(result.scalars[1]).toEqual(createScalar("total"));
-    expect(result.scalars[2]).toEqual(createScalar(expectedValue));
-    expect(result.scalars[3]).toEqual(createScalar(null));
+    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "total"));
+    expect(result.scalars[1]).toEqual(createScalar("total", "name"));
+    expect(result.scalars[2]).toEqual(createScalar(expectedValue, "list")); // Array values don't get names
+    expect(result.scalars[3]).toEqual(createScalar(null, "nullValue"));
+    expect(result.vertices).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map vertex in array", () => {
@@ -82,6 +92,9 @@ describe("mapResults", () => {
 
     expect(result.vertices).toHaveLength(1);
     expect(result.vertices[0]).toEqual(vertex);
+    expect(result.edges).toHaveLength(0);
+    expect(result.scalars).toHaveLength(0);
+    expect(result.bundles).toHaveLength(0);
   });
 
   it("should map edge in array", () => {
@@ -116,7 +129,7 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue));
+    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "n"));
   });
 
   it("should map nested objects", () => {
@@ -247,7 +260,7 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue));
+    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "collect"));
   });
 
   it("should map collect with array of records", () => {
@@ -262,7 +275,63 @@ describe("mapResults", () => {
     });
 
     expect(result.scalars).toHaveLength(1);
-    expect(result.scalars[0]).toEqual(createScalar(expectedValue));
+    expect(result.scalars[0]).toEqual(createScalar(expectedValue, "values"));
+  });
+
+  it("should preserve scalar names from top-level keys", () => {
+    const result = mapResults({
+      results: [
+        {
+          count: 42,
+          message: "hello",
+          isActive: true,
+          data: null,
+        },
+      ],
+    });
+
+    expect(result.scalars).toHaveLength(4);
+    expect(result.scalars[0]).toEqual(createScalar(42, "count"));
+    expect(result.scalars[1]).toEqual(createScalar("hello", "message"));
+    expect(result.scalars[2]).toEqual(createScalar(true, "isActive"));
+    expect(result.scalars[3]).toEqual(createScalar(null, "data"));
+  });
+
+  it("should preserve names for scalars in nested objects", () => {
+    const result = mapResults({
+      results: [
+        {
+          user: {
+            name: "John",
+            age: 30,
+          },
+        },
+      ],
+    });
+
+    expect(result.scalars).toHaveLength(2);
+    // Scalars from nested objects don't get names since they're flattened
+    expect(result.scalars[0]).toEqual(createScalar("John", "name"));
+    expect(result.scalars[1]).toEqual(createScalar(30, "age"));
+  });
+
+  it("should preserve names for scalars in arrays", () => {
+    const result = mapResults({
+      results: [
+        {
+          numbers: [1, 2, 3],
+          strings: ["a", "b"],
+        },
+      ],
+    });
+
+    expect(result.scalars).toHaveLength(5);
+    // Array elements don't get names
+    expect(result.scalars[0]).toEqual(createScalar(1, "numbers"));
+    expect(result.scalars[1]).toEqual(createScalar(2, "numbers"));
+    expect(result.scalars[2]).toEqual(createScalar(3, "numbers"));
+    expect(result.scalars[3]).toEqual(createScalar("a", "strings"));
+    expect(result.scalars[4]).toEqual(createScalar("b", "strings"));
   });
 });
 

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
@@ -90,7 +90,7 @@ function mapValue(value: CypherValue, name?: string): Entity[] {
     typeof value === "string" ||
     typeof value === "boolean"
   ) {
-    return [createScalar(value, name)];
+    return [createScalar({ value, name })];
   }
 
   if (Array.isArray(value)) {

--- a/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/openCypher/mappers/mapResults.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import { fromError } from "zod-validation-error";
 import mapApiVertex from "./mapApiVertex";
 import mapApiEdge from "./mapApiEdge";
-import { MapValueResult, mapValuesToQueryResults } from "@/connector/mapping";
+import { mapValuesToQueryResults } from "@/connector/mapping";
 import { OCEdge, OCVertex } from "../types";
-import { createScalar } from "@/core";
+import { createScalar, Entity } from "@/core";
 
 const cypherScalarValueSchema = z.union([
   z.number(),
@@ -71,27 +71,30 @@ export function parseResults(data: unknown) {
  */
 export function mapResults(data: unknown) {
   const results = parseResults(data);
-  const values = results.flatMap(mapValue);
+  const values = results.flatMap(result =>
+    Object.entries(result).flatMap(([key, value]) => mapValue(value, key))
+  );
   return mapValuesToQueryResults(values);
 }
 
 /**
  * Recursively maps a value from the OpenCypher query to the expected format
  * @param value The value to map
+ * @param name The name/key for the value (used for scalar naming)
  * @returns The mapped value
  */
-function mapValue(value: CypherValue): MapValueResult[] {
+function mapValue(value: CypherValue, name?: string): Entity[] {
   if (
     value === null ||
     typeof value === "number" ||
     typeof value === "string" ||
     typeof value === "boolean"
   ) {
-    return [createScalar(value)];
+    return [createScalar(value, name)];
   }
 
   if (Array.isArray(value)) {
-    return value.flatMap(mapValue);
+    return value.flatMap(v => mapValue(v, name));
   }
 
   // Map record types
@@ -105,7 +108,9 @@ function mapValue(value: CypherValue): MapValueResult[] {
       edge.__isFragment = true;
       return [edge];
     }
-    return Object.values(value).flatMap(mapValue);
+    return Object.entries(value).flatMap(([key, value]) =>
+      mapValue(value, key)
+    );
   }
 
   // Unsupported type

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -7,7 +7,6 @@ import {
   Vertex,
   VertexId,
   NormalizedConnection,
-  EntityPropertyValue,
   Scalar,
 } from "@/core";
 
@@ -71,8 +70,6 @@ export type Criterion = {
    */
   dataType?: "String" | "Number" | "Date";
 };
-
-export type ScalarValue = EntityPropertyValue | Date;
 
 /**
  * Results from any query.

--- a/packages/graph-explorer/src/core/entities/entities.ts
+++ b/packages/graph-explorer/src/core/entities/entities.ts
@@ -1,5 +1,8 @@
 import { Vertex, VertexId } from "./vertex";
 import { Edge, EdgeId } from "./edge";
+import { Scalar } from "./scalar";
+
+export type Entity = Vertex | Edge | Scalar;
 
 export type Entities = {
   nodes: Map<VertexId, Vertex>;

--- a/packages/graph-explorer/src/core/entities/scalar.test.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.test.ts
@@ -121,11 +121,11 @@ describe("scalar", () => {
     });
 
     it("should return number for integer scalar", () => {
-      const scalar = createScalar({ value: 123 });
+      const scalar = createScalar({ value: 123456 });
 
       const result = getDisplayValueForScalar(scalar);
 
-      expect(result).toBe("123");
+      expect(result).toBe("123,456");
     });
 
     it("should return number for double scalar", () => {

--- a/packages/graph-explorer/src/core/entities/scalar.test.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.test.ts
@@ -3,12 +3,13 @@ import {
   createRandomDouble,
   createRandomInteger,
 } from "@shared/utils/testing";
-import { createScalar, Scalar } from "./scalar";
+import { createScalar, getDisplayValueForScalar, Scalar } from "./scalar";
+import { MISSING_DISPLAY_VALUE } from "@/utils";
 
 describe("scalar", () => {
   describe("createScalar", () => {
     it("should create a null scalar", () => {
-      const result = createScalar(null);
+      const result = createScalar({ value: null });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -18,7 +19,7 @@ describe("scalar", () => {
     });
 
     it("should create a string scalar", () => {
-      const result = createScalar("hello world");
+      const result = createScalar({ value: "hello world" });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -28,7 +29,7 @@ describe("scalar", () => {
     });
 
     it("should create a string scalar from empty string", () => {
-      const result = createScalar("");
+      const result = createScalar({ value: "" });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -39,7 +40,7 @@ describe("scalar", () => {
 
     it("should create a number scalar from integer", () => {
       const value = createRandomInteger();
-      const result = createScalar(value);
+      const result = createScalar({ value });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -50,7 +51,7 @@ describe("scalar", () => {
 
     it("should create a number scalar from double", () => {
       const value = createRandomDouble();
-      const result = createScalar(value);
+      const result = createScalar({ value });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -60,7 +61,7 @@ describe("scalar", () => {
     });
 
     it("should create a number scalar from zero", () => {
-      const result = createScalar(0);
+      const result = createScalar({ value: 0 });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -70,7 +71,7 @@ describe("scalar", () => {
     });
 
     it("should create a number scalar from negative number", () => {
-      const result = createScalar(-100);
+      const result = createScalar({ value: -100 });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -81,7 +82,7 @@ describe("scalar", () => {
 
     it("should create a boolean scalar", () => {
       const value = createRandomBoolean();
-      const result = createScalar(value);
+      const result = createScalar({ value });
 
       expect(result).toEqual({
         entityType: "scalar",
@@ -92,13 +93,64 @@ describe("scalar", () => {
 
     it("should create a date scalar", () => {
       const date = new Date("2023-12-25T10:30:00Z");
-      const result = createScalar(date);
+      const result = createScalar({ value: date });
 
       expect(result).toEqual({
         entityType: "scalar",
         type: "date",
         value: date,
       } satisfies Scalar);
+    });
+  });
+
+  describe("getDisplayValueForScalar", () => {
+    it("should return null for null scalar", () => {
+      const scalar = createScalar({ value: null });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe(MISSING_DISPLAY_VALUE);
+    });
+
+    it("should return string for string scalar", () => {
+      const scalar = createScalar({ value: "hello world" });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe("hello world");
+    });
+
+    it("should return number for integer scalar", () => {
+      const scalar = createScalar({ value: 123 });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe("123");
+    });
+
+    it("should return number for double scalar", () => {
+      const scalar = createScalar({ value: 123.45 });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe("123.45");
+    });
+
+    it("should return boolean for boolean scalar", () => {
+      const scalar = createScalar({ value: true });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe("true");
+    });
+
+    it("should return date for date scalar", () => {
+      const date = new Date("2023-12-25T10:30:00Z");
+      const scalar = createScalar({ value: date });
+
+      const result = getDisplayValueForScalar(scalar);
+
+      expect(result).toBe("Dec 25 2023, 10:30 AM");
     });
   });
 });

--- a/packages/graph-explorer/src/core/entities/scalar.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.ts
@@ -9,12 +9,17 @@ type ScalarTypedValue =
 
 export type Scalar = {
   entityType: "scalar";
+  name?: string;
 } & ScalarTypedValue;
 
 /** Constructs a Scalar instance from the given values. */
-export function createScalar(value: EntityPropertyValue | Date | null): Scalar {
+export function createScalar(
+  value: EntityPropertyValue | Date | null,
+  name?: string
+): Scalar {
   return {
     entityType: "scalar" as const,
+    name,
     ...createTypedValue(value),
   };
 }

--- a/packages/graph-explorer/src/core/entities/scalar.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.ts
@@ -1,3 +1,4 @@
+import { formatDate, MISSING_DISPLAY_VALUE } from "@/utils";
 import { EntityPropertyValue } from "./shared";
 
 type ScalarTypedValue =
@@ -13,10 +14,13 @@ export type Scalar = {
 } & ScalarTypedValue;
 
 /** Constructs a Scalar instance from the given values. */
-export function createScalar(
-  value: EntityPropertyValue | Date | null,
-  name?: string
-): Scalar {
+export function createScalar({
+  value,
+  name,
+}: {
+  value: EntityPropertyValue | Date | null;
+  name?: string;
+}): Scalar {
   return {
     entityType: "scalar" as const,
     name,
@@ -39,5 +43,20 @@ function createTypedValue(
     return { type: "boolean" as const, value };
   } else {
     return { type: "string" as const, value: String(value) };
+  }
+}
+
+export function getDisplayValueForScalar(scalar: Scalar) {
+  switch (scalar.type) {
+    case "string":
+      return scalar.value;
+    case "number":
+      return new Intl.NumberFormat().format(scalar.value);
+    case "boolean":
+      return String(scalar.value);
+    case "date":
+      return formatDate(scalar.value);
+    case "null":
+      return MISSING_DISPLAY_VALUE;
   }
 }

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -20,7 +20,6 @@
     --color-gray-950: 10 10 10;
 
     --color-input-background: var(--color-white);
-    --color-input-hover: var(--color-white);
     --color-input-border: var(--color-gray-300);
 
     --color-text-primary: 33 33 33;
@@ -80,7 +79,6 @@
     --color-black: 15 15 15;
 
     --color-input-background: var(--color-gray-900);
-    --color-input-hover: var(--color-gray-800);
 
     --color-text-primary: var(--color-white);
     --color-text-secondary: 224 224 224;

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -19,8 +19,9 @@
     --color-gray-900: 23 23 23;
     --color-gray-950: 10 10 10;
 
-    --color-input-background: var(--color-gray-50);
-    --color-input-hover: var(--color-gray-100);
+    --color-input-background: var(--color-white);
+    --color-input-hover: var(--color-white);
+    --color-input-border: var(--color-gray-300);
 
     --color-text-primary: 33 33 33;
     --color-text-secondary: 115 115 115;

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -126,33 +126,3 @@
     grid-area: 1 / 1 / 2 / 2;
   }
 }
-
-@layer utilities {
-  .CollapsibleContent {
-    overflow: hidden;
-  }
-  .CollapsibleContent[data-state="open"] {
-    animation: collapsibleSlideDown 150ms ease-out;
-  }
-  .CollapsibleContent[data-state="closed"] {
-    animation: collapsibleSlideUp 150ms ease-out;
-  }
-
-  @keyframes collapsibleSlideDown {
-    from {
-      height: 0;
-    }
-    to {
-      height: var(--radix-collapsible-content-height);
-    }
-  }
-
-  @keyframes collapsibleSlideUp {
-    from {
-      height: var(--radix-collapsible-content-height);
-    }
-    to {
-      height: 0;
-    }
-  }
-}

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -127,3 +127,33 @@
     grid-area: 1 / 1 / 2 / 2;
   }
 }
+
+@layer utilities {
+  .CollapsibleContent {
+    overflow: hidden;
+  }
+  .CollapsibleContent[data-state="open"] {
+    animation: collapsibleSlideDown 150ms ease-out;
+  }
+  .CollapsibleContent[data-state="closed"] {
+    animation: collapsibleSlideUp 150ms ease-out;
+  }
+
+  @keyframes collapsibleSlideDown {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-collapsible-content-height);
+    }
+  }
+
+  @keyframes collapsibleSlideUp {
+    from {
+      height: var(--radix-collapsible-content-height);
+    }
+    to {
+      height: 0;
+    }
+  }
+}

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -45,7 +45,7 @@ export function EdgeSearchResult({
       <CollapsibleTrigger asChild>
         <div
           role="button"
-          className="group flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
+          className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
         >
           <SearchResultExpandChevron />
           <EdgeRow

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -1,9 +1,14 @@
 import { Edge, useDisplayEdgeFromEdge } from "@/core";
 import {
   ButtonProps,
+  CollapsibleContent,
+  CollapsibleTrigger,
   EdgeRow,
   IconButton,
-  SearchResult,
+  SearchResultAttribute,
+  SearchResultAttributeName,
+  SearchResultAttributeValue,
+  SearchResultCollapsible,
   SearchResultExpandChevron,
   Spinner,
   stopPropagation,
@@ -16,9 +21,14 @@ import {
 } from "@/hooks";
 import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
 import { useState } from "react";
-import EntityAttribute from "../EntityDetails/EntityAttribute";
 
-export function EdgeSearchResult({ edge }: { edge: Edge }) {
+export function EdgeSearchResult({
+  edge,
+  level = 0,
+}: {
+  edge: Edge;
+  level?: number;
+}) {
   const [expanded, setExpanded] = useState(false);
 
   const displayEdge = useDisplayEdgeFromEdge(edge);
@@ -34,32 +44,43 @@ export function EdgeSearchResult({ edge }: { edge: Edge }) {
   );
 
   return (
-    <SearchResult data-expanded={expanded}>
-      <div
-        onClick={() => setExpanded(e => !e)}
-        className="group-data-[expanded=true]:border-background-secondary group flex w-full flex-row items-center gap-2 p-3 text-left ring-0 hover:cursor-pointer"
-      >
-        <SearchResultExpandChevron />
-        <EdgeRow
-          edge={displayEdge}
-          source={source}
-          target={target}
-          className="grow"
-        />
-        <AddOrRemoveButton edge={edge} />
-      </div>
-      <div className="border-border pl-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
-        <ul className="divide-y divide-gray-200">
+    <SearchResultCollapsible
+      level={level}
+      open={expanded}
+      onOpenChange={setExpanded}
+    >
+      <CollapsibleTrigger asChild>
+        <div
+          role="button"
+          className="group flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
+        >
+          <SearchResultExpandChevron open={expanded} />
+          <EdgeRow
+            edge={displayEdge}
+            source={source}
+            target={target}
+            className="grow"
+          />
+          <AddOrRemoveButton edge={edge} />
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <ul className="space-y-3 p-3">
           {displayEdge.attributes.map(attr => (
-            <EntityAttribute
-              key={attr.name}
-              attribute={attr}
-              className="px-3 py-2"
-            />
+            <li key={attr.name} className="w-full">
+              <SearchResultAttribute>
+                <SearchResultAttributeName>
+                  {attr.name}
+                </SearchResultAttributeName>
+                <SearchResultAttributeValue>
+                  {attr.displayValue}
+                </SearchResultAttributeValue>
+              </SearchResultAttribute>
+            </li>
           ))}
         </ul>
-      </div>
-    </SearchResult>
+      </CollapsibleContent>
+    </SearchResultCollapsible>
   );
 }
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -20,7 +20,6 @@ import {
   useRemoveEdgeFromGraph,
 } from "@/hooks";
 import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
-import { useState } from "react";
 
 export function EdgeSearchResult({
   edge,
@@ -29,8 +28,6 @@ export function EdgeSearchResult({
   edge: Edge;
   level?: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
-
   const displayEdge = useDisplayEdgeFromEdge(edge);
 
   // Get the display vertices
@@ -44,17 +41,13 @@ export function EdgeSearchResult({
   );
 
   return (
-    <SearchResultCollapsible
-      level={level}
-      open={expanded}
-      onOpenChange={setExpanded}
-    >
+    <SearchResultCollapsible level={level}>
       <CollapsibleTrigger asChild>
         <div
           role="button"
           className="group flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
         >
-          <SearchResultExpandChevron open={expanded} />
+          <SearchResultExpandChevron />
           <EdgeRow
             edge={displayEdge}
             source={source}

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -3,6 +3,8 @@ import {
   ButtonProps,
   EdgeRow,
   IconButton,
+  SearchResult,
+  SearchResultExpandChevron,
   Spinner,
   stopPropagation,
 } from "@/components";
@@ -12,12 +14,7 @@ import {
   useHasEdgeBeenAddedToGraph,
   useRemoveEdgeFromGraph,
 } from "@/hooks";
-import { cn } from "@/utils";
-import {
-  ChevronRightIcon,
-  MinusCircleIcon,
-  PlusCircleIcon,
-} from "lucide-react";
+import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
 import { useState } from "react";
 import EntityAttribute from "../EntityDetails/EntityAttribute";
 
@@ -37,19 +34,12 @@ export function EdgeSearchResult({ edge }: { edge: Edge }) {
   );
 
   return (
-    <div
-      className={cn(
-        "bg-background-default group w-full overflow-hidden transition-all"
-      )}
-      data-expanded={expanded}
-    >
+    <SearchResult data-expanded={expanded}>
       <div
         onClick={() => setExpanded(e => !e)}
         className="group-data-[expanded=true]:border-background-secondary group flex w-full flex-row items-center gap-2 p-3 text-left ring-0 hover:cursor-pointer"
       >
-        <div>
-          <ChevronRightIcon className="text-primary-dark/50 size-5 transition-transform duration-200 ease-in-out group-data-[expanded=true]:rotate-90" />
-        </div>
+        <SearchResultExpandChevron />
         <EdgeRow
           edge={displayEdge}
           source={source}
@@ -69,7 +59,7 @@ export function EdgeSearchResult({ edge }: { edge: Edge }) {
           ))}
         </ul>
       </div>
-    </div>
+    </SearchResult>
   );
 }
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -53,6 +53,7 @@ export function ScalarSearchResult({
 }) {
   const displayValue = getDisplayValue(scalar);
   const Icon = getIcon(scalar);
+  const subtitle = scalar.name ?? "Scalar value";
 
   return (
     <div
@@ -72,7 +73,7 @@ export function ScalarSearchResult({
           <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
             <div className="font-bold">{displayValue}</div>
             <div className="text-text-secondary/90 line-clamp-2">
-              Scalar value
+              {subtitle}
             </div>
           </div>
         </div>

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -1,10 +1,10 @@
 import {
   SearchResult,
   SearchResultSubtitle,
+  SearchResultSymbol,
   SearchResultTitle,
 } from "@/components";
 import { getDisplayValueForScalar, Scalar } from "@/core";
-import { cn } from "@/utils";
 import {
   BanIcon,
   CalendarIcon,
@@ -13,7 +13,6 @@ import {
   HashIcon,
   QuoteIcon,
 } from "lucide-react";
-import { ComponentPropsWithoutRef } from "react";
 
 function getIcon(scalar: Scalar) {
   switch (scalar.type) {
@@ -34,19 +33,16 @@ function getIcon(scalar: Scalar) {
   }
 }
 
-export function ScalarSearchResult({
-  scalar,
-}: {
-  scalar: Scalar;
-  resultsHaveExpandableRows: boolean;
-}) {
+export function ScalarSearchResult({ scalar }: { scalar: Scalar }) {
   const Icon = getIcon(scalar);
   const title = scalar.name ?? "Scalar value";
   const subtitle = getDisplayValueForScalar(scalar);
 
   return (
     <SearchResult className="flex w-full flex-row items-center gap-2 p-3">
-      <ScalarSymbol>{Icon}</ScalarSymbol>
+      <SearchResultSymbol className="text-primary-main bg-primary-main/20 rounded-lg">
+        {Icon}
+      </SearchResultSymbol>
       <div>
         <SearchResultTitle>{title}</SearchResultTitle>
         <SearchResultSubtitle className="line-clamp-none">
@@ -54,19 +50,5 @@ export function ScalarSearchResult({
         </SearchResultSubtitle>
       </div>
     </SearchResult>
-  );
-}
-export function ScalarSymbol({
-  className,
-  ...props
-}: ComponentPropsWithoutRef<"div">) {
-  return (
-    <div
-      className={cn(
-        "text-primary-main bg-primary-main/20 grid size-[36px] shrink-0 place-content-center rounded-lg p-2 text-[2em]",
-        className
-      )}
-      {...props}
-    />
   );
 }

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -3,8 +3,8 @@ import {
   SearchResultSubtitle,
   SearchResultTitle,
 } from "@/components";
-import { Scalar } from "@/core";
-import { cn, MISSING_DISPLAY_VALUE } from "@/utils";
+import { getDisplayValueForScalar, Scalar } from "@/core";
+import { cn } from "@/utils";
 import {
   BanIcon,
   CalendarIcon,
@@ -14,21 +14,6 @@ import {
   QuoteIcon,
 } from "lucide-react";
 import { ComponentPropsWithoutRef } from "react";
-
-function getDisplayValue(scalar: Scalar) {
-  switch (scalar.type) {
-    case "string":
-      return scalar.value;
-    case "number":
-      return new Intl.NumberFormat().format(scalar.value);
-    case "boolean":
-      return String(scalar.value);
-    case "date":
-      return new Intl.DateTimeFormat().format(scalar.value);
-    case "null":
-      return MISSING_DISPLAY_VALUE;
-  }
-}
 
 function getIcon(scalar: Scalar) {
   switch (scalar.type) {
@@ -51,31 +36,22 @@ function getIcon(scalar: Scalar) {
 
 export function ScalarSearchResult({
   scalar,
-  resultsHaveExpandableRows,
 }: {
   scalar: Scalar;
   resultsHaveExpandableRows: boolean;
 }) {
-  const displayValue = getDisplayValue(scalar);
   const Icon = getIcon(scalar);
-  const subtitle = scalar.name ?? "Scalar value";
+  const title = scalar.name ?? "Scalar value";
+  const subtitle = getDisplayValueForScalar(scalar);
 
   return (
-    <SearchResult>
-      <div className="flex w-full flex-row items-center gap-2 p-3 text-left ring-0">
-        <div className="flex grow flex-row items-center gap-2">
-          <div
-            className={cn(resultsHaveExpandableRows ? "invisible" : "hidden")}
-          >
-            {/* Just here to align with node & edge results. This is never visible. */}
-            <div className="size-5" />
-          </div>
-          <ScalarSymbol>{Icon}</ScalarSymbol>
-          <div>
-            <SearchResultTitle>{displayValue}</SearchResultTitle>
-            <SearchResultSubtitle>{subtitle}</SearchResultSubtitle>
-          </div>
-        </div>
+    <SearchResult className="flex w-full flex-row items-center gap-2 p-3">
+      <ScalarSymbol>{Icon}</ScalarSymbol>
+      <div>
+        <SearchResultTitle>{title}</SearchResultTitle>
+        <SearchResultSubtitle className="line-clamp-none">
+          {subtitle}
+        </SearchResultSubtitle>
       </div>
     </SearchResult>
   );

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -1,3 +1,8 @@
+import {
+  SearchResult,
+  SearchResultSubtitle,
+  SearchResultTitle,
+} from "@/components";
 import { Scalar } from "@/core";
 import { cn, MISSING_DISPLAY_VALUE } from "@/utils";
 import {
@@ -56,11 +61,7 @@ export function ScalarSearchResult({
   const subtitle = scalar.name ?? "Scalar value";
 
   return (
-    <div
-      className={cn(
-        "bg-background-default w-full overflow-hidden transition-all"
-      )}
-    >
+    <SearchResult>
       <div className="flex w-full flex-row items-center gap-2 p-3 text-left ring-0">
         <div className="flex grow flex-row items-center gap-2">
           <div
@@ -70,15 +71,13 @@ export function ScalarSearchResult({
             <div className="size-5" />
           </div>
           <ScalarSymbol>{Icon}</ScalarSymbol>
-          <div className="inline-block text-pretty text-base leading-snug [word-break:break-word]">
-            <div className="font-bold">{displayValue}</div>
-            <div className="text-text-secondary/90 line-clamp-2">
-              {subtitle}
-            </div>
+          <div>
+            <SearchResultTitle>{displayValue}</SearchResultTitle>
+            <SearchResultSubtitle>{subtitle}</SearchResultSubtitle>
           </div>
         </div>
       </div>
-    </div>
+    </SearchResult>
   );
 }
 export function ScalarSymbol({

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -39,8 +39,8 @@ export function SearchResultsList(results: MappedQueryResults) {
 
   return (
     <>
-      <div className="bg-background-contrast/35 flex grow flex-col p-3">
-        <ul className="border-divider divide-border flex flex-col divide-y overflow-hidden rounded-xl border shadow">
+      <div className="grow p-3">
+        <ul className="flex flex-col space-y-4 overflow-hidden">
           {currentPageRows.map(row => (
             <li key={row.key} className="content-auto intrinsic-size-16">
               {row.render()}

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -40,11 +40,9 @@ export function SearchResultsList(results: MappedQueryResults) {
   return (
     <>
       <div className="grow p-3">
-        <ul className="flex flex-col space-y-4 overflow-hidden">
+        <ul className="flex flex-col space-y-4">
           {currentPageRows.map(row => (
-            <li key={row.key} className="content-auto intrinsic-size-16">
-              {row.render()}
-            </li>
+            <li key={row.key}>{row.render()}</li>
           ))}
         </ul>
       </div>

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -105,10 +105,6 @@ function ResultCounts({ results }: { results: MappedQueryResults }) {
 
 /** Create a list of functions that render a row for each result type */
 function createRows({ vertices, edges, scalars }: MappedQueryResults) {
-  // When true, the scalar value will render with extra space on the left to
-  // align with the node and edge results properly
-  const resultsHaveExpandableRows = vertices.length + edges.length > 0;
-
   return vertices
     .map(entity => ({
       key: `node:${entity.type}:${entity.id}`,
@@ -123,12 +119,7 @@ function createRows({ vertices, edges, scalars }: MappedQueryResults) {
     .concat(
       scalars.map((entity, index) => ({
         key: `scalar:${String(entity.value)}:${index}`,
-        render: () => (
-          <ScalarSearchResult
-            scalar={entity}
-            resultsHaveExpandableRows={resultsHaveExpandableRows}
-          />
-        ),
+        render: () => <ScalarSearchResult scalar={entity} />,
       }))
     );
 }

--- a/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
@@ -2,6 +2,8 @@ import { useDisplayVertexFromVertex, Vertex } from "@/core";
 import {
   ButtonProps,
   IconButton,
+  SearchResult,
+  SearchResultExpandChevron,
   Spinner,
   stopPropagation,
   VertexRow,
@@ -11,11 +13,7 @@ import {
   useHasVertexBeenAddedToGraph,
   useRemoveNodeFromGraph,
 } from "@/hooks";
-import {
-  ChevronRightIcon,
-  MinusCircleIcon,
-  PlusCircleIcon,
-} from "lucide-react";
+import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
 import { useState } from "react";
 import EntityAttribute from "../EntityDetails/EntityAttribute";
 
@@ -25,17 +23,12 @@ export function VertexSearchResult({ vertex }: { vertex: Vertex }) {
   const displayNode = useDisplayVertexFromVertex(vertex);
 
   return (
-    <div
-      className="bg-background-default group w-full overflow-hidden transition-all"
-      data-expanded={expanded}
-    >
+    <SearchResult data-expanded={expanded}>
       <div
         onClick={() => setExpanded(e => !e)}
         className="group-data-[expanded=true]:border-background-secondary group flex w-full flex-row items-center gap-2 p-3 text-left ring-0 hover:cursor-pointer"
       >
-        <div>
-          <ChevronRightIcon className="text-primary-dark/50 size-5 transition-transform duration-200 ease-in-out group-data-[expanded=true]:rotate-90" />
-        </div>
+        <SearchResultExpandChevron />
         <VertexRow vertex={displayNode} className="grow" />
         <AddOrRemoveButton vertex={vertex} />
       </div>
@@ -50,7 +43,7 @@ export function VertexSearchResult({ vertex }: { vertex: Vertex }) {
           ))}
         </ul>
       </div>
-    </div>
+    </SearchResult>
   );
 }
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
@@ -1,8 +1,13 @@
 import { useDisplayVertexFromVertex, Vertex } from "@/core";
 import {
   ButtonProps,
+  CollapsibleContent,
+  CollapsibleTrigger,
   IconButton,
-  SearchResult,
+  SearchResultAttribute,
+  SearchResultAttributeName,
+  SearchResultAttributeValue,
+  SearchResultCollapsible,
   SearchResultExpandChevron,
   Spinner,
   stopPropagation,
@@ -15,35 +20,50 @@ import {
 } from "@/hooks";
 import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
 import { useState } from "react";
-import EntityAttribute from "../EntityDetails/EntityAttribute";
 
-export function VertexSearchResult({ vertex }: { vertex: Vertex }) {
+export function VertexSearchResult({
+  vertex,
+  level = 0,
+}: {
+  vertex: Vertex;
+  level?: number;
+}) {
   const [expanded, setExpanded] = useState(false);
-
   const displayNode = useDisplayVertexFromVertex(vertex);
 
   return (
-    <SearchResult data-expanded={expanded}>
-      <div
-        onClick={() => setExpanded(e => !e)}
-        className="group-data-[expanded=true]:border-background-secondary group flex w-full flex-row items-center gap-2 p-3 text-left ring-0 hover:cursor-pointer"
-      >
-        <SearchResultExpandChevron />
-        <VertexRow vertex={displayNode} className="grow" />
-        <AddOrRemoveButton vertex={vertex} />
-      </div>
-      <div className="border-border pl-8 transition-all group-data-[expanded=false]:h-0 group-data-[expanded=true]:h-auto group-data-[expanded=true]:border-t">
-        <ul className="divide-y divide-gray-200">
+    <SearchResultCollapsible
+      level={level}
+      open={expanded}
+      onOpenChange={setExpanded}
+    >
+      <CollapsibleTrigger asChild>
+        <div
+          role="button"
+          className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
+        >
+          <SearchResultExpandChevron open={expanded} />
+          <VertexRow vertex={displayNode} className="grow" />
+          <AddOrRemoveButton vertex={vertex} />
+        </div>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <ul className="space-y-3 p-3">
           {displayNode.attributes.map(attr => (
-            <EntityAttribute
-              key={attr.name}
-              attribute={attr}
-              className="px-3 py-2"
-            />
+            <li key={attr.name} className="w-full">
+              <SearchResultAttribute>
+                <SearchResultAttributeName>
+                  {attr.name}
+                </SearchResultAttributeName>
+                <SearchResultAttributeValue>
+                  {attr.displayValue}
+                </SearchResultAttributeValue>
+              </SearchResultAttribute>
+            </li>
           ))}
         </ul>
-      </div>
-    </SearchResult>
+      </CollapsibleContent>
+    </SearchResultCollapsible>
   );
 }
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
@@ -19,7 +19,6 @@ import {
   useRemoveNodeFromGraph,
 } from "@/hooks";
 import { MinusCircleIcon, PlusCircleIcon } from "lucide-react";
-import { useState } from "react";
 
 export function VertexSearchResult({
   vertex,
@@ -28,21 +27,16 @@ export function VertexSearchResult({
   vertex: Vertex;
   level?: number;
 }) {
-  const [expanded, setExpanded] = useState(false);
   const displayNode = useDisplayVertexFromVertex(vertex);
 
   return (
-    <SearchResultCollapsible
-      level={level}
-      open={expanded}
-      onOpenChange={setExpanded}
-    >
+    <SearchResultCollapsible level={level}>
       <CollapsibleTrigger asChild>
         <div
           role="button"
           className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
         >
-          <SearchResultExpandChevron open={expanded} />
+          <SearchResultExpandChevron />
           <VertexRow vertex={displayNode} className="grow" />
           <AddOrRemoveButton vertex={vertex} />
         </div>

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -10,7 +10,7 @@ import localforage from "localforage";
 
 expect.extend(matchers);
 
-// Set the test environment timezone so it is consistent across machines
+// Set the test environment timezone & locale so it is consistent across machines
 const defaultLocale = "en-US";
 process.env.TZ = "UTC";
 process.env.LC_ALL = `${defaultLocale}.UTF-8`;

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -10,6 +10,9 @@ import localforage from "localforage";
 
 expect.extend(matchers);
 
+// Set the test environment timezone so it is consistent across machines
+process.env.TZ = "UTC";
+
 afterEach(() => {
   cleanup();
   vi.unstubAllEnvs();

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -11,7 +11,24 @@ import localforage from "localforage";
 expect.extend(matchers);
 
 // Set the test environment timezone so it is consistent across machines
+const defaultLocale = "en-US";
 process.env.TZ = "UTC";
+process.env.LC_ALL = `${defaultLocale}.UTF-8`;
+process.env.LANG = `${defaultLocale}.UTF-8`;
+process.env.LANGUAGE = defaultLocale;
+
+// Also mock Intl to ensure consistency
+const originalIntl = global.Intl;
+
+vi.stubGlobal("Intl", {
+  ...originalIntl,
+  NumberFormat: function (locale = defaultLocale, options) {
+    return new originalIntl.NumberFormat(locale, options);
+  } as typeof originalIntl.NumberFormat,
+  DateTimeFormat: function (locale = defaultLocale, options) {
+    return new originalIntl.DateTimeFormat(locale, options);
+  } as typeof originalIntl.DateTimeFormat,
+});
 
 afterEach(() => {
   cleanup();

--- a/packages/graph-explorer/src/utils/index.ts
+++ b/packages/graph-explorer/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from "./constants";
 export * from "./NetworkError";
 export * from "./formatEntityCounts";
 export * from "./formatRelativeDate";
+export * from "./numbers";

--- a/packages/graph-explorer/src/utils/numbers.ts
+++ b/packages/graph-explorer/src/utils/numbers.ts
@@ -1,0 +1,7 @@
+export function isEven(n: number) {
+  return n % 2 === 0;
+}
+
+export function isOdd(n: number) {
+  return !isEven(n);
+}

--- a/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
+++ b/packages/graph-explorer/src/utils/testing/graphsonHelpers.ts
@@ -9,6 +9,7 @@ import {
   GMap,
   GProperty,
   GScalar,
+  GType,
   GVertex,
   GVertexProperty,
 } from "@/connector/gremlin/types";
@@ -221,5 +222,12 @@ export function createGDate(value: Date): GDate {
   return {
     "@type": "g:Date",
     "@value": value.getTime(),
+  };
+}
+
+export function createGType(name: string): GType {
+  return {
+    "@type": "g:T" as const,
+    "@value": name,
   };
 }

--- a/packages/graph-explorer/tailwind.config.ts
+++ b/packages/graph-explorer/tailwind.config.ts
@@ -148,6 +148,7 @@ export default {
       },
       data: {
         open: 'state="open"',
+        closed: 'state="closed"',
       },
       transitionProperty: {
         width: "width",

--- a/packages/graph-explorer/tailwind.config.ts
+++ b/packages/graph-explorer/tailwind.config.ts
@@ -159,6 +159,7 @@ export default {
       },
       borderColor: {
         DEFAULT: "rgb(var(--color-border) / <alpha-value>)",
+        input: "rgb(var(--color-input-border) / <alpha-value>)",
       },
       maxWidth: {
         paragraph: "36rem",

--- a/packages/graph-explorer/tailwind.config.ts
+++ b/packages/graph-explorer/tailwind.config.ts
@@ -171,6 +171,28 @@ export default {
         menu: "1400",
         tooltip: "1500",
       },
+      keyframes: {
+        expand: {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "auto",
+          },
+        },
+        collapse: {
+          from: {
+            height: "auto",
+          },
+          to: {
+            height: "0",
+          },
+        },
+      },
+      animation: {
+        expand: "expand 0.2s cubic-bezier(0.87, 0, 0.13, 1)",
+        collapse: "collapse 0.2s cubic-bezier(0.87, 0, 0.13, 1)",
+      },
     },
   },
   plugins: [

--- a/packages/graph-explorer/tailwind.config.ts
+++ b/packages/graph-explorer/tailwind.config.ts
@@ -33,7 +33,6 @@ export default {
       red: colors.red,
       input: {
         background: "rgb(var(--color-input-background) / <alpha-value>)",
-        hover: "rgb(var(--color-input-hover) / <alpha-value>)",
       },
       primary: {
         light: "hsl(var(--color-primary-light) / <alpha-value>)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.2
         version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1631,6 +1634,19 @@ packages:
 
   '@radix-ui/react-checkbox@1.3.2':
     resolution: {integrity: sha512-yd+dI56KZqawxKZrJ31eENUwqc1QSqg4OZ15rybGjF2ZNwMO+wCyHzAVLRp9qoYJf7kYy0YpZ2b0JCzJ42HZpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.11':
+    resolution: {integrity: sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6973,6 +6989,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-collapsible@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

- Update vertex, edge, and scalar result UI
  - Use common component `SearchResult` and related components
  - Use `Collapsible` from Radix
  - Properties are now laid out horizontally, unless there is not enough room
  - Results have a gray background and children of results have white background
  - If more than one level of nesting (not in this PR) then alternate the backgrounds
- Scalar values can now have names
  - Element maps now render better in gremlin
  - Moved the name to the title and value to the subtitle
  - Added `GType` to `GScalar` since it comes back for `g.V().elementMap()` for ID and label

### Other changes

- Update input and select UI to remove background and hover colors (it conflicted with the search results)
- Set test environment timezone to be UTC & locale to `en-US` for consistency across machines

## Validation

<img width="2854" height="2402" alt="CleanShot 2025-07-30 at 18 16 59@2x" src="https://github.com/user-attachments/assets/a1fcc308-4a4a-41bc-9889-d6ef000606fa" />

<img width="2854" height="2402" alt="CleanShot 2025-07-30 at 18 17 23@2x" src="https://github.com/user-attachments/assets/19808163-64f0-458e-8d51-114b86bf7de5" />

## Related Issues

- Resolves #976 
- Part of #975

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
