### PR TITLE
Update prefixes to use specific hook

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -259,11 +259,6 @@ export function getDefaultEdgeTypeConfig(edgeType: string): EdgeTypeConfig {
   };
 }
 
-export const allNamespacePrefixesSelector = atom(get => {
-  const configuration = get(mergedConfigurationSelector);
-  return configuration?.schema?.prefixes ?? [];
-});
-
 /**
  * Removes the displayLabel property from a vertex or edge config and any
  * attributes.

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -49,6 +49,7 @@ const schemaByIdAtom = atomFamily((id: ConfigurationId | null) => {
 const emptySchema: SchemaInference = {
   vertices: [],
   edges: [],
+  prefixes: [],
 };
 
 export const activeSchemaAtom = atom(get => {
@@ -60,6 +61,17 @@ export const activeSchemaAtom = atom(get => {
 export function useActiveSchema(): SchemaInference {
   return useDeferredValue(useAtomValue(activeSchemaAtom));
 }
+
+/** Gets the stored prefixes from the active schema. */
+export function usePrefixes(): PrefixTypeConfig[] {
+  const schema = useActiveSchema();
+  return schema.prefixes ?? [];
+}
+
+export const prefixesAtom = atom(get => {
+  const schema = get(activeSchemaAtom);
+  return schema.prefixes ?? [];
+});
 
 function createVertexSchema(vtConfig: VertexTypeConfig) {
   return {

--- a/packages/graph-explorer/src/hooks/useTextTransform.ts
+++ b/packages/graph-explorer/src/hooks/useTextTransform.ts
@@ -1,6 +1,5 @@
 import replacePrefixes from "@/utils/replacePrefixes";
-import { allNamespacePrefixesSelector } from "@/core/StateProvider/configuration";
-import { queryEngineSelector } from "@/core/connector";
+import { prefixesAtom, queryEngineSelector } from "@/core";
 import { atom, useAtomValue } from "jotai";
 import { logger } from "@/utils";
 
@@ -8,7 +7,7 @@ export type TextTransformer = (text: string) => string;
 
 export const textTransformSelector = atom(get => {
   const queryEngine = get(queryEngineSelector);
-  const prefixes = get(allNamespacePrefixesSelector);
+  const prefixes = get(prefixesAtom);
 
   logger.debug("Creating text transform", prefixes);
 

--- a/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
@@ -9,7 +9,7 @@ import {
   SearchBar,
   useSearchItems,
 } from "@/components";
-import { type PrefixTypeConfig, useConfiguration } from "@/core";
+import { type PrefixTypeConfig, usePrefixes } from "@/core";
 import { Virtuoso } from "react-virtuoso";
 
 const GeneratedPrefixes = () => {
@@ -53,9 +53,9 @@ function Layout(props: ComponentPropsWithoutRef<"div">) {
 }
 
 function useGeneratedPrefixes() {
-  const config = useConfiguration();
+  const prefixes = usePrefixes();
 
-  return (config?.schema?.prefixes || [])
+  return prefixes
     .filter(
       prefixConfig =>
         prefixConfig.__inferred === true &&

--- a/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
@@ -30,7 +30,7 @@ import {
   type PrefixTypeConfig,
   useConfiguration,
 } from "@/core";
-import { schemaAtom } from "@/core/StateProvider/schema";
+import { schemaAtom, usePrefixes } from "@/core/StateProvider/schema";
 import { Virtuoso } from "react-virtuoso";
 import { useAtomCallback } from "jotai/utils";
 
@@ -56,10 +56,8 @@ const UserPrefixes = () => {
 };
 
 function useCustomPrefixes() {
-  const config = useConfiguration();
-  return (config?.schema?.prefixes || []).filter(
-    prefixConfig => prefixConfig.__inferred !== true,
-  );
+  const prefixes = usePrefixes();
+  return prefixes.filter(prefixConfig => prefixConfig.__inferred !== true);
 }
 
 function SearchablePrefixes({


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds `usePrefixes()` hook that uses the active schema to get the prefixes or empty array. This removes the null checking and removes another set of dependencies from `mergedConfiguration`.

## Validation

* Ensured prefixes are still applied

## Related Issues

* Part of #1176

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
