### PR TITLE
Add `user: root` to docker-compose.yaml to avoid permission errors

### DIFF
--- a/samples/air_routes/docker-compose.yaml
+++ b/samples/air_routes/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
 
   database:
     image: tinkerpop/gremlin-server:latest
+    user: root
     volumes:
       - ./sample:/opt/gremlin-server/sample
     command: /opt/gremlin-server/sample/conf/gremlin-server-air-routes.yaml


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR adds `user: root` to the docker-compose.yaml file in the sample/ directory.

## Validation

<!-- How do you know this is working? What should a reviewer look for? Provide a screenshot if your change is visual.-->

After adding the line, the permission error mentioned in the issue is no longer thrown.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

Fixes #1284

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
