### PR TITLE
fix(infra): use cross-platform compatible checks script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coverage": "vitest run --coverage",
     "check:types": "pnpm -r --include-workspace-root --parallel --stream run typecheck",
     "typecheck": "tsc --noEmit",
-    "checks": "pnpm run '/^check:.*/'",
+    "checks": "pnpm run check:lint && pnpm run check:format && pnpm run check:types",
     "start": "pnpm --filter \"graph-explorer-proxy-server\" run start",
     "clean": "pnpm --stream -r run clean",
     "clean:dep": "rm -rf node_modules && pnpm -r exec rm -rf node_modules",


### PR DESCRIPTION
## Summary
Replace the pnpm regex pattern with explicit commands chained via `&&`. The regex pattern with single quotes does not work properly on Windows cmd.exe.

## Changes
- Changed line 25 in `package.json` from `"checks": "pnpm run '/^check:.*/'",` to `"checks": "pnpm run check:lint && pnpm run check:format && pnpm run check:types",`

## Test plan
- [x] Code review passed
- [x] All check scripts verified to exist in package.json
- [x] `&&` operator is cross-platform compatible

Fixes #1512