### PR TITLE
Fix container query issues

### DIFF
--- a/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
@@ -37,7 +37,7 @@ function ConnectionRow({
   return (
     <div
       onClick={setActiveConfig}
-      className="flex flex-row items-center gap-4 px-6 py-4 hover:cursor-pointer"
+      className="@container flex flex-row items-center gap-4 px-6 py-4 hover:cursor-pointer"
     >
       <DatabaseIcon className="text-primary-main hidden size-8 shrink-0 @md:block" />
       <ListRowContent>

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -123,7 +123,7 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
           />
         </PanelHeaderActions>
       </PanelHeader>
-      <PanelContent>
+      <PanelContent className="@container">
         <InfoBar className="hidden @sm:flex">
           <InfoItem className="shrink-0">
             <InfoItemIcon>


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Removing `@container/panel` in my last PR (#1298) broke the container queries for the connections screen. I've added more specific container definitions for these specific views to avoid the nested container issue that was causing the `Legend` component to not even render.

## Validation

* Tested connections screen responsive layout changes at different widths
* Tested Legend behavior in graph canvas

## Related Issues

* Part of #1276 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
