### PR TITLE
Fix input lag when changing node and edge colors

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -24,29 +24,29 @@ describe("useVertexStyling", () => {
     expect(result.current.vertexStyle).toEqual(style);
   });
 
-  it("should insert the vertex style when none exist", async () => {
+  it("should insert the vertex style when none exist", () => {
     const dbState = new DbState();
     const { result } = renderHookWithJotai(
       () => useVertexStyling("test"),
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() => result.current.setVertexStyle({ color: "red" }));
+    act(() => result.current.setVertexStyle({ color: "red" }));
 
     expect(result.current.vertexStyle).toEqual({ type: "test", color: "red" });
   });
 
-  it("should update the existing style, merging new styles", async () => {
+  it("should update the existing style, merging new styles", () => {
     const dbState = new DbState();
     const { result } = renderHookWithJotai(
       () => useVertexStyling("test"),
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() =>
+    act(() =>
       result.current.setVertexStyle({ color: "red", borderColor: "green" })
     );
-    await act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+    act(() => result.current.setVertexStyle({ borderColor: "blue" }));
 
     expect(result.current.vertexStyle).toEqual({
       type: "test",
@@ -55,7 +55,7 @@ describe("useVertexStyling", () => {
     });
   });
 
-  it("should reset the vertex style", async () => {
+  it("should reset the vertex style", () => {
     const dbState = new DbState();
     dbState.addVertexStyle("test", { borderColor: "blue" });
 
@@ -64,7 +64,7 @@ describe("useVertexStyling", () => {
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() => result.current.resetVertexStyle());
+    act(() => result.current.resetVertexStyle());
 
     expect(result.current.vertexStyle).toBeUndefined();
   });
@@ -92,14 +92,14 @@ describe("useEdgeStyling", () => {
     expect(result.current.edgeStyle).toEqual(style);
   });
 
-  it("should insert the edge style when none exist", async () => {
+  it("should insert the edge style when none exist", () => {
     const dbState = new DbState();
     const { result } = renderHookWithJotai(
       () => useEdgeStyling("test"),
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() => result.current.setEdgeStyle({ lineColor: "red" }));
+    act(() => result.current.setEdgeStyle({ lineColor: "red" }));
 
     expect(result.current.edgeStyle).toEqual({
       type: "test",
@@ -107,17 +107,17 @@ describe("useEdgeStyling", () => {
     });
   });
 
-  it("should update the existing style, merging new styles", async () => {
+  it("should update the existing style, merging new styles", () => {
     const dbState = new DbState();
     const { result } = renderHookWithJotai(
       () => useEdgeStyling("test"),
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() =>
+    act(() =>
       result.current.setEdgeStyle({ lineColor: "red", labelColor: "green" })
     );
-    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+    act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
 
     expect(result.current.edgeStyle).toEqual({
       type: "test",
@@ -126,15 +126,15 @@ describe("useEdgeStyling", () => {
     });
   });
 
-  it("should reset the edge style", async () => {
+  it("should reset the edge style", () => {
     const dbState = new DbState();
     const { result } = renderHookWithJotai(
       () => useEdgeStyling("test"),
       snapshot => dbState.applyTo(snapshot)
     );
 
-    await act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
-    await act(() => result.current.resetEdgeStyle());
+    act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+    act(() => result.current.resetEdgeStyle());
 
     expect(result.current.edgeStyle).toBeUndefined();
   });

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -125,7 +125,7 @@ function Content({ vertexType }: { vertexType: string }) {
     }
     try {
       const result = await file2Base64(file);
-      await setVertexStyle({ iconUrl: result, iconImageType: file.type });
+      setVertexStyle({ iconUrl: result, iconImageType: file.type });
     } catch (error) {
       console.error("Unable to convert uploaded image to base64: ", error);
     }

--- a/packages/graph-explorer/src/routes/DataExplorer/DataExplorer.tsx
+++ b/packages/graph-explorer/src/routes/DataExplorer/DataExplorer.tsx
@@ -192,13 +192,13 @@ function DisplayNameAndDescriptionOptions({
 
   const { setVertexStyle: setPreferences } = useVertexStyling(vertexType);
   const onDisplayNameChange =
-    (field: "name" | "longName") => async (value: string | string[]) => {
+    (field: "name" | "longName") => (value: string | string[]) => {
       if (field === "name") {
-        await setPreferences({ displayNameAttribute: value as string });
+        setPreferences({ displayNameAttribute: value as string });
       }
 
       if (field === "longName") {
-        await setPreferences({ longDisplayNameAttribute: value as string });
+        setPreferences({ longDisplayNameAttribute: value as string });
       }
     };
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR improves the input lag for the color pickers in both the `NodeStyleDialog` and the `EdgeStyleDialog` by implementing a helper function/hook `useDeferredAtom` as kindly suggested by @kmcginnes.

This function defers the actual updating of the atom state and allows for instant visual updates. 

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

The color updates on the canvas are happening much more rapidly than before and seem at least a little bit smoother.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #1104

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
