### PR TITLE
Fix expand neighbor query when edge ID is UUID

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -19,18 +19,18 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toEqual(
       normalize(`
-        g.V("124")
+        g.V("124").as("start")
           .both()
           .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
           .filter(__.not(__.hasId("256")))
           .dedup()
           .range(0, 10)
-          .as("v")
+          .as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("124"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -44,13 +44,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
-          .both().dedup().as("v")
+        g.V("12").as("start")
+          .both().dedup().as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -65,15 +65,15 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
+        g.V("12").as("start")
           .both()
           .filter(__.not(__.hasId("256", "512")))
-          .dedup().as("v")
+          .dedup().as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -87,13 +87,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V(12L)
-          .both().dedup().as("v")
+        g.V(12L).as("start")
+          .both().dedup().as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is(12L))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -109,13 +109,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
-          .both().dedup().range(5, 10).as("v")
+        g.V("12").as("start")
+          .both().dedup().range(5, 10).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -132,13 +132,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
-          .both().hasLabel("country").dedup().range(5, 15).as("v")
+        g.V("12").as("start")
+          .both().hasLabel("country").dedup().range(5, 15).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -155,13 +155,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
-          .both().hasLabel("country", "airport", "continent").dedup().range(5, 15).as("v")
+        g.V("12").as("start")
+          .both().hasLabel("country", "airport", "continent").dedup().range(5, 15).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)
@@ -182,15 +182,15 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12")
+        g.V("12").as("start")
           .both().hasLabel("country")
             .and(has("longest",gte(10000)),has("country",containing("ES")))
-            .dedup().range(5, 15).as("v")
+            .dedup().range(5, 15).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
-              __.select("v").bothE()
-                .where(otherV().id().is("12"))
+              __.select("start").bothE()
+                .where(otherV().where(eq("neighbor")))
                 .dedup().fold()
             )
       `)

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -117,21 +117,20 @@ function criterionTemplate(criterion: Criterion): string {
  * limit = 10
  * offset = 0
  *
- * g.V("124")
- *  .both()
- *  .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
- *  .filter(__.not(__.hasId("256")))
- *  .dedup()
- *  .order().by(id())
- *  .range(0, 10)
- *  .as("v")
- *  .project("vertex", "edges")
- *    .by()
- *    .by(
- *      __.select("v").bothE()
- *        .where(otherV().id().is("124"))
- *        .dedup().fold()
- *    )
+ * g.V("124").as("start")
+ *   .both()
+ *   .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
+ *   .filter(__.not(__.hasId("256")))
+ *   .dedup()
+ *   .range(0, 10)
+ *   .as("neighbor")
+ *   .project("vertex", "edges")
+ *     .by()
+ *     .by(
+ *       __.select("start").bothE()
+ *         .where(otherV().where(eq("neighbor")))
+ *         .dedup().fold()
+ *     )
  */
 export default function oneHopTemplate({
   vertexId,
@@ -175,18 +174,18 @@ export default function oneHopTemplate({
     : ``;
 
   return query`
-    g.V(${idTemplate})
+    g.V(${idTemplate}).as("start")
       .both()
       ${nodeFiltersTemplate}
       ${excludedTemplate}
       .dedup()
       ${range}
-      .as("v")
+      .as("neighbor")
       .project("vertex", "edges")
         .by()
         .by(
-          __.select("v").bothE(${edgeTypesTemplate})
-            .where(otherV().id().is(${idTemplate}))
+          __.select("start").bothE(${edgeTypesTemplate})
+            .where(otherV().where(eq("neighbor")))
             .dedup().fold()
         )
   `;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes a situation where the expand query would not return any edge results. The original query tried to use the vertex ID as a filter in the subquery for edges, but doesn't match properly when the ID type is UUID.

The solution actually simplifies the query a bit by naming the starting vertex `start`, updating the the neighbor name to `neighbor` for clarity, and changing the edge query to get all edges from `start` to any node in `neighbor`.

This removes the need for the ID to be injected in to the query in the edge part of the query.

```java
g.V("124").as("start")
  .both()
  .dedup()
  .range(0, 10)
  .as("neighbor")
  .project("vertex", "edges")
    .by()
    .by(
      __.select("start").bothE()
        .where(otherV().where(eq("neighbor")))
        .dedup().fold()
    )
```

## Validation

- Tested in Neptune with string IDs
- Tested in Gremlin Server with UUID IDs

## Related Issues

- Resolves #1135 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
