### PR TITLE
Fix SPARQL query optimization issue (again)

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.test.ts
@@ -1,0 +1,180 @@
+import blankNodeOneHopNeighborsTemplate from "./blankNodeOneHopNeighborsTemplate";
+import { query } from "@/utils";
+import { normalizeWithNewlines as normalize } from "@/utils/testing";
+
+describe("blankNodeOneHopNeighborsTemplate", () => {
+  it("should produce query with simple subquery", () => {
+    const subQuery =
+      "SELECT ?bNode WHERE { ?bNode a <http://example.org/Type> }";
+    const template = blankNodeOneHopNeighborsTemplate(subQuery);
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            SELECT ?bNode WHERE { ?bNode a <http://example.org/Type> }
+          }
+
+          {
+            SELECT DISTINCT ?bNode ?neighbor 
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              } 
+              UNION 
+              {
+                ?bNode ?predicate ?neighbor .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              }
+            }
+          }
+
+          {
+            SELECT *
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                BIND(?neighbor as ?subject) 
+                BIND(?bNode as ?object)
+              } UNION {
+                ?bNode ?predicate ?neighbor .
+                BIND(?bNode as ?subject) 
+                BIND(?neighbor as ?object)
+              } UNION {
+                ?neighbor ?predicate ?object .
+                FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+                BIND(?neighbor as ?subject)
+              }
+            }
+          }
+        }
+      `),
+    );
+  });
+
+  it("should produce query with complex subquery containing BIND", () => {
+    const subQuery = query`
+      SELECT ?bNode 
+      WHERE { 
+        BIND(<http://example.org/resource> AS ?resource)
+        ?resource ?p ?bNode .
+        FILTER(isBlank(?bNode))
+      }
+    `;
+    const template = blankNodeOneHopNeighborsTemplate(subQuery);
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            SELECT ?bNode 
+            WHERE { 
+              BIND(<http://example.org/resource> AS ?resource)
+              ?resource ?p ?bNode .
+              FILTER(isBlank(?bNode))
+            }
+          }
+
+          {
+            SELECT DISTINCT ?bNode ?neighbor 
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              } 
+              UNION 
+              {
+                ?bNode ?predicate ?neighbor .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              }
+            }
+          }
+
+          {
+            SELECT *
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                BIND(?neighbor as ?subject) 
+                BIND(?bNode as ?object)
+              } UNION {
+                ?bNode ?predicate ?neighbor .
+                BIND(?bNode as ?subject) 
+                BIND(?neighbor as ?object)
+              } UNION {
+                ?neighbor ?predicate ?object .
+                FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+                BIND(?neighbor as ?subject)
+              }
+            }
+          }
+        }
+      `),
+    );
+  });
+
+  it("should produce query with subquery containing UNION", () => {
+    const subQuery = query`
+      SELECT ?bNode 
+      WHERE { 
+        { ?bNode a <http://example.org/TypeA> }
+        UNION
+        { ?bNode a <http://example.org/TypeB> }
+      }
+    `;
+    const template = blankNodeOneHopNeighborsTemplate(subQuery);
+
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            SELECT ?bNode 
+            WHERE { 
+              { ?bNode a <http://example.org/TypeA> }
+              UNION
+              { ?bNode a <http://example.org/TypeB> }
+            }
+          }
+
+          {
+            SELECT DISTINCT ?bNode ?neighbor 
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              } 
+              UNION 
+              {
+                ?bNode ?predicate ?neighbor .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              }
+            }
+          }
+
+          {
+            SELECT *
+            WHERE {
+              {
+                ?neighbor ?predicate ?bNode .
+                BIND(?neighbor as ?subject) 
+                BIND(?bNode as ?object)
+              } UNION {
+                ?bNode ?predicate ?neighbor .
+                BIND(?bNode as ?subject) 
+                BIND(?neighbor as ?object)
+              } UNION {
+                ?neighbor ?predicate ?object .
+                FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+                BIND(?neighbor as ?subject)
+              }
+            }
+          }
+        }
+      `),
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchBlankNodeNeighbors/blankNodeOneHopNeighborsTemplate.ts
@@ -39,20 +39,30 @@ export default function blankNodeOneHopNeighborsTemplate(subQuery: string) {
 
       # Now get the data for these specific neighbors
       {
-        # Connection predicate
-        ?neighbor ?predicate ?bNode .
-        BIND(?neighbor as ?subject) 
-        BIND(?bNode as ?object)
-      } UNION {
-        # Connection predicate
-        ?bNode ?predicate ?neighbor .
-        BIND(?bNode as ?subject) 
-        BIND(?neighbor as ?object)
-      } UNION {
-        # Neighbor properties
-        ?neighbor ?predicate ?object .
-        FILTER(isLiteral(?object) || ?predicate = ${rdfTypeUriTemplate})
-        BIND(?neighbor as ?subject)
+        # Executed as a subquery to workaround a query optimization issue
+        # [Original Fix PR #942](https://github.com/aws/graph-explorer/pull/942)
+        # [Regression PR #1065](https://github.com/aws/graph-explorer/pull/1065)
+        # [Second fix PR #1402](https://github.com/aws/graph-explorer/pull/1402)
+      
+        SELECT *
+        WHERE {
+          {
+            # Connection predicate
+            ?neighbor ?predicate ?bNode .
+            BIND(?neighbor as ?subject) 
+            BIND(?bNode as ?object)
+          } UNION {
+            # Connection predicate
+            ?bNode ?predicate ?neighbor .
+            BIND(?bNode as ?subject) 
+            BIND(?neighbor as ?object)
+          } UNION {
+            # Neighbor properties
+            ?neighbor ?predicate ?object .
+            FILTER(isLiteral(?object) || ?predicate = ${rdfTypeUriTemplate})
+            BIND(?neighbor as ?subject)
+          }
+        }
       }
     }
   `;

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -253,27 +253,32 @@ describe("oneHopNeighborsTemplate", () => {
  * parts of the query change from test to test.
  */
 function commonPartOfQuery(resourceURI: string) {
-  return query`  
+  return query`
     {
-      BIND(<${resourceURI}> AS ?resource)
-      ?neighbor ?pToSource ?resource
-      BIND(?neighbor as ?subject)
-      BIND(?pToSource as ?predicate)
-      BIND(?resource as ?object)
-    }
-    UNION
-    {
-      BIND(<${resourceURI}> AS ?resource)
-      ?resource ?pFromSource ?neighbor
-      BIND(?neighbor as ?object)
-      BIND(?pFromSource as ?predicate)
-      BIND(?resource as ?subject)
-    }
-    UNION
-    {
-      ?neighbor ?predicate ?object
-      FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
-      BIND(?neighbor as ?subject)
+      SELECT *
+      WHERE {
+        {
+          BIND(<${resourceURI}> AS ?resource)
+          ?neighbor ?pToSource ?resource
+          BIND(?neighbor as ?subject)
+          BIND(?pToSource as ?predicate)
+          BIND(?resource as ?object)
+        }
+        UNION
+        {
+          BIND(<${resourceURI}> AS ?resource)
+          ?resource ?pFromSource ?neighbor
+          BIND(?neighbor as ?object)
+          BIND(?pFromSource as ?predicate)
+          BIND(?resource as ?subject)
+        }
+        UNION
+        {
+          ?neighbor ?predicate ?object
+          FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+          BIND(?neighbor as ?subject)
+        }
+      }
     }
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -126,28 +126,38 @@ export function oneHopNeighborsTemplate(
       # - neighbor values
 
       {
-        # Incoming connection predicate
-        BIND(${resourceTemplate} AS ?resource)
-        ?neighbor ?pToSource ?resource
-        BIND(?neighbor as ?subject)
-        BIND(?pToSource as ?predicate)
-        BIND(?resource as ?object)
-      }
-      UNION
-      {
-        # Outgoing connection predicate
-        BIND(${resourceTemplate} AS ?resource)
-        ?resource ?pFromSource ?neighbor
-        BIND(?neighbor as ?object)
-        BIND(?pFromSource as ?predicate)
-        BIND(?resource as ?subject)
-      }
-      UNION
-      {
-        # Values and types
-        ?neighbor ?predicate ?object
-        FILTER(isLiteral(?object) || ?predicate = ${rdfTypeUriTemplate})
-        BIND(?neighbor as ?subject)
+        # Executed as a subquery to workaround a query optimization issue
+        # [Original Fix PR #942](https://github.com/aws/graph-explorer/pull/942)
+        # [Regression PR #1065](https://github.com/aws/graph-explorer/pull/1065)
+        # [Second fix PR #1402](https://github.com/aws/graph-explorer/pull/1402)
+        
+        SELECT * 
+        WHERE {
+          {
+            # Incoming connection predicate
+            BIND(${resourceTemplate} AS ?resource)
+            ?neighbor ?pToSource ?resource
+            BIND(?neighbor as ?subject)
+            BIND(?pToSource as ?predicate)
+            BIND(?resource as ?object)
+          }
+          UNION
+          {
+            # Outgoing connection predicate
+            BIND(${resourceTemplate} AS ?resource)
+            ?resource ?pFromSource ?neighbor
+            BIND(?neighbor as ?object)
+            BIND(?pFromSource as ?predicate)
+            BIND(?resource as ?subject)
+          }
+          UNION
+          {
+            # Values and types
+            ?neighbor ?predicate ?object
+            FILTER(isLiteral(?object) || ?predicate = ${rdfTypeUriTemplate})
+            BIND(?neighbor as ?subject)
+          }
+        }
       }
     }
   `;


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fixes a regression in the neighbor expansion query. The part of the query that gathers the literals and types must be inside a sub-query. If it is not, then Neptune treats the union as unbounded, resulting in poor performance.

I had fixed this in previous versions (#942), but the fix was lost during some other query changes (#1065). I've added comments to the query that include links to all 3 PRs (including this one) to prevent future regressions.

I've also expanded the fix to other queries that follow similar query patterns.

## Validation

- Tested in Neptune SPARQL (multiple databases)
- Tested in Nobel Prize DB (non-Neptune SPARQL database)
- Tested in Medical Subject Headings DB (non-Neptune SPARQL database)

## Related Issues

* Resolves #1403
* Original Fix PR #942
* Regression PR #1065

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
