### PR TITLE
Fix bug in testable edge with rdf values

### DIFF
--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -372,6 +372,7 @@ export function createTestableEdge() {
     attributes: EntityProperties;
     source: TestableVertex;
     target: TestableVertex;
+    hasRdfValues?: boolean;
   }) => {
     return {
       ...testable,
@@ -388,16 +389,23 @@ export function createTestableEdge() {
           target: rdfTarget,
           // RDF edge never has attributes
           attributes: {},
+          hasRdfValues: true,
         });
       },
       with: (newTestable: Partial<typeof testable>) => {
         return createInternal({ ...testable, ...newTestable });
       },
       withSource: (source: TestableVertex) => {
-        return createInternal({ ...testable, source });
+        const id = testable.hasRdfValues
+          ? createRdfEdgeId(source.id, testable.type, testable.target.id)
+          : testable.id;
+        return createInternal({ ...testable, id, source });
       },
       withTarget: (target: TestableVertex) => {
-        return createInternal({ ...testable, target });
+        const id = testable.hasRdfValues
+          ? createRdfEdgeId(testable.source.id, testable.type, target.id)
+          : testable.id;
+        return createInternal({ ...testable, id, target });
       },
       asEdge: () =>
         createEdge({


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes an issue where if you do this:

```ts
const edge = createTestableEdge()
  .withRdfValues()
  .withSource(vertex1)
  .withTarget(vertex2);
```

instead of this:

```ts
const edge = createTestableEdge()
  .withSource(vertex1)
  .withTarget(vertex2)
  .withRdfValues();
```

You'll end up with incorrect results because the edge ID is not properly set for the source and target.

## Validation

* Used in tests the wrong way and got failures before the fix

## Related Issues

* Part of #1233

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
