### PR TITLE
Don’t add missing attributes to vertex or edge

### DIFF
--- a/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/useConfiguration.ts
@@ -31,37 +31,6 @@ const assembledConfigSelector = atom(get => {
   return result;
 });
 
-export const vertexTypeAttributesSelector = atomFamily(
-  (vertexTypes: string[]) =>
-    atom(get => {
-      const attributesByNameMap = new Map(
-        vertexTypes
-          .values()
-          .map(vt => get(vertexTypeConfigSelector(vt)))
-          .filter(vt => vt != null)
-          .flatMap(vt => vt.attributes)
-          .map(attr => [attr.name, attr])
-      );
-
-      return attributesByNameMap.values().toArray();
-    })
-);
-
-export const edgeTypeAttributesSelector = atomFamily((edgeTypes: string[]) =>
-  atom(get => {
-    const attributesByNameMap = new Map(
-      edgeTypes
-        .values()
-        .map(et => get(edgeTypeConfigSelector(et)))
-        .filter(et => et != null)
-        .flatMap(et => et.attributes)
-        .map(attr => [attr.name, attr])
-    );
-
-    return attributesByNameMap.values().toArray();
-  })
-);
-
 export const vertexTypeConfigSelector = atomFamily((vertexType: string) =>
   atom(
     get =>

--- a/packages/graph-explorer/src/core/StateProvider/displayAttribute.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayAttribute.test.ts
@@ -12,7 +12,7 @@ import {
   createRandomInteger,
   createRandomName,
 } from "@shared/utils/testing";
-import { formatDate, LABELS } from "@/utils";
+import { formatDate } from "@/utils";
 import { getDisplayValueForScalar } from "@/connector/entities";
 import { RDFS_LABEL_URI } from "./sortAttributeByName";
 
@@ -61,17 +61,6 @@ describe("mapToDisplayAttribute", () => {
     });
   });
 
