### PR TITLE
Fix table view to expand when graph view is hidden

### DIFF
--- a/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
+++ b/packages/graph-explorer/src/routes/GraphExplorer/GraphExplorer.tsx
@@ -135,14 +135,20 @@ const GraphExplorer = () => {
           >
             <GraphViewer />
           </div>
-          <div className={cn("hidden flex-none", isTableVisible && "block")}>
+          <div
+            className={cn(
+              "hidden min-h-0",
+              isTableVisible && "block",
+              isGraphVisible ? "flex-none" : "flex-1",
+            )}
+          >
             <Resizable
-              enable={RESIZE_ENABLE_TOP}
+              enable={isGraphVisible ? RESIZE_ENABLE_TOP : false}
               size={{
                 width: "100%",
-                height: tableViewHeight,
+                height: isGraphVisible ? tableViewHeight : "100%",
               }}
-              minHeight={DEFAULT_TABLE_VIEW_HEIGHT}
+              minHeight={isGraphVisible ? DEFAULT_TABLE_VIEW_HEIGHT : undefined}
               onResizeStop={(_e, _dir, _ref, delta) =>
                 setTableViewHeight(delta.height)
               }


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Fix table view to expand to full height when graph view is hidden. Previously,
the table remained at a fixed height even when it was the only visible view. Now
the table container uses `flex-1` and `height: 100%` when the graph is hidden,
and resize is disabled since there's nothing to resize against.

## Validation

* Ensured table view expands when graph hidden
* Ensured resizing is not possible when only the table view is shown

<img width="3634" height="2456" alt="CleanShot 2026-02-02 at 12 12 42@2x" src="https://github.com/user-attachments/assets/c24be525-53cc-4090-ab15-bb33d546325d" />
<img width="3634" height="2456" alt="CleanShot 2026-02-02 at 12 12 45@2x" src="https://github.com/user-attachments/assets/c44b3a8d-bd28-4c76-a0e2-c78e13f83097" />

## Related Issues

- Resolves #1496

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
