### PR TITLE
Make style dialogs more global

### DIFF
--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -22,11 +22,23 @@ import {
 } from "./arrowsStyling";
 import { LINE_STYLE_OPTIONS } from "./lineStyling";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
-import { atom, useAtom } from "jotai";
+import { atom, useAtom, useSetAtom } from "jotai";
 
-export const customizeEdgeTypeAtom = atom<string | undefined>(undefined);
+const customizeEdgeTypeAtom = atom<string | undefined>(undefined);
 
-export default function EdgeStyleDialog() {
+/**
+ * Open the dialog to customize the edge style
+ * @returns callback to open the dialog
+ */
+export function useOpenEdgeStyleDialog() {
+  const setCustomizeEdgeType = useSetAtom(customizeEdgeTypeAtom);
+
+  return (edgeType: string) => {
+    setCustomizeEdgeType(edgeType);
+  };
+}
+
+export function EdgeStyleDialog() {
   const [customizeEdgeType, setCustomizeEdgeType] = useAtom(
     customizeEdgeTypeAtom
   );

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgesStyling.tsx
@@ -11,7 +11,6 @@ import { useDisplayEdgeTypeConfigs } from "@/core";
 import useTranslations from "@/hooks/useTranslations";
 import SingleEdgeStyling from "./SingleEdgeStyling";
 import { SidebarCloseButton } from "../SidebarCloseButton";
-import EdgeStyleDialog from "./EdgeStyleDialog";
 import { Virtuoso } from "react-virtuoso";
 
 function EdgesStyling() {
@@ -42,7 +41,6 @@ function EdgesStyling() {
             </Fragment>
           )}
         />
-        <EdgeStyleDialog />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/SingleEdgeStyling.tsx
@@ -4,8 +4,7 @@ import { useDisplayEdgeTypeConfig } from "@/core";
 import { useEdgeStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { LABELS } from "@/utils";
-import { customizeEdgeTypeAtom } from "./EdgeStyleDialog";
-import { useSetAtom } from "jotai";
+import { useOpenEdgeStyleDialog } from "./EdgeStyleDialog";
 
 export type SingleEdgeStylingProps = {
   edgeType: string;
@@ -16,7 +15,7 @@ export default function SingleEdgeStyling({
   ...rest
 }: SingleEdgeStylingProps) {
   const { setEdgeStyle } = useEdgeStyling(edgeType);
-  const setCustomizeEdgeType = useSetAtom(customizeEdgeTypeAtom);
+  const openEdgeStyleDialog = useOpenEdgeStyleDialog();
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
@@ -50,7 +49,7 @@ export default function SingleEdgeStyling({
         <Button
           icon={<StylingIcon />}
           variant="text"
-          onClick={() => setCustomizeEdgeType(edgeType)}
+          onClick={() => openEdgeStyleDialog(edgeType)}
         >
           Customize
         </Button>

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -32,9 +32,21 @@ import {
   RESERVED_TYPES_PROPERTY,
 } from "@/utils/constants";
 import { cn } from "@/utils";
-import { atom, useAtom } from "jotai";
+import { atom, useAtom, useSetAtom } from "jotai";
 
-export const customizeNodeTypeAtom = atom<string | undefined>(undefined);
+const customizeNodeTypeAtom = atom<string | undefined>(undefined);
+
+/**
+ * Open the dialog to customize the node style
+ * @returns callback to open the dialog
+ */
+export function useOpenNodeStyleDialog() {
+  const setCustomizeNodeType = useSetAtom(customizeNodeTypeAtom);
+
+  return (vertexType: string) => {
+    setCustomizeNodeType(vertexType);
+  };
+}
 
 const file2Base64 = (file: File): Promise<string> => {
   return new Promise<string>((resolve, reject) => {
@@ -46,7 +58,7 @@ const file2Base64 = (file: File): Promise<string> => {
   });
 };
 
-export default function NodeStyleDialog() {
+export function NodeStyleDialog() {
   const styleWithTheme = useWithTheme();
 
   const [customizeNodeType, setCustomizeNodeType] = useAtom(

--- a/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodesStyling.tsx
@@ -12,7 +12,6 @@ import SingleNodeStyling from "./SingleNodeStyling";
 import { Fragment } from "react/jsx-runtime";
 import { SidebarCloseButton } from "../SidebarCloseButton";
 import { Virtuoso } from "react-virtuoso";
-import NodeStyleDialog from "./NodeStyleDialog";
 
 function NodesStyling() {
   const vtConfigs = useDisplayVertexTypeConfigs().values().toArray();
@@ -41,7 +40,6 @@ function NodesStyling() {
             </Fragment>
           )}
         />
-        <NodeStyleDialog />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/SingleNodeStyling.tsx
@@ -4,8 +4,7 @@ import { useDisplayVertexTypeConfig } from "@/core";
 import { useVertexStyling } from "@/core/StateProvider/userPreferences";
 import { useDebounceValue, usePrevious } from "@/hooks";
 import { LABELS } from "@/utils/constants";
-import { customizeNodeTypeAtom } from "./NodeStyleDialog";
-import { useSetAtom } from "jotai";
+import { useOpenNodeStyleDialog } from "./NodeStyleDialog";
 
 export type SingleNodeStylingProps = {
   vertexType: string;
@@ -20,7 +19,7 @@ export default function SingleNodeStyling({
 
   const [displayAs, setDisplayAs] = useState(displayConfig.displayLabel);
 
-  const setCustomizeNodeType = useSetAtom(customizeNodeTypeAtom);
+  const openNodeStyleDialog = useOpenNodeStyleDialog();
 
   // Delayed update of display name to prevent input lag
   const debouncedDisplayAs = useDebounceValue(displayAs, 400);
@@ -52,7 +51,7 @@ export default function SingleNodeStyling({
         <Button
           icon={<StylingIcon />}
           variant="text"
-          onClick={() => setCustomizeNodeType(vertexType)}
+          onClick={() => openNodeStyleDialog(vertexType)}
         >
           Customize
         </Button>

--- a/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
@@ -30,14 +30,14 @@ import {
 } from "@/core";
 import { totalFilteredCount } from "@/core/StateProvider/filterCount";
 import useTranslations from "@/hooks/useTranslations";
-import EdgesStyling from "@/modules/EdgesStyling/EdgesStyling";
+import { EdgesStyling, EdgeStyleDialog } from "@/modules/EdgesStyling";
 import EntitiesFilter from "@/modules/EntitiesFilter";
 import EntitiesTabular from "@/modules/EntitiesTabular/EntitiesTabular";
 import EntityDetails from "@/modules/EntityDetails";
 import GraphViewer from "@/modules/GraphViewer";
 import Namespaces from "@/modules/Namespaces/Namespaces";
 import NodeExpand from "@/modules/NodeExpand";
-import { NodesStyling } from "@/modules/NodesStyling";
+import { NodesStyling, NodeStyleDialog } from "@/modules/NodesStyling";
 import { LABELS } from "@/utils/constants";
 import { SearchSidebarPanel } from "@/modules/SearchSidebar";
 import { useAtomValue } from "jotai";
@@ -131,6 +131,8 @@ const GraphExplorer = () => {
             <EntitiesTabular />
           </Resizable>
         </Activity>
+        <NodeStyleDialog />
+        <EdgeStyleDialog />
       </Workspace.Content>
 
       <Workspace.SideBar direction="row">


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When accessing the style dialog from the graph context menu, Graph Explorer would switch to the node/edge style sidebar then show the dialog. This doesn't make much sense to do.

Now the dialog is hosted by the `GraphExplorer`, which is the root of the route. So, the dialog can be shown without switching to the correct side bar first.

I also changed it so that the node/edge no longer is selected.

## Validation

* Tested customize node/edge from context menu
* Tested customize node/edge from sidebar panels
* Tested with auto open details toggled on

## Related Issues

- Part of #1283

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
