### PR TITLE
Include headers in IAM request signing

### DIFF
--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -73,6 +73,7 @@ const retryFetch = async (
         region,
         method: options.method,
         body: options.body ?? undefined,
+        headers: options.headers,
       });
 
       options = {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This ensures the right headers are applied when IAM auth signing is occurring.

Before, the headers set in the gremlin/openCypher/sparql endpoints were ignored and replaced by whatever the default headers were for `aws4.sign()`. This was mostly fine as JSON is what we want as a response and that was the default. And the default headers were used when IAM is enabled, which limited this bug to Neptune scenarios.

## Validation

* Tested against all three query engines
* Tested on non-Neptune SPARQL database
* Tested on Neptune with and without IAM 

## Related Issues

* Resolves #1170

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
