### PR TITLE
Move ASCII constants to module

### DIFF
--- a/packages/graph-explorer/src/components/EdgeRow.tsx
+++ b/packages/graph-explorer/src/components/EdgeRow.tsx
@@ -1,7 +1,7 @@
 import { DisplayEdge, DisplayVertex } from "@/core";
 import { ComponentPropsWithoutRef } from "react";
 import { EdgeSymbol } from "./EdgeSymbol";
-import { cn, NBSP, RSAQUO } from "@/utils";
+import { ASCII, cn } from "@/utils";
 import { SearchResultSubtitle, SearchResultTitle } from "./SearchResult";
 
 /**
@@ -26,7 +26,7 @@ export function EdgeRow({
   const nameIsSameAsTypes = edge.displayTypes === edge.displayName;
   const displayName = nameIsSameAsTypes
     ? edge.displayName
-    : `${edge.displayTypes}${NBSP}${RSAQUO} ${edge.displayName}`;
+    : `${edge.displayTypes}${ASCII.NBSP}${ASCII.RSAQUO} ${edge.displayName}`;
   const title = `${resultName}${displayName}`;
 
   return (

--- a/packages/graph-explorer/src/components/VertexRow.tsx
+++ b/packages/graph-explorer/src/components/VertexRow.tsx
@@ -1,7 +1,7 @@
 import { DisplayVertex } from "@/core";
 import { SearchResultSubtitle, SearchResultTitle, VertexSymbol } from ".";
 import { ComponentPropsWithoutRef } from "react";
-import { cn, NBSP, RSAQUO } from "@/utils";
+import { ASCII, cn } from "@/utils";
 
 export function VertexRow({
   name,
@@ -16,7 +16,7 @@ export function VertexRow({
   const nameIsSameAsTypes = vertex.displayTypes === vertex.displayName;
   const displayName = nameIsSameAsTypes
     ? vertex.displayName
-    : `${vertex.displayTypes}${NBSP}${RSAQUO} ${vertex.displayName}`;
+    : `${vertex.displayTypes}${ASCII.NBSP}${ASCII.RSAQUO} ${vertex.displayName}`;
   const title = `${resultName}${displayName}`;
 
   return (

--- a/packages/graph-explorer/src/connector/entities/bundle.test.ts
+++ b/packages/graph-explorer/src/connector/entities/bundle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createPatchedResultBundle, getDisplayValueForBundle } from "./bundle";
 import { createResultScalar } from "./scalar";
-import { MISSING_DISPLAY_VALUE, NBSP } from "@/utils/constants";
+import { MISSING_DISPLAY_VALUE, ASCII } from "@/utils/constants";
 import { createTestableEdge, createTestableVertex } from "@/utils/testing";
 
 describe("getDisplayValueForBundle", () => {
@@ -17,7 +17,9 @@ describe("getDisplayValueForBundle", () => {
 
     const result = getDisplayValueForBundle(bundle);
 
-    expect(result).toBe(`Name: John${NBSP}• Age: 25${NBSP}• Active: true`);
+    expect(result).toBe(
+      `Name: John${ASCII.NBSP}• Age: 25${ASCII.NBSP}• Active: true`
+    );
   });
 
   it("should format scalar values without names", () => {
@@ -31,7 +33,7 @@ describe("getDisplayValueForBundle", () => {
 
     const result = getDisplayValueForBundle(bundle);
 
-    expect(result).toBe(`John${NBSP}• 25${NBSP}• false`);
+    expect(result).toBe(`John${ASCII.NBSP}• 25${ASCII.NBSP}• false`);
   });
 
   it("should format null scalar values", () => {
@@ -45,7 +47,7 @@ describe("getDisplayValueForBundle", () => {
     const result = getDisplayValueForBundle(bundle);
 
     expect(result).toBe(
-      `EmptyField: ${MISSING_DISPLAY_VALUE}${NBSP}• ${MISSING_DISPLAY_VALUE}`
+      `EmptyField: ${MISSING_DISPLAY_VALUE}${ASCII.NBSP}• ${MISSING_DISPLAY_VALUE}`
     );
   });
 
@@ -62,7 +64,7 @@ describe("getDisplayValueForBundle", () => {
     const expectedDateFormat = "Dec 25 2023, 10:30 AM";
 
     expect(result).toBe(
-      `CreatedAt: ${expectedDateFormat}${NBSP}• ${expectedDateFormat}`
+      `CreatedAt: ${expectedDateFormat}${ASCII.NBSP}• ${expectedDateFormat}`
     );
   });
 
@@ -168,7 +170,7 @@ describe("getDisplayValueForBundle", () => {
     const result = getDisplayValueForBundle(bundle);
 
     expect(result).toBe(
-      `Name: John${NBSP}• Profile: v(v123)${NBSP}• Connection: e(e456)${NBSP}• SubBundle: [...]`
+      `Name: John${ASCII.NBSP}• Profile: v(v123)${ASCII.NBSP}• Connection: e(e456)${ASCII.NBSP}• SubBundle: [...]`
     );
   });
 
@@ -195,7 +197,7 @@ describe("getDisplayValueForBundle", () => {
     const expectedPopulation = new Intl.NumberFormat().format(1000000);
 
     expect(result).toBe(
-      `Price: ${expectedPrice}${NBSP}• Population: ${expectedPopulation}`
+      `Price: ${expectedPrice}${ASCII.NBSP}• Population: ${expectedPopulation}`
     );
   });
 
@@ -211,7 +213,7 @@ describe("getDisplayValueForBundle", () => {
       const upperCaseTransformer = (text: string) => text.toUpperCase();
       const result = getDisplayValueForBundle(bundle, upperCaseTransformer);
 
-      expect(result).toBe(`USER_NAME: JOHN DOE${NBSP}• STATUS: ACTIVE`);
+      expect(result).toBe(`USER_NAME: JOHN DOE${ASCII.NBSP}• STATUS: ACTIVE`);
     });
 
     it("should apply text transformer to scalar values without names", () => {
@@ -225,7 +227,7 @@ describe("getDisplayValueForBundle", () => {
       const upperCaseTransformer = (text: string) => text.toUpperCase();
       const result = getDisplayValueForBundle(bundle, upperCaseTransformer);
 
-      expect(result).toBe(`HELLO WORLD${NBSP}• TEST VALUE`);
+      expect(result).toBe(`HELLO WORLD${ASCII.NBSP}• TEST VALUE`);
     });
 
     it("should apply text transformer to bundle names", () => {
@@ -258,7 +260,7 @@ describe("getDisplayValueForBundle", () => {
       const result = getDisplayValueForBundle(bundle, upperCaseTransformer);
 
       expect(result).toBe(
-        `user_profile: v(v123)${NBSP}• connection_edge: e(e456)`
+        `user_profile: v(v123)${ASCII.NBSP}• connection_edge: e(e456)`
       );
     });
 
@@ -274,7 +276,7 @@ describe("getDisplayValueForBundle", () => {
       const result = getDisplayValueForBundle(bundle, upperCaseTransformer);
 
       expect(result).toBe(
-        `EMPTY_FIELD: ${MISSING_DISPLAY_VALUE}${NBSP}• ${MISSING_DISPLAY_VALUE}`
+        `EMPTY_FIELD: ${MISSING_DISPLAY_VALUE}${ASCII.NBSP}• ${MISSING_DISPLAY_VALUE}`
       );
     });
 
@@ -295,7 +297,7 @@ describe("getDisplayValueForBundle", () => {
       const result = getDisplayValueForBundle(bundle, upperCaseTransformer);
 
       expect(result).toBe(
-        `NAME: JOHN${NBSP}• profile: v(v123)${NBSP}• SUB_BUNDLE: [...]`
+        `NAME: JOHN${ASCII.NBSP}• profile: v(v123)${ASCII.NBSP}• SUB_BUNDLE: [...]`
       );
     });
 
@@ -310,7 +312,7 @@ describe("getDisplayValueForBundle", () => {
       const identityTransformer = (text: string) => text;
       const result = getDisplayValueForBundle(bundle, identityTransformer);
 
-      expect(result).toBe(`Name: John${NBSP}• Age: 25`);
+      expect(result).toBe(`Name: John${ASCII.NBSP}• Age: 25`);
     });
 
     it("should handle complex transformations", () => {
@@ -325,7 +327,7 @@ describe("getDisplayValueForBundle", () => {
         text.replace(/_/g, "-").toLowerCase();
       const result = getDisplayValueForBundle(bundle, kebabCaseTransformer);
 
-      expect(result).toBe(`field-name: user-name${NBSP}• some value`);
+      expect(result).toBe(`field-name: user-name${ASCII.NBSP}• some value`);
     });
   });
 });

--- a/packages/graph-explorer/src/connector/entities/bundle.ts
+++ b/packages/graph-explorer/src/connector/entities/bundle.ts
@@ -1,6 +1,6 @@
 import { getDisplayValueForScalar } from "./scalar";
 import { PatchedResultEntity, ResultEntity } from "./entities";
-import { NBSP } from "@/utils";
+import { ASCII } from "@/utils";
 import { TextTransformer } from "@/hooks";
 
 /**
@@ -129,5 +129,5 @@ export function getDisplayValueForBundle(
             : `[...]`;
       }
     })
-    .join(`${NBSP}• `);
+    .join(`${ASCII.NBSP}• `);
 }

--- a/packages/graph-explorer/src/utils/constants.ts
+++ b/packages/graph-explorer/src/utils/constants.ts
@@ -28,8 +28,10 @@ export const MISSING_DISPLAY_TYPE = "---";
 /** Used as the label for the ID of a blank node in the node details or query results. */
 export const LABEL_FOR_BLANK_NODE_ID = "Blank Node Id";
 
-/** Non breaking space */
-export const NBSP = "\u00A0";
-
-/** Small arrow character */
-export const RSAQUO = "\u203A";
+/** ASCII characters used in strings */
+export const ASCII = {
+  /** Non breaking space */
+  NBSP: "\u00A0",
+  /** Small arrow character */
+  RSAQUO: "\u203A",
+} as const;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds an `ASCII` module around the ASCII characters we use in strings.

## Validation

- Smoke test

## Related Issues

- Part of #1250 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
