### PR TITLE
Remove offset and edgeTypes from neighbor request

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -14,7 +14,6 @@ describe("Gremlin > oneHopTemplate", () => {
       ],
       excludedVertices: new Set([createVertexId("256")]),
       limit: 10,
-      offset: 0,
     });
 
     expect(normalize(template)).toEqual(
@@ -100,17 +99,16 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
-  it("Should return a template with an offset and limit", () => {
+  it("Should return a template with a limit", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      offset: 5,
       limit: 5,
     });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12").as("start")
-          .both().dedup().range(5, 10).as("neighbor")
+          .both().dedup().range(0, 5).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
@@ -126,14 +124,13 @@ describe("Gremlin > oneHopTemplate", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country"],
-      offset: 5,
       limit: 10,
     });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12").as("start")
-          .both().hasLabel("country").dedup().range(5, 15).as("neighbor")
+          .both().hasLabel("country").dedup().range(0, 10).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
@@ -149,14 +146,13 @@ describe("Gremlin > oneHopTemplate", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country", "airport", "continent"],
-      offset: 5,
       limit: 10,
     });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V("12").as("start")
-          .both().hasLabel("country", "airport", "continent").dedup().range(5, 15).as("neighbor")
+          .both().hasLabel("country", "airport", "continent").dedup().range(0, 10).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(
@@ -176,7 +172,6 @@ describe("Gremlin > oneHopTemplate", () => {
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },
         { name: "country", value: "ES", operator: "like" },
       ],
-      offset: 5,
       limit: 10,
     });
 
