### PR TITLE
Fix null prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@
 
 ## Project Commands
 
+- All commands should be run from the root of the project repository
+
 ### Development
 
 - `pnpm dev` - Start dev servers
@@ -36,6 +38,7 @@
 - `pnpm test` - Run tests
 - `pnpm test:watch` - Watch mode
 - `pnpm coverage` - Test coverage
+- `pnpm vitest --run <path-to-file>` - Run tests for specific file
 
 ### Maintenance
 

--- a/packages/graph-explorer/src/utils/generatePrefixes.test.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.test.ts
@@ -193,4 +193,45 @@ describe("generatePrefixes", () => {
       __matches: new Set(["http://SecretSpyOrg/data/hasText"]),
     });
   });
+
+  it("should ignore file URIs since they don't have an origin", () => {
+    const updatedPrefixes = generatePrefixes(
+      new Set(["file://foo/bar.txt"]),
+      []
+    );
+
+    expect(updatedPrefixes).toBeNull();
+  });
+
+  it("should ignore any non-path URIs", () => {
+    const updatedPrefixes = generatePrefixes(
+      new Set([
+        "urn:Person",
+        "urn:knows",
+        "urn:name",
+        "urn:isbn:1234567890",
+        "mailto:example@abc.com",
+        "custom-scheme:foo",
+      ]),
+      []
+    );
+
+    expect(updatedPrefixes).toBeNull();
+  });
+
+  it("should handle any pathed URI", () => {
+    const updatedPrefixes = generatePrefixes(
+      new Set(["ftp://foo/bar.txt"]),
+      []
+    );
+
+    expect(updatedPrefixes).toEqual([
+      {
+        __inferred: true,
+        uri: "ftp://foo/",
+        prefix: "foo",
+        __matches: new Set(["ftp://foo/bar.txt"]),
+      },
+    ]);
+  });
 });

--- a/packages/graph-explorer/src/utils/generatePrefixes.ts
+++ b/packages/graph-explorer/src/utils/generatePrefixes.ts
@@ -18,11 +18,18 @@ function normalizeUri(uri: string) {
   return uri.toLowerCase().trim();
 }
 
-/** Checks if the given string is a valid URL. */
+/** Checks if the given string is a valid URL with a path. */
 function isUrl(str: string) {
   try {
-    new URL(str);
-    return true;
+    const url = new URL(str);
+
+    // Check for invalid origin (`urn:Person` has "null" origin)
+    if (url.origin.length === 0 || url.origin === "null") {
+      return false;
+    }
+
+    // Must contain a path or a hash
+    return url.pathname.length > 0 || url.hash.length > 0;
   } catch {
     return false;
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The prefix generation logic did not handl `urn:Person` very well. So I've added some logic to filter URIs like this out so they won't be processed.

## Validation

* Added test scenarios for the values to be filtered out
* Ran schema sync to see null prefix disappear in app

## Related Issues

* Resolves #1299

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
