### PR TITLE
Fix auto open details

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userLayout.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.ts
@@ -2,7 +2,7 @@ import { useAtom } from "jotai";
 import { atomWithLocalForage } from "./localForageEffect";
 import { useQueryEngine } from "../connector";
 
-type ToggleableView = "graph-viewer" | "table-view";
+export type ToggleableView = "graph-viewer" | "table-view";
 
 type UserLayout = {
   activeToggles: Set<ToggleableView>;

--- a/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.test.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.test.ts
@@ -1,0 +1,67 @@
+import { type ToggleableView, useSidebar, userLayoutAtom } from "@/core";
+import { renderHookWithJotai } from "@/utils/testing";
+import { act } from "react";
+import { useAutoOpenDetailsSidebar } from "./useAutoOpenDetailsSidebar";
+
+describe("useAutoOpenDetailsSidebar", () => {
+  it("should auto-open details when detailsAutoOpenOnSelection is true", async () => {
+    const { result } = renderHookWithJotai(
+      () => {
+        const autoOpen = useAutoOpenDetailsSidebar();
+        const sidebar = useSidebar();
+        return { autoOpen, sidebar };
+      },
+      store =>
+        store.set(userLayoutAtom, {
+          activeSidebarItem: "search",
+          activeToggles: new Set<ToggleableView>(),
+          detailsAutoOpenOnSelection: true,
+        })
+    );
+
+    await act(() => result.current.autoOpen());
+
+    expect(result.current.sidebar.activeSidebarItem).toBe("details");
+  });
+
+  it("should do nothing when detailsAutoOpenOnSelection is true and sidebar is already details", async () => {
+    const { result } = renderHookWithJotai(
+      () => {
+        const autoOpen = useAutoOpenDetailsSidebar();
+        const sidebar = useSidebar();
+        return { autoOpen, sidebar };
+      },
+      store =>
+        store.set(userLayoutAtom, {
+          activeSidebarItem: "details",
+          activeToggles: new Set<ToggleableView>(),
+          detailsAutoOpenOnSelection: true,
+        })
+    );
+
+    await act(() => result.current.autoOpen());
+
+    expect(result.current.sidebar.activeSidebarItem).toBe("details");
+    expect(result.current.sidebar.isSidebarOpen).toBe(true);
+  });
+
+  it("should not auto-open details when detailsAutoOpenOnSelection is false", async () => {
+    const { result } = renderHookWithJotai(
+      () => {
+        const autoOpen = useAutoOpenDetailsSidebar();
+        const sidebar = useSidebar();
+        return { autoOpen, sidebar };
+      },
+      store =>
+        store.set(userLayoutAtom, {
+          activeSidebarItem: "search",
+          activeToggles: new Set<ToggleableView>(),
+          detailsAutoOpenOnSelection: false,
+        })
+    );
+
+    await act(() => result.current.autoOpen());
+
+    expect(result.current.sidebar.activeSidebarItem).toBe("search");
+  });
+});

--- a/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useAutoOpenDetailsSidebar.ts
@@ -1,29 +1,20 @@
 import { userLayoutAtom } from "@/core";
-import { useAtomCallback } from "jotai/utils";
-import { useCallback } from "react";
+import { useSetAtom } from "jotai";
 
 export function useAutoOpenDetailsSidebar() {
-  return useAtomCallback(
-    useCallback(async (get, set) => {
-      const userLayout = get(userLayoutAtom);
+  const setUserLayout = useSetAtom(userLayoutAtom);
+  return async () => {
+    await setUserLayout(async prevPromise => {
+      const prev = await prevPromise;
 
-      // If feature is disabled then do nothing
-      if (userLayout.detailsAutoOpenOnSelection === false) {
-        return;
+      if (prev.detailsAutoOpenOnSelection !== true) {
+        return prev;
       }
 
-      // If sidebar is already open then do nothing
-      if (userLayout.activeSidebarItem != null) {
-        return;
-      }
-
-      // Sidebar is closed, so open it to details
-      await set(userLayoutAtom, async prevState => {
-        return {
-          ...(await prevState),
-          activeSidebarItem: "details" as const,
-        };
-      });
-    }, [])
-  );
+      return {
+        ...prev,
+        activeSidebarItem: "details",
+      };
+    });
+  };
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Updates behavior of the auto open details to work even when the sidebar is open. This matches most people's expectations for the feature.

- Move check for current state inside the `setUserLayout` call
- Remove check for the sidebar being open or closed
- Always set the sidebar item to `details` when enabled
- Added tests

## Validation

- Tested in UI
- Added tests

## Related Issues

- Resolves #1259 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
