### PR TITLE
Show message when multiple items selected in schema graph

### DIFF
--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaDetailsContent.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaDetailsContent.tsx
@@ -23,18 +23,8 @@ export type SchemaDetailsContentProps = {
 export function SchemaDetailsContent({ selection }: SchemaDetailsContentProps) {
   const t = useTranslations();
   const graphSchema = useGraphSchema();
-  const hasSelection = Boolean(
-    selection.vertexType || selection.edgeConnectionId,
-  );
 
-  // Get the edge connection from the schema
-  const edgeConnection = selection.edgeConnectionId
-    ? graphSchema.edgeConnections.byEdgeConnectionId.get(
-        selection.edgeConnectionId,
-      )
-    : null;
-
-  if (!hasSelection) {
+  if (!selection) {
     return (
       <Panel className="size-full" variant="sidebar">
         <PanelHeader>
@@ -51,14 +41,30 @@ export function SchemaDetailsContent({ selection }: SchemaDetailsContentProps) {
     );
   }
 
-  if (selection.vertexType) {
+  if (selection.type === "multiple") {
     return (
-      <NodeLabelDetails
-        vertexType={selection.vertexType}
-        className="size-full"
-      />
+      <Panel className="size-full" variant="sidebar">
+        <PanelHeader>
+          <PanelTitle>{LABELS.SIDEBAR.SELECTION_DETAILS}</PanelTitle>
+        </PanelHeader>
+        <PanelContent className="p-6">
+          <PanelEmptyState
+            icon={<GraphIcon />}
+            title="Multiple Selection"
+            subtitle="Select a single item to see its details"
+          />
+        </PanelContent>
+      </Panel>
     );
   }
+
+  if (selection.type === "vertex-type") {
+    return <NodeLabelDetails vertexType={selection.id} className="size-full" />;
+  }
+
+  const edgeConnection = graphSchema.edgeConnections.byEdgeConnectionId.get(
+    selection.id,
+  );
 
   if (edgeConnection) {
     return (

--- a/packages/graph-explorer/src/modules/SchemaGraph/toSchemaGraphSelection.test.ts
+++ b/packages/graph-explorer/src/modules/SchemaGraph/toSchemaGraphSelection.test.ts
@@ -1,0 +1,76 @@
+import { createEdgeType, createVertexType } from "@/core";
+import { createEdgeConnectionId } from "@/core/StateProvider/edgeConnectionId";
+
+import { toSchemaGraphSelection } from "./SchemaGraph";
+
+function createSelectedElements(
+  nodeIds: string[] = [],
+  edgeIds: string[] = [],
+) {
+  return {
+    nodeIds: new Set(nodeIds),
+    edgeIds: new Set(edgeIds),
+    groupIds: new Set<string>(),
+  };
+}
+
+describe("toSchemaGraphSelection", () => {
+  test("returns null when nothing is selected", () => {
+    const result = toSchemaGraphSelection(createSelectedElements());
+    expect(result).toBeNull();
+  });
+
+  test("returns a single vertex-type selection", () => {
+    const result = toSchemaGraphSelection(createSelectedElements(["Person"]));
+    expect(result).toStrictEqual({
+      type: "vertex-type",
+      id: createVertexType("Person"),
+    });
+  });
+
+  test("returns a single edge-connection selection", () => {
+    const edgeId = createEdgeConnectionId({
+      sourceVertexType: createVertexType("Person"),
+      edgeType: createEdgeType("knows"),
+      targetVertexType: createVertexType("Person"),
+    });
+
+    const result = toSchemaGraphSelection(createSelectedElements([], [edgeId]));
+    expect(result).toStrictEqual({
+      type: "edge-connection",
+      id: edgeId,
+    });
+  });
+
+  test("returns multiple selection for two nodes", () => {
+    const result = toSchemaGraphSelection(
+      createSelectedElements(["Person", "Company"]),
+    );
+    expect(result).toStrictEqual({
+      type: "multiple",
+      items: [
+        { type: "vertex-type", id: createVertexType("Person") },
+        { type: "vertex-type", id: createVertexType("Company") },
+      ],
+    });
+  });
+
+  test("returns multiple selection for a node and an edge", () => {
+    const edgeId = createEdgeConnectionId({
+      sourceVertexType: createVertexType("Person"),
+      edgeType: createEdgeType("worksAt"),
+      targetVertexType: createVertexType("Company"),
+    });
+
+    const result = toSchemaGraphSelection(
+      createSelectedElements(["Person"], [edgeId]),
+    );
+    expect(result).toStrictEqual({
+      type: "multiple",
+      items: [
+        { type: "vertex-type", id: createVertexType("Person") },
+        { type: "edge-connection", id: edgeId },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Handle multi-select in the schema graph. When multiple nodes or edges are selected, the sidebar now shows a message prompting the user to select a single item instead of displaying stale or partial details.

Refactors `SchemaGraphSelection` from a flat object with nullable fields to a discriminated union (`vertex-type`, `edge-connection`, or `multiple`), and adds unit tests for the new `toSchemaGraphSelection` mapping function.

## Validation

* Ensured multiple selection shows message
* Ensured single selection does not show message
* Ensured "no selection" message still shows

## Related Issues

* Resolves #1493

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
