### PR TITLE
Improve SPARQL schema graph and update RDF terminology

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -1,0 +1,26 @@
+import { createEdgeType } from "@/core";
+import { query } from "@/utils";
+
+import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
+
+describe("edgeConnectionsTemplate", () => {
+  it("should produce a subquery with LIMIT inside and DISTINCT outside", () => {
+    const predicate = createEdgeType("http://example.org/knows");
+
+    const result = edgeConnectionsTemplate(predicate);
+
+    expect(result).toBe(query`
+      SELECT DISTINCT ?sourceType ?targetType
+      WHERE {
+        SELECT ?sourceType ?targetType
+        WHERE {
+          ?s <http://example.org/knows> ?o .
+          FILTER(!isLiteral(?o))
+          ?s a ?sourceType .
+          ?o a ?targetType .
+        }
+        LIMIT 10000
+      }
+    `);
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.ts
@@ -2,6 +2,8 @@ import type { EdgeType } from "@/core";
 
 import { DEFAULT_SAMPLE_SIZE, query } from "@/utils";
 
+import { idParam } from "../idParam";
+
 /**
  * Returns a SPARQL query to discover distinct edge connection patterns for a specific predicate.
  * Uses sampling to efficiently discover patterns in large databases.
@@ -13,11 +15,14 @@ export default function edgeConnectionsTemplate(predicate: EdgeType) {
   return query`
     SELECT DISTINCT ?sourceType ?targetType
     WHERE {
-      ?s <${predicate}> ?o .
-      FILTER(!isLiteral(?o))
-      ?s a ?sourceType .
-      ?o a ?targetType .
+      SELECT ?sourceType ?targetType
+      WHERE {
+        ?s ${idParam(predicate)} ?o .
+        FILTER(!isLiteral(?o))
+        ?s a ?sourceType .
+        ?o a ?targetType .
+      }
+      LIMIT ${DEFAULT_SAMPLE_SIZE}
     }
-    LIMIT ${DEFAULT_SAMPLE_SIZE}
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.ts
@@ -2,6 +2,8 @@ import type { VertexType } from "@/core";
 
 import { query } from "@/utils";
 
+import { idParam } from "../idParam";
+
 // Return all predicates which are connected from the given class
 export default function predicatesByClassTemplate(props: {
   class: VertexType;
@@ -13,7 +15,7 @@ export default function predicatesByClassTemplate(props: {
       {
         SELECT ?subject
         WHERE {
-          ?subject a <${props.class}>.
+          ?subject a ${idParam(props.class)}.
         }
         LIMIT 1
       }

--- a/packages/graph-explorer/src/connector/sparql/fetchVertexCountsByType/classWithCountsTemplates.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchVertexCountsByType/classWithCountsTemplates.ts
@@ -1,11 +1,13 @@
 import { query } from "@/utils";
 
+import { idParam } from "../idParam";
+
 // It returns the number of instances of the given class
 export default function classWithCountsTemplates(className: string) {
   return query`
     # Fetch the number of instances of the given class
     SELECT (COUNT(?start) AS ?instancesCount) {
-      ?start a <${className}>
+      ?start a ${idParam(className)}
     }
   `;
 }

--- a/packages/graph-explorer/src/hooks/translations/sparql-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/sparql-translations.json
@@ -26,13 +26,13 @@
     "title": "Predicate Styling"
   },
   "keyword-search": {
-    "node-type-placeholder": "Select a resource class",
+    "node-type-placeholder": "Select a class",
     "node-attribute-placeholder": "Select a predicate"
   },
   "connection-detail": {
-    "search-placeholder": "Search for resource classes",
-    "no-search-title": "No Resource Classes",
-    "no-search-subtitle": "No resource classes found with searched criteria",
+    "search-placeholder": "Search for classes",
+    "no-search-title": "No Classes",
+    "no-search-subtitle": "No classes found with searched criteria",
     "no-elements-title": "No Resources",
     "no-elements-subtitle": "No resources found to be shown in this list"
   },

--- a/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraphToolbar.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraphToolbar.tsx
@@ -2,6 +2,7 @@ import { RefreshCcwIcon } from "lucide-react";
 
 import {
   Button,
+  InfoTooltip,
   PanelHeader,
   PanelHeaderActions,
   PanelHeaderDivider,
@@ -25,7 +26,13 @@ import { schemaGraphLayoutAtom } from "./SchemaGraph";
 export function SchemaGraphToolbar() {
   return (
     <PanelHeader>
-      <PanelTitle>Schema Graph</PanelTitle>
+      <PanelTitle>
+        Schema Graph{" "}
+        <InfoTooltip>
+          This schema was implicitly discovered by sampling the structure of the
+          data and may not represent the complete schema.
+        </InfoTooltip>
+      </PanelTitle>
       <PanelHeaderActions className="gap-1.5">
         <SelectLayout
           className="max-w-64 min-w-auto"


### PR DESCRIPTION
<!--
Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/aws/graph-explorer/blob/main/CONTRIBUTING.md) before opening a pull request.
-->

## Description

SPARQL schema and RDF UI improvements:

- Fix `edgeConnectionsTemplate` to use a subquery so `LIMIT` applies to sampled triples before `DISTINCT`, improving performance on large RDF datasets.
- Use `idParam()` consistently for URI wrapping in SPARQL query templates (`edgeConnectionsTemplate`, `classWithCountsTemplates`, `predicatesByClassTemplate`).
- Simplify "resource class" terminology to "class" in SPARQL translation strings.
- Add an `InfoTooltip` to the Schema Graph toolbar explaining the schema is discovered by sampling.
- Add unit test for `edgeConnectionsTemplate` query structure.

## Validation

- Verified schema sync continues to work

<img width="1124" height="322" alt="CleanShot 2026-02-17 at 15 11 23@2x" src="https://github.com/user-attachments/assets/780544cd-f648-4848-ab53-5a9f9d051a1b" />

## Related Issues

- Fixes some small issues found during an internal review

### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
