### PR TITLE
fix: EdgeDiscoveryBoundary preserves children after initial edge discovery

### DIFF
--- a/packages/graph-explorer/src/modules/SchemaGraph/EdgeDiscoveryBoundary.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/EdgeDiscoveryBoundary.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { EdgeDiscoveryBoundary } from "./EdgeDiscoveryBoundary";
+
+vi.mock("@/core", async () => {
+  const actual = await vi.importActual("@/core");
+  return {
+    ...actual,
+    useMaybeActiveSchema: vi.fn(),
+  };
+});
+
+vi.mock("@/hooks/useSchemaSync", () => ({
+  useSchemaSync: vi.fn(),
+  useCancelSchemaSync: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/hooks", async () => {
+  const actual = await vi.importActual("@/hooks");
+  return {
+    ...actual,
+    useTranslations: () => (key: string) => key,
+  };
+});
+
+import { useMaybeActiveSchema } from "@/core";
+import { useSchemaSync } from "@/hooks/useSchemaSync";
+import { createRandomEdgeConnection } from "@/utils/testing/randomData";
+
+const mockedUseMaybeActiveSchema = vi.mocked(useMaybeActiveSchema);
+const mockedUseSchemaSync = vi.mocked(useSchemaSync);
+
+function createMockSchemaSync(
+  overrides: Partial<ReturnType<typeof useSchemaSync>> = {},
+): ReturnType<typeof useSchemaSync> {
+  return {
+    schemaDiscoveryQuery: {
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useSchemaSync>["schemaDiscoveryQuery"],
+    edgeDiscoveryQuery: {
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useSchemaSync>["edgeDiscoveryQuery"],
+    refreshSchema: vi.fn(),
+    isFetching: false,
+    ...overrides,
+  };
+}
+
+describe("EdgeDiscoveryBoundary", () => {
+  test("renders children when edgeConnections is defined", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: [createRandomEdgeConnection()],
+    });
+    mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.getByText("Children")).toBeInTheDocument();
+  });
+
+  test("renders children when edgeConnections exists even if edge query has error", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: [createRandomEdgeConnection()],
+    });
+    mockedUseSchemaSync.mockReturnValue(
+      createMockSchemaSync({
+        edgeDiscoveryQuery: {
+          isLoading: false,
+          error: new Error("Query failed"),
+          refetch: vi.fn(),
+        } as unknown as ReturnType<typeof useSchemaSync>["edgeDiscoveryQuery"],
+      }),
+    );
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.getByText("Children")).toBeInTheDocument();
+  });
+
+  test("renders children when edgeConnections exists even if edgeConnectionDiscoveryFailed is true", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: [createRandomEdgeConnection()],
+      edgeConnectionDiscoveryFailed: true,
+    });
+    mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.getByText("Children")).toBeInTheDocument();
+  });
+
+  test("renders loading when edgeConnections is undefined and queries are loading", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: undefined,
+    });
+    mockedUseSchemaSync.mockReturnValue(
+      createMockSchemaSync({
+        edgeDiscoveryQuery: {
+          isLoading: true,
+          error: null,
+          refetch: vi.fn(),
+        } as unknown as ReturnType<typeof useSchemaSync>["edgeDiscoveryQuery"],
+      }),
+    );
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.getByText("Synchronizing...")).toBeInTheDocument();
+    expect(screen.queryByText("Children")).not.toBeInTheDocument();
+  });
+
+  test("renders error with retry when edgeConnections is undefined and schema query has error", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: undefined,
+    });
+    mockedUseSchemaSync.mockReturnValue(
+      createMockSchemaSync({
+        schemaDiscoveryQuery: {
+          isLoading: false,
+          error: new Error("Schema query failed"),
+          refetch: vi.fn(),
+        } as unknown as ReturnType<
+          typeof useSchemaSync
+        >["schemaDiscoveryQuery"],
+      }),
+    );
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.queryByText("Children")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  test("renders error with retry when edgeConnections is undefined and edge query has error", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: undefined,
+    });
+    mockedUseSchemaSync.mockReturnValue(
+      createMockSchemaSync({
+        edgeDiscoveryQuery: {
+          isLoading: false,
+          error: new Error("Query failed"),
+          refetch: vi.fn(),
+        } as unknown as ReturnType<typeof useSchemaSync>["edgeDiscoveryQuery"],
+      }),
+    );
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.queryByText("Children")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  test("renders failure state when edgeConnections is undefined and discovery failed", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue({
+      vertices: [],
+      edges: [],
+      edgeConnections: undefined,
+      edgeConnectionDiscoveryFailed: true,
+    });
+    mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+    render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.getByText(/discovery failed/)).toBeInTheDocument();
+    expect(screen.queryByText("Children")).not.toBeInTheDocument();
+  });
+
+  test("renders nothing when schema is undefined", () => {
+    mockedUseMaybeActiveSchema.mockReturnValue(undefined);
+    mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+    const { container } = render(
+      <EdgeDiscoveryBoundary>
+        <div>Children</div>
+      </EdgeDiscoveryBoundary>,
+    );
+
+    expect(screen.queryByText("Children")).not.toBeInTheDocument();
+    expect(container.innerHTML).toBe("");
+  });
+});


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

Improve EdgeDiscoveryBoundary so that once edge connections have been discovered at least once, children always render regardless of subsequent query failures. Previously, a transient error after initial discovery could replace the schema graph with an error screen.

Also extracts a shared Layout component to reduce repeated nesting, adds unit tests, and narrows the props type from ComponentPropsWithoutRef<"div"> to PropsWithChildren.

## Validation

- Tested manually using Neptune with and without network access

## Related Issues

- Resolves #1514

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
