### PR TITLE
Fix explorer creation on app load

### DIFF
--- a/packages/graph-explorer/src/core/ExplorerInjector.test.tsx
+++ b/packages/graph-explorer/src/core/ExplorerInjector.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider } from "jotai";
+import { ExplorerInjector } from "./ExplorerInjector";
+import { explorerForTestingAtom } from "./connector";
+import { getAppStore } from "./StateProvider/appStore";
+import { createMockExplorer } from "@/utils/testing";
+
+function renderExplorerInjector(queryClient: QueryClient) {
+  const store = getAppStore();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <ExplorerInjector />
+      </Provider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExplorerInjector", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  test("should render null", () => {
+    const { container } = renderExplorerInjector(queryClient);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("should set default options on query client", () => {
+    const store = getAppStore();
+    const explorer = createMockExplorer();
+    store.set(explorerForTestingAtom, explorer);
+
+    renderExplorerInjector(queryClient);
+
+    const defaultOptions = queryClient.getDefaultOptions();
+    expect(defaultOptions.queries?.meta?.explorer).toBe(explorer);
+    expect(defaultOptions.queries?.meta?.store).toBe(store);
+    expect(defaultOptions.mutations?.meta?.explorer).toBe(explorer);
+    expect(defaultOptions.mutations?.meta?.store).toBe(store);
+  });
+
+  test("should clear cache when explorer changes", () => {
+    const store = getAppStore();
+    const explorer1 = createMockExplorer();
+    store.set(explorerForTestingAtom, explorer1);
+
+    const clearSpy = vi.spyOn(queryClient, "clear");
+    const setDefaultOptionsSpy = vi.spyOn(queryClient, "setDefaultOptions");
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <ExplorerInjector />
+        </Provider>
+      </QueryClientProvider>,
+    );
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    expect(setDefaultOptionsSpy).toHaveBeenCalledTimes(1);
+
+    // Change the explorer
+    const explorer2 = createMockExplorer();
+    act(() => {
+      store.set(explorerForTestingAtom, explorer2);
+    });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <ExplorerInjector />
+        </Provider>
+      </QueryClientProvider>,
+    );
+
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+    expect(setDefaultOptionsSpy).toHaveBeenCalledTimes(2);
+
+    const defaultOptions = queryClient.getDefaultOptions();
+    expect(defaultOptions.queries?.meta?.explorer).toBe(explorer2);
+  });
+
+  test("should not clear cache when explorer remains the same", () => {
+    const store = getAppStore();
+    const explorer = createMockExplorer();
+    store.set(explorerForTestingAtom, explorer);
+
+    const clearSpy = vi.spyOn(queryClient, "clear");
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <ExplorerInjector />
+        </Provider>
+      </QueryClientProvider>,
+    );
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+
+    // Rerender without changing explorer
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <ExplorerInjector />
+        </Provider>
+      </QueryClientProvider>,
+    );
+
+    // Should still be 1 since explorer didn't change
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/graph-explorer/src/core/ExplorerInjector.tsx
+++ b/packages/graph-explorer/src/core/ExplorerInjector.tsx
@@ -1,8 +1,8 @@
 import { logger } from "@/utils";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type DefaultOptions } from "@tanstack/react-query";
 import { createDefaultOptions } from "./queryClient";
 import { useAtomValue } from "jotai";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { explorerAtom } from "./connector";
 import { getAppStore } from "./StateProvider/appStore";
 
@@ -15,14 +15,20 @@ export function ExplorerInjector() {
   const queryClient = useQueryClient();
   const explorer = useAtomValue(explorerAtom);
   const store = getAppStore();
-  const defaultOptions = createDefaultOptions(explorer, store);
-  const [prevDefaultOptions, setPrevDefaultOptions] = useState(defaultOptions);
+
+  // Only crate a new defaultOptions when explorer or store changes
+  const defaultOptions = useMemo(
+    () => createDefaultOptions(explorer, store),
+    [explorer, store],
+  );
+
+  // Start with null to ensure first render sets the default options properly
+  const [prevDefaultOptions, setPrevDefaultOptions] =
+    useState<DefaultOptions<Error> | null>(null);
 
   if (prevDefaultOptions !== defaultOptions) {
     setPrevDefaultOptions(defaultOptions);
-    logger.log(
-      "Clearing cache and updating query default options due to connection change",
-    );
+    logger.log("Clearing cache and updating query default options");
     queryClient.clear();
     queryClient.setDefaultOptions(defaultOptions);
   }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes an issue I somehow missed before merging #1387. 

The query client does not get the proper connection on initial app load. This is because it no longer changes after the initial render pass.

So instead, I start with `null` to force the first render to set the query client's default options with the connection.

Any further connection change will cause the default options to be updated and the cache to be cleared, just as before.

## Validation

* Added tests for `ExplorerInjector`
* Refreshing app on connection screen ensuring schema sync works
* Refreshing app on graph screen ensuring queries execute
* Refreshing app on data explorer screen ensuring data loads in table
* Switching connections to ensure queries execute with correct connection

## Related Issues

* Part of #1387 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
