### PR TITLE
Consolidate blank node mapping logic

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.ts
@@ -1,4 +1,6 @@
 import { query } from "@/utils";
+import { idParam } from "../idParam";
+import { rdfTypeUri } from "../types";
 
 /**
  * Fetch all neighbors and their predicates, values, and classes
@@ -7,20 +9,52 @@ import { query } from "@/utils";
  * @see oneHopNeighborsTemplate
  */
 export default function blankNodeOneHopNeighborsTemplate(subQuery: string) {
+  const rdfTypeUriTemplate = idParam(rdfTypeUri);
+
   return query`
-	  # Fetch all neighbors and their predicates, values, and classes given a blank node sub-query.
-		SELECT ?bNode ?subject ?pred ?value ?subjectClass ?pToSubject ?pFromSubject {
-			?subject a     ?subjectClass ;
-							 ?pred ?value .
-			{
-				SELECT DISTINCT ?bNode ?subject ?pToSubject ?pFromSubject {
-					{ ?bNode ?pToSubject ?subject }
-					UNION
-					{ ?subject ?subjectClass ?bNode }
-					{ ${subQuery} }
-				}
-			}
-			FILTER(isLiteral(?value))
-		}
+    # Fetch all neighbors and their predicates, values, and classes for blank node
+    SELECT DISTINCT ?subject ?predicate ?object
+    WHERE {
+      # Find the blank nodes using the original search or expand query
+      {
+        ${subQuery}
+      }
+
+      # Get all neighbors for the blank nodes
+      {
+        SELECT DISTINCT ?bNode ?neighbor 
+        WHERE {
+          {
+            ?neighbor ?p ?bNode .
+            ?neighbor a ?class .
+            FILTER(!isLiteral(?neighbor) && ?p != ${rdfTypeUriTemplate})
+          } 
+          UNION 
+          {
+            ?bNode ?p ?neighbor .
+            ?neighbor a ?class .
+            FILTER(!isLiteral(?neighbor) && ?p != ${rdfTypeUriTemplate})
+          }
+        }
+      }
+
+      # Now get the data for these specific neighbors
+      {
+        # Connection predicate
+        ?neighbor ?predicate ?bNode .
+        BIND(?neighbor as ?subject) 
+        BIND(?bNode as ?object)
+      } UNION {
+        # Connection predicate
+        ?bNode ?predicate ?neighbor .
+        BIND(?bNode as ?subject) 
+        BIND(?neighbor as ?object)
+      } UNION {
+        # Neighbor properties
+        ?neighbor ?predicate ?object .
+        FILTER(isLiteral(?object) || ?predicate = ${rdfTypeUriTemplate})
+        BIND(?neighbor as ?subject)
+      }
+    }
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeSubjectPredicatesTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeSubjectPredicatesTemplate.ts
@@ -8,10 +8,10 @@ import { idParam } from "../idParam";
  *
  * @see subjectPredicatesTemplate
  */
-const blankNodeSubjectPredicatesTemplate = ({
+function blankNodeSubjectPredicatesTemplate({
   subQuery,
   subjectURIs = [],
-}: SPARQLBlankNodeNeighborsPredicatesRequest): string => {
+}: SPARQLBlankNodeNeighborsPredicatesRequest): string {
   const getSubjectURIs = () => {
     if (!subjectURIs?.length) {
       return "";
@@ -38,9 +38,11 @@ const blankNodeSubjectPredicatesTemplate = ({
         ?subject ?predFromSubject ?bNode;
                  a                ?subjectClass.
       }
-      { ${subQuery} }
+      {
+        ${subQuery}
+      }
     }
   `;
-};
+}
 
 export default blankNodeSubjectPredicatesTemplate;

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.ts
@@ -1,8 +1,6 @@
 import { query } from "@/utils";
 import { SPARQLNeighborsRequest } from "../types";
-import { getFilters, getSubjectClasses } from "./helpers";
-import { idParam } from "../idParam";
-import { getLimit } from "../getLimit";
+import { findNeighborsUsingFilters } from "./oneHopNeighborsTemplate";
 
 /**
  * Generate a template with the same constraints that oneHopNeighborsTemplate
@@ -10,33 +8,15 @@ import { getLimit } from "../getLimit";
  *
  * @see oneHopNeighborsTemplate
  */
