### PR TITLE
Save query state on every change

### DIFF
--- a/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
@@ -51,6 +51,12 @@ export function QuerySearchTabContent() {
     },
   });
 
+  // Sync form changes to Jotai atom in real-time
+  const handleQueryChange = (value: string) => {
+    setQueryText(value);
+    form.setValue("query", value);
+  };
+
   // Execute the query when the form is submitted
   const onSubmit = async (data: FormData) => {
     logger.debug("Executing query:", data);
@@ -88,6 +94,7 @@ export function QuerySearchTabContent() {
                 <FormControl>
                   <QueryTextArea
                     {...field}
+                    onChange={e => handleQueryChange(e.target.value)}
                     className="pr-14"
                     onSubmit={onKeyboardShortcutSubmit}
                   />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Updates the existing Jotai atom with the current query state whenever it changes.

This is a temporary low risk change for this release. This will be removed in the next release when we update to React 19.2 and migrate to the `Activity` component, which will maintain state of hidden views across the app.

## Validation

- Tested to ensure performance is fine and the value saves when expected

## Related Issues

- Resolves #1268 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
