### PR TITLE
Increase randomness in generated test strings

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,11 +12,9 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "uuid": "^11.1.0",
     "zod": "^3.25.64"
   },
   "devDependencies": {
-    "@types/uuid": "^10.0.0",
     "@vitest/coverage-v8": "3.2.3",
     "rimraf": "^6.0.1",
     "vitest": "3.2.3"

--- a/packages/shared/src/utils/testing/randomData.ts
+++ b/packages/shared/src/utils/testing/randomData.ts
@@ -1,5 +1,3 @@
-import { v4 } from "uuid";
-
 /*
 
 # Developer Note
@@ -17,10 +15,20 @@ affected by those values, regardless of what they are.
 /**
  * Creates a random string with a prefix, if provided.
  * @param prefix The prefix to prepend to the string.
- * @returns A random string that will resemble "prefix-8d49f0".
+ * @returns A random string that will resemble "prefix-8d49f0zp5t".
  */
 export function createRandomName(prefix: string = ""): string {
-  return `${prefix}${prefix.length > 0 ? "-" : ""}${v4().substring(0, 6)}`;
+  // Available characters for random string creation
+  const chars = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+  // Grab 10 randome characters from the character array
+  const random = Array.from(
+    { length: 10 },
+    () => chars[Math.floor(Math.random() * chars.length)]
+  ).join("");
+
+  // Join with the prefix if provided
+  return `${prefix}${prefix.length > 0 ? "-" : ""}${random}`;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -475,16 +475,10 @@ importers:
 
   packages/shared:
     dependencies:
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
       zod:
         specifier: ^3.25.64
         version: 3.25.64
     devDependencies:
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@vitest/coverage-v8':
         specifier: 3.2.3
         version: 3.2.3(vitest@3.2.3(@types/node@24.0.1)(happy-dom@18.0.1)(jiti@1.21.7)(jsdom@26.1.0)(terser@5.42.0)(tsx@4.20.3)(yaml@2.8.0))


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

* Remove use of `uuid` package for random string creation
* Use full range of numbers and lower case letters for random string, increasing the pool of possibilities
* Increase the count of random characters in the generated random string from 6 to 10

## Validation

Ran test multiple times. Collisions were already super rare. This should make it ever more rare.

## Related Issues

- Resolves #1149

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
