### PR TITLE
Fix button within button error

### DIFF
--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -48,19 +48,20 @@ export function SearchResultCollapsibleTrigger({
   ...props
 }: ComponentPropsWithRef<typeof CollapsibleTrigger>) {
   return (
-    <CollapsibleTrigger
-      className={cn(
-        "group/search-result-collapsible-trigger flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer",
-        className,
-      )}
-      {...props}
-    >
-      <ChevronRightIcon
+    <CollapsibleTrigger asChild {...props}>
+      <div
         className={cn(
-          "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[state=open]/search-result-collapsible-trigger:rotate-90",
+          "group/search-result-collapsible-trigger flex w-full flex-row items-center gap-2 p-3 text-left hover:cursor-pointer",
+          className,
         )}
-      />
-      {children}
+      >
+        <ChevronRightIcon
+          className={cn(
+            "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[state=open]/search-result-collapsible-trigger:rotate-90",
+          )}
+        />
+        {children}
+      </div>
     </CollapsibleTrigger>
   );
 }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix an error only shown in the console reporting a button within a button.

The Collapsible trigger is a button, and the content of the trigger contains an add/remove button. To fix it I nest the content in a `div` and use `asChild`.

## Validation

* Ensured search results still expand
* Ensured vertex can still be added

## Related Issues

* None

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
