### PR TITLE
Fix result count alignment when nothing to add to graph

### DIFF
--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -49,7 +49,7 @@ export function SearchResultsList({
 
       <PanelFooter className="sticky bottom-0 flex flex-row items-center justify-between gap-2">
         <AddAllToGraphButton entities={results} />
-        <div className="flex min-h-10 items-center gap-2">
+        <div className="flex min-h-10 grow items-center justify-end gap-2">
           <ResultCounts results={results} />
           {isPagingNecessary ? (
             <div className="flex">


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When there are no results to add to the graph, the add all button is hidden. This would cause the result count to become left aligned.

I've fixed this by making the result count container grow in width and right align its contents.

## Validation

- Verified with vertex results
- Verified with scalar results

## Related Issues

- Resolves #1108 

### Screenshots

<img width="1844" height="2086" alt="CleanShot 2025-08-18 at 12 16 04@2x" src="https://github.com/user-attachments/assets/58687818-9d40-4a00-b33e-f3b56384193c" />
<img width="1844" height="2086" alt="CleanShot 2025-08-18 at 12 16 15@2x" src="https://github.com/user-attachments/assets/04aba194-1c23-48c6-ac12-9b32c7b443ef" />

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
