### PR TITLE
Add data type descriptions to schema sidebar details

### DIFF
--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -460,6 +460,17 @@ styling, configuration, or type-only changes.
 - Use descriptive test names that explain the expected outcome
 - Focus on the user-facing behavior when possible
 
+### Do Not Test Styling or Layout
+
+- Do not write tests that assert on CSS classes, HTML element types, or layout
+  structure
+- These tests are fragile and break on routine visual changes that have no
+  functional impact
+- Instead, test the behavioral logic: conditional rendering, data
+  transformations, user interactions, and state changes
+- If a component is purely presentational with no branching logic, it does not
+  need a test
+
 ### Performance
 
 - Use `renderHookWithState()` for hook testing (includes query client setup)

--- a/packages/graph-explorer/src/components/EmptyState.tsx
+++ b/packages/graph-explorer/src/components/EmptyState.tsx
@@ -66,9 +66,9 @@ EmptyStateContent.displayName = "EmptyStateContent";
 function EmptyStateTitle({
   className,
   ...props
-}: React.ComponentPropsWithRef<"h1">) {
+}: React.ComponentPropsWithRef<"h3">) {
   return (
-    <h1
+    <h3
       className={cn(
         "text-text-primary gx-wrap-break-word text-lg font-bold text-balance",
         className,

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import type { DisplayConfigAttribute } from "@/core";
+
+import { PropertiesDetails } from "./Details";
+
+vi.mock("@/hooks", async () => {
+  const actual = await vi.importActual("@/hooks");
+  return {
+    ...actual,
+    useTranslations: () => (key: string) => key,
+  };
+});
+
+function createAttribute(
+  overrides: Partial<DisplayConfigAttribute> = {},
+): DisplayConfigAttribute {
+  return {
+    name: "attr-name",
+    displayLabel: "Attr Name",
+    dataType: "String",
+    isSearchable: true,
+    ...overrides,
+  };
+}
+
+describe("PropertiesDetails", () => {
+  test("renders empty state when attributes is empty", () => {
+    render(<PropertiesDetails attributes={[]} />);
+
+    expect(screen.getByText("No properties")).toBeInTheDocument();
+    expect(
+      screen.getByText("This item has no properties."),
+    ).toBeInTheDocument();
+  });
+
+  test("renders attribute list when attributes are provided", () => {
+    const attributes = [
+      createAttribute({
+        name: "name",
+        displayLabel: "Name",
+        dataType: "String",
+      }),
+      createAttribute({
+        name: "age",
+        displayLabel: "Age",
+        dataType: "Integer",
+      }),
+    ];
+
+    render(<PropertiesDetails attributes={attributes} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("String")).toBeInTheDocument();
+    expect(screen.getByText("Age")).toBeInTheDocument();
+    expect(screen.getByText("Integer")).toBeInTheDocument();
+  });
+
+  test("renders the attribute count", () => {
+    const attributes = [
+      createAttribute({ name: "a" }),
+      createAttribute({ name: "b" }),
+      createAttribute({ name: "c" }),
+    ];
+
+    render(<PropertiesDetails attributes={attributes} />);
+
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  test("renders description text", () => {
+    render(<PropertiesDetails attributes={[]} />);
+
+    expect(
+      screen.getByText(
+        /properties and their data types, which are inferred from query responses/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
@@ -1,5 +1,15 @@
 import type { ComponentPropsWithRef } from "react";
 
+import { ListIcon } from "lucide-react";
+
+import {
+  Chip,
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateTitle,
+  toHumanString,
+} from "@/components";
 import {
   type DisplayConfigAttribute,
   type EdgeConnection,
@@ -9,19 +19,43 @@ import {
   useVertexPreferences,
   type VertexType,
 } from "@/core";
+import { useTranslations } from "@/hooks";
 import { ASCII, cn } from "@/utils";
+
+/** Container for a detail section with consistent vertical spacing. */
+export function Details({ className, ...props }: ComponentPropsWithRef<"div">) {
+  return <div className={cn("space-y-5", className)} {...props} />;
+}
+
+/** Groups a title and optional description or value with tight spacing. */
+export function DetailsHeader({
+  className,
+  ...props
+}: ComponentPropsWithRef<"div">) {
+  return <div className={cn("space-y-1", className)} {...props} />;
+}
 
 /** Title text for detail sections */
 export function DetailsTitle({
   className,
   ...props
-}: ComponentPropsWithRef<"div">) {
+}: ComponentPropsWithRef<"h2">) {
   return (
-    <div
-      className={cn(
-        "text-text-primary text-base leading-tight font-bold",
-        className,
-      )}
+    <h2
+      className={cn("text-text-primary text-base/7 font-bold", className)}
+      {...props}
+    />
+  );
+}
+
+/** Muted description text for a detail section. */
+export function DetailsDescription({
+  className,
+  ...props
+}: ComponentPropsWithRef<"p">) {
+  return (
+    <p
+      className={cn("text-muted-foreground text-sm/6 text-pretty", className)}
       {...props}
     />
   );
@@ -43,29 +77,66 @@ export function DetailsValue({
   );
 }
 
-/** List of attributes with name and data type */
-export function AttributeList({
+/**
+ * Displays a list of schema attributes with their inferred data types.
+ * Shows an empty state when no attributes exist.
+ */
+export function PropertiesDetails({
   attributes,
 }: {
   attributes: DisplayConfigAttribute[];
 }) {
+  const t = useTranslations();
+
   return (
-    <ul className="space-y-2">
-      {attributes.map(attr => (
-        <li
-          key={attr.name}
-          className="flex flex-wrap items-center justify-between gap-2"
-        >
-          <DetailsValue>{attr.displayLabel}</DetailsValue>
-          <div className="text-muted-foreground bg-muted border-neutral-subtle-hover place-self-end rounded-md border px-2 py-1.5 text-right font-mono text-sm leading-none lowercase">
-            {attr.dataType}
-          </div>
-        </li>
-      ))}
-    </ul>
+    <Details>
+      <DetailsHeader>
+        <DetailsTitle className="flex justify-between gap-2">
+          {t("properties")}
+          <Chip variant="neutral-subtle">
+            {toHumanString(attributes.length)}
+          </Chip>
+        </DetailsTitle>
+        <DetailsDescription>
+          {t("properties")} and their data types, which are inferred from query
+          responses.
+        </DetailsDescription>
+      </DetailsHeader>
+      <div>
+        {attributes.length === 0 ? (
+          <EmptyState className="pt-8">
+            <ListIcon className="text-muted-foreground mb-4 size-8 opacity-50" />
+            <EmptyStateContent>
+              <EmptyStateTitle>No {t("properties")}</EmptyStateTitle>
+              <EmptyStateDescription>
+                This item has no {t("properties").toLocaleLowerCase()}.
+              </EmptyStateDescription>
+            </EmptyStateContent>
+          </EmptyState>
+        ) : (
+          <ul className="space-y-2">
+            {attributes.map(attr => (
+              <li
+                key={attr.name}
+                className="flex flex-wrap items-center justify-between gap-2"
+              >
+                <DetailsValue>{attr.displayLabel}</DetailsValue>
+                <div className="text-muted-foreground bg-muted border-neutral-subtle-hover place-self-end rounded-md border px-2 py-1.5 text-right font-mono text-sm leading-none lowercase">
+                  {attr.dataType}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Details>
   );
 }
 
+/**
+ * Renders an edge connection as "SourceType → EdgeType → TargetType" with the
+ * selected vertex type highlighted.
+ */
 export function EdgeConnectionRow({
   selectedVertexType,
   edgeConnection,

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/EdgeConnectionDetails.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/EdgeConnectionDetails.tsx
@@ -1,7 +1,6 @@
 import type { ComponentPropsWithRef } from "react";
 
 import {
-  Chip,
   EdgeIcon,
   Panel,
   PanelContent,
@@ -18,10 +17,13 @@ import { useTranslations } from "@/hooks";
 import { LABELS } from "@/utils";
 
 import {
-  AttributeList,
+  Details,
+  DetailsDescription,
+  DetailsHeader,
   DetailsTitle,
   DetailsValue,
   EdgeConnectionRow,
+  PropertiesDetails,
 } from "./Details";
 
 export type EdgeConnectionDetailsProps = {
@@ -42,46 +44,35 @@ export function EdgeConnectionDetails({
       <PanelHeader>
         <PanelTitle>{LABELS.SIDEBAR.SELECTION_DETAILS}</PanelTitle>
       </PanelHeader>
-      <PanelContent className="space-y-6 p-3">
+      <PanelContent className="space-y-8 p-3">
         <div className="flex flex-row items-center justify-between">
-          <div className="flex flex-col gap-1.5">
+          <DetailsHeader>
             <DetailsTitle>{t("edge-type")}</DetailsTitle>
             <DetailsValue>{edgeConnection.edgeType}</DetailsValue>
-          </div>
+          </DetailsHeader>
           <div className="bg-muted text-muted-foreground flex aspect-square h-10 items-center justify-center rounded-md border shadow-xs">
             <EdgeIcon className="size-6" />
           </div>
         </div>
 
         {total != null && (
-          <div>
+          <DetailsHeader>
             <DetailsTitle>Total Count</DetailsTitle>
             <DetailsValue>{toHumanString(total)}</DetailsValue>
-          </div>
+          </DetailsHeader>
         )}
 
-        <div className="space-y-4">
-          <DetailsTitle>{t("edge-connection")}</DetailsTitle>
+        <Details>
+          <DetailsHeader>
+            <DetailsTitle>{t("edge-connection")}</DetailsTitle>
+            <DetailsDescription>
+              The currently selected {t("edge-connection").toLowerCase()}.
+            </DetailsDescription>
+          </DetailsHeader>
           <EdgeConnectionRow edgeConnection={edgeConnection} />
-        </div>
+        </Details>
 
-        <div className="space-y-4">
-          <DetailsTitle className="flex justify-between gap-2">
-            {t("properties")}
-            <Chip variant="primary-subtle">
-              {toHumanString(config.attributes.length)}
-            </Chip>
-          </DetailsTitle>
-          <div>
-            {config.attributes.length === 0 ? (
-              <DetailsValue>
-                No {t("properties").toLocaleLowerCase()}
-              </DetailsValue>
-            ) : (
-              <AttributeList attributes={config.attributes} />
-            )}
-          </div>
-        </div>
+        <PropertiesDetails attributes={config.attributes} />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/NodeLabelDetails.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/NodeLabelDetails.tsx
@@ -1,7 +1,6 @@
 import type { ComponentPropsWithRef } from "react";
 
 import {
-  Chip,
   Panel,
   PanelContent,
   PanelHeader,
@@ -20,10 +19,13 @@ import { useTranslations } from "@/hooks";
 import { LABELS } from "@/utils";
 
 import {
-  AttributeList,
+  Details,
+  DetailsDescription,
+  DetailsHeader,
   DetailsTitle,
   DetailsValue,
   EdgeConnectionRow,
+  PropertiesDetails,
 } from "./Details";
 
 export type NodeLabelDetailsProps = {
@@ -48,24 +50,30 @@ export function NodeLabelDetails({
       <PanelHeader>
         <PanelTitle>{LABELS.SIDEBAR.SELECTION_DETAILS}</PanelTitle>
       </PanelHeader>
-      <PanelContent className="space-y-6 p-3">
+      <PanelContent className="space-y-8 p-3">
         <div className="flex flex-row items-center justify-between gap-2">
-          <div className="flex flex-col gap-1.5">
+          <DetailsHeader>
             <DetailsTitle>{t("node-type")}</DetailsTitle>
             <DetailsValue>{vertexType}</DetailsValue>
-          </div>
+          </DetailsHeader>
           <VertexSymbolByType vertexType={vertexType} />
         </div>
 
         {total != null && (
-          <div>
+          <DetailsHeader>
             <DetailsTitle>Total Count</DetailsTitle>
             <DetailsValue>{toHumanString(total)}</DetailsValue>
-          </div>
+          </DetailsHeader>
         )}
 
-        <div className="space-y-4">
-          <DetailsTitle>{t("edge-connections")}</DetailsTitle>
+        <Details>
+          <DetailsHeader>
+            <DetailsTitle>{t("edge-connections")}</DetailsTitle>
+            <DetailsDescription>
+              All discovered {t("edge-connections").toLowerCase()} related to
+              this {t("node-type").toLowerCase()}.
+            </DetailsDescription>
+          </DetailsHeader>
           <ul className="space-y-3">
             {edgeConnections?.map(edgeConnection => (
               <li key={createEdgeConnectionId(edgeConnection)}>
@@ -82,25 +90,9 @@ export function NodeLabelDetails({
               </li>
             )}
           </ul>
-        </div>
+        </Details>
 
-        <div className="space-y-4">
-          <DetailsTitle className="flex justify-between gap-2">
-            {t("properties")}
-            <Chip variant="primary-subtle">
-              {toHumanString(config.attributes.length)}
-            </Chip>
-          </DetailsTitle>
-          <div>
-            {config.attributes.length === 0 ? (
-              <DetailsValue>
-                No {t("properties").toLocaleLowerCase()}
-              </DetailsValue>
-            ) : (
-              <AttributeList attributes={config.attributes} />
-            )}
-          </div>
-        </div>
+        <PropertiesDetails attributes={config.attributes} />
       </PanelContent>
     </Panel>
   );


### PR DESCRIPTION
## Description

Refactor the schema sidebar detail components to add descriptive headers, an empty state for properties, and shared layout primitives. Also adds a steering rule against testing styling/layout and includes behavioral tests for `PropertiesDetails`.

- Extract shared `Details`, `DetailsHeader`, `DetailsDescription` layout components to reduce duplication across `NodeLabelDetails` and `EdgeConnectionDetails`
- Rename `AttributeList` to `PropertiesDetails` and move the section title, count chip, description, and empty state handling into it so both panels get consistent behavior
- Change `DetailsTitle` from `div` to `h2` for better semantics
- Change the properties count chip variant from `primary-subtle` to `neutral-subtle`
- Add JSDoc comments to all exported components in `Details.tsx`
- Add tests for `PropertiesDetails` covering empty state, populated list, attribute count, and description text
- Add "Do Not Test Styling or Layout" rule to `.kiro/steering/testing.md`

## Validation

- All existing tests pass (`pnpm test`)
- New tests pass for `PropertiesDetails` (4 tests)
- No type errors, lint errors, or formatting issues (`pnpm checks`)
- Visual review of the schema sidebar in the browser

<img width="358" height="825" alt="CleanShot 2026-02-21 at 12 55 22@2x" src="https://github.com/user-attachments/assets/cdeb7fba-34cc-4900-aa8f-1d5500cfe0ca" />
<img width="352" height="520" alt="CleanShot 2026-02-21 at 12 55 11@2x" src="https://github.com/user-attachments/assets/8eccbe32-f91f-4871-9a37-65ac5c58b998" />
<img width="354" height="899" alt="CleanShot 2026-02-21 at 12 57 27@2x" src="https://github.com/user-attachments/assets/ca212112-d5de-4d34-8939-f387ffa7c26f" />
<img width="358" height="626" alt="CleanShot 2026-02-21 at 12 57 13@2x" src="https://github.com/user-attachments/assets/52b81f3e-ae8e-4343-9831-1230a5234714" />

## Related Issues

- Resolves #1519

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
