### PR TITLE
Hide Display Name Property Selector for SPARQL Edge Styling

### DIFF
--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -25,7 +25,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/Dialog";
-import { type EdgeType, useDisplayEdgeTypeConfig } from "@/core";
+import {
+  type EdgeType,
+  useDisplayEdgeTypeConfig,
+  useQueryEngine,
+} from "@/core";
 import {
   type ArrowStyle,
   type LineStyle,
@@ -69,9 +73,12 @@ export function EdgeStyleDialog() {
 function Content({ edgeType }: { edgeType: EdgeType }) {
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
   const t = useTranslations();
+  const queryEngine = useQueryEngine();
 
   const { edgeStyle, setEdgeStyle, resetEdgeStyle } = useEdgeStyling(edgeType);
 
+  // In SPARQL there are no edge attributes, so predicate is the only and default option
+  const hideDisplayNameAttribute = queryEngine === "sparql";
   const selectOptions = (() => {
     const options = displayConfig.attributes.map(attr => ({
       value: attr.name,
@@ -97,28 +104,31 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
         </DialogHeader>
         <DialogBody>
           <FieldSet>
-            <FieldGroup>
-              <Field>
-                <FieldLabel>Display Name {t("property")}</FieldLabel>
-                <Select
-                  value={edgeStyle.displayNameAttribute}
-                  onValueChange={value =>
-                    setEdgeStyle({ displayNameAttribute: value })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a display attribute" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {selectOptions.map(option => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-            </FieldGroup>
+            {hideDisplayNameAttribute ? null : (
+              <FieldGroup>
+                <Field>
+                  <FieldLabel>Display Name {t("property")}</FieldLabel>
+                  <Select
+                    value={edgeStyle.displayNameAttribute}
+                    onValueChange={value =>
+                      setEdgeStyle({ displayNameAttribute: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a display attribute" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectOptions.map(option => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              </FieldGroup>
+            )}
+
             <FieldSet>
               <FieldLegend>Label Styling</FieldLegend>
               <FieldGroup className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

In SPARQL graphs, edges (predicates) don't have attributes beyond the predicate itself. This change hides the "Display Name Property" selector in the Edge Style Dialog when using SPARQL, since the predicate is the only available option and is already used by default.

### Changes
- Added `useQueryEngine()` hook to detect SPARQL query engine
- Conditionally hide the display name attribute selector for SPARQL connections
- Added explanatory comment about SPARQL edge attribute behavior

## Validation

<img width="1048" height="1184" alt="CleanShot 2026-01-22 at 17 16 06@2x" src="https://github.com/user-attachments/assets/73a8a607-0c2a-40f2-baff-67fd07d440fc" />

## Related Issues

* Part of #1471

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
