### PR TITLE
Change re-layout button icon

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -47,8 +47,8 @@ import {
   BadgeInfoIcon,
   CircleSlash2,
   FullscreenIcon,
+  GitCompareArrowsIcon,
   ImageDownIcon,
-  RefreshCwIcon,
   ZoomInIcon,
   ZoomOutIcon,
 } from "lucide-react";
@@ -153,7 +153,7 @@ export default function GraphViewer({
             <SelectLayout className="max-w-64 min-w-auto" />
             <IconButton
               tooltipText="Re-run Layout"
-              icon={<RefreshCwIcon />}
+              icon={<GitCompareArrowsIcon />}
               variant="text"
               onClick={() => {
                 graphRef.current?.runLayout();


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The "Re-run Layout" button icon conflicts with the refresh button. So it needed to change.

## Validation

<img width="328" height="232" alt="CleanShot 2025-11-21 at 17 24 57@2x" src="https://github.com/user-attachments/assets/6aea0ff3-62f6-4f84-856f-9d24ede857a5" />

## Related Issues

* Resolves #1346

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