-  it("should map null value", () => {
-    const name = createRandomName("name");
-    const value = null;
-    const displayAttribute = mapToDisplayAttribute(name, value, transformNoOp);
-    expect(displayAttribute).toStrictEqual({
-      name,
-      displayLabel: name,
-      displayValue: LABELS.MISSING_VALUE,
-    });
-  });
-
   it("should use the transformer for display name", () => {
     const value = createRandomName("value");
     const config = createRandomAttributeConfig();
@@ -98,27 +87,16 @@ describe("getSortedDisplayAttributes", () => {
     const matchedConfig = createRandomAttributeConfig();
     matchedConfig.name = matchedName;
 
-    const configAttributes = [
-      createRandomAttributeConfig(),
-      createRandomAttributeConfig(),
-      matchedConfig,
-    ];
-
     const vertex = createRandomVertex();
     vertex.attributes[matchedName] = value;
 
     const sortedDisplayAttributes = getSortedDisplayAttributes(
       vertex,
-      configAttributes,
       transformNoOp
     );
 
     const expected = [
-      // All the non-matched attribute config types
-      ...configAttributes
-        .filter(({ name }) => name !== matchedName)
-        .map(config => mapToDisplayAttribute(config.name, null, transformNoOp)),
-      // All the non-matched vertex attributes value values
+      // All the matched vertex attributes value values
       ...Object.entries(vertex.attributes)
         .filter(([name]) => name !== matchedName)
         .map(([name, value]) =>
@@ -140,16 +118,8 @@ describe("getSortedDisplayAttributes", () => {
       email: "john@example.com",
     };
 
-    const configAttributes = [
-      { name: "name", dataType: "String" },
-      { name: "age", dataType: "Number" },
-      { name: RDFS_LABEL_URI, dataType: "String" },
-      { name: "email", dataType: "String" },
-    ];
-
     const sortedDisplayAttributes = getSortedDisplayAttributes(
       vertex,
-      configAttributes,
       transformNoOp
     );
 
@@ -166,16 +136,8 @@ describe("getSortedDisplayAttributes", () => {
       zzz: "value3",
     };
 
-    const configAttributes = [
-      { name: "aaa", dataType: "String" },
-      { name: "bbb", dataType: "String" },
-      { name: RDFS_LABEL_URI, dataType: "String" },
-      { name: "zzz", dataType: "String" },
-    ];
-
     const sortedDisplayAttributes = getSortedDisplayAttributes(
       vertex,
-      configAttributes,
       transformNoOp
     );
 
@@ -185,29 +147,6 @@ describe("getSortedDisplayAttributes", () => {
       "bbb",
       "zzz",
     ]);
-  });
-
-  it("should handle rdfs:label when it has no value", () => {
-    const vertex = createRandomVertex();
-    vertex.attributes = {
-      name: "John Doe",
-      age: 30,
-    };
-
-    const configAttributes = [
-      { name: "name", dataType: "String" },
-      { name: RDFS_LABEL_URI, dataType: "String" },
-      { name: "age", dataType: "Number" },
-    ];
-
-    const sortedDisplayAttributes = getSortedDisplayAttributes(
-      vertex,
-      configAttributes,
-      transformNoOp
-    );
-
-    expect(sortedDisplayAttributes[0].name).toBe(RDFS_LABEL_URI);
-    expect(sortedDisplayAttributes[0].displayValue).toBe(LABELS.MISSING_VALUE);
   });
 });
 

--- a/packages/graph-explorer/src/core/StateProvider/displayAttribute.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayAttribute.ts
@@ -1,48 +1,29 @@
-import { Vertex, Edge, AttributeConfig, EntityPropertyValue } from "@/core";
+import { Vertex, Edge, EntityPropertyValue } from "@/core";
 import { TextTransformer } from "@/hooks";
 import { getDisplayValueForScalar } from "@/connector/entities";
 import { sortAttributeByName } from "./sortAttributeByName";
 
 /** Represents an attribute's display information after all transformations have been applied. */
-export type DisplayAttribute = {
-  name: string;
-  displayLabel: string;
-  displayValue: string | null;
-};
+export type DisplayAttribute = ReturnType<typeof mapToDisplayAttribute>;
 
 /** Maps a `Vertex` or `Edge` instance's attributes to a list of `DisplayAttribute` instances using the schema and any user preferences. */
 export function getSortedDisplayAttributes(
   entity: Vertex | Edge,
-  typeAttributes: AttributeConfig[],
   textTransform: TextTransformer
 ): DisplayAttribute[] {
-  const entityAttributeNames = Object.keys(entity.attributes);
-  const typeAttributeNames = typeAttributes.map(attr => attr.name);
-  const uniqueAttributeNames = new Set([
-    ...entityAttributeNames,
-    ...typeAttributeNames,
-  ]);
-  const sortedAttributes = uniqueAttributeNames
-    .values()
-    .map(name => {
-      const value = entity.attributes[name] ?? null;
-
-      return mapToDisplayAttribute(name, value, textTransform);
-    })
-    .toArray()
+  return Object.entries(entity.attributes)
+    .map(([name, value]) => mapToDisplayAttribute(name, value, textTransform))
     .toSorted(sortAttributeByName);
-
-  return sortedAttributes;
 }
 
 export function mapToDisplayAttribute(
   name: string,
-  value: EntityPropertyValue | null,
+  value: EntityPropertyValue,
   textTransform: TextTransformer
-): DisplayAttribute {
+) {
   return {
     name,
     displayLabel: textTransform(name),
     displayValue: getDisplayValueForScalar(value),
-  } satisfies DisplayAttribute;
+  };
 }

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.ts
@@ -11,7 +11,6 @@ import {
   edgesSelectedIdsAtom,
   queryEngineSelector,
   edgeSelector,
-  edgeTypeAttributesSelector,
 } from "@/core";
 import { textTransformSelector } from "@/hooks";
 import { LABELS, RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
@@ -76,12 +75,7 @@ const displayEdgeSelector = atomFamily((edge: Edge) =>
     const rawStringId = String(getRawId(edge.id));
     const displayId = isSparql ? displayTypes : rawStringId;
 
-    const typeAttributes = get(edgeTypeAttributesSelector(edgeTypes));
-    const sortedAttributes = getSortedDisplayAttributes(
-      edge,
-      typeAttributes,
-      textTransform
-    );
+    const sortedAttributes = getSortedDisplayAttributes(edge, textTransform);
 
     // Get the display name and description for the edge
     function getDisplayAttributeValueByName(name: string | undefined) {

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
@@ -17,7 +17,7 @@ import {
   useDisplayVertexFromVertex,
   Vertex,
 } from "@/core";
-import { formatDate } from "@/utils";
+import { formatDate, LABELS } from "@/utils";
 import { schemaAtom } from "./schema";
 import {
   activeConfigurationAtom,
@@ -26,7 +26,6 @@ import {
   patchToRemoveDisplayLabel,
 } from "./configuration";
 import { createRandomDate, createRandomName } from "@shared/utils/testing";
-import { LABELS } from "@/utils/constants";
 import { mapToDisplayVertexTypeConfig } from "./displayTypeConfigs";
 import { QueryEngine } from "@shared/types";
 import { getDisplayValueForScalar } from "@/connector/entities";
@@ -191,31 +190,18 @@ describe("useDisplayVertexFromVertex", () => {
     );
   });
 
-  it("should include missing attributes with --- as value", () => {
+  it("should not add missing attributes from schema config", () => {
     const vertex = createRandomVertex();
     const schema = createRandomSchema();
     const vtConfig = createRandomVertexTypeConfig();
     vtConfig.type = vertex.type;
     schema.vertices.push(vtConfig);
-    const configAttributeNames = vtConfig.attributes.map(attr => attr.name);
 
-    const actualAttributesMatchingConfig = act(
-      vertex,
-      withSchema(schema)
-    ).attributes.filter(a => configAttributeNames.includes(a.name));
+    const result = act(vertex, withSchema(schema));
 
-    const expected = vtConfig.attributes
-      .map(
-        attr =>
-          <DisplayAttribute>{
-            name: attr.name,
-            displayLabel: attr.name,
-            displayValue: LABELS.MISSING_VALUE,
-          }
-      )
-      .toSorted((a, b) => a.displayLabel.localeCompare(b.displayLabel));
-
-    expect(actualAttributesMatchingConfig).toStrictEqual(expected);
+    expect(Object.keys(result.attributes)).not.toBe(
+      expect.arrayContaining(vtConfig.attributes.map(a => a.name))
+    );
   });
 
   it("should replace uri with prefixes when available", () => {

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -1,7 +1,6 @@
 import {
   DisplayAttribute,
   getSortedDisplayAttributes,
-  vertexTypeAttributesSelector,
   nodesAtom,
   nodesSelectedIdsAtom,
   DisplayVertexTypeConfig,
@@ -89,12 +88,7 @@ const displayVertexSelector = atomFamily((vertex: Vertex) =>
       .join(", ");
 
     // Map all the attributes for displaying
-    const typeAttributes = get(vertexTypeAttributesSelector(vertexTypes));
-    const sortedAttributes = getSortedDisplayAttributes(
-      vertex,
-      typeAttributes,
-      textTransform
-    );
+    const sortedAttributes = getSortedDisplayAttributes(vertex, textTransform);
 
     // Get the display name and description for the vertex
     function getDisplayAttributeValueByName(name: string | undefined) {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

- Removes the logic that added missing attributes to `DisplayVertex` and `DisplayEdge`
- Update tests
- Remove unused helpers

## Validation

- Smoke test

## Related Issues

- Resolves #1249 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
