### PR TITLE
Ensure rdfs:label is first attribute

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/displayAttribute.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayAttribute.ts
@@ -1,6 +1,7 @@
 import { Vertex, Edge, AttributeConfig, EntityPropertyValue } from "@/core";
 import { TextTransformer } from "@/hooks";
 import { getDisplayValueForScalar } from "@/connector/entities";
+import { sortAttributeByName } from "./sortAttributeByName";
 
 /** Represents an attribute's display information after all transformations have been applied. */
 export type DisplayAttribute = {
@@ -29,7 +30,7 @@ export function getSortedDisplayAttributes(
       return mapToDisplayAttribute(name, value, textTransform);
     })
     .toArray()
-    .toSorted((a, b) => a.displayLabel.localeCompare(b.displayLabel));
+    .toSorted(sortAttributeByName);
 
   return sortedAttributes;
 }

--- a/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
@@ -12,10 +12,12 @@ import {
   useDisplayEdgeTypeConfig,
   useDisplayVertexTypeConfig,
   mapToDisplayVertexTypeConfig,
+  mapToDisplayEdgeTypeConfig,
 } from "./displayTypeConfigs";
 import { createRandomName } from "@shared/utils/testing";
 import { LABELS } from "@/utils";
 import type { TextTransformer } from "@/hooks";
+import { RDFS_LABEL_URI } from "./sortAttributeByName";
 
 // Simple identity text transformer for testing (non-SPARQL behavior)
 const identityTextTransform: TextTransformer = (text: string) => text;
@@ -178,6 +180,51 @@ describe("mapToDisplayVertexTypeConfig", () => {
     ]);
   });
 
+  it("should sort rdfs:label as the first attribute", () => {
+    const vtConfig = createRandomVertexTypeConfig();
+    vtConfig.attributes = [
+      { name: "zebra", dataType: "String" },
+      { name: RDFS_LABEL_URI, dataType: "String" },
+      { name: "apple", dataType: "String" },
+      { name: "middle", dataType: "String" },
+    ];
+
+    const result = mapToDisplayVertexTypeConfig(
+      vtConfig,
+      identityTextTransform
+    );
+
+    expect(result.attributes.map(a => a.name)).toStrictEqual([
+      RDFS_LABEL_URI,
+      "apple",
+      "middle",
+      "zebra",
+    ]);
+  });
+
+  it("should sort rdfs:label first even when it appears last", () => {
+    const vtConfig = createRandomVertexTypeConfig();
+    vtConfig.attributes = [
+      { name: "aaa", dataType: "String" },
+      { name: "bbb", dataType: "String" },
+      { name: "ccc", dataType: "String" },
+      { name: RDFS_LABEL_URI, dataType: "String" },
+    ];
+
+    const result = mapToDisplayVertexTypeConfig(
+      vtConfig,
+      identityTextTransform
+    );
+
+    expect(result.attributes[0].name).toBe(RDFS_LABEL_URI);
+    expect(result.attributes.map(a => a.name)).toStrictEqual([
+      RDFS_LABEL_URI,
+      "aaa",
+      "bbb",
+      "ccc",
+    ]);
+  });
+
   it("should mark String attributes as searchable by default", () => {
     const vtConfig = createRandomVertexTypeConfig();
     vtConfig.attributes = [
@@ -318,6 +365,25 @@ describe("mapToDisplayVertexTypeConfig", () => {
       "EMAIL",
       "FIRSTNAME",
       "LASTNAME",
+    ]);
+  });
+});
+
+describe("mapToDisplayEdgeTypeConfig", () => {
+  it("should sort rdfs:label as the first attribute", () => {
+    const etConfig = createRandomEdgeTypeConfig();
+    etConfig.attributes = [
+      { name: "weight", dataType: "Number" },
+      { name: RDFS_LABEL_URI, dataType: "String" },
+      { name: "created", dataType: "Date" },
+    ];
+
+    const result = mapToDisplayEdgeTypeConfig(etConfig, identityTextTransform);
+
+    expect(result.attributes.map(a => a.name)).toStrictEqual([
+      RDFS_LABEL_URI,
+      "created",
+      "weight",
     ]);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.ts
@@ -16,6 +16,7 @@ import { LABELS, RESERVED_TYPES_PROPERTY } from "@/utils";
 import { atomFamily, useAtomCallback } from "jotai/utils";
 import { atom, useAtomValue } from "jotai";
 import { useCallback } from "react";
+import { sortAttributeByName } from "./sortAttributeByName";
 
 export type DisplayVertexStyle = {
   color: string;
@@ -141,7 +142,7 @@ export function mapToDisplayVertexTypeConfig(
       displayLabel: textTransform(attr.name),
       isSearchable: isAttributeSearchable(attr),
     }))
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+    .toSorted(sortAttributeByName);
 
   const result: DisplayVertexTypeConfig = {
     type: typeConfig.type,
@@ -178,7 +179,7 @@ export function mapToDisplayEdgeTypeConfig(
       displayLabel: textTransform(attr.name),
       isSearchable: isAttributeSearchable(attr),
     }))
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+    .toSorted(sortAttributeByName);
 
   const style: DisplayEdgeStyle = {
     sourceArrowStyle:

--- a/packages/graph-explorer/src/core/StateProvider/sortAttributeByName.ts
+++ b/packages/graph-explorer/src/core/StateProvider/sortAttributeByName.ts
@@ -1,0 +1,19 @@
+import { DisplayAttribute } from "./displayAttribute";
+import { DisplayConfigAttribute } from "./displayTypeConfigs";
+
+/** The RDFS label property name that should be sorted first in attribute lists */
+export const RDFS_LABEL_URI = "http://www.w3.org/2000/01/rdf-schema#label";
+
+/**
+ * Sorts the given attributes by `displayLabel` alphabetically, with any
+ * `rdfs:label` attributes moved to the first position.
+ */
+export function sortAttributeByName(
+  a: DisplayConfigAttribute | DisplayAttribute,
+  b: DisplayConfigAttribute | DisplayAttribute
+) {
+  // rdfs:label should always be first
+  if (a.name === RDFS_LABEL_URI) return -1;
+  if (b.name === RDFS_LABEL_URI) return 1;
+  return a.displayLabel.localeCompare(b.displayLabel);
+}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Ensures `rdfs:label` is first attribute in all displays areas where the attributes are listed.

This ensures `rdfs:label` is used as the default name attribute when the user hasn't selected anything.

## Validation

- Tested in clean empty Graph Explorer database
  - Verified rdfs:label is used by default for any type that has one
  - Verified rdfs:label is first property after URI and class
  - Verified rdfs:label is default property for neighbor expansion filter

## Related Issues

- Depends on #1246 
- Resolves #1232 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
