### PR TITLE
Remove order by ID in fetch neighbors

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -24,7 +24,6 @@ describe("Gremlin > oneHopTemplate", () => {
           .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
           .filter(__.not(__.hasId("256")))
           .dedup()
-          .order().by(id())
           .range(0, 10)
           .as("v")
           .project("vertex", "edges")
@@ -46,7 +45,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().dedup().order().by(id()).as("v")
+          .both().dedup().as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -69,7 +68,7 @@ describe("Gremlin > oneHopTemplate", () => {
         g.V("12")
           .both()
           .filter(__.not(__.hasId("256", "512")))
-          .dedup().order().by(id()).as("v")
+          .dedup().as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -89,7 +88,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V(12L)
-          .both().dedup().order().by(id()).as("v")
+          .both().dedup().as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -111,7 +110,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().dedup().order().by(id()).range(5, 10).as("v")
+          .both().dedup().range(5, 10).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -134,7 +133,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().hasLabel("country").dedup().order().by(id()).range(5, 15).as("v")
+          .both().hasLabel("country").dedup().range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -157,7 +156,7 @@ describe("Gremlin > oneHopTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12")
-          .both().hasLabel("country", "airport", "continent").dedup().order().by(id()).range(5, 15).as("v")
+          .both().hasLabel("country", "airport", "continent").dedup().range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(
@@ -186,7 +185,7 @@ describe("Gremlin > oneHopTemplate", () => {
         g.V("12")
           .both().hasLabel("country")
             .and(has("longest",gte(10000)),has("country",containing("ES")))
-            .dedup().order().by(id()).range(5, 15).as("v")
+            .dedup().range(5, 15).as("v")
           .project("vertex", "edges")
             .by()
             .by(

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -180,7 +180,6 @@ export default function oneHopTemplate({
       ${nodeFiltersTemplate}
       ${excludedTemplate}
       .dedup()
-      .order().by(id())
       ${range}
       .as("v")
       .project("vertex", "edges")


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The `.order().by(id())` in the neighbor fetch for gremlin was unnecessary. It did provide some amount of stability for the returned results when double clicking, but that order was not chosen by the user.

Keeping that sorting step causes performance issues on larger databases, so removing it is preferable.

## Validation

- Verified with Neptune Gremlin

## Related Issues

- Resolves #1085

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
