### PR TITLE
Disable retries for user query

### DIFF
--- a/packages/graph-explorer/src/connector/queries/executeUserQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/executeUserQuery.ts
@@ -21,6 +21,8 @@ export function executeUserQuery(
     staleTime: Infinity,
     // Keep the query results around for 5 minutes if the user happens to be on another tab
     gcTime: 1000 /* ms */ * 60 /* sec */ * 5 /* min */,
+    // Disable retries since query could be a mutation
+    retry: false,
     queryFn: async ({ signal, meta, client }) => {
       const explorer = getExplorer(meta);
       const results = await explorer.rawQuery({ query }, { signal });


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

User queries should not be retried. The could be mutations. And if there is a failure on the GE side, which would retry, then the mutation could be executed multiple times.

## Validation

* Smoke tested

## Related Issues

* Resolves #1202

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
