### PR TITLE
Add basic schema explorer route

### DIFF
--- a/packages/graph-explorer/src/App.tsx
+++ b/packages/graph-explorer/src/App.tsx
@@ -5,6 +5,7 @@ import Connections from "./routes/Connections";
 import DataExplorer from "./routes/DataExplorer";
 import DefaultLayout from "./routes/DefaultLayout";
 import GraphExplorer from "./routes/GraphExplorer";
+import SchemaExplorer from "./routes/SchemaExplorer";
 import {
   SettingsAbout,
   SettingsGeneral,
@@ -18,6 +19,7 @@ export default function App() {
         <Route path="/connections" element={<Connections />} />
         <Route path="/data-explorer/:vertexType" element={<DataExplorer />} />
         <Route path="/graph-explorer" element={<GraphExplorer />} />
+        <Route path="/schema-explorer" element={<SchemaExplorer />} />
         <Route path="/settings" element={<SettingsRoot />}>
           <Route path="general" element={<SettingsGeneral />} />
           <Route path="about" element={<SettingsAbout />} />

--- a/packages/graph-explorer/src/components/RouteButton.tsx
+++ b/packages/graph-explorer/src/components/RouteButton.tsx
@@ -3,6 +3,7 @@ import type { VariantProps } from "cva";
 import {
   CompassIcon,
   DatabaseIcon,
+  NetworkIcon,
   SettingsIcon,
   TableIcon,
 } from "lucide-react";
@@ -12,6 +13,7 @@ import { useHasActiveSchema } from "@/core";
 import { cn } from "@/utils";
 
 import { buttonStyles } from "./Button";
+import NotInProduction from "./NotInProduction";
 
 type RouteButtonProps = {
   variant?: VariantProps<typeof buttonStyles>["variant"];
@@ -60,5 +62,21 @@ export function DataExplorerRouteButton({ variant }: RouteButtonProps) {
       <TableIcon />
       Data Explorer
     </Link>
+  );
+}
+
+export function SchemaExplorerRouteButton({ variant }: RouteButtonProps) {
+  const hasSchema = useHasActiveSchema();
+  return (
+    <NotInProduction>
+      <Link
+        to={hasSchema ? "/schema-explorer" : "/connections"}
+        className={cn(buttonStyles({ variant }))}
+        aria-disabled={!hasSchema}
+      >
+        <NetworkIcon />
+        Schema Explorer
+      </Link>
+    </NotInProduction>
   );
 }

--- a/packages/graph-explorer/src/routes/Connections/Connections.tsx
+++ b/packages/graph-explorer/src/routes/Connections/Connections.tsx
@@ -12,6 +12,7 @@ import {
   PanelContent,
   PanelEmptyState,
   PanelGroup,
+  SchemaExplorerRouteButton,
   SettingsRouteButton,
   Workspace,
   WorkspaceContent,
@@ -41,6 +42,7 @@ export default function Connections() {
           <NavBarVersion>{__GRAPH_EXP_VERSION__}</NavBarVersion>
           <div className="flex gap-2">
             <SettingsRouteButton />
+            <SchemaExplorerRouteButton />
             <GraphExplorerRouteButton variant="filled" />
           </div>
         </NavBarActions>

--- a/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
@@ -17,6 +17,7 @@ import {
   NavBarTitle,
   NavBarVersion,
   PanelGroup,
+  SchemaExplorerRouteButton,
   Workspace,
   WorkspaceContent,
 } from "@/components";
@@ -94,6 +95,7 @@ const GraphExplorer = () => {
 
           <Divider axis="vertical" className="h-[50%]" />
 
+          <SchemaExplorerRouteButton />
           <ConnectionsRouteButton variant="filled" />
         </NavBarActions>
       </NavBar>

--- a/packages/graph-explorer/src/routes/SchemaExplorer/SchemaExplorer.tsx
+++ b/packages/graph-explorer/src/routes/SchemaExplorer/SchemaExplorer.tsx
@@ -1,0 +1,56 @@
+import {
+  ConnectionsRouteButton,
+  GraphExplorerRouteButton,
+  NavBar,
+  NavBarActions,
+  NavBarContent,
+  NavBarTitle,
+  NavBarVersion,
+  Panel,
+  PanelContent,
+  PanelGroup,
+  Workspace,
+  WorkspaceContent,
+} from "@/components";
+import Redirect from "@/components/Redirect";
+import { useConfiguration, useHasActiveSchema } from "@/core";
+
+export default function SchemaExplorer() {
+  const config = useConfiguration();
+  const hasSchema = useHasActiveSchema();
+
+  if (!hasSchema) {
+    return <Redirect to="/connections" />;
+  }
+
+  return (
+    <Workspace>
+      <NavBar logoVisible>
+        <NavBarContent>
+          <NavBarTitle
+            title="Schema Explorer"
+            subtitle={`Connection: ${config?.displayLabel || config?.id || "none"}`}
+          />
+        </NavBarContent>
+
+        <NavBarActions>
+          <NavBarVersion>{__GRAPH_EXP_VERSION__}</NavBarVersion>
+
+          <ConnectionsRouteButton />
+          <GraphExplorerRouteButton variant="filled" />
+        </NavBarActions>
+      </NavBar>
+      <WorkspaceContent>
+        <PanelGroup>
+          <Panel className="flex-1">
+            <PanelContent className="flex items-center justify-center">
+              <p className="text-text-secondary text-lg">
+                Schema visualization coming soon...
+              </p>
+            </PanelContent>
+          </Panel>
+        </PanelGroup>
+      </WorkspaceContent>
+    </Workspace>
+  );
+}

--- a/packages/graph-explorer/src/routes/SchemaExplorer/index.ts
+++ b/packages/graph-explorer/src/routes/SchemaExplorer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SchemaExplorer";


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Adds the foundation for a new Schema Explorer feature with placeholder UI and
navigation integration.

### Changes

- New `/schema-explorer` route with basic layout (navbar + placeholder content)
- New `SchemaExplorerRouteButton` component for navigation
- Navigation buttons added to Connections and Graph Explorer pages
- Wrapped in `NotInProduction` to hide from production builds until feature is
  complete

> [!NOTE]
> 
> This is a placeholder implementation. The actual schema visualization will be
added in a follow-up PR.

## Validation

* Ensured schema explorer route button does not appear in production builds

### Connections
<img width="3104" height="2154" alt="CleanShot 2026-01-19 at 18 38 42@2x" src="https://github.com/user-attachments/assets/d872455a-7dc7-4551-a7d8-884545b30ca0" />

### Graph Explorer
<img width="3104" height="2154" alt="CleanShot 2026-01-19 at 18 38 45@2x" src="https://github.com/user-attachments/assets/c6b69043-a587-4f32-88d3-dab9a761c2ee" />

### Schema Explorer
<img width="3104" height="2154" alt="CleanShot 2026-01-19 at 18 38 50@2x" src="https://github.com/user-attachments/assets/61b1e47b-b691-41aa-a24c-d995ad29e3c8" />

## Related Issues

- Resolves #1373

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
