### PR TITLE
Update sidebar tab style to better match nav

### DIFF
--- a/packages/graph-explorer/src/components/SidebarTabs.tsx
+++ b/packages/graph-explorer/src/components/SidebarTabs.tsx
@@ -23,7 +23,7 @@ function SidebarTabsList({
   return (
     <TabsPrimitive.List
       className={cn(
-        "bg-background-default text-text-secondary sticky top-0 flex w-full flex-row items-center border-b",
+        "bg-default text-muted-foreground sticky top-0 flex w-full flex-row items-center border-b",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ function SidebarTabsTrigger({
   return (
     <TabsPrimitive.Trigger
       className={cn(
-        "focus-visible:ring-ring-3 bg-background-default text-text-secondary ring-offset-muted data-[state=active]:border-primary-main data-[state=active]:text-text-primary inline-flex grow items-center justify-center gap-2 border-b-2 border-transparent px-4 py-2 text-base font-bold whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-5",
+        "focus-visible:ring-ring-3 bg-background-default text-text-secondary ring-offset-muted data-[state=active]:border-b-primary-foreground data-[state=active]:text-primary-foreground inline-flex grow items-center justify-center gap-2 border-y-2 border-transparent border-y-transparent px-4 py-2 text-base font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:font-medium [&_svg]:size-5",
         className,
       )}
       {...props}


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Update sidebar tab styling to better match the nav bar. Changes include updating the active tab indicator to use `border-b-primary-foreground` and `text-primary-foreground`, switching font weight from bold to medium, and adjusting the tab list background and text color classes for consistency.

## Validation

<img width="808" height="818" alt="CleanShot 2026-02-12 at 16 09 50@2x" src="https://github.com/user-attachments/assets/7de2476e-4837-46bf-b8b6-ec048781abb5" />


## Related Issues

- Part of #1508

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
