### PR TITLE
Remove vertexTypes from expand neighbors request

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -75,7 +75,6 @@ describe("Gremlin > fetchNeighbors", () => {
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
       vertexId: createVertexId("2018"),
-      vertexTypes: ["airport"],
     });
 
     expect(response).toStrictEqual({
@@ -182,7 +181,6 @@ describe("Gremlin > fetchNeighbors", () => {
 
     const response = await fetchNeighbors(mockGremlinFetch(), {
       vertexId: createVertexId("2018"),
-      vertexTypes: ["airport"],
       filterByVertexTypes: ["airport"],
       filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],
     });

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
@@ -18,7 +18,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const neighborVertex = createTestableVertex().withRdfValues();
     const edge = createTestableEdge()
@@ -47,7 +46,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const neighbor1 = createTestableVertex().withRdfValues();
     const neighbor2 = createTestableVertex().withRdfValues();
@@ -74,7 +72,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const mockResponse = createQuadSparqlResponse([]);
     mockSparqlFetch.mockResolvedValue(mockResponse);
@@ -92,7 +89,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
 
     const bindings = createQuadBindingsForEntities([sourceVertex], []);
@@ -112,7 +108,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const malformedResponse = {
       head: { vars: ["subject", "predicate", "object"] },
@@ -137,7 +132,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const invalidResponse = {
       head: { vars: ["subject", "predicate", "object"] },
@@ -162,7 +156,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const invalidResponse = {
       // Missing head
@@ -181,7 +174,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const invalidResponse = {
       head: { vars: ["subject", "predicate", "object"] },
@@ -198,7 +190,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const blankNodeVertex = createTestableVertex().withRdfValues({
       isBlankNode: true,
@@ -227,7 +218,6 @@ describe("fetchNeighbors", () => {
     // Arrange
     const request: SPARQLNeighborsRequest = {
       resourceURI: createRandomUrlString() as any,
-      resourceClasses: [createRandomUrlString(), createRandomUrlString()],
       subjectClasses: [createRandomUrlString()],
       filterCriteria: [
         { predicate: "http://example.com/name", object: "test" },
@@ -258,7 +248,6 @@ describe("fetchNeighbors", () => {
     const sourceVertex = createTestableVertex().withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
     const fetchError = new Error("Network error");
     mockSparqlFetch.mockRejectedValue(fetchError);
@@ -279,7 +268,6 @@ describe("fetchNeighbors", () => {
       .withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: targetVertex.id,
-      resourceClasses: [],
     };
 
     // Only include target vertex in bindings, not the edge source
@@ -307,7 +295,6 @@ describe("fetchNeighbors", () => {
       .withRdfValues();
     const request: SPARQLNeighborsRequest = {
       resourceURI: sourceVertex.id,
-      resourceClasses: [],
     };
 
     // Only include source vertex in bindings, not the edge source

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -8,7 +8,6 @@ describe("oneHopNeighborsTemplate", () => {
     // This represents the filter criteria used in the example documentation
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       subjectClasses: ["http://www.example.com/soccer/ontology/Team"],
       filterCriteria: [
         {
@@ -64,7 +63,6 @@ describe("oneHopNeighborsTemplate", () => {
   it("should produce query for resource", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       limit: 10,
       offset: 0,
     });
@@ -100,7 +98,6 @@ describe("oneHopNeighborsTemplate", () => {
   it("should produce query for multiple subject classes", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       subjectClasses: [
         "http://www.example.com/soccer/ontology/Team",
         "http://www.example.com/soccer/ontology/Player",
@@ -138,7 +135,6 @@ describe("oneHopNeighborsTemplate", () => {
   it("should produce query with limit of zero", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       limit: 0,
     });
 
@@ -172,7 +168,6 @@ describe("oneHopNeighborsTemplate", () => {
   it("should produce query with limit and offset", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       limit: 10,
       offset: 5,
     });
@@ -208,7 +203,6 @@ describe("oneHopNeighborsTemplate", () => {
   it("should produce query excluding resources", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
-      resourceClasses: [],
       excludedVertices: new Set([
         createVertexId("http://www.example.com/soccer/resource#EFL"),
         createVertexId("http://www.example.com/soccer/resource#EFL2"),

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -112,7 +112,6 @@ export function createSparqlExplorer(
       remoteLogger.info("[SPARQL Explorer] Fetching neighbors...");
       const request: SPARQLNeighborsRequest = {
         resourceURI: req.vertexId,
-        resourceClasses: req.vertexTypes,
         subjectClasses: req.filterByVertexTypes,
         filterCriteria: req.filterCriteria?.map((c: Criterion) => ({
           predicate: c.name,

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -23,10 +23,6 @@ export type SPARQLNeighborsRequest = {
    */
   resourceURI: VertexId;
   /**
-   * Resource classes.
-   */
-  resourceClasses: Vertex["types"];
-  /**
    * Filter by subject classes
    */
   subjectClasses?: Array<string>;

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -81,16 +81,6 @@ export type NeighborsRequest = {
    * Source vertex ID & type.
    */
   vertexId: VertexId;
-  /**
-   * Source vertex types.
-   *
-   * Used only by the SPARQL implementation to patch the edges returned with the
-   * source vertex type.
-   *
-   * NOTE: This should be removed once the SPARQL queries are updated to
-   * retrieve the resource class from the database.
-   */
-  vertexTypes: Vertex["types"];
 
   /**
    * Vertices to exclude from the results.

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -132,7 +132,6 @@ export default function GraphViewer({
 
     expandNode({
       vertexId,
-      vertexTypes: vertex.types,
       limit: defaultNeighborExpansionLimit ?? undefined,
     });
   };

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   VertexRow,
 } from "@/components";
-import { type DisplayVertex, useNeighbors, useVertex } from "@/core";
+import { type DisplayVertex, useNeighbors } from "@/core";
 import { useExpandNode } from "@/hooks";
 import useNeighborsOptions, {
   type NeighborOption,
@@ -152,16 +152,13 @@ function ExpandButton({
   isDisabled: boolean;
   filters: ExpandNodeFilters;
 }) {
-  const vertex = useVertex(vertexId);
   const { expandNode, isPending } = useExpandNode();
 
   return (
     <Button
       variant="filled"
       isDisabled={isPending || isDisabled}
-      onPress={() =>
-        expandNode({ vertexId, vertexTypes: vertex.types, ...filters })
-      }
+      onPress={() => expandNode({ vertexId, ...filters })}
     >
       <Spinner loading={isPending}>
         <ExpandGraphIcon />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The expand neighbors request used to pass the source vertex types down through the request. This was because the old sparql query did not retrieve the source vertex type.

Now that the sparql queries all get the full vertex data, passing this information down is no longer necessary.

## Validation

* Tested expansion in sparql with double click and filtered by type
* Tested expansion in gremlin

## Related Issues

* N/A

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
