### PR TITLE
Simplify vertex detail query

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.ts
@@ -47,23 +47,8 @@ export async function vertexDetails(
         ${request.vertexIds.map(idParam).join("\n")}
       }
 
-      {
-        # Get the resource attributes
-        SELECT ?resource ?label ?value
-        WHERE {
-          ?resource ?label ?value .
-          FILTER(isLiteral(?value))
-        }
-      }
-      UNION
-      {
-        # Get the resource type
-        SELECT ?resource ?label ?value
-        WHERE {
-          ?resource a ?value .
-          BIND(IRI("${rdfTypeUri}") AS ?label)
-        }
-      }
+      ?resource ?label ?value .
+      FILTER(isLiteral(?value) || ?label = rdf:type)
     }
   `;
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Simplifies the vertex details query to remove nested queries. This pattern is already used by the expand neighbor query.

## Validation

* Tested in Neptune in multiple databases

## Related Issues

- N/A

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
