### PR TITLE
Streamline useGraphStyles hook

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/renderNode.test.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/renderNode.test.ts
@@ -32,7 +32,7 @@ describe("renderNode", () => {
 
     const result = await renderNode(client, node);
 
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
     expect(fetchMock).not.toBeCalled();
     expect(client.getQueryData(["icon", node.iconUrl])).toBeUndefined();
   });
@@ -49,7 +49,7 @@ describe("renderNode", () => {
     const result = await renderNode(client, node);
 
     expect(fetchMock).toBeCalledWith(node.iconUrl);
-    expect(result).toBeUndefined();
+    expect(result).toBeNull();
     expect(client.getQueryData(["icon", node.iconUrl])).toBeUndefined();
     expect(vi.mocked(logger.error)).toHaveBeenCalledOnce();
   });
@@ -172,6 +172,6 @@ ${svgContent}`;
 }
 
 /** Decodes the string and removes the data type URL prefix, returning only the SVG portion. */
-function decodeSvg(result: string | undefined) {
+function decodeSvg(result: string | null) {
   return decodeURIComponent(result!).replace("data:image/svg+xml;utf8,", "");
 }

--- a/packages/graph-explorer/src/modules/GraphViewer/renderNode.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/renderNode.tsx
@@ -43,9 +43,9 @@ const iconStyledQueryOptions = (iconData: string, color: string) =>
 export async function renderNode(
   client: QueryClient,
   vtConfig: VertexIconConfig
-): Promise<string | undefined> {
+): Promise<string | null> {
   if (!vtConfig.iconUrl) {
-    return;
+    return null;
   }
 
   if (vtConfig.iconImageType !== "image/svg+xml") {
@@ -62,7 +62,7 @@ export async function renderNode(
     return iconStyled;
   } catch (e) {
     logger.error("Failed to retrieve and style the icon", e, vtConfig.iconUrl);
-    return;
+    return null;
   }
 }
 

--- a/packages/graph-explorer/src/modules/GraphViewer/useBackgroundImageMap.test.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useBackgroundImageMap.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi, beforeEach, Mock } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { useBackgroundImageMap } from "./useBackgroundImageMap";
+import { renderNode } from "./renderNode";
+import {
+  renderHookWithState,
+  DbState,
+  createRandomVertexTypeConfig,
+} from "@/utils/testing";
+
+// Mock the renderNode function
+vi.mock("./renderNode");
+const mockRenderNode = renderNode as Mock;
+
+describe("useBackgroundImageMap", () => {
+  let dbState: DbState;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState = new DbState();
+    mockRenderNode.mockResolvedValue("data:image/svg+xml;utf8,<svg></svg>");
+  });
+
+  it("should return empty map when no vertex configs provided", () => {
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([]),
+      dbState
+    );
+
+    expect(result.current).toEqual(new Map());
+  });
+
+  it("should generate background image map for single vertex config", async () => {
+    const vertexConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    const expectedImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+    mockRenderNode.mockResolvedValue(expectedImage);
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([vertexConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(expectedImage);
+    });
+
+    expect(mockRenderNode).toHaveBeenCalledWith(
+      expect.any(Object),
+      vertexConfig
+    );
+  });
+
+  it("should generate background image map for multiple vertex configs", async () => {
+    const personConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    const companyConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+    };
+
+    const personImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+    const companyImage = "data:image/svg+xml;utf8,<svg>company</svg>";
+
+    mockRenderNode
+      .mockResolvedValueOnce(personImage)
+      .mockResolvedValueOnce(companyImage);
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([personConfig, companyConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(personImage);
+      expect(result.current.get("Company")).toBe(companyImage);
+    });
+
+    expect(mockRenderNode).toHaveBeenCalledTimes(2);
+    expect(mockRenderNode).toHaveBeenCalledWith(
+      expect.any(Object),
+      personConfig
+    );
+    expect(mockRenderNode).toHaveBeenCalledWith(
+      expect.any(Object),
+      companyConfig
+    );
+  });
+
+  it("should filter out failed renders from the map", async () => {
+    const personConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    const companyConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+    };
+
+    const personImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+
+    mockRenderNode
+      .mockResolvedValueOnce(personImage)
+      .mockResolvedValueOnce(null); // Failed render
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([personConfig, companyConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(personImage);
+      expect(result.current.has("Company")).toBe(false);
+      expect(result.current.size).toBe(1);
+    });
+  });
+
+  it("should handle renderNode returning undefined", async () => {
+    const vertexConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    mockRenderNode.mockResolvedValue(undefined);
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([vertexConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.has("Person")).toBe(false);
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  it("should handle renderNode throwing an error", async () => {
+    const vertexConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    mockRenderNode.mockRejectedValue(new Error("Render failed"));
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([vertexConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.has("Person")).toBe(false);
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  it("should update map when vertex configs change", async () => {
+    const initialConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    const updatedConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+    };
+
+    const personImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+    const companyImage = "data:image/svg+xml;utf8,<svg>company</svg>";
+
+    // Test initial render
+    mockRenderNode.mockResolvedValueOnce(personImage);
+
+    const { result: initialResult } = renderHookWithState(
+      () => useBackgroundImageMap([initialConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(initialResult.current.get("Person")).toBe(personImage);
+    });
+
+    // Test updated render with different config
+    mockRenderNode.mockResolvedValueOnce(companyImage);
+
+    const { result: updatedResult } = renderHookWithState(
+      () => useBackgroundImageMap([updatedConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(updatedResult.current.get("Company")).toBe(companyImage);
+      expect(updatedResult.current.has("Person")).toBe(false);
+    });
+  });
+
+  it("should handle mixed success and failure renders", async () => {
+    const configs = [
+      { ...createRandomVertexTypeConfig(), type: "Person" },
+      { ...createRandomVertexTypeConfig(), type: "Company" },
+      { ...createRandomVertexTypeConfig(), type: "Product" },
+    ];
+
+    const personImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+    const productImage = "data:image/svg+xml;utf8,<svg>product</svg>";
+
+    mockRenderNode
+      .mockResolvedValueOnce(personImage)
+      .mockResolvedValueOnce(null) // Company fails
+      .mockResolvedValueOnce(productImage);
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap(configs),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(personImage);
+      expect(result.current.get("Product")).toBe(productImage);
+      expect(result.current.has("Company")).toBe(false);
+      expect(result.current.size).toBe(2);
+    });
+  });
+
+  it("should use correct query key for caching", async () => {
+    const vertexConfig = { ...createRandomVertexTypeConfig(), type: "Person" };
+    mockRenderNode.mockResolvedValue("data:image/svg+xml;utf8,<svg></svg>");
+
+    renderHookWithState(() => useBackgroundImageMap([vertexConfig]), dbState);
+
+    await waitFor(() => {
+      expect(mockRenderNode).toHaveBeenCalledWith(
+        expect.any(Object),
+        vertexConfig
+      );
+    });
+
+    // Verify the query client was passed correctly
+    const queryClient = mockRenderNode.mock.calls[0][0];
+    expect(queryClient).toBeDefined();
+  });
+
+  it("should handle vertex configs with different image types", async () => {
+    const svgConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+      iconImageType: "image/svg+xml",
+    };
+    const pngConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+      iconImageType: "image/png",
+    };
+
+    const svgImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+    const pngImage = "https://example.com/company.png";
+
+    mockRenderNode
+      .mockResolvedValueOnce(svgImage)
+      .mockResolvedValueOnce(pngImage);
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([svgConfig, pngConfig]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(svgImage);
+      expect(result.current.get("Company")).toBe(pngImage);
+    });
+  });
+
+  it("should handle vertex configs with no icon URL", async () => {
+    const configWithIcon = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+      iconUrl: "https://example.com/icon.svg",
+    };
+    const configWithoutIcon = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+      iconUrl: undefined,
+    };
+
+    const personImage = "data:image/svg+xml;utf8,<svg>person</svg>";
+
+    mockRenderNode
+      .mockResolvedValueOnce(personImage)
+      .mockResolvedValueOnce(null); // No icon URL returns null
+
+    const { result } = renderHookWithState(
+      () => useBackgroundImageMap([configWithIcon, configWithoutIcon]),
+      dbState
+    );
+
+    await waitFor(() => {
+      expect(result.current.get("Person")).toBe(personImage);
+      expect(result.current.has("Company")).toBe(false);
+      expect(result.current.size).toBe(1);
+    });
+  });
+});

--- a/packages/graph-explorer/src/modules/GraphViewer/useBackgroundImageMap.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useBackgroundImageMap.ts
@@ -1,0 +1,31 @@
+import { VertexTypeConfig } from "@/core";
+import { useQueries } from "@tanstack/react-query";
+import { renderNode } from "./renderNode";
+
+/**
+ * Generates appropriate background images from vertex type configurations,
+ * considering the image type and applying colors for SVG icons.
+ *
+ * @param vtConfigs - Array of vertex type configurations containing styling and
+ * display information
+ * @returns A Map where keys are vertex type names and values are their
+ * corresponding background image strings
+ */
+export function useBackgroundImageMap(vtConfigs: VertexTypeConfig[]) {
+  return useQueries({
+    queries: vtConfigs.map(vtConfig => ({
+      queryKey: ["vertexIcon", vtConfig],
+      queryFn: async ({ client }) => {
+        const backgroundImage = await renderNode(client, vtConfig);
+        return { backgroundImage, type: vtConfig.type };
+      },
+    })),
+    combine: results =>
+      results.reduce((map, item) => {
+        if (item.data != null && item.data.backgroundImage != null) {
+          map.set(item.data.type, item.data.backgroundImage);
+        }
+        return map;
+      }, new Map<string, string>()),
+  });
+}

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -1,0 +1,373 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, Mock } from "vitest";
+import useGraphStyles from "./useGraphStyles";
+import { renderNode } from "./renderNode";
+import { MISSING_DISPLAY_VALUE } from "@/utils/constants";
+import { getEdgeIdFromRenderedEdgeId } from "@/core";
+import type { RenderedEdgeId } from "@/core";
+import type { GraphProps } from "@/components";
+import {
+  DbState,
+  renderHookWithState,
+  createRandomVertexTypeConfig,
+  createRandomEdgeTypeConfig,
+} from "@/utils/testing";
+
+// Mock dependencies
+vi.mock("./renderNode");
+vi.mock("@/core", async () => {
+  const actual = await vi.importActual("@/core");
+  return {
+    ...actual,
+    getEdgeIdFromRenderedEdgeId: vi.fn(),
+    useDisplayEdgesInCanvas: vi.fn(),
+  };
+});
+
+const mockRenderNode = renderNode as Mock;
+const mockGetEdgeIdFromRenderedEdgeId = getEdgeIdFromRenderedEdgeId as Mock;
+
+// Import the mocked function
+import { useDisplayEdgesInCanvas } from "@/core";
+const mockUseDisplayEdgesInCanvas = useDisplayEdgesInCanvas as Mock;
+
+describe("useGraphStyles", () => {
+  let dbState: DbState;
+
+  // Helper function to safely access result.current
+  const getStyles = (result: { current: GraphProps["styles"] | undefined }) => {
+    if (!result.current) {
+      throw new Error("result.current is undefined");
+    }
+    return result.current;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState = new DbState();
+
+    // Setup mock implementations
+    mockRenderNode.mockResolvedValue("data:image/svg+xml;utf8,<svg></svg>");
+    mockGetEdgeIdFromRenderedEdgeId.mockReturnValue("edge-1");
+    mockUseDisplayEdgesInCanvas.mockReturnValue(new Map());
+  });
+
+  it("should generate vertex styles correctly", async () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+      color: "#128EE5",
+      backgroundOpacity: 0.8,
+      borderColor: "#000000",
+      borderWidth: 2,
+      borderStyle: "solid" as const,
+      shape: "ellipse" as const,
+    };
+    dbState.activeSchema.vertices = [vertexConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    await waitFor(() => {
+      const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+      expect(vertexStyle).toEqual({
+        "background-image": "data:image/svg+xml;utf8,<svg></svg>",
+        "background-color": "#128EE5",
+        "background-opacity": 0.8,
+        "border-color": "#000000",
+        "border-width": 2,
+        "border-opacity": 1,
+        "border-style": "solid",
+        shape: "ellipse",
+        width: 24,
+        height: 24,
+      });
+    });
+  });
+
+  it("should generate edge styles correctly", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+      labelColor: "#17457b",
+      lineColor: "#b3b3b3",
+      lineStyle: "solid" as const,
+      lineThickness: 2,
+      sourceArrowStyle: "none" as const,
+      targetArrowStyle: "triangle" as const,
+      labelBackgroundOpacity: 0.8,
+      labelBorderWidth: 1,
+      labelBorderColor: "#000000",
+      labelBorderStyle: "solid" as const,
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    expect(edgeStyle).toMatchObject({
+      color: "#FFFFFF", // White text for dark background
+      "line-color": "#b3b3b3",
+      "line-style": "solid",
+      "line-dash-pattern": undefined,
+      "source-arrow-shape": "none",
+      "source-arrow-color": "#b3b3b3",
+      "target-arrow-shape": "triangle",
+      "target-arrow-color": "#b3b3b3",
+      "text-background-opacity": 0.8,
+      "text-background-color": "#17457b",
+      "text-border-width": 1,
+      "text-border-color": "#000000",
+      "text-border-style": "solid",
+      width: 2,
+      "source-distance-from-node": 0,
+      "target-distance-from-node": 0,
+    });
+  });
+
+  it("should handle vertex config without border width", () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+      borderWidth: 0,
+    };
+    dbState.activeSchema.vertices = [vertexConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+    expect(vertexStyle["border-opacity"]).toBe(0);
+  });
+
+  it("should handle edge config with dotted line style", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+      lineStyle: "dotted" as const,
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    expect(edgeStyle["line-style"]).toBe("dashed");
+    expect(edgeStyle["line-dash-pattern"]).toEqual([1, 2]);
+  });
+
+  it("should handle edge config with dashed line style", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+      lineStyle: "dashed" as const,
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    expect(edgeStyle["line-style"]).toBe("dashed");
+    expect(edgeStyle["line-dash-pattern"]).toEqual([5, 6]);
+  });
+
+  it("should use light text color for light label background", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+      labelColor: "#ffffff",
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    expect(edgeStyle.color).toBe("#000000"); // Black text for light background
+  });
+
+  it("should handle text transformation for edge labels", () => {
+    const edgeConfig = createRandomEdgeTypeConfig();
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    // The hook should work with the text transform functionality
+    // This test verifies the integration works properly
+    expect(getStyles(result)[`edge[type="${edgeConfig.type}"]`]).toBeDefined();
+  });
+
+  it("should truncate long edge labels", () => {
+    const longEdgeType = "VERY_LONG_EDGE_TYPE_NAME_THAT_EXCEEDS_LIMIT";
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: longEdgeType,
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    // The label function should be defined, but we can't easily test the truncation
+    // without mocking the text transform function more specifically
+    const edgeStyle = getStyles(result)[`edge[type="${longEdgeType}"]`] as any;
+    expect(edgeStyle.label).toBeDefined();
+  });
+
+  it("should handle edge label function with display edges", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const mockDisplayEdge = {
+      displayName: "Custom Display Name",
+    };
+    const mockDisplayEdgesMap = new Map([["edge-1", mockDisplayEdge]]);
+    mockUseDisplayEdgesInCanvas.mockReturnValue(mockDisplayEdgesMap);
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    const labelFunction = edgeStyle.label as (el: {
+      id: () => RenderedEdgeId;
+    }) => string;
+
+    // Mock cytoscape edge element
+    const mockEdgeElement = {
+      id: () => "rendered-edge-1" as RenderedEdgeId,
+    };
+
+    const label = labelFunction(mockEdgeElement);
+    expect(label).toBe("Custom Display Name");
+  });
+
+  it("should return missing display value when edge not found", () => {
+    const edgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "KNOWS",
+    };
+    dbState.activeSchema.edges = [edgeConfig];
+
+    const mockDisplayEdgesMap = new Map(); // Empty map
+    mockUseDisplayEdgesInCanvas.mockReturnValue(mockDisplayEdgesMap);
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="KNOWS"]`] as any;
+    const labelFunction = edgeStyle.label as (el: {
+      id: () => RenderedEdgeId;
+    }) => string;
+
+    // Mock cytoscape edge element
+    const mockEdgeElement = {
+      id: () => "rendered-edge-1" as RenderedEdgeId,
+    };
+
+    const label = labelFunction(mockEdgeElement);
+    expect(label).toBe(MISSING_DISPLAY_VALUE);
+  });
+
+  it("should handle renderNode failure gracefully", () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+    };
+    dbState.activeSchema.vertices = [vertexConfig];
+
+    mockRenderNode.mockResolvedValue(undefined);
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+    expect(vertexStyle["background-image"]).toBeUndefined();
+  });
+
+  it("should handle multiple vertex and edge types", () => {
+    const personConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+    };
+    const companyConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Company",
+      color: "#ff0000",
+    };
+
+    const knowsConfig = createRandomEdgeTypeConfig();
+    const worksAtConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "WORKS_AT",
+      lineColor: "#00ff00",
+    };
+
+    dbState.activeSchema.vertices = [personConfig, companyConfig];
+    dbState.activeSchema.edges = [knowsConfig, worksAtConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    expect(
+      (getStyles(result)[`node[type="Company"]`] as any)["background-color"]
+    ).toBe("#ff0000");
+    expect(
+      (getStyles(result)[`edge[type="WORKS_AT"]`] as any)["line-color"]
+    ).toBe("#00ff00");
+  });
+
+  it("should update styles when configs change", () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: "Person",
+      color: "#ff0000",
+    };
+    const edgeConfig = createRandomEdgeTypeConfig();
+
+    const updatedDbState = new DbState();
+    updatedDbState.activeSchema.vertices = [vertexConfig];
+    updatedDbState.activeSchema.edges = [edgeConfig];
+
+    const { result } = renderHookWithState(
+      () => useGraphStyles(),
+      updatedDbState
+    );
+
+    expect(
+      (getStyles(result)[`node[type="Person"]`] as any)["background-color"]
+    ).toBe("#ff0000");
+  });
+
+  it("should handle edge config with undefined optional properties", () => {
+    const minimalEdgeConfig = {
+      ...createRandomEdgeTypeConfig(),
+      type: "MINIMAL",
+      // Remove optional properties to test undefined handling
+      labelBackgroundOpacity: undefined,
+      labelBorderWidth: undefined,
+      labelColor: undefined,
+    };
+
+    dbState.activeSchema.edges = [minimalEdgeConfig];
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const edgeStyle = getStyles(result)[`edge[type="MINIMAL"]`] as any;
+    expect(edgeStyle["text-background-opacity"]).toBeUndefined();
+    expect(edgeStyle["text-background-color"]).toBeUndefined();
+    expect(edgeStyle["text-border-width"]).toBeUndefined();
+  });
+
+  it("should use deferred values for performance", () => {
+    const vertexConfig = createRandomVertexTypeConfig();
+    const edgeConfig = createRandomEdgeTypeConfig();
+
+    dbState.activeSchema.vertices = [vertexConfig];
+    dbState.activeSchema.edges = [edgeConfig];
+
+    // This test ensures that the hook uses useDeferredValue for configs
+    // The actual deferring behavior is handled by React, so we just verify
+    // that the hook works with the provided configs
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    // Verify that the hook successfully processes the configurations
+    expect(
+      getStyles(result)[`node[type="${vertexConfig.type}"]`]
+    ).toBeDefined();
+    expect(getStyles(result)[`edge[type="${edgeConfig.type}"]`]).toBeDefined();
+  });
+});

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -1,19 +1,21 @@
 import Color from "color";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue } from "react";
 import {
+  DisplayEdge,
+  EdgeId,
+  EdgeTypeConfig,
   getEdgeIdFromRenderedEdgeId,
   RenderedEdgeId,
   useDisplayEdgesInCanvas,
+  VertexTypeConfig,
 } from "@/core";
 import type { GraphProps } from "@/components";
