### PR TITLE
Fix node icon color change

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/renderNode.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/renderNode.tsx
@@ -19,8 +19,9 @@ export async function renderNode(
   }
 
   // To avoid multiple requests, cache icons under the same URL
-  if (ICONS_CACHE.get(vtConfig.iconUrl)) {
-    return ICONS_CACHE.get(vtConfig.iconUrl);
+  const cacheKey = `${vtConfig.iconUrl}::${vtConfig.color || "#128EE5"}`;
+  if (ICONS_CACHE.get(cacheKey)) {
+    return ICONS_CACHE.get(cacheKey);
   }
 
   try {
@@ -33,7 +34,7 @@ export async function renderNode(
     iconText = encodeSvg(iconText);
 
     // Save to the cache
-    ICONS_CACHE.set(vtConfig.iconUrl, iconText);
+    ICONS_CACHE.set(cacheKey, iconText);
     return iconText;
   } catch (error) {
     // Ignore the error and move on


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR fixes the node color on the canvas not updating when it is changed in the `NodeStyleDialog`. This is achieved by adding the icon color to the cache key. 

To avoid too many updates and potential react errors from happening due to the frequent cache updates I used the `useDebounceValue` hook which also has the added benefit of reducing the input lag when dragging inside the color picker.

So both color pickers are aligned, I also added the debouncing logic for the border color.

Additionally I added the border styling to the icon preview / icon upload button inside the modal

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

Tested by selecting new colors for node icons and border colors. Stress tested by rapidly changing colors.



## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes: #1056

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
