### PR TITLE
Refactor entity count formatting to support translations

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.ts
@@ -3,7 +3,8 @@ import { toast } from "sonner";
 
 import { fetchEntityDetails, notifyOnIncompleteRestoration } from "@/connector";
 import { useAddToGraph } from "@/hooks";
-import { formatEntityCounts, logger } from "@/utils";
+import { useEntityCountFormatterCallback } from "@/hooks/useEntityCountFormatter";
+import { logger } from "@/utils";
 import { createDisplayError } from "@/utils/createDisplayError";
 
 import type { GraphSessionStorageModel } from "./storage";
@@ -14,6 +15,7 @@ import type { GraphSessionStorageModel } from "./storage";
 export function useRestoreGraphSession() {
   const queryClient = useQueryClient();
   const addToGraph = useAddToGraph();
+  const formatEntityCounts = useEntityCountFormatterCallback();
 
   const mutation = useMutation({
     mutationFn: async (graph: GraphSessionStorageModel) => {

--- a/packages/graph-explorer/src/hooks/useEntityCountFormatter.test.ts
+++ b/packages/graph-explorer/src/hooks/useEntityCountFormatter.test.ts
@@ -1,0 +1,89 @@
+import { vi } from "vitest";
+
+import { renderHookWithJotai } from "@/utils/testing";
+
+import {
+  useEntityCountFormatterCallback,
+  useFormattedEntityCounts,
+} from "./useEntityCountFormatter";
+
+// Mock useTranslations
+vi.mock("./useTranslations", () => ({
+  default: () => (key: string) => {
+    const translations: Record<string, string> = {
+      node: "node",
+      nodes: "nodes",
+      edge: "edge",
+      edges: "edges",
+    };
+    return translations[key] || key;
+  },
+}));
+
+describe("useFormattedEntityCounts", () => {
+  it("should format single node and single edge", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(1, 1),
+    );
+    expect(result.current).toBe("1 node and 1 edge");
+  });
+
+  it("should format multiple nodes and multiple edges", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(5, 3),
+    );
+    expect(result.current).toBe("5 nodes and 3 edges");
+  });
+
+  it("should format only nodes when edge count is zero", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(2, 0),
+    );
+    expect(result.current).toBe("2 nodes");
+  });
+
+  it("should format only edges when node count is zero", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(0, 4),
+    );
+    expect(result.current).toBe("4 edges");
+  });
+
+  it("should return empty string when both counts are zero", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(0, 0),
+    );
+    expect(result.current).toBe("");
+  });
+
+  it("should format large numbers with locale formatting", () => {
+    const { result } = renderHookWithJotai(() =>
+      useFormattedEntityCounts(1000, 2500),
+    );
+    expect(result.current).toBe("1,000 nodes and 2,500 edges");
+  });
+});
+
+describe("useEntityCountFormatterCallback", () => {
+  it("should return a function that formats counts", () => {
+    const { result } = renderHookWithJotai(() =>
+      useEntityCountFormatterCallback(),
+    );
+
+    expect(typeof result.current).toBe("function");
+    expect(result.current(1, 1)).toBe("1 node and 1 edge");
+  });
+
+  it("should handle different count combinations", () => {
+    const { result } = renderHookWithJotai(() =>
+      useEntityCountFormatterCallback(),
+    );
+
+    const format = result.current;
+
+    expect(format(0, 0)).toBe("");
+    expect(format(1, 0)).toBe("1 node");
+    expect(format(0, 1)).toBe("1 edge");
+    expect(format(10, 5)).toBe("10 nodes and 5 edges");
+  });
+});

--- a/packages/graph-explorer/src/hooks/useEntityCountFormatter.ts
+++ b/packages/graph-explorer/src/hooks/useEntityCountFormatter.ts
@@ -1,0 +1,29 @@
+import useTranslations from "./useTranslations";
+
+export function useFormattedEntityCounts(
+  vertexCount: number,
+  edgeCount: number,
+) {
+  const format = useEntityCountFormatterCallback();
+  return format(vertexCount, edgeCount);
+}
+
+export function useEntityCountFormatterCallback() {
+  const t = useTranslations();
+
+  const format = (vertexCount: number, edgeCount: number) => {
+    const nodeMessage =
+      vertexCount === 0
+        ? null
+        : `${vertexCount.toLocaleString()} ${vertexCount === 1 ? t("node") : t("nodes")}`.toLocaleLowerCase();
+    const edgeMessage =
+      edgeCount === 0
+        ? null
+        : `${edgeCount.toLocaleString()} ${edgeCount === 1 ? t("edge") : t("edges")}`.toLocaleLowerCase();
+
+    return [nodeMessage, edgeMessage]
+      .filter(message => message != null)
+      .join(" and ");
+  };
+  return format;
+}

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewerEmptyState.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewerEmptyState.tsx
@@ -10,7 +10,8 @@ import {
   useAvailablePreviousSession,
   useRestoreGraphSession,
 } from "@/core";