-import useTextTransform from "@/hooks/useTextTransform";
-import { renderNode } from "./renderNode";
 import {
   useEdgeTypeConfigs,
   useVertexTypeConfigs,
 } from "@/core/ConfigurationProvider/useConfiguration";
 import { MISSING_DISPLAY_VALUE } from "@/utils/constants";
-import { useQueryClient } from "@tanstack/react-query";
+import { useBackgroundImageMap } from "./useBackgroundImageMap";
 
 const LINE_PATTERN = {
   solid: undefined,
@@ -21,100 +23,85 @@ const LINE_PATTERN = {
   dotted: [1, 2],
 };
 
-const useGraphStyles = () => {
+export default function useGraphStyles() {
   const vtConfigs = useVertexTypeConfigs();
   const etConfigs = useEdgeTypeConfigs();
-  const textTransform = useTextTransform();
-  const [styles, setStyles] = useState<GraphProps["styles"]>({});
   const displayEdges = useDisplayEdgesInCanvas();
-  const client = useQueryClient();
 
   const deferredVtConfigs = useDeferredValue(vtConfigs);
   const deferredEtConfigs = useDeferredValue(etConfigs);
 
-  useEffect(() => {
-    (async () => {
-      const styles: GraphProps["styles"] = {};
+  const backgroundImageMap = useBackgroundImageMap(deferredVtConfigs);
 
-      for (const vtConfig of deferredVtConfigs) {
-        const vt = vtConfig.type;
-
-        // Process the image data or SVG
-        const backgroundImage = await renderNode(client, vtConfig);
-
-        styles[`node[type="${vt}"]`] = {
-          "background-image": backgroundImage,
-          "background-color": vtConfig.color,
-          "background-opacity": vtConfig.backgroundOpacity,
-          "border-color": vtConfig.borderColor,
-          "border-width": vtConfig.borderWidth,
-          "border-opacity": vtConfig.borderWidth ? 1 : 0,
-          "border-style": vtConfig.borderStyle,
-          shape: vtConfig.shape,
-          width: 24,
-          height: 24,
-        };
-      }
-
-      for (const etConfig of deferredEtConfigs) {
-        const et = etConfig?.type;
-
-        let label = textTransform(et);
-        if (label.length > 20) {
-          label = label.substring(0, 17) + "...";
-        }
-
-        styles[`edge[type="${et}"]`] = {
-          label,
-          "source-distance-from-node": 0,
-          "target-distance-from-node": 0,
-        };
-
-        styles[`edge[type="${et}"]`] = {
-          label: (el: cytoscape.EdgeSingular) => {
-            const edgeId = el.id() as RenderedEdgeId;
-            const displayEdge = displayEdges.get(
-              getEdgeIdFromRenderedEdgeId(edgeId)
-            );
-            return displayEdge
-              ? displayEdge.displayName
-              : MISSING_DISPLAY_VALUE;
-          },
-          color: new Color(etConfig?.labelColor || "#17457b").isDark()
-            ? "#FFFFFF"
-            : "#000000",
-          "line-color": etConfig.lineColor,
-          "line-style":
-            etConfig.lineStyle === "dotted" ? "dashed" : etConfig.lineStyle,
-          "line-dash-pattern": etConfig.lineStyle
-            ? LINE_PATTERN[etConfig.lineStyle]
-            : undefined,
-          "source-arrow-shape": etConfig.sourceArrowStyle,
-          "source-arrow-color": etConfig.lineColor,
-          "target-arrow-shape": etConfig.targetArrowStyle,
-          "target-arrow-color": etConfig.lineColor,
-          "text-background-opacity": etConfig?.labelBackgroundOpacity,
-          "text-background-color": etConfig?.labelColor,
-          "text-border-width": etConfig?.labelBorderWidth,
-          "text-border-color": etConfig?.labelBorderColor,
-          "text-border-style": etConfig?.labelBorderStyle,
-          width: etConfig.lineThickness,
-          "source-distance-from-node": 0,
-          "target-distance-from-node": 0,
-        };
-      }
-
-      setStyles(styles);
-    })();
-  }, [
-    client,
-    deferredEtConfigs,
+  return createGraphStyles(
     deferredVtConfigs,
-    displayEdges,
-    textTransform,
-  ]);
+    deferredEtConfigs,
+    backgroundImageMap,
+    displayEdges
+  );
+}
 
+function createGraphStyles(
+  deferredVtConfigs: VertexTypeConfig[],
+  deferredEtConfigs: EdgeTypeConfig[],
+  backgroundImageMap: Map<string, string | null>,
+  displayEdges: Map<EdgeId, DisplayEdge>
+): GraphProps["styles"] {
+  const styles: GraphProps["styles"] = {};
+
+  for (const vtConfig of deferredVtConfigs) {
+    const vt = vtConfig.type;
+
+    // Process the image data or SVG
+    const backgroundImage = backgroundImageMap.get(vt) ?? undefined;
+
+    styles[`node[type="${vt}"]`] = {
+      "background-image": backgroundImage,
+      "background-color": vtConfig.color,
+      "background-opacity": vtConfig.backgroundOpacity,
+      "border-color": vtConfig.borderColor,
+      "border-width": vtConfig.borderWidth,
+      "border-opacity": vtConfig.borderWidth ? 1 : 0,
+      "border-style": vtConfig.borderStyle,
+      shape: vtConfig.shape,
+      width: 24,
+      height: 24,
+    };
+  }
+
+  for (const etConfig of deferredEtConfigs) {
+    const et = etConfig?.type;
+
+    styles[`edge[type="${et}"]`] = {
+      label: (el: cytoscape.EdgeSingular) => {
+        const edgeId = el.id() as RenderedEdgeId;
+        const displayEdge = displayEdges.get(
+          getEdgeIdFromRenderedEdgeId(edgeId)
+        );
+        return displayEdge ? displayEdge.displayName : MISSING_DISPLAY_VALUE;
+      },
+      color: new Color(etConfig?.labelColor || "#17457b").isDark()
+        ? "#FFFFFF"
+        : "#000000",
+      "line-color": etConfig.lineColor,
+      "line-style":
+        etConfig.lineStyle === "dotted" ? "dashed" : etConfig.lineStyle,
+      "line-dash-pattern": etConfig.lineStyle
+        ? LINE_PATTERN[etConfig.lineStyle]
+        : undefined,
+      "source-arrow-shape": etConfig.sourceArrowStyle,
+      "source-arrow-color": etConfig.lineColor,
+      "target-arrow-shape": etConfig.targetArrowStyle,
+      "target-arrow-color": etConfig.lineColor,
+      "text-background-opacity": etConfig?.labelBackgroundOpacity,
+      "text-background-color": etConfig?.labelColor,
+      "text-border-width": etConfig?.labelBorderWidth,
+      "text-border-color": etConfig?.labelBorderColor,
+      "text-border-style": etConfig?.labelBorderStyle,
+      width: etConfig.lineThickness,
+      "source-distance-from-node": 0,
+      "target-distance-from-node": 0,
+    };
+  }
   return styles;
-};
-
-export default useGraphStyles;
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The `useGraphStyles()` hook had a few issues that needed to be addressed:

* No tests
* Used text transformer when it didn't need to
* Had an `useEffect` to execute an async function when not necessary

### Changes

* Added `useBackgroundImageMap` to get rendered icons in to a Map that can be used synchronously
* Extracted style creation out to a function
* Removed `useEffect`
* Removed unused text transform
* Added tests

## Validation

* Modified vertex styles to see graph update
* New tests

## Related Issues

* Related to #1056 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
