### PR TITLE
Export placeholder missing values as empty in CSV/JSON

### DIFF
--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.test.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.test.ts
@@ -1,10 +1,10 @@
 import dedent from "dedent";
 
+import { LABELS } from "@/utils/constants";
+
 import type { TabularColumnInstance } from "../../helpers/tableInstanceToTabularInstance";
 
 import { transformToCsv } from "./transformToCsv";
-
-import { LABELS } from "@/utils/constants";
 
 describe("transformToCsv", () => {
   it("should transform empty data to empty csv", () => {
@@ -251,6 +251,187 @@ describe("transformToCsv", () => {
     );
   });
 
+  it("should export MISSING_TYPE as empty cell with string accessor", () => {
+    const result = transformToCsv(
+      [
+        {
+          type: LABELS.MISSING_TYPE,
+          name: "test",
+        },
+      ],
+      [createColumn("type"), createColumn("name")],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        type,name
+        ,test
+      `),
+    );
+  });
+
+  it("should export EMPTY_VALUE as empty cell with string accessor", () => {
+    const result = transformToCsv(
+      [
+        {
+          description: LABELS.EMPTY_VALUE,
+          name: "test",
+        },
+      ],
+      [createColumn("description"), createColumn("name")],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        description,name
+        ,test
+      `),
+    );
+  });
+
+  it("should export all placeholder constants as empty cells in same row", () => {
+    const result = transformToCsv(
+      [
+        {
+          type: LABELS.MISSING_TYPE,
+          value: LABELS.MISSING_VALUE,
+          description: LABELS.EMPTY_VALUE,
+          name: "test",
+        },
+      ],
+      [
+        createColumn("type"),
+        createColumn("value"),
+        createColumn("description"),
+        createColumn("name"),
+      ],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        type,value,description,name
+        ,,,test
+      `),
+    );
+  });
+
+  it("should export MISSING_VALUE as empty cell when returned by function accessor", () => {
+    const result = transformToCsv(
+      [
+        {
+          id: "1",
+          name: "test",
+        },
+      ],
+      [
+        createColumn("id"),
+        createColumnWithFunction("computed", () => LABELS.MISSING_VALUE),
+        createColumn("name"),
+      ],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        id,computed,name
+        1,,test
+      `),
+    );
+  });
+
+  it("should export MISSING_TYPE as empty cell when returned by function accessor", () => {
+    const result = transformToCsv(
+      [
+        {
+          id: "1",
+          name: "test",
+        },
+      ],
+      [
+        createColumn("id"),
+        createColumnWithFunction("computed", () => LABELS.MISSING_TYPE),
+        createColumn("name"),
+      ],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        id,computed,name
+        1,,test
+      `),
+    );
+  });
+
+  it("should export EMPTY_VALUE as empty cell when returned by function accessor", () => {
+    const result = transformToCsv(
+      [
+        {
+          id: "1",
+          name: "test",
+        },
+      ],
+      [
+        createColumn("id"),
+        createColumnWithFunction("computed", () => LABELS.EMPTY_VALUE),
+        createColumn("name"),
+      ],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        id,computed,name
+        1,,test
+      `),
+    );
+  });
+
+  it("should handle mixed placeholder values from string and function accessors", () => {
+    const result = transformToCsv(
+      [
+        {
+          id: "1",
+          type: LABELS.MISSING_TYPE,
+          name: "test",
+        },
+      ],
+      [
+        createColumn("id"),
+        createColumn("type"),
+        createColumnWithFunction("computed", () => LABELS.MISSING_VALUE),
+        createColumn("name"),
+      ],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        id,type,computed,name
+        1,,,test
+      `),
+    );
+  });
+
+  it("should handle multiple rows with placeholder values", () => {
+    const result = transformToCsv(
+      [
+        {
+          id: "1",
+          type: LABELS.MISSING_TYPE,
+          name: "first",
+        },
+        {
+          id: "2",
+          type: "Person",
+          name: LABELS.MISSING_VALUE,
+        },
+        {
+          id: "3",
+          type: "Company",
+          name: LABELS.EMPTY_VALUE,
+        },
+      ],
+      [createColumn("id"), createColumn("type"), createColumn("name")],
+    );
+    expect(csv(result)).toEqual(
+      csv(`
+        id,type,name
+        1,,first
+        2,Person,
+        3,Company,
+      `),
+    );
+  });
 });
 
 function createColumn<T extends object>(

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.ts
@@ -4,7 +4,6 @@ import type { TabularColumnInstance } from "@/components/Tabular/helpers/tableIn
 
 import { LABELS } from "@/utils/constants";
 
-
 export function transformToCsv<T extends object>(
   data: readonly T[],
   columns: TabularColumnInstance<T>[],
@@ -12,29 +11,32 @@ export function transformToCsv<T extends object>(
   const csvRows = data.map(row =>
     columns.map(col => {
       const accessor = col.definition?.accessor;
-      if (accessor == null) {
+      if (!accessor) {
         return null;
       }
+
+      let value: unknown;
+
       if (typeof accessor === "function") {
-        return (accessor as (row: T) => unknown)(row);
+        value = (accessor as (row: T) => unknown)(row);
+      } else if (typeof accessor === "string") {
+        value = (row as Record<string, unknown>)[accessor];
+      } else {
+        return null;
       }
-      if (typeof accessor === "string") {
-        const value = (row as Record<string, unknown>)[accessor];
 
-            if (
-      value === LABELS.MISSING_TYPE ||
-      value === LABELS.MISSING_VALUE ||
-      value === LABELS.EMPTY_VALUE
+      if (
+        value === LABELS.MISSING_TYPE ||
+        value === LABELS.MISSING_VALUE ||
+        value === LABELS.EMPTY_VALUE
       ) {
-      return null;
-        }
-
-        return value;
-
+        return null;
       }
-      return null;
+
+      return value ?? null;
     }),
   );
+
   const headers = columns.map(col => col.definition?.label || col.instance.id);
 
   return unparse([headers, ...csvRows], { header: false });

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToJson.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToJson.ts
@@ -16,12 +16,15 @@ export function transformToJson<T extends object>(
         let value: string | number | null;
 
         if (typeof accessor === "function") {
-          value = (accessor as (row: T) => unknown)(row) as string | number | null;
+          value = (accessor as (row: T) => unknown)(row) as
+            | string
+            | number
+            | null;
         } else {
           value = (row as Record<string, unknown>)[accessor as string] as
-          |string
-          |number
-          |null;
+            | string
+            | number
+            | null;
         }
 
         if (
@@ -29,7 +32,7 @@ export function transformToJson<T extends object>(
           value === LABELS.MISSING_VALUE ||
           value === LABELS.EMPTY_VALUE
         ) {
-          value = null;
+          return null;
         }
 
         const label = col.definition?.label || col.instance.id;
@@ -37,7 +40,7 @@ export function transformToJson<T extends object>(
       })
       .filter(
         (item): item is readonly [string, string | number | null] =>
-          item !== null
+          item !== null,
       )
       .reduce(
         (acc, [label, value]) => {


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

This PR updates CSV and JSON export behavior to ensure placeholder strings such as «No Value», «Empty Value», and «No Type» are treated as missing data and exported as empty/null values instead of literal strings.
 

## Validation

- Verified via existing export-related tests (`transformToCsv` and `transformToJson`)
- Manual review confirms placeholder values are converted to empty cells in CSV
- Full test suite was executed locally; failures observed were OS path and
  locale-specific (Windows / Indian numbering format), unrelated to this change


## Related Issues

Fixes #1481

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
