### PR TITLE
Adjust styles in DialogFooter

### DIFF
--- a/packages/graph-explorer/src/components/Dialog.tsx
+++ b/packages/graph-explorer/src/components/Dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "bg-background-default data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid max-h-full w-[500px] overflow-y-auto duration-200 sm:rounded-lg",
+          "bg-background-default data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid max-h-full w-[500px] overflow-y-auto rounded-lg duration-200",
           className
         )}
         {...props}
@@ -62,10 +62,7 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-1.5 p-6 pb-3 text-center sm:text-left",
-      className
-    )}
+    className={cn("flex flex-col space-y-1.5 p-6 pb-3", className)}
     {...props}
   />
 );
@@ -75,13 +72,7 @@ const DialogBody = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col gap-5 p-6 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
+  <div className={cn("flex flex-col gap-5 p-6", className)} {...props} />
 );
 DialogBody.displayName = "DialogBody";
 

--- a/packages/graph-explorer/src/components/Dialog.tsx
+++ b/packages/graph-explorer/src/components/Dialog.tsx
@@ -91,7 +91,7 @@ const DialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse bg-gray-100 p-6 sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-3 p-6 sm:flex-row sm:justify-end",
       className
     )}
     {...props}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adjusted the styles for the `Dialog` and related components

* Removed gray background from dialog footer since it clashes with the default button style
* Adjusted layout of restricted width dialogs so all text is left aligned
* Fixed spacing between buttons within the `DialogFooter`

## Validation

There was not an existing dialog that has two buttons, so I temporarily added one to the create prefix dialog to test out the styles.

### Standard width screen

* Buttons spaced apart properly
* Call to action on far right

<img width="542" height="370" alt="CleanShot 2025-09-04 at 16 54 16@2x" src="https://github.com/user-attachments/assets/d846a2ad-c47b-4a6b-9dce-f2cc4b881f3d" />

### Restricted width screen

* Buttons stack in reverse order so call to action is on top

<img width="329" height="422" alt="CleanShot 2025-09-04 at 16 54 34@2x" src="https://github.com/user-attachments/assets/2142c0e0-8e78-41f7-b5e5-7c371ab75a4a" />


## Related Issues

* Part of #751 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
