### PR TITLE
Use verbatimModuleSyntax in proxy server

### DIFF
--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import { getRequestLoggerPrefix, logger } from "./logging.js";
 
 /**

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -1,6 +1,6 @@
-import { NextFunction, Request, Response } from "express";
-import { LevelWithSilent, pino } from "pino";
-import { PrettyOptions } from "pino-pretty";
+import type { NextFunction, Request, Response } from "express";
+import { type LevelWithSilent, pino } from "pino";
+import type { PrettyOptions } from "pino-pretty";
 import { env } from "./env.js";
 
 export type LogLevel = LevelWithSilent;

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -1,14 +1,14 @@
-import express, { NextFunction, Response } from "express";
+import express, { type NextFunction, type Response } from "express";
 import cors from "cors";
 import compression from "compression";
-import fetch, { RequestInit } from "node-fetch";
+import fetch, { type RequestInit } from "node-fetch";
 import https from "https";
 import bodyParser from "body-parser";
 import fs from "fs";
 import path from "path";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import aws4 from "aws4";
-import { IncomingHttpHeaders } from "http";
+import type { IncomingHttpHeaders } from "http";
 import { logger as proxyLogger, requestLoggingMiddleware } from "./logging.js";
 import { clientRoot, proxyServerRoot } from "./paths.js";
 import { errorHandlingMiddleware, handleError } from "./error-handler.js";

--- a/packages/graph-explorer-proxy-server/tsconfig.json
+++ b/packages/graph-explorer-proxy-server/tsconfig.json
@@ -13,6 +13,7 @@
     /* Interop Constraints */
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
 
     /* Paths */
     "outDir": "./dist",


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Use `verbatimModuleSyntax` as suggested by [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html?#im-compiling-and-running-the-outputs-in-nodejs)

## Validation

* Built Docker image and ran locally

## Related Issues

* N/A tech debt

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
