### PR TITLE
Add expand option to single target

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -20,11 +20,13 @@ import {
 } from "@/core";
 import {
   useClearGraph,
+  useExpandNode,
   useRefreshEntities,
   useRemoveFromGraph,
   useTranslations,
   useContextMenuTarget,
 } from "@/hooks";
+import { useDefaultNeighborExpansionLimit } from "@/hooks/useExpandNode";
 import useGraphGlobalActions from "../useGraphGlobalActions";
 import {
   CircleSlash2,
@@ -94,9 +96,16 @@ function SingleVertexMenu({ vertexId }: { vertexId: VertexId }) {
   const removeFromGraph = useRemoveFromGraph();
   const openNodeStyleDialog = useOpenNodeStyleDialog();
   const { onCenterVertex, onFitVertexToCanvas } = useGraphGlobalActions();
+  const { expandNode } = useExpandNode();
+  const defaultNeighborExpansionLimit = useDefaultNeighborExpansionLimit();
 
   const handleCenter = () => onCenterVertex(vertexId);
   const handleFit = () => onFitVertexToCanvas(vertexId);
+  const handleExpand = () =>
+    expandNode({
+      vertexId,
+      limit: defaultNeighborExpansionLimit ?? undefined,
+    });
 
   const openSidebarPanel = (panelName: SidebarItems) => () => {
     setUserLayout(prev => ({ ...prev, activeSidebarItem: panelName }));
@@ -118,6 +127,15 @@ function SingleVertexMenu({ vertexId }: { vertexId: VertexId }) {
         {vertex.displayName}
       </ContextMenuTitle>
       <Divider />
+      <ContextMenuItem onClick={handleExpand}>
+        <ExpandGraphIcon />
+        Expand {t("graph-viewer.node").toLowerCase()}
+      </ContextMenuItem>
+      <ContextMenuItem onClick={handleRefresh}>
+        <RefreshCwIcon />
+        Refresh {t("graph-viewer.node").toLowerCase()}
+      </ContextMenuItem>
+      <Divider />
       <ContextMenuItem onClick={handleFit}>
         <FullscreenIcon />
         Fit {t("graph-viewer.node").toLowerCase()} to frame
@@ -126,18 +144,14 @@ function SingleVertexMenu({ vertexId }: { vertexId: VertexId }) {
         <CenterGraphIcon />
         Center {t("graph-viewer.node").toLowerCase()}
       </ContextMenuItem>
-      <ContextMenuItem onClick={handleRefresh}>
-        <RefreshCwIcon />
-        Refresh {t("graph-viewer.node").toLowerCase()}
-      </ContextMenuItem>
       <Divider />
       <ContextMenuItem onClick={openSidebarPanel("details")}>
         <DetailsIcon />
-        Details panel
+        Show details panel
       </ContextMenuItem>
       <ContextMenuItem onClick={openSidebarPanel("expand")}>
         <ExpandGraphIcon />
-        Expand panel
+        Show expand panel
       </ContextMenuItem>
       <ContextMenuItem onClick={handleOpenStyle}>
         <StylingIcon />
@@ -184,6 +198,11 @@ function SingleEdgeMenu({ edgeId }: { edgeId: EdgeId }) {
         {edge.displayTypes}
       </ContextMenuTitle>
       <Divider />
+      <ContextMenuItem onClick={handleRefresh}>
+        <RefreshCwIcon />
+        Refresh {t("graph-viewer.edge").toLowerCase()}
+      </ContextMenuItem>
+      <Divider />
       <ContextMenuItem onClick={handleFit}>
         <FullscreenIcon />
         Fit {t("graph-viewer.edge").toLowerCase()} to frame
@@ -192,14 +211,10 @@ function SingleEdgeMenu({ edgeId }: { edgeId: EdgeId }) {
         <CenterGraphIcon />
         Center {t("graph-viewer.edge").toLowerCase()}
       </ContextMenuItem>
-      <ContextMenuItem onClick={handleRefresh}>
-        <RefreshCwIcon />
-        Refresh {t("graph-viewer.edge").toLowerCase()}
-      </ContextMenuItem>
       <Divider />
       <ContextMenuItem onClick={openSidebarPanel("details")}>
         <DetailsIcon />
-        Details panel
+        Show details panel
       </ContextMenuItem>
       <ContextMenuItem onClick={handleOpenStyle}>
         <StylingIcon />


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

* Tweaked order of context menu actions
* Changed actions that show a sidebar to be "Show xxx panel"
* Added action for single vertex to expand that vertex (same as double click)

## Validation

| Node Menu | Edge Menu |
| --- | --- |
| <img width="978" height="1066" alt="CleanShot 2025-11-25 at 15 03 57@2x" src="https://github.com/user-attachments/assets/64c83853-ccf4-4644-b228-2c03fa32255f" /> | <img width="840" height="906" alt="CleanShot 2025-11-25 at 15 04 12@2x" src="https://github.com/user-attachments/assets/1fa774d9-7430-4c47-99fa-16637dd99644" /> |

## Related Issues

* Resolves #1003

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
