### PR TITLE
Move searchable attributes to a hook

### DIFF
--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
   Switch,
 } from "@/components";
-import { useDisplayVertexTypeConfig } from "@/core";
+import { useSearchableAttributes } from "@/core";
 import useTranslations from "@/hooks/useTranslations";
 import type { PropsWithChildren } from "react";
 import { ListFilterPlusIcon, Trash2Icon } from "lucide-react";
@@ -42,6 +42,14 @@ export type NodeExpandFiltersProps = {
   onLimitEnabledToggle(enabled: boolean): void;
 };
 
+function useAttributeOptions(selectedType: string) {
+  const allSearchableAttributes = useSearchableAttributes(selectedType);
+  return allSearchableAttributes.map(a => ({
+    label: a.displayLabel,
+    value: a.name,
+  }));
+}
+
 const NodeExpandFilters = ({
   neighborsOptions,
   selectedType,
@@ -55,14 +63,7 @@ const NodeExpandFilters = ({
 }: NodeExpandFiltersProps) => {
   const t = useTranslations();
 
-  const displayVertexTypeConfig = useDisplayVertexTypeConfig(selectedType);
-  const attributeSelectOptions: SelectOption[] =
-    displayVertexTypeConfig.attributes
-      .filter(a => a.isSearchable)
-      .map(attr => ({
-        label: attr.displayLabel,
-        value: attr.name,
-      }));
+  const attributeSelectOptions = useAttributeOptions(selectedType);
   const hasSearchableAttributes = attributeSelectOptions.length > 0;
 
   const onFilterAdd = () => {
@@ -203,7 +204,7 @@ const NodeExpandFilters = ({
 };
 
 function Section({ children }: PropsWithChildren) {
-  return <div className="space-y-[1.125rem]">{children}</div>;
+  return <div className="space-y-4.5">{children}</div>;
 }
 
 function SectionTitle({ children }: PropsWithChildren) {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Moves searchable attributes list out of Jotai atoms and in to a hook with tests.

This is part of my decoupling work for `mergeConfiguration`.

## Validation

* Tested filter search
* Tested filtered expansion

## Related Issues

* Part of #1176

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