-export default function oneHopNeighborsBlankNodesIdsTemplate({
-  resourceURI,
-  subjectClasses = [],
-  filterCriteria = [],
-  limit = 0,
-  offset = 0,
-}: SPARQLNeighborsRequest) {
+export default function oneHopNeighborsBlankNodesIdsTemplate(
+  request: SPARQLNeighborsRequest
+) {
   return query`
-    # Sub-query to fetch blank node ids for one hop neighbors
-    SELECT DISTINCT (?subject AS ?bNode) {
-      BIND(${idParam(resourceURI)} AS ?argument)
-      ${getSubjectClasses(subjectClasses)}
+    SELECT DISTINCT (?neighbor AS ?bNode) {
       {
-        ?argument ?pToSubject ?subject.
-        ?subject a         ?subjectClass;
-                 ?sPred    ?sValue .
-        ${getFilters(filterCriteria)}
+        ${findNeighborsUsingFilters(request)}
       }
-      UNION
-      {
-        ?subject ?pFromSubject ?argument;
-                 a         ?subjectClass;
-                 ?sPred    ?sValue .
-       ${getFilters(filterCriteria)}
-      }
-      FILTER(isBlank(?subject))
+      FILTER(isBlank(?neighbor))
     }
-    ${getLimit(limit, offset)}
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/helpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/helpers.ts
@@ -18,7 +18,7 @@ export function getFilterPredicates(predicates?: string[]) {
   return `FILTER (?pValue IN (${filteredPredicates.map(idParam).join(", ")}))`;
 }
 
-export function getFilterObject(exactMatch: boolean, searchTerm?: string) {
+export function getFilterObject(exactMatch?: boolean, searchTerm?: string) {
   if (!searchTerm) {
     return "";
   }

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.ts
@@ -1,11 +1,6 @@
 import { query } from "@/utils";
 import { SPARQLKeywordSearchRequest } from "../types";
-import {
-  getFilterObject,
-  getFilterPredicates,
-  getSubjectClasses,
-} from "./helpers";
-import { getLimit } from "../getLimit";
+import { findSubjectsMatchingFilters } from "./keywordSearchTemplate";
 
 /**
  * This generates a template to get all blank nodes ids from
@@ -13,31 +8,18 @@ import { getLimit } from "../getLimit";
  *
  * @see keywordSearchTemplate
  */
-export default function keywordSearchBlankNodesIdsTemplate({
-  searchTerm,
-  subjectClasses = [],
-  predicates = [],
-  limit,
-  offset = 0,
-  exactMatch = true,
-}: SPARQLKeywordSearchRequest): string {
+export default function keywordSearchBlankNodesIdsTemplate(
+  request: SPARQLKeywordSearchRequest
+) {
   return query`
     # Fetch all blank nodes ids from a generic keyword search request
-    SELECT DISTINCT ?bNode
+    SELECT DISTINCT (?subject as ?bNode)
     WHERE {
       {
         # This sub-query will find any matching instances to the given filters and limit the results
-        SELECT DISTINCT ?bNode
-        WHERE {
-          ?bNode a       ?class ;
-                 ?pValue ?value .
-          ${getFilterPredicates(predicates)}
-          ${getSubjectClasses(subjectClasses)}
-          ${getFilterObject(exactMatch, searchTerm)}
-        }
-        ${getLimit(limit, offset)}
+        ${findSubjectsMatchingFilters(request)}
       }
-      FILTER(isBlank(?bNode))
+      FILTER(isBlank(?subject))
     }
   `;
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Updates the queries and mapping for blank node neighbors. These queries are executed when getting the neighbor counts. The subquery is the query that originally found the blank node (either search or expand neighbors). That subquery is used to find the blank node again, then the blank node is matched to any neighbors it might have and returns them all without limit. This provides a neighbor count and a cache of neighbors that can be expanded from the blank node. 

That is all how it has always worked. I'm not trying to change that behavior here. I'm only updating the shape of the result and how the result is mapped in to vertices, edges, and blank node cache items.

* Combines separate neighbor queries in to one
* Use new parseAndMapQuads
* Split out core keyword search query to be reused for blank node neighbor query

## Validation

* Tested in Neptune with premiere league data
* Tested with searching for `soc:Game` items in filter search then expanding to see `soc:Goal` blank nodes
* Tested with searching for `soc:Goal` blank nodes directly

## Related Issues

* Part of #1233 
* Resolves #1193

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
