### PR TITLE
Fix search result disclosure chevron state

### DIFF
--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -1,7 +1,7 @@
 import { cn, isEven } from "@/utils";
 import { ChevronRightIcon } from "lucide-react";
 import type { ComponentPropsWithRef } from "react";
-import { Collapsible } from "./Collapsible";
+import { Collapsible, CollapsibleTrigger } from "./Collapsible";
 
 export function SearchResult({
   className,
@@ -39,6 +39,29 @@ export function SearchResultCollapsible({
         className,
       )}
     />
+  );
+}
+
+export function SearchResultCollapsibleTrigger({
+  className,
+  children,
+  ...props
+}: ComponentPropsWithRef<typeof CollapsibleTrigger>) {
+  return (
+    <CollapsibleTrigger
+      className={cn(
+        "group/search-result-collapsible-trigger flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      <ChevronRightIcon
+        className={cn(
+          "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[state=open]/search-result-collapsible-trigger:rotate-90",
+        )}
+      />
+      {children}
+    </CollapsibleTrigger>
   );
 }
 

--- a/packages/graph-explorer/src/modules/SearchSidebar/BundleSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/BundleSearchResult.tsx
@@ -1,9 +1,8 @@
 import { BracketsIcon } from "lucide-react";
 import {
   CollapsibleContent,
-  CollapsibleTrigger,
   SearchResultCollapsible,
-  SearchResultExpandChevron,
+  SearchResultCollapsibleTrigger,
   SearchResultSubtitle,
   SearchResultSymbol,
   SearchResultTitle,
@@ -28,18 +27,15 @@ export function BundleSearchResult({
 
   return (
     <SearchResultCollapsible level={level}>
-      <CollapsibleTrigger asChild>
-        <div className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer">
-          <SearchResultExpandChevron />
-          <SearchResultSymbol className="bg-primary-main/20 text-primary-main rounded-lg">
-            <BracketsIcon className="size-5" />
-          </SearchResultSymbol>
-          <div>
-            {title && <SearchResultTitle>{title}</SearchResultTitle>}
-            <SearchResultSubtitle>{subtitle}</SearchResultSubtitle>
-          </div>
+      <SearchResultCollapsibleTrigger>
+        <SearchResultSymbol className="bg-primary-main/20 text-primary-main rounded-lg">
+          <BracketsIcon className="size-5" />
+        </SearchResultSymbol>
+        <div>
+          {title && <SearchResultTitle>{title}</SearchResultTitle>}
+          <SearchResultSubtitle>{subtitle}</SearchResultSubtitle>
         </div>
-      </CollapsibleTrigger>
+      </SearchResultCollapsibleTrigger>
       <CollapsibleContent>
         <ul className="space-y-3 p-3">
           {bundle.values.map(entity => (

--- a/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/EdgeSearchResult.tsx
@@ -7,11 +7,10 @@ import {
 import {
   type ButtonProps,
   CollapsibleContent,
-  CollapsibleTrigger,
   EdgeRow,
   IconButton,
   SearchResultCollapsible,
-  SearchResultExpandChevron,
+  SearchResultCollapsibleTrigger,
   Spinner,
   stopPropagation,
 } from "@/components";
@@ -48,22 +47,16 @@ export function EdgeSearchResult({
 
   return (
     <SearchResultCollapsible level={level} highlighted={hasBeenAdded}>
-      <CollapsibleTrigger asChild>
-        <div
-          role="button"
-          className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
-        >
-          <SearchResultExpandChevron />
-          <EdgeRow
-            edge={displayEdge}
-            source={source}
-            target={target}
-            name={edge.name}
-            className="grow"
-          />
-          <AddOrRemoveButton edge={edge} />
-        </div>
-      </CollapsibleTrigger>
+      <SearchResultCollapsibleTrigger>
+        <EdgeRow
+          edge={displayEdge}
+          source={source}
+          target={target}
+          name={edge.name}
+          className="grow"
+        />
+        <AddOrRemoveButton edge={edge} />
+      </SearchResultCollapsibleTrigger>
       <CollapsibleContent>
         <ul className="space-y-3 p-3">
           {attributes.map(attr => (

--- a/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/VertexSearchResult.tsx
@@ -2,10 +2,9 @@ import { createVertex, useDisplayVertexFromVertex } from "@/core";
 import {
   type ButtonProps,
   CollapsibleContent,
-  CollapsibleTrigger,
   IconButton,
   SearchResultCollapsible,
-  SearchResultExpandChevron,
+  SearchResultCollapsibleTrigger,
   Spinner,
   stopPropagation,
   VertexRow,
@@ -33,16 +32,10 @@ export function VertexSearchResult({
 
   return (
     <SearchResultCollapsible level={level} highlighted={hasBeenAdded}>
-      <CollapsibleTrigger asChild>
-        <div
-          role="button"
-          className="flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer"
-        >
-          <SearchResultExpandChevron />
-          <VertexRow vertex={displayNode} name={vertex.name} className="grow" />
-          <AddOrRemoveButton vertex={vertex} />
-        </div>
-      </CollapsibleTrigger>
+      <SearchResultCollapsibleTrigger>
+        <VertexRow vertex={displayNode} name={vertex.name} className="grow" />
+        <AddOrRemoveButton vertex={vertex} />
+      </SearchResultCollapsibleTrigger>
       <CollapsibleContent>
         <ul className="space-y-3 p-3">
           {attributes.map(attr => (


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

When multiple layers of nested search results exist Tailwind can't disambiguate which group is the direct parent. That results in any expanded parent causing all children to show the expanded state of the chevron.

To fix it, I created a shared `SearchResultCollapsibleTrigger` component that pulls in the container layout classes and the expanded logic. I can then depend on a different group name that will not be in the parent tree of any nested items.

## Validation

* Tested vertex results
* Tested edge results
* Tested bundle results

## Related Issues

* Resolves #1413 

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
