### PR TITLE
Simplify Scalar type

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapResults.ts
@@ -42,7 +42,7 @@ function mapAnyValue(data: GAnyValue, name?: string): Entity[] {
           const mapped = mapAnyValue(key);
           const firstScalar = mapped.filter(m => m.entityType === "scalar")[0];
           const displayValue = firstScalar
-            ? getDisplayValueForScalar(firstScalar)
+            ? getDisplayValueForScalar(firstScalar.value)
             : undefined;
           // Only use string scalar values as name
           return displayValue;

--- a/packages/graph-explorer/src/core/entities/scalar.test.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.test.ts
@@ -3,7 +3,12 @@ import {
   createRandomDouble,
   createRandomInteger,
 } from "@shared/utils/testing";
-import { createScalar, getDisplayValueForScalar, Scalar } from "./scalar";
+import {
+  createScalar,
+  createTypedValue,
+  getDisplayValueForScalar,
+  Scalar,
+} from "./scalar";
 import { MISSING_DISPLAY_VALUE } from "@/utils";
 
 describe("scalar", () => {
@@ -13,7 +18,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "null",
         value: null,
       } satisfies Scalar);
     });
@@ -23,7 +27,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "string",
         value: "hello world",
       } satisfies Scalar);
     });
@@ -33,7 +36,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "string",
         value: "",
       } satisfies Scalar);
     });
@@ -44,7 +46,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "number",
         value: value,
       } satisfies Scalar);
     });
@@ -55,7 +56,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "number",
         value: value,
       } satisfies Scalar);
     });
@@ -65,7 +65,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "number",
         value: 0,
       } satisfies Scalar);
     });
@@ -75,7 +74,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "number",
         value: -100,
       } satisfies Scalar);
     });
@@ -86,7 +84,6 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "boolean",
         value,
       } satisfies Scalar);
     });
@@ -97,59 +94,87 @@ describe("scalar", () => {
 
       expect(result).toEqual({
         entityType: "scalar",
-        type: "date",
         value: date,
       } satisfies Scalar);
     });
   });
 
+  describe("createTypedValue", () => {
+    it("should return type 'null'", () => {
+      expect(createTypedValue(null)).toEqual({
+        type: "null",
+        value: null,
+      });
+    });
+
+    it("should return type 'string'", () => {
+      expect(createTypedValue("hello world")).toEqual({
+        type: "string",
+        value: "hello world",
+      });
+    });
+
+    it("should return type 'number' for integer", () => {
+      const value = createRandomInteger();
+      expect(createTypedValue(value)).toEqual({
+        type: "number",
+        value: value,
+      });
+    });
+
+    it("should return type 'number' for double", () => {
+      const value = createRandomDouble();
+      expect(createTypedValue(value)).toEqual({
+        type: "number",
+        value: value,
+      });
+    });
+
+    it("should return type 'boolean'", () => {
+      const value = createRandomBoolean();
+      expect(createTypedValue(value)).toEqual({
+        type: "boolean",
+        value,
+      });
+    });
+
+    it("should return type 'date'", () => {
+      const date = new Date("2023-12-25T10:30:00Z");
+      expect(createTypedValue(date)).toEqual({
+        type: "date",
+        value: date,
+      });
+    });
+  });
+
   describe("getDisplayValueForScalar", () => {
     it("should return null for null scalar", () => {
-      const scalar = createScalar({ value: null });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar(null);
       expect(result).toBe(MISSING_DISPLAY_VALUE);
     });
 
     it("should return string for string scalar", () => {
-      const scalar = createScalar({ value: "hello world" });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar("hello world");
       expect(result).toBe("hello world");
     });
 
     it("should return number for integer scalar", () => {
-      const scalar = createScalar({ value: 123456 });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar(123456);
       expect(result).toBe("123,456");
     });
 
     it("should return number for double scalar", () => {
-      const scalar = createScalar({ value: 123.45 });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar(123.45);
       expect(result).toBe("123.45");
     });
 
     it("should return boolean for boolean scalar", () => {
-      const scalar = createScalar({ value: true });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar(true);
       expect(result).toBe("true");
     });
 
     it("should return date for date scalar", () => {
-      const date = new Date("2023-12-25T10:30:00Z");
-      const scalar = createScalar({ value: date });
-
-      const result = getDisplayValueForScalar(scalar);
-
+      const result = getDisplayValueForScalar(new Date("2023-12-25T10:30:00Z"));
       expect(result).toBe("Dec 25 2023, 10:30 AM");
     });
   });

