### PR TITLE
Add toggle buttons to graph view empty state

### DIFF
--- a/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
@@ -15,7 +15,6 @@ import {
   EmptyStateTitle,
   IconButton,
   NamespaceIcon,
-  PanelEmptyState,
 } from "@/components";
 import {
   DatabaseIcon,


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Add toggle buttons to the empty state when neither the graph view or table view is toggled on. Also updated the messaging to be a bit more clear.

## Validation

<img width="3302" height="1930" alt="CleanShot 2025-11-26 at 17 22 43@2x" src="https://github.com/user-attachments/assets/37e2c6ad-fcfe-4e06-96bd-e7d77159106f" />


## Related Issues

* Resolve #1364 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
