### PR TITLE
Remove `searchable` and `hidden` from `AttributeConfig`

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/index.ts
@@ -97,7 +97,6 @@ const fetchPredicatesByClass = async (
             item =>
               ({
                 name: item.pred.value,
-                searchable: true,
                 dataType: TYPE_MAP[item.sample.datatype || ""] || "String",
               }) satisfies AttributeConfig
           )

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -22,12 +22,6 @@ export type AttributeConfig = {
    * DB data type
    */
   dataType?: string;
-
-  /**
-   * For searching purposes, attributes can be enabled or disable
-   * from the search request
-   */
-  searchable?: boolean;
 };
 
 export type VertexTypeConfig = {
@@ -78,7 +72,7 @@ export type EdgeTypeConfig = {
   /**
    * List of attributes for the edge type
    */
-  attributes: Array<Omit<AttributeConfig, "searchable">>;
+  attributes: Array<AttributeConfig>;
   /**
    * Total number of edges of this type
    */

--- a/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.test.ts
@@ -229,7 +229,7 @@ describe("mapToDisplayVertexTypeConfig", () => {
     const vtConfig = createRandomVertexTypeConfig();
     vtConfig.attributes = [
       { name: "name", dataType: "String" },
-      { name: "email", dataType: "String", searchable: true },
+      { name: "email", dataType: "String" },
     ];
 
     const result = mapToDisplayVertexTypeConfig(
@@ -270,9 +270,9 @@ describe("mapToDisplayVertexTypeConfig", () => {
   it("should mark non-String attributes as not searchable even when searchable in schema", () => {
     const vtConfig = createRandomVertexTypeConfig();
     vtConfig.attributes = [
-      { name: "age", dataType: "Number", searchable: true },
-      { name: "active", dataType: "Boolean", searchable: true },
-      { name: "created", dataType: "Date", searchable: true },
+      { name: "age", dataType: "Number" },
+      { name: "active", dataType: "Boolean" },
+      { name: "created", dataType: "Date" },
     ];
 
     const result = mapToDisplayVertexTypeConfig(
@@ -281,32 +281,6 @@ describe("mapToDisplayVertexTypeConfig", () => {
     );
 
     expect(result.attributes.every(a => !a.isSearchable)).toBe(true);
-  });
-
-  it("should respect searchable: false for String attributes", () => {
-    const vtConfig = createRandomVertexTypeConfig();
-    vtConfig.attributes = [
-      { name: "name", dataType: "String", searchable: false },
-      { name: "email", dataType: "String", searchable: true },
-    ];
-
-    const result = mapToDisplayVertexTypeConfig(
-      vtConfig,
-      identityTextTransform
-    );
-
-    expect(result.attributes).toStrictEqual([
-      {
-        name: "email",
-        displayLabel: "email",
-        isSearchable: true,
-      },
-      {
-        name: "name",
-        displayLabel: "name",
-        isSearchable: false,
-      },
-    ]);
   });
 
   it("should handle attributes without dataType", () => {

--- a/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayTypeConfigs.ts
@@ -202,5 +202,5 @@ export function mapToDisplayEdgeTypeConfig(
 }
 
 function isAttributeSearchable(attribute: AttributeConfig) {
-  return attribute.searchable !== false && attribute.dataType === "String";
+  return attribute.dataType === "String";
 }

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
@@ -124,7 +124,6 @@ describe("useKeywordSearch", () => {
       config.connection!.queryEngine = "sparql";
       schema.vertices[0].attributes.push({
         name: "rdfs:label",
-        searchable: true,
         dataType: "String",
       });
 

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -75,14 +75,12 @@ affected by those values, regardless of what they are.
  */
 export function createRandomAttributeConfig(): AttributeConfig {
   const dataType = randomlyUndefined(createRandomName("dataType"));
-  const searchable = randomlyUndefined(createRandomBoolean());
   const displayLabel = randomlyUndefined(createRandomName("displayLabel"));
 
   return {
     name: createRandomName("name"),
     ...(displayLabel && { displayLabel }),
     ...(dataType && { dataType }),
-    ...(searchable && { searchable }),
   };
 }
 


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The `hidden` field wasn't being used at all. The `searchable` field is redundant with the `dataType` field. Essentially `dataType === "String"` is all that is needed.

## Validation

* All string fields are still searchable
* Schema sync still works

## Related Issues

* Resolves #1224 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
