### PR TITLE
Add descriptive error for patching entity details

### DIFF
--- a/packages/graph-explorer/src/connector/queries/executeUserQuery.test.ts
+++ b/packages/graph-explorer/src/connector/queries/executeUserQuery.test.ts
@@ -165,7 +165,9 @@ describe("executeUserQuery", () => {
       executeUserQuery("query", mockUpdateSchema)
     );
 
-    await expect(result).rejects.toThrow("Failed to fetch entity details");
+    await expect(result).rejects.toThrow(
+      "Failed to fetch the details of 2 vertices and 1 edge."
+    );
     expect(rawQuerySpy).toBeCalledTimes(1);
     expect(vertexDetailsSpy).toBeCalledTimes(1);
     expect(edgeDetailsSpy).toBeCalledTimes(1);

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -1,6 +1,7 @@
 import { ZodError } from "zod";
 import { NetworkError } from "./NetworkError";
 import { isCancellationError } from "./isCancellationError";
+import { PatchEntityDetailsError } from "@/connector/queries/patchEntityDetails";
 
 export type DisplayError = {
   title: string;
@@ -115,6 +116,13 @@ export function createDisplayError(error: any): DisplayError {
       title: `Network Response ${error.statusCode}`,
       message:
         extractMessageFromData(error.data) ?? defaultDisplayError.message,
+    };
+  }
+
+  if (error instanceof PatchEntityDetailsError) {
+    return {
+      title: "Failed to update entity details",
+      message: error.message,
     };
   }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds a friendly error message when patching entity details fails.

* Added custom error type
* Updated `getDisplayError` to render message

## Validation

<img width="752" height="800" alt="CleanShot 2025-10-20 at 15 18 12@2x" src="https://github.com/user-attachments/assets/7e5294d8-4ac2-45d5-abb7-c742a205d769" />


## Related Issues

- Part of #1228

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
