### PR TITLE
Add GraphContext to contain the graphRef

### DIFF
--- a/packages/graph-explorer/src/components/Graph/Graph.tsx
+++ b/packages/graph-explorer/src/components/Graph/Graph.tsx
@@ -38,6 +38,7 @@ import type { BadgeRenderer } from "./hooks/useRenderBadges";
 import useRenderBadges from "./hooks/useRenderBadges";
 import useUpdateLayout from "./hooks/useRunLayout";
 import useUpdateGraphElements from "./hooks/useUpdateGraphElements";
+import { useGraphRef } from "./GraphContext";
 
 cytoscape.use(klay);
 cytoscape.use(dagre);
@@ -132,7 +133,6 @@ export interface GraphProps<
   hideDefaultEdgeLabels?: boolean;
   defaultEdgeLabelAttribute?: string;
   hideEdges?: boolean;
-  ref?: React.Ref<GraphRef>;
 }
 
 const DEFAULT_LAYOUT_CONFIG = {};
@@ -202,7 +202,6 @@ export const Graph = ({
   defaultEdgeLabelAttribute,
   hideDefaultEdgeLabels = false,
   hideEdges,
-  ref,
   ...props
 }: GraphProps) => {
   // capture wrapper via callbackRef so it triggers a re-render (and thus our cy mounting effect)
@@ -351,8 +350,10 @@ export const Graph = ({
     mounted,
   });
 
+  // Set the graphRef context value so that the GraphContextProvider can access the graphRef
+  const graphRef = useGraphRef();
   useImperativeHandle(
-    ref,
+    graphRef,
     () => ({
       cytoscape: cy,
       runLayout: () => {

--- a/packages/graph-explorer/src/components/Graph/GraphContext.tsx
+++ b/packages/graph-explorer/src/components/Graph/GraphContext.tsx
@@ -1,0 +1,32 @@
+import type { GraphRef } from "@/components/Graph/Graph";
+import {
+  createContext,
+  useContext,
+  useRef,
+  type PropsWithChildren,
+  type RefObject,
+} from "react";
+
+interface GraphContextValue {
+  graphRef: RefObject<GraphRef | null>;
+}
+
+const GraphContext = createContext<GraphContextValue | null>(null);
+
+export function GraphProvider({ children }: PropsWithChildren) {
+  const graphRef = useRef<GraphRef | null>(null);
+
+  return (
+    <GraphContext.Provider value={{ graphRef }}>
+      {children}
+    </GraphContext.Provider>
+  );
+}
+
+export function useGraphRef() {
+  const context = useContext(GraphContext);
+  if (!context) {
+    throw new Error("useGraphRef must be used within a GraphProvider");
+  }
+  return context.graphRef;
+}

--- a/packages/graph-explorer/src/components/Graph/index.ts
+++ b/packages/graph-explorer/src/components/Graph/index.ts
@@ -3,4 +3,5 @@ export { default as useGraphControls } from "./hooks/useGraphControls";
 export type { GraphProps } from "./Graph";
 export type { Badge } from "./hooks/useRenderBadges";
 export { availableLayoutsConfig } from "./helpers/layoutConfig";
+export { GraphProvider, useGraphRef } from "./GraphContext";
 export { default } from "./Graph";

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, RefObject } from "react";
+import type { PropsWithChildren } from "react";
 import {
   Divider,
   EdgeIcon,
@@ -6,7 +6,6 @@ import {
   ListItem,
   StylingIcon,
 } from "@/components";
-import type { GraphRef } from "@/components/Graph/Graph";
 import {
   CenterGraphIcon,
   DetailsIcon,
@@ -44,14 +43,12 @@ import { useGraphSelection } from "../useGraphSelection";
 export type ContextMenuProps = {
   affectedNodesIds: VertexId[];
   affectedEdgesIds: EdgeId[];
-  graphRef: RefObject<GraphRef | null>;
   onClose?(): void;
 };
 
 const ContextMenu = ({
   affectedNodesIds,
   affectedEdgesIds,
-  graphRef,
   onClose,
 }: ContextMenuProps) => {
   const t = useTranslations();
@@ -71,7 +68,7 @@ const ContextMenu = ({
     onSaveScreenshot,
     onZoomIn,
     onZoomOut,
-  } = useGraphGlobalActions(graphRef);
+  } = useGraphGlobalActions();
 
   const nonEmptySelection =
     graphSelection.vertices.length || graphSelection.edges.length;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Refactor to move `graphRef` in to a shared React Context. This will reduce prop drilling in `ContextMenu` and will come in handy when I work on the schema visualization graph.

## Validation

* Smoke test of graph actions

## Related Issues

* Part of #1347 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