--- a/packages/graph-explorer/src/core/entities/scalar.ts
+++ b/packages/graph-explorer/src/core/entities/scalar.ts
@@ -1,36 +1,30 @@
 import { formatDate, MISSING_DISPLAY_VALUE } from "@/utils";
-import { EntityPropertyValue } from "./shared";
 
-type ScalarTypedValue =
-  | { type: "null"; value: null }
-  | { type: "string"; value: string }
-  | { type: "number"; value: number }
-  | { type: "boolean"; value: boolean }
-  | { type: "date"; value: Date };
+type ScalarValue = string | number | boolean | Date | null;
 
 export type Scalar = {
   entityType: "scalar";
   name?: string;
-} & ScalarTypedValue;
+  value: ScalarValue;
+};
 
 /** Constructs a Scalar instance from the given values. */
 export function createScalar({
   value,
   name,
 }: {
-  value: EntityPropertyValue | Date | null;
+  value: ScalarValue;
   name?: string;
 }): Scalar {
   return {
     entityType: "scalar" as const,
     name,
-    ...createTypedValue(value),
+    value,
   };
 }
 
-function createTypedValue(
-  value: EntityPropertyValue | Date | null
-): ScalarTypedValue {
+/** Determines the type of the value and casts it. Falls back to string if the type can not be determined. */
+export function createTypedValue(value: ScalarValue) {
   if (value === null) {
     return { type: "null" as const, value: null };
   } else if (value instanceof Date) {
@@ -46,16 +40,17 @@ function createTypedValue(
   }
 }
 
-export function getDisplayValueForScalar(scalar: Scalar) {
-  switch (scalar.type) {
+export function getDisplayValueForScalar(value: ScalarValue) {
+  const typedValue = createTypedValue(value);
+  switch (typedValue.type) {
     case "string":
-      return scalar.value;
+      return typedValue.value;
     case "number":
-      return new Intl.NumberFormat().format(scalar.value);
+      return new Intl.NumberFormat().format(typedValue.value);
     case "boolean":
-      return String(scalar.value);
+      return String(typedValue.value);
     case "date":
-      return formatDate(scalar.value);
+      return formatDate(typedValue.value);
     case "null":
       return MISSING_DISPLAY_VALUE;
   }

--- a/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ScalarSearchResult.tsx
@@ -4,7 +4,7 @@ import {
   SearchResultSymbol,
   SearchResultTitle,
 } from "@/components";
-import { getDisplayValueForScalar, Scalar } from "@/core";
+import { createTypedValue, getDisplayValueForScalar, Scalar } from "@/core";
 import {
   BanIcon,
   CalendarIcon,
@@ -15,13 +15,14 @@ import {
 } from "lucide-react";
 
 function getIcon(scalar: Scalar) {
-  switch (scalar.type) {
+  const typedValue = createTypedValue(scalar.value);
+  switch (typedValue.type) {
     case "string":
       return <QuoteIcon className="size-5" />;
     case "number":
       return <HashIcon className="size-5" />;
     case "boolean":
-      return scalar.value ? (
+      return typedValue.value ? (
         <CircleCheckIcon className="size-5" />
       ) : (
         <CircleIcon className="size-5" />
@@ -36,7 +37,7 @@ function getIcon(scalar: Scalar) {
 export function ScalarSearchResult({ scalar }: { scalar: Scalar }) {
   const Icon = getIcon(scalar);
   const title = scalar.name ?? "Scalar value";
-  const subtitle = getDisplayValueForScalar(scalar);
+  const subtitle = getDisplayValueForScalar(scalar.value);
 
   return (
     <SearchResult className="flex w-full flex-row items-center gap-2 p-3">


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removes the complex discriminated union type, which caused some TypeScript headaches for some future changes.

Instead, use simple value type inference to mimic the same behavior.

## Validation

- Teste with query editor

## Related Issues

- Part of #1087

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
