### PR TITLE
Use universal Jotai store

### DIFF
--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -217,7 +217,7 @@ test("should generate correct query", async () => {
 import { render, screen } from "@testing-library/react";
 import { DbState, createTestableVertex, TestProvider } from "@/utils/testing";
 import { createQueryClient } from "@/core/queryClient";
-import { createStore } from "jotai";
+import { getAppStore } from "@/core";
 
 test("should render vertex correctly", () => {
   const state = new DbState();
@@ -228,7 +228,7 @@ test("should render vertex correctly", () => {
   state.addTestableVertexToGraph(vertex);
 
   // Set values on the Jotai store
-  const store = createStore();
+  const store = getAppStore();
   state.applyTo(store);
 
   // Create the query client using the mock explorer

--- a/packages/graph-explorer/src/connector/queries/helpers.ts
+++ b/packages/graph-explorer/src/connector/queries/helpers.ts
@@ -71,3 +71,12 @@ export function getExplorer(meta: GraphExplorerMeta | undefined) {
   }
   return meta.explorer;
 }
+
+/** Extracts the Jotai store from the meta objects */
+export function getStore(meta: GraphExplorerMeta | undefined) {
+  if (!meta?.store) {
+    logger.error("No Jotai store found in the query client meta object");
+    throw new Error("No Jotai store found in the query client meta object");
+  }
+  return meta.store;
+}

--- a/packages/graph-explorer/src/core/ExplorerInjector.tsx
+++ b/packages/graph-explorer/src/core/ExplorerInjector.tsx
@@ -1,16 +1,21 @@
 import { logger } from "@/utils";
 import { useQueryClient } from "@tanstack/react-query";
-import { defaultOptionsAtom } from "./queryClient";
+import { createDefaultOptions } from "./queryClient";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
+import { explorerAtom } from "./connector";
+import { getAppStore } from "./StateProvider/appStore";
 
 /**
- * Ensures the query client has the correct explorer for the connection injected
- * in to the `meta` object. It also clears the cache when the explorer changes.
+ * Ensures the query client has the correct explorer for the connection and
+ * Jotai store injected in to the `meta` object. It also clears the cache when
+ * the explorer changes.
  */
 export function ExplorerInjector() {
   const queryClient = useQueryClient();
-  const defaultOptions = useAtomValue(defaultOptionsAtom);
+  const explorer = useAtomValue(explorerAtom);
+  const store = getAppStore();
+  const defaultOptions = createDefaultOptions(explorer, store);
   const [prevDefaultOptions, setPrevDefaultOptions] = useState(defaultOptions);
 
   if (prevDefaultOptions !== defaultOptions) {

--- a/packages/graph-explorer/src/core/StateProvider/appStore.ts
+++ b/packages/graph-explorer/src/core/StateProvider/appStore.ts
@@ -1,0 +1,15 @@
+import { getDefaultStore } from "jotai";
+
+/**
+ * Gets the store used for all app state.
+ *
+ * This represents the Jotai store. By default it uses getDefaultStore() from
+ * Jotai. For tests it is mocked out automatically for just a standard
+ * createStore().
+ * @returns a Jotai store
+ */
+export function getAppStore() {
+  return getDefaultStore();
+}
+
+export type AppStore = ReturnType<typeof getAppStore>;

--- a/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayEdge.test.ts
@@ -1,4 +1,4 @@
-import { type Edge, getRawId } from "@/core";
+import { type AppStore, type Edge, getRawId } from "@/core";
 import {
   createRandomEdge,
   createRandomEdgePreferences,
@@ -6,7 +6,6 @@ import {
   createRandomRawConfiguration,
   createRandomSchema,
   DbState,
-  type JotaiStore,
   renderHookWithJotai,
   renderHookWithState,
 } from "@/utils/testing";
@@ -236,7 +235,7 @@ describe("useDisplayEdgeFromEdge", () => {
 
   // Helpers
 
-  function act(edge: Edge, initializeState?: (store: JotaiStore) => void) {
+  function act(edge: Edge, initializeState?: (store: AppStore) => void) {
     const { result } = renderHookWithJotai(
       () => useDisplayEdgeFromEdge(edge),
       initializeState
@@ -246,7 +245,7 @@ describe("useDisplayEdgeFromEdge", () => {
 
   function withSchema(schema: Schema) {
     const config = createRandomRawConfiguration();
-    return (store: JotaiStore) => {
+    return (store: AppStore) => {
       store.set(configurationAtom, new Map([[config.id, config]]));
       store.set(schemaAtom, new Map([[config.id, schema]]));
       store.set(activeConfigurationAtom, config.id);
@@ -256,7 +255,7 @@ describe("useDisplayEdgeFromEdge", () => {
   function withSchemaAndConnection(schema: Schema, queryEngine: QueryEngine) {
     const config = createRandomRawConfiguration();
     config.connection!.queryEngine = queryEngine;
-    return (store: JotaiStore) => {
+    return (store: AppStore) => {
       store.set(configurationAtom, new Map([[config.id, config]]));
       store.set(schemaAtom, new Map([[config.id, schema]]));
       store.set(activeConfigurationAtom, config.id);

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
@@ -5,11 +5,11 @@ import {
   createRandomVertexPreferences,
   createRandomVertexTypeConfig,
   DbState,
-  type JotaiStore,
   renderHookWithJotai,
   renderHookWithState,
 } from "@/utils/testing";
 import {
+  type AppStore,
   createVertexId,
   type DisplayAttribute,
   getRawId,
@@ -231,7 +231,7 @@ describe("useDisplayVertexFromVertex", () => {
 
   // Helpers
 
-  function act(vertex: Vertex, initializeState?: (store: JotaiStore) => void) {
+  function act(vertex: Vertex, initializeState?: (store: AppStore) => void) {
     const { result } = renderHookWithJotai(
       () => useDisplayVertexFromVertex(vertex),
       initializeState
@@ -241,7 +241,7 @@ describe("useDisplayVertexFromVertex", () => {
 
   function withSchema(schema: Schema) {
     const config = createRandomRawConfiguration();
-    return (store: JotaiStore) => {
+    return (store: AppStore) => {
       store.set(configurationAtom, new Map([[config.id, config]]));
       store.set(schemaAtom, new Map([[config.id, schema]]));
       store.set(activeConfigurationAtom, config.id);
@@ -251,7 +251,7 @@ describe("useDisplayVertexFromVertex", () => {
   function withSchemaAndConnection(schema: Schema, queryEngine: QueryEngine) {
     const config = createRandomRawConfiguration();
     config.connection!.queryEngine = queryEngine;
-    return (store: JotaiStore) => {
+    return (store: AppStore) => {
       store.set(configurationAtom, new Map([[config.id, config]]));
       store.set(schemaAtom, new Map([[config.id, schema]]));
       store.set(activeConfigurationAtom, config.id);

--- a/packages/graph-explorer/src/core/StateProvider/index.ts
+++ b/packages/graph-explorer/src/core/StateProvider/index.ts
@@ -1,3 +1,4 @@
+export * from "./appStore";
 export * from "./configuration";
 export * from "./displayAttribute";
 export * from "./displayEdge";

--- a/packages/graph-explorer/src/core/queryClient.ts
+++ b/packages/graph-explorer/src/core/queryClient.ts
@@ -5,8 +5,8 @@ import {
   QueryCache,
   QueryClient,
 } from "@tanstack/react-query";
-import { atom } from "jotai";
-import { explorerAtom } from "./connector";
+import type { Store } from "jotai/vanilla/store";
+import { getAppStore } from "./StateProvider/appStore";
 
 function exponentialBackoff(attempt: number): number {
   return Math.min(attempt > 1 ? 2 ** attempt * 1000 : 1000, 30 * 1000);
@@ -17,6 +17,7 @@ const HTTP_STATUS_TO_NOT_RETRY = [400, 401, 403, 404, 429];
 
 export interface GraphExplorerMeta extends Record<string, unknown> {
   explorer?: Explorer;
+  store?: Store;
 }
 
 declare module "@tanstack/react-query" {
@@ -31,10 +32,16 @@ declare module "@tanstack/react-query" {
  * @param explorer The explorer to use for the query client.
  * @returns A new query client.
  */
-export function createQueryClient({ explorer }: { explorer: Explorer }) {
+export function createQueryClient({
+  explorer,
+  store = getAppStore(),
+}: {
+  explorer: Explorer;
+  store?: Store;
+}) {
   logger.debug("Creating new query client with explorer:", explorer);
   return new QueryClient({
-    defaultOptions: createDefaultOptions(explorer),
+    defaultOptions: createDefaultOptions(explorer, store),
     queryCache: new QueryCache({
       onError(error, query) {
         logger.error("Query failed to execute:", query.queryKey, error);
@@ -43,22 +50,20 @@ export function createQueryClient({ explorer }: { explorer: Explorer }) {
   });
 }
 
-export const defaultOptionsAtom = atom(get =>
-  createDefaultOptions(get(explorerAtom))
-);
-
 /**
  * Creates the query client's default options with the explorer instance
  * injected in to the `meta` object.
  * @param explorer The explorer to use for the default options.
  * @returns The query client default options
  */
-function createDefaultOptions(explorer: Explorer): DefaultOptions<Error> {
+export function createDefaultOptions(
+  explorer: Explorer,
+  store: Store
+): DefaultOptions<Error> {
+  const meta: GraphExplorerMeta = { explorer, store };
   return {
     queries: {
-      meta: {
-        explorer,
-      } as const,
+      meta,
       retry: (failureCount, error) => {
         if (failureCount >= MAX_RETRIES) {
           return false;
@@ -80,9 +85,7 @@ function createDefaultOptions(explorer: Explorer): DefaultOptions<Error> {
       refetchOnWindowFocus: false,
     },
     mutations: {
-      meta: {
-        explorer,
-      } as const,
+      meta,
     },
   };
 }

--- a/packages/graph-explorer/src/hooks/useTextTransform.test.ts
+++ b/packages/graph-explorer/src/hooks/useTextTransform.test.ts
@@ -1,18 +1,18 @@
 import {
   activeConfigurationAtom,
   configurationAtom,
-} from "@/core/StateProvider/configuration";
+  schemaAtom,
+  type AppStore,
+} from "@/core";
 import {
   createRandomRawConfiguration,
   createRandomSchema,
-  type JotaiStore,
   renderHookWithJotai,
 } from "@/utils/testing";
 import useTextTransform from "./useTextTransform";
 import { vi } from "vitest";
-import { schemaAtom } from "@/core/StateProvider/schema";
 
-function initializeConfigWithPrefix(store: JotaiStore) {
+function initializeConfigWithPrefix(store: AppStore) {
   // Create config and setup schema
   const config = createRandomRawConfiguration();
   const schema = createRandomSchema();

--- a/packages/graph-explorer/src/modules/AvailableConnections/useImportConnectionFile.test.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/useImportConnectionFile.test.tsx
@@ -6,6 +6,7 @@ import {
   activeConfigurationAtom,
   configurationAtom,
   createNewConfigurationId,
+  getAppStore,
   schemaAtom,
 } from "@/core";
 import { createRandomName, createRandomUrlString } from "@shared/utils/testing";
@@ -25,7 +26,7 @@ vi.mock("@/core/StateProvider/useResetState", () => ({
 describe("useImportConnectionFile", () => {
   test("should import valid configuration file", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -55,13 +56,13 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const configs = store.get(configurationAtom);
+    const configs = getAppStore().get(configurationAtom);
     expect(configs.size).toBe(2);
 
-    const schemas = store.get(schemaAtom);
+    const schemas = getAppStore().get(schemaAtom);
     expect(schemas.size).toBe(2);
 
-    const activeConfigId = store.get(activeConfigurationAtom);
+    const activeConfigId = getAppStore().get(activeConfigurationAtom);
     expect(activeConfigId).not.toBe(state.activeConfig.id);
 
     const importedConfig = Array.from(configs.values()).find(
@@ -90,7 +91,7 @@ describe("useImportConnectionFile", () => {
 
   test("should reject invalid configuration file", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -107,7 +108,7 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const configs = store.get(configurationAtom);
+    const configs = getAppStore().get(configurationAtom);
     expect(configs.size).toBe(1);
 
     expect(mockEnqueueNotification).toHaveBeenCalledWith({
@@ -121,7 +122,7 @@ describe("useImportConnectionFile", () => {
 
   test("should create new ID to avoid collisions", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -149,16 +150,16 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const configs = store.get(configurationAtom);
+    const configs = getAppStore().get(configurationAtom);
     expect(configs.size).toBe(2);
 
-    const activeConfigId = store.get(activeConfigurationAtom);
+    const activeConfigId = getAppStore().get(activeConfigurationAtom);
     expect(activeConfigId).not.toBe(state.activeConfig.id);
   });
 
   test("should handle schema with prefixes", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -193,7 +194,7 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = store.get(schemaAtom);
+    const schemas = getAppStore().get(schemaAtom);
     const importedSchema = Array.from(schemas.values()).find(
       (_, index) => index === 1
     );
@@ -209,7 +210,7 @@ describe("useImportConnectionFile", () => {
 
   test("should handle schema with lastUpdate date", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -239,7 +240,7 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = store.get(schemaAtom);
+    const schemas = getAppStore().get(schemaAtom);
     const importedSchema = Array.from(schemas.values()).find(
       (_, index) => index === 1
     );
@@ -252,7 +253,7 @@ describe("useImportConnectionFile", () => {
 
   test("should handle empty schema arrays", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -280,7 +281,7 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = store.get(schemaAtom);
+    const schemas = getAppStore().get(schemaAtom);
     const importedSchema = Array.from(schemas.values()).find(
       (_, index) => index === 1
     );
@@ -291,7 +292,7 @@ describe("useImportConnectionFile", () => {
 
   test("should handle file with complex schema", async () => {
     const state = new DbState();
-    const { result, store } = renderHookWithState(
+    const { result } = renderHookWithState(
       () => useImportConnectionFile(),
       state
     );
@@ -344,7 +345,7 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = store.get(schemaAtom);
+    const schemas = getAppStore().get(schemaAtom);
     const importedSchema = Array.from(schemas.values()).find(
       (_, index) => index === 1
     );

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
@@ -4,14 +4,14 @@ import {
   createRandomSchema,
   renderHookWithJotai,
   createRandomRawConfiguration,
-  type JotaiStore,
 } from "@/utils/testing";
 import {
   activeConfigurationAtom,
   configurationAtom,
-} from "@/core/StateProvider/configuration";
+  schemaAtom,
+  type AppStore,
+} from "@/core";
 import { vi } from "vitest";
-import { schemaAtom } from "@/core/StateProvider/schema";
 
 vi.mock("./useKeywordSearchQuery", () => ({
   useKeywordSearchQuery: vi.fn().mockReturnValue({
@@ -21,7 +21,7 @@ vi.mock("./useKeywordSearchQuery", () => ({
 }));
 
 function initializeConfigWithQueryEngine(queryEngine: QueryEngine) {
-  return (store: JotaiStore) => {
+  return (store: AppStore) => {
     // Create config and setup schema
     const config = createRandomRawConfiguration();
     config.connection!.queryEngine = queryEngine;
@@ -117,7 +117,7 @@ describe("useKeywordSearch", () => {
   });
 
   describe("SPARQL", () => {
-    function initializeConfigWithRdfLabel(store: JotaiStore) {
+    function initializeConfigWithRdfLabel(store: AppStore) {
       // Create config and setup schema
       const config = createRandomRawConfiguration();
       const schema = createRandomSchema();

--- a/packages/graph-explorer/src/utils/testing/DbState.ts
+++ b/packages/graph-explorer/src/utils/testing/DbState.ts
@@ -24,6 +24,7 @@ import {
   type Vertex,
   type VertexId,
   type VertexPreferences,
+  type AppStore,
 } from "@/core";
 import {
   createRandomSchema,
@@ -34,7 +35,6 @@ import {
   type TestableEdge,
   type TestableVertex,
 } from "./randomData";
-import type { JotaiStore } from "./renderHookWithJotai";
 import { createMockExplorer } from "./createMockExplorer";
 import type { Explorer } from "@/connector";
 
@@ -156,7 +156,7 @@ export class DbState {
   }
 
   /** Applies the state to the given Jotai store. */
-  applyTo(store: JotaiStore) {
+  applyTo(store: AppStore) {
     // Config
     store.set(
       configurationAtom,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Consolidates the logic around creating and accessing the Jotai store around a singular "app store". I'm also injecting the store in to the React Query metadata context so it can be accessed during queries.

This will be used in future code changes to keep Jotai state updated with new query results without having to dip in to React logic.

## Validation

* Smoke test

## Related Issues

* Part of #1161

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