@@ -185,7 +180,7 @@ describe("Gremlin > oneHopTemplate", () => {
         g.V("12").as("start")
           .both().hasLabel("country")
             .and(has("longest",gte(10000)),has("country",containing("ES")))
-            .dedup().range(5, 15).as("neighbor")
+            .dedup().range(0, 10).as("neighbor")
           .project("vertex", "edges")
             .by()
             .by(

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -93,29 +93,12 @@ function criterionTemplate(criterion: Criterion): string {
  * @example
  * sourceId = "124"
  * vertexTypes = ["airport"]
- * edgeTypes = ["route"]
- * limit = 10
- * offset = 0
- *
- * g.V("124")
- *  .project("vertices", "edges")
- *  .by(
- *    both().hasLabel("airport").dedup().range(0,10).fold()
- *  )
- *  .by(
- *    bothE("route").dedup().range(0,10).fold()
- *  )
- *
- *  @example
- * sourceId = "124"
- * vertexTypes = ["airport"]
  * filterCriteria = [
  *   { name: "longest", dataType: "Int", operator: "gt", value: 10000 },
  *   { name: "country", dataType: "String", operator: "like", value: "ES" }
  * ]
  * excludedVertices = new Set(["256"])
  * limit = 10
- * offset = 0
  *
  * g.V("124").as("start")
  *   .both()
@@ -136,13 +119,11 @@ export default function oneHopTemplate({
   vertexId,
   excludedVertices = new Set(),
   filterByVertexTypes = [],
-  edgeTypes = [],
   filterCriteria = [],
   limit = 0,
-  offset = 0,
 }: Omit<NeighborsRequest, "vertexTypes">): string {
   const idTemplate = idParam(vertexId);
-  const range = limit > 0 ? `.range(${offset}, ${offset + limit})` : "";
+  const range = limit > 0 ? `.range(0, ${limit})` : "";
 
   const vertexTypes = filterByVertexTypes.flatMap(type => type.split("::"));
   const vertexTypesTemplate =
@@ -161,8 +142,6 @@ export default function oneHopTemplate({
 
   const nodeFiltersTemplate =
     nodeFilters.length > 0 ? `.${nodeFilters.join(".")}` : ``;
-
-  const edgeTypesTemplate = edgeTypes.map(type => `"${type}"`).join(",");
 
   const excludedList = excludedVertices
     .values()
@@ -184,7 +163,7 @@ export default function oneHopTemplate({
       .project("vertex", "edges")
         .by()
         .by(
-          __.select("start").bothE(${edgeTypesTemplate})
+          __.select("start").bothE()
             .where(otherV().where(eq("neighbor")))
             .dedup().fold()
         )

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -36,10 +36,9 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
-  it("Should return a template with an offset and limit", () => {
+  it("Should return a template with a limit", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      offset: 5,
       limit: 5,
     });
 
@@ -49,7 +48,6 @@ describe("OpenCypher > oneHopTemplate", () => {
         WHERE ID(v) = "12" 
         WITH DISTINCT v, tgt 
         ORDER BY toInteger(ID(tgt)) 
-        SKIP 5 
         LIMIT 5
         MATCH (v)-[e]-(tgt)
         RETURN 
@@ -63,7 +61,6 @@ describe("OpenCypher > oneHopTemplate", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country"],
-      offset: 5,
       limit: 10,
     });
 
@@ -73,7 +70,6 @@ describe("OpenCypher > oneHopTemplate", () => {
         WHERE ID(v) = "12" 
         WITH DISTINCT v, tgt 
         ORDER BY toInteger(ID(tgt)) 
-        SKIP 5 
         LIMIT 10
         MATCH (v)-[e]-(tgt)
         RETURN 
@@ -100,30 +96,6 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
-  it("Should return a template for specific edge type", () => {
-    const template = oneHopTemplate({
-      vertexId: createVertexId("12"),
-      edgeTypes: ["locatedIn"],
-      offset: 5,
-      limit: 10,
-    });
-
-    expect(template).toBe(
-      query`
-        MATCH (v)-[e:locatedIn]-(tgt) 
-        WHERE ID(v) = "12" 
-        WITH DISTINCT v, tgt 
-        ORDER BY toInteger(ID(tgt)) 
-        SKIP 5 
-        LIMIT 10
-        MATCH (v)-[e:locatedIn]-(tgt)
-        RETURN 
-          collect(DISTINCT tgt) AS vObjects, 
-          collect(e) AS eObjects 
-      `,
-    );
-  });
-
   it("Should return a template with specific filter criteria", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
@@ -132,7 +104,6 @@ describe("OpenCypher > oneHopTemplate", () => {
         { name: "longest", value: 10000, operator: "gte", dataType: "Number" },
         { name: "country", value: "ES", operator: "like" },
       ],
-      offset: 5,
       limit: 10,
     });
 
@@ -142,7 +113,6 @@ describe("OpenCypher > oneHopTemplate", () => {
         WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" 
         WITH DISTINCT v, tgt 
         ORDER BY toInteger(ID(tgt)) 
-        SKIP 5 
         LIMIT 10
         MATCH (v)-[e]-(tgt)
         RETURN 
@@ -156,20 +126,17 @@ describe("OpenCypher > oneHopTemplate", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("124"),
       filterByVertexTypes: ["airport"],
-      edgeTypes: ["route"],
       limit: 10,
-      offset: 10,
     });
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e:route]-(tgt:airport) 
+        MATCH (v)-[e]-(tgt:airport) 
         WHERE ID(v) = "124"
         WITH DISTINCT v, tgt 
         ORDER BY toInteger(ID(tgt)) 
-        SKIP 10
         LIMIT 10
-        MATCH (v)-[e:route]-(tgt)
+        MATCH (v)-[e]-(tgt)
         RETURN 
           collect(DISTINCT tgt) AS vObjects, 
           collect(e) AS eObjects 

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
@@ -224,7 +224,6 @@ describe("fetchNeighbors", () => {
       ],
       excludedVertices: new Set([createRandomUrlString() as any]),
       limit: 10,
-      offset: 5,
     };
 
     const mockResponse = createQuadSparqlResponse([]);
@@ -240,7 +239,6 @@ describe("fetchNeighbors", () => {
     // Verify the query template contains expected elements
     expect(queryTemplate).toContain(request.resourceURI);
     expect(queryTemplate).toContain("LIMIT 10");
-    expect(queryTemplate).toContain("OFFSET 5");
   });
 
   test("should handle sparqlFetch rejection", async () => {

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -20,7 +20,6 @@ describe("oneHopNeighborsTemplate", () => {
         },
       ],
       limit: 2,
-      offset: 0,
     });
 
     expect(normalize(template)).toEqual(
@@ -64,7 +63,6 @@ describe("oneHopNeighborsTemplate", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
       limit: 10,
-      offset: 0,
     });
 
     expect(normalize(template)).toEqual(
@@ -165,11 +163,10 @@ describe("oneHopNeighborsTemplate", () => {
     );
   });
 
-  it("should produce query with limit and offset", () => {
+  it("should produce query with limit", () => {
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
       limit: 10,
-      offset: 5,
     });
 
     expect(normalize(template)).toEqual(
@@ -192,7 +189,7 @@ describe("oneHopNeighborsTemplate", () => {
                 FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
               }
             }
-            LIMIT 10 OFFSET 5
+            LIMIT 10
           }
           ${commonPartOfQuery("http://www.example.com/soccer/resource#EPL")}
         }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -31,7 +31,6 @@ import {
  *   { predicate: "http://www.example.com/soccer/ontology/nickname", object: "Gunners" },
  * ]
  * limit = 2
- * offset = 0
  *
  * SELECT DISTINCT ?subject ?predicate ?object
  * WHERE {
@@ -165,7 +164,6 @@ export function findNeighborsUsingFilters({
   filterCriteria = [],
   excludedVertices = new Set(),
   limit = 0,
-  offset = 0,
 }: SPARQLNeighborsRequest): string {
   const resourceTemplate = idParam(resourceURI);
 
@@ -191,7 +189,7 @@ export function findNeighborsUsingFilters({
       }
       ${getFilterTemplate(filterCriteria)}
     }
-    ${getLimit(limit, offset)}
+    ${getLimit(limit)}
   `;
 }
 

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
@@ -43,10 +43,7 @@ export const storedBlankNodeNeighborsRequest = (
     });
 
     resolve({
-      vertices: filteredVertices.slice(
-        req.offset ?? 0,
-        req.limit ? req.limit + (req.offset ?? 0) : undefined,
-      ),
+      vertices: filteredVertices.slice(0, req.limit ?? undefined),
       edges: bNode.neighbors.edges,
     });
   });

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -119,7 +119,6 @@ export function createSparqlExplorer(
         })),
         excludedVertices: req.excludedVertices,
         limit: req.limit,
-        offset: req.offset,
       };
 
       const bNode = blankNodes.get(req.vertexId);

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -39,10 +39,6 @@ export type SPARQLNeighborsRequest = {
    * 0 = No limit.
    */
   limit?: number;
-  /**
-   * Skip the given number of results.
-   */
-  offset?: number;
 };
 
 export type SPARQLNeighborsPredicatesRequest = {

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -94,10 +94,6 @@ export type NeighborsRequest = {
    */
   filterByVertexTypes?: Array<string>;
   /**
-   * Filter by edge types.
-   */
-  edgeTypes?: Array<string>;
-  /**
    * Filter by vertex attributes.
    */
   filterCriteria?: Array<Criterion>;
@@ -106,10 +102,6 @@ export type NeighborsRequest = {
    * 0 = No limit.
    */
   limit?: number;
-  /**
-   * Skip the given number of results.
-   */
-  offset?: number;
 };
 
 /**


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

The `offset` and `edgeTypes` filters in `NeighborsRequest` were unused, and I don't foresee us adding them to the UI any time soon. If so, we can always refer back to this PR to undo the change to the queries.

## Validation

* Tested all three query languages
* Tried a filtered expansion

## Related Issues

* None

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
