### PR TITLE
Add EdgeConnection type for Schema Explorer

### DIFF
--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -1,5 +1,6 @@
 import type {
   ConfigurationContextProps,
+  EdgeConnection,
   EdgeTypeConfig,
   VertexTypeConfig,
   Edge,
@@ -51,6 +52,11 @@ export type SchemaResponse = {
    * List of edges definitions.
    */
   edges: EdgeSchemaResponse[];
+  /**
+   * Edge connections between node labels.
+   * Used by Schema Explorer to visualize relationships between node types.
+   */
+  edgeConnections?: EdgeConnection[];
 };
 
 export type Criterion = {

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.test.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import type { RawConfiguration } from "./types";
+import { serializeData, deserializeData } from "../StateProvider/serializeData";
+import {
+  createRandomRawConfiguration,
+  createRandomSchema,
+} from "@/utils/testing";
+import { createArray } from "@shared/utils/testing";
+import type { SchemaStorageModel } from "../StateProvider";
+
+describe("Schema", () => {
+  test("serialization round-trip preserves schema data", () => {
+    const schema = createRandomSchema();
+
+    const serialized = serializeData(schema);
+    const deserialized = deserializeData(serialized) as SchemaStorageModel;
+
+    expect(deserialized).toStrictEqual(schema);
+  });
+
+  test("serialization round-trip preserves array of schemas", () => {
+    const schemas = createArray(5, createRandomSchema);
+
+    const serialized = serializeData(schemas);
+    const deserialized = deserializeData(serialized) as SchemaStorageModel[];
+
+    expect(deserialized).toStrictEqual(schemas);
+  });
+
+  test("serialization round-trip preserves schema with lastUpdate date", () => {
+    const schema = createRandomSchema();
+    schema.lastUpdate = new Date("2025-06-15T10:30:00.000Z");
+
+    const serialized = serializeData(schema);
+    const deserialized = deserializeData(serialized) as SchemaStorageModel;
+
+    expect(deserialized.lastUpdate).toBeInstanceOf(Date);
+    expect(deserialized.lastUpdate).toStrictEqual(schema.lastUpdate);
+  });
+});
+
+describe("RawConfiguration", () => {
+  test("serialization round-trip preserves configuration data", () => {
+    const config = createRandomRawConfiguration();
+
+    const serialized = serializeData(config);
+    const deserialized = deserializeData(serialized) as RawConfiguration;
+
+    expect(deserialized).toStrictEqual(config);
+  });
+
+  test("serialization round-trip preserves array of configurations", () => {
+    const configs = createArray(5, createRandomRawConfiguration);
+
+    const serialized = serializeData(configs);
+    const deserialized = deserializeData(serialized) as RawConfiguration[];
+
+    expect(deserialized).toStrictEqual(configs);
+  });
+
+  test("serialization round-trip preserves configuration with schema", () => {
+    const config = createRandomRawConfiguration();
+    config.schema = createRandomSchema();
+
+    const serialized = serializeData(config);
+    const deserialized = deserializeData(serialized) as RawConfiguration;
+
+    expect(deserialized).toStrictEqual(config);
+    expect(deserialized.schema?.lastUpdate).toBeInstanceOf(Date);
+  });
+});

--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -99,6 +99,29 @@ export type PrefixTypeConfig = {
   __matches?: Set<string>;
 };
 
+/**
+ * Represents a connection between node labels via an edge type.
+ * Used by Schema Explorer to visualize relationships between node types.
+ */
+export type EdgeConnection = {
+  /**
+   * The edge type name
+   */
+  edgeType: EdgeType;
+  /**
+   * The source node label
+   */
+  sourceVertexType: VertexType;
+  /**
+   * The target node label
+   */
+  targetVertexType: VertexType;
+  /**
+   * Count of edges with this connection pattern
+   */
+  count?: number;
+};
+
 export type RawConfiguration = {
   /**
    * Unique identifier for this config

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -86,10 +86,14 @@ describe("mergedConfiguration", () => {
           ...e,
         }))
         .map(patchToRemoveDisplayLabel),
+      edgeConnections: schema.edgeConnections,
     } satisfies SchemaStorageModel;
 
     expect(result.schema?.vertices).toEqual(expectedSchema.vertices);
     expect(result.schema?.edges).toEqual(expectedSchema.edges);
+    expect(result.schema?.edgeConnections).toEqual(
+      expectedSchema.edgeConnections,
+    );
     expect(result.schema).toEqual(expectedSchema);
     expect(result).toEqual({
       ...config,
@@ -139,10 +143,14 @@ describe("mergedConfiguration", () => {
           ...style,
         };
       }),
+      edgeConnections: schema.edgeConnections,
     } satisfies SchemaStorageModel;
 
     expect(result.schema?.vertices).toEqual(expectedSchema.vertices);
     expect(result.schema?.edges).toEqual(expectedSchema.edges);
+    expect(result.schema?.edgeConnections).toEqual(
+      expectedSchema.edgeConnections,
+    );
     expect(result.schema).toEqual(expectedSchema);
     expect(result).toEqual({
       ...config,

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -101,6 +101,7 @@ export function mergeConfiguration(
       lastSyncFail: currentSchema?.lastSyncFail,
       totalVertices: currentSchema?.totalVertices ?? 0,
       totalEdges: currentSchema?.totalEdges ?? 0,
+      edgeConnections: currentSchema?.edgeConnections,
     },
   };
 }

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -1,8 +1,12 @@
 import {
   createRandomEdge,
+  createRandomEdgeConnection,
   createRandomEntities,
   createRandomSchema,
   createRandomVertex,
+  createRandomVertexType,
+  renderHookWithState,
+  DbState,
 } from "@/utils/testing";
 import {
   mapVertexToTypeConfigs,
@@ -10,6 +14,7 @@ import {
   shouldUpdateSchemaFromEntities,
   updateSchemaFromEntities,
   updateSchemaPrefixes,
+  useGraphSchema,
 } from "./schema";
 import { createArray, createRandomName } from "@shared/utils/testing";
 import type {
@@ -419,5 +424,87 @@ describe("referential integrity", () => {
 
     expect(result.edges[0]).not.toBe(schema.edges[0]);
     expect(result.edges[0].attributes).not.toBe(schema.edges[0].attributes);
+  });
+});
+
+describe("useGraphSchema edgeConnections", () => {
+  test("should return empty edgeConnections when schema has none", () => {
+    const state = new DbState();
+    state.activeSchema.edgeConnections = undefined;
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    expect(result.current.edgeConnections.all).toStrictEqual([]);
+    expect(result.current.edgeConnections.byVertexType.size).toBe(0);
+  });
+
+  test("should return all edge connections", () => {
+    const conn1 = createRandomEdgeConnection();
+    const conn2 = createRandomEdgeConnection();
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [conn1, conn2];
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    expect(result.current.edgeConnections.all).toStrictEqual([conn1, conn2]);
+  });
+
+  test("should group connections by vertex type", () => {
+    const sharedVertexType = createRandomVertexType();
+    const conn1 = createRandomEdgeConnection();
+    const conn2 = createRandomEdgeConnection();
+    conn1.sourceVertexType = sharedVertexType;
+    conn2.targetVertexType = sharedVertexType;
+
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [conn1, conn2];
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    const connectionsForShared =
+      result.current.edgeConnections.byVertexType.get(sharedVertexType);
+    expect(connectionsForShared).toStrictEqual([conn1, conn2]);
+  });
+
+  test("forVertexType should return connections for a vertex type", () => {
+    const vertexType = createRandomVertexType();
+    const conn = createRandomEdgeConnection();
+    conn.sourceVertexType = vertexType;
+
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [conn];
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    expect(
+      result.current.edgeConnections.forVertexType(vertexType),
+    ).toStrictEqual([conn]);
+  });
+
+  test("forVertexType should return empty array for unknown vertex type", () => {
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [createRandomEdgeConnection()];
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    expect(
+      result.current.edgeConnections.forVertexType(createRandomVertexType()),
+    ).toStrictEqual([]);
+  });
+
+  test("should not duplicate connection when source equals target", () => {
+    const vertexType = createRandomVertexType();
+    const conn = createRandomEdgeConnection();
+    conn.sourceVertexType = vertexType;
+    conn.targetVertexType = vertexType;
+
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [conn];
+
+    const { result } = renderHookWithState(() => useGraphSchema(), state);
+
+    expect(
+      result.current.edgeConnections.forVertexType(vertexType),
+    ).toStrictEqual([conn]);
   });
 });

--- a/packages/graph-explorer/src/utils/saveConfigurationToFile.test.ts
+++ b/packages/graph-explorer/src/utils/saveConfigurationToFile.test.ts
@@ -281,4 +281,86 @@ describe("saveConfigurationToFile", () => {
     expect(parsed.connection).toBeDefined();
     expect(parsed.schema).toBeDefined();
   });
+
+  it("should export edgeConnections when present", async () => {
+    const config: ConfigurationContextProps = {
+      ...createRandomRawConfiguration(),
+      schema: {
+        vertices: [],
+        edges: [],
+        prefixes: [],
+        totalVertices: 0,
+        totalEdges: 0,
+        lastUpdate: new Date(),
+        lastSyncFail: false,
+        triedToSync: true,
+        edgeConnections: [
+          {
+            edgeType: createEdgeType("knows"),
+            sourceVertexType: createVertexType("Person"),
+            targetVertexType: createVertexType("Person"),
+            count: 42,
+          },
+          {
+            edgeType: createEdgeType("worksAt"),
+            sourceVertexType: createVertexType("Person"),
+            targetVertexType: createVertexType("Company"),
+          },
+        ],
+      },
+      totalVertices: 0,
+      vertexTypes: [],
+      totalEdges: 0,
+      edgeTypes: [],
+    };
+
+    saveConfigurationToFile(config);
+
+    const [blob] = saveAsMock.mock.calls[0];
+    const text = await (blob as Blob).text();
+    const parsed = JSON.parse(text);
+
+    expect(parsed.schema.edgeConnections).toStrictEqual([
+      {
+        edgeType: "knows",
+        sourceVertexType: "Person",
+        targetVertexType: "Person",
+        count: 42,
+      },
+      {
+        edgeType: "worksAt",
+        sourceVertexType: "Person",
+        targetVertexType: "Company",
+      },
+    ]);
+  });
+
+  it("should handle undefined edgeConnections", async () => {
+    const config: ConfigurationContextProps = {
+      ...createRandomRawConfiguration(),
+      schema: {
+        vertices: [],
+        edges: [],
+        prefixes: [],
+        totalVertices: 0,
+        totalEdges: 0,
+        lastUpdate: new Date(),
+        lastSyncFail: false,
+        triedToSync: true,
+        edgeConnections: undefined,
+      },
+      totalVertices: 0,
+      vertexTypes: [],
+      totalEdges: 0,
+      edgeTypes: [],
+    };
+
+    saveConfigurationToFile(config);
+
+    const [blob] = saveAsMock.mock.calls[0];
+    const text = await (blob as Blob).text();
+    const parsed = JSON.parse(text);
+
+    expect(parsed.schema.edgeConnections).toBeUndefined();
+  });
 });

--- a/packages/graph-explorer/src/utils/saveConfigurationToFile.ts
+++ b/packages/graph-explorer/src/utils/saveConfigurationToFile.ts
@@ -18,6 +18,7 @@ const saveConfigurationToFile = (config: ConfigurationContextProps) => {
         __matches: Array.from(prefix.__matches || []),
       })),
       lastUpdate: config.schema?.lastUpdate?.toISOString(),
+      edgeConnections: config.schema?.edgeConnections,
     },
   };
 

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -9,6 +9,7 @@ import {
   createVertex,
   createVertexId,
   createVertexPreference,
+  type EdgeConnection,
   type EdgeId,
   type EdgePreferences,
   type EdgePreferencesStorageModel,
@@ -177,15 +178,31 @@ export function createRandomPrefixTypeConfig(): PrefixTypeConfig {
 }
 
 /**
+ * Creates a random EdgeConnection object.
+ * Used for testing Schema Explorer edge connection functionality.
+ * @returns A random EdgeConnection object.
+ */
+export function createRandomEdgeConnection(): EdgeConnection {
+  return {
+    edgeType: createRandomEdgeType(),
+    sourceVertexType: createRandomVertexType(),
+    targetVertexType: createRandomVertexType(),
+    count: randomlyUndefined(createRandomInteger({ min: 1, max: 1000 })),
+  };
+}
+
+/**
  * Creates a random schema object.
  * @returns A random SchemaStorageModel object.
  */
 export function createRandomSchema(): SchemaStorageModel {
   const edges = createArray(3, createRandomEdgeTypeConfig);
   const vertices = createArray(3, createRandomVertexTypeConfig);
+  const edgeConnections = createArray(5, createRandomEdgeConnection);
   const schema: SchemaStorageModel = {
     edges,
     vertices,
+    edgeConnections: randomlyUndefined(edgeConnections),
     totalEdges: edges
       .map(e => e.total ?? 0)
       .reduce((prev, current) => current + prev, 0),


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Introduces `EdgeConnection` to represent relationships between node labels (source → edge type → target). Adds `edgeConnections` to `schema` with lookup helpers (`byVertexType`, `forVertexType`). Includes serialization support and file export. For use by Schema Explorer to visualize node type relationships.

Nothing is filling this code with data yet. It is just a preparation step

## Validation

* Smoke test
* Ran tests

## Related Issues

* Part of #1372

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
