### PR TITLE
Use DialogFooter in LoadConfigButton dialog

### DIFF
--- a/packages/graph-explorer/src/routes/Settings/LoadConfigButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/LoadConfigButton.tsx
@@ -15,6 +15,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogFooter,
 } from "@/components";
 import {
   readBackupDataFromFile,
@@ -127,34 +128,33 @@ function ConfirmationModal({
                   <i>Any connected graph databases will be unaffected.</i>
                 </Paragraph>
               </div>
-              <div className="flex flex-row gap-2 self-end">
-                <Button size="large" isDisabled={isPending} onPress={onCancel}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="filled"
-                  color="danger"
-                  size="large"
-                  onPress={onConfirm}
-                  isDisabled={isPending}
-                  className="relative transition-opacity"
-                >
-                  <span className={cn(isPending && "opacity-0")}>
-                    Replace {APP_NAME} Configuration
-                  </span>
-                  <div
-                    className={cn(
-                      "absolute inset-auto opacity-0",
-                      isPending && "opacity-100"
-                    )}
-                  >
-                    <LoaderIcon className="animate-spin" />
-                  </div>
-                </Button>
-              </div>
             </div>
           </div>
         </DialogBody>
+        <DialogFooter>
+          <Button isDisabled={isPending} onPress={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            variant="filled"
+            color="danger"
+            onPress={onConfirm}
+            isDisabled={isPending}
+            className="relative transition-opacity"
+          >
+            <span className={cn(isPending && "opacity-0")}>
+              Replace {APP_NAME} Configuration
+            </span>
+            <div
+              className={cn(
+                "absolute inset-auto opacity-0",
+                isPending && "opacity-100"
+              )}
+            >
+              <LoaderIcon className="animate-spin" />
+            </div>
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
@@ -183,23 +183,21 @@ function ParseFailureModal({
             <div className="py-1">
               <ErrorIcon className="text-warning-main size-16" />
             </div>
-            <div className="flex grow flex-col gap-8">
-              <div>
-                <Paragraph>
-                  Could not parse the contents of the config file provided.
-                  Perhaps the file is not a config file from {APP_NAME} or the
-                  file is corrupted.
-                </Paragraph>
-                <Paragraph>
-                  <b>{fileName ?? debouncedFileName ?? "No file selected"}</b>
-                </Paragraph>
-              </div>
-              <Button size="large" onPress={onCancel} className="self-end">
-                Cancel
-              </Button>
+            <div>
+              <Paragraph>
+                Could not parse the contents of the config file provided.
+                Perhaps the file is not a config file from {APP_NAME} or the
+                file is corrupted.
+              </Paragraph>
+              <Paragraph>
+                <b>{fileName ?? debouncedFileName ?? "No file selected"}</b>
+              </Paragraph>
             </div>
           </div>
         </DialogBody>
+        <DialogFooter>
+          <Button onPress={onCancel}>Close</Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
@@ -217,23 +215,18 @@ function SuccessModal({ success }: { success: boolean }) {
             <div className="py-1">
               <CheckIcon className="text-success-main size-16" />
             </div>
-            <div className="flex grow flex-col gap-8">
-              <div>
-                <Paragraph className="w-full min-w-0">
-                  All data was restored successfully. Please reload {APP_NAME}
-                  to complete the process.
-                </Paragraph>
-              </div>
-
-              {/* Force a full reload of the app in the browser */}
-              <a href={RELOAD_URL} className="self-end">
-                <Button variant="filled" size="large">
-                  Reload {APP_NAME}
-                </Button>
-              </a>
-            </div>
+            <Paragraph className="w-full min-w-0">
+              All data was restored successfully. Please reload {APP_NAME}
+              to complete the process.
+            </Paragraph>
           </div>
         </DialogBody>
+        <DialogFooter>
+          {/* Force a full reload of the app in the browser */}
+          <a href={RELOAD_URL}>
+            <Button variant="filled">Reload {APP_NAME}</Button>
+          </a>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

* Use DialogFooter in LoadConfigButton dialog
* Use default size buttons instead of large
* Changed error dialog button label to "Close" instead of "Cancel" since there is nothing to cancel
* Removed unnecessary `div` and styles

## Validation

* Recommend to hide whitespace in GitHub file diff view

> [!NOTE]
> The footer will be white once PR #1147 goes in

<img width="1246" height="710" alt="CleanShot 2025-09-04 at 17 10 26@2x" src="https://github.com/user-attachments/assets/f0aff662-a6c3-474e-b3e2-17693d2eb4a0" />

<img width="1244" height="534" alt="CleanShot 2025-09-04 at 17 10 34@2x" src="https://github.com/user-attachments/assets/30d283be-59ff-4252-bd54-c86149407e91" />

<img width="1236" height="556" alt="CleanShot 2025-09-04 at 17 15 50@2x" src="https://github.com/user-attachments/assets/3d691dff-b061-4db7-91dc-de8ff3ecd6d3" />

## Related Issues

- Part of #751

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