-import { cn, formatEntityCounts } from "@/utils";
+import { useFormattedEntityCounts } from "@/hooks/useEntityCountFormatter";
+import { cn } from "@/utils";
 
 export function GraphViewerEmptyState(props: ComponentPropsWithRef<"div">) {
   const availablePrevSession = useAvailablePreviousSession();
@@ -35,7 +36,7 @@ function RestorePreviousSessionEmptyState({
 } & ComponentPropsWithRef<"div">) {
   const restore = useRestoreGraphSession();
 
-  const entityCounts = formatEntityCounts(
+  const entityCounts = useFormattedEntityCounts(
     prevSession.vertices.size,
     prevSession.edges.size,
   );

--- a/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/ImportGraphButton.tsx
@@ -8,8 +8,9 @@ import { FileButton, PanelHeaderActionButton, Spinner } from "@/components";
 import { fetchEntityDetails, notifyOnIncompleteRestoration } from "@/connector";
 import { configurationAtom, type ConnectionWithId, useExplorer } from "@/core";
 import { useAddToGraph } from "@/hooks";
+import { useEntityCountFormatterCallback } from "@/hooks/useEntityCountFormatter";
 import { getTranslation } from "@/hooks/useTranslations";
-import { formatEntityCounts, logger } from "@/utils";
+import { logger } from "@/utils";
 import { fromFileToJson } from "@/utils/fileData";
 
 import {
@@ -40,6 +41,7 @@ function useImportGraphMutation() {
   const queryClient = useQueryClient();
   const explorer = useExplorer();
   const addToGraph = useAddToGraph();
+  const formatEntityCounts = useEntityCountFormatterCallback();
   const allConfigs = useAtomValue(configurationAtom);
   const allConnections = allConfigs
     .values()


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR refactors entity count formatting from a static utility function into a custom hook that properly integrates with the translation system, enabling query-language-specific terminology.

#### New Hook: `useEntityCountFormatter`

Created a new hook that replaces the static `formatEntityCounts` utility with translation-aware formatting:

- **`useFormattedEntityCounts(vertexCount, edgeCount)`** - Direct formatting hook for use in components
- **`useEntityCountFormatterCallback()`** - Returns a callback function for use in mutations and async operations

**Key improvements:**
- Integrates with the translation system to use query-language-specific terms (e.g., "relationships" for openCypher, "predicates" for SPARQL)
- Maintains locale-aware number formatting (e.g., "1,000 nodes")
- Handles singular/plural forms correctly
- Comprehensive test coverage with 89 lines of tests

#### Updated Components

- **`GraphViewerEmptyState`** - Now uses `useFormattedEntityCounts` hook
- **`ImportGraphButton`** - Now uses `useEntityCountFormatterCallback` for mutation callbacks
- **`useRestoreGraphSession`** - Now uses `useEntityCountFormatterCallback` for mutation callbacks

This change ensures that entity count messages throughout the application respect the active query language's terminology.

## Validation

### Gremlin
<img width="1144" height="570" alt="CleanShot 2026-01-22 at 15 55 23@2x" src="https://github.com/user-attachments/assets/33e77881-ff34-46a7-85b2-bdd6662ce296" />

### Cypher
<img width="1160" height="644" alt="CleanShot 2026-01-22 at 15 56 36@2x" src="https://github.com/user-attachments/assets/34f408f8-1d21-4a96-9703-9024d19ab85e" />

### SPARQL
<img width="1084" height="600" alt="CleanShot 2026-01-22 at 15 57 06@2x" src="https://github.com/user-attachments/assets/eff9f49a-396c-4935-a632-354d432e360c" />

## Related Issues

* Part of #1471

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
