### PR TITLE
Add confirmation to deleting a connection

### DIFF
--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
@@ -1,0 +1,78 @@
+import {
+  DeleteIcon,
+  PanelHeaderActionButton,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  Paragraph,
+  Button,
+  TrayArrowIcon,
+  ErrorIcon,
+} from "@/components";
+import { useState } from "react";
+
+export default function ConnectionDeleteButton({
+  connectionName,
+  isSync,
+  deleteActiveConfig,
+  saveCopy,
+}: {
+  connectionName: string;
+  isSync: boolean;
+  deleteActiveConfig: () => void;
+  saveCopy: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <PanelHeaderActionButton
+        label="Delete connection"
+        icon={<DeleteIcon />}
+        color="danger"
+        isDisabled={isSync}
+        onActionClick={() => setIsOpen(true)}
+      />
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {connectionName}</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <div className="flex flex-row items-start gap-8">
+              <div className="py-1">
+                <ErrorIcon className="text-warning-main size-16" />
+              </div>
+              <div>
+                <Paragraph>
+                  Are you sure you want to delete this connection?
+                </Paragraph>
+                <Paragraph>
+                  This action is permanent and cannot be undone.
+                </Paragraph>
+              </div>
+            </div>
+            <div className="flex w-full justify-between">
+              <Button onPress={saveCopy} variant="text">
+                <TrayArrowIcon />
+                Export Copy
+              </Button>
+              <div className="flex gap-2 self-end justify-self-end">
+                <Button onPress={() => setIsOpen(false)}>Cancel</Button>
+                <Button
+                  onPress={deleteActiveConfig}
+                  color="danger"
+                  variant="filled"
+                >
+                  Delete Connection
+                </Button>
+              </div>
+            </div>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -10,7 +10,6 @@ import { useState } from "react";
 import {
   Button,
   Chip,
-  DeleteIcon,
   EdgeIcon,
   EditIcon,
   GraphIcon,
@@ -54,6 +53,7 @@ import {
 import saveConfigurationToFile from "@/utils/saveConfigurationToFile";
 import CreateConnection from "@/modules/CreateConnection";
 import ConnectionData from "./ConnectionData";
+import ConnectionDeleteButton from "./ConnectionDeleteButton";
 import { useQueryClient } from "@tanstack/react-query";
 import useEntitiesCounts from "@/hooks/useEntitiesCounts";
 import {
@@ -120,12 +120,11 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
             isDisabled={isSync}
             onActionClick={() => setEdit(true)}
           />
-          <PanelHeaderActionButton
-            label="Delete connection"
-            icon={<DeleteIcon />}
-            color="danger"
-            isDisabled={isSync}
-            onActionClick={deleteActiveConfig}
+          <ConnectionDeleteButton
+            connectionName={connectionName}
+            isSync={isSync}
+            deleteActiveConfig={deleteActiveConfig}
+            saveCopy={onConfigExport}
           />
         </PanelHeaderActions>
       </PanelHeader>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR adds a new component `ConnectionDeleteButton` that extends the former delete button with a confirmation dialog. The dialog also offers to trigger an export.

<img width="1624" height="1056" alt="Screenshot 2025-08-30 at 12 56 49" src="https://github.com/user-attachments/assets/25209cce-25f3-4d98-9af2-17c80cca55a7" />

## Validation

Tested all new buttons for their functionality as well as making sure the button still remains disabled while the connection is syncing.

## Related Issues

Adresses #1120 

Maybe a merge should be held off until this PR #1117 is merged so we can also use the dialog footer here instead of having them in the dialog body.

I'm also very open for better wording suggestions in this dialog!

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
