### PR TITLE
Move the project management steering to a skill

### DIFF
--- a/.kiro/skills/github/SKILL.md
+++ b/.kiro/skills/github/SKILL.md
@@ -1,8 +1,13 @@
 ---
-inclusion: always
+name: github
+description:
+  Handle management of any GitHub related tasks, including creating or modifying
+  issues, publishing a branch as a pull requests (or PRs), or creating or
+  modifying sub-issues or child issues.
+tools: ["git", "fs_read", "grep", "glob", "web_search"]
 ---
 
-# Project Management
+# GitHub Project Management
 
 ## General
 
@@ -54,21 +59,19 @@ Example:
 ```markdown
 ## Related Issues
 
-- Fixes #123
+- Resolves #123
 - Part of #456
 ```
-
-## Commit Messages & PR Titles
-
-- Describe the change conceptually (e.g., "Add vertex filtering to graph view")
-- Do not use conventional commit prefixes like `docs:`, `feature:`, `refactor:`,
-  `fix:`, etc.
 
 ## Pull Requests
 
 - Always publish pull requests as drafts
+- In the title, describe the changes conceptually (e.g., "Add vertex filtering
+  to graph view")
+- In the title, do not use conventional commit prefixes like `docs:`,
+  `feature:`, `refactor:`, `fix:`, etc
 - Follow the pull request template in `.github/pull_request_template.md`
 - Link to the corresponding issue when one exists (e.g., `Fixes #123`)
-- Keep descriptions concise
+- Keep descriptions concise and focused
 - Include a bulleted list of changes at the conceptual level with reasons for
   each change so reviewers can scan quickly


### PR DESCRIPTION
## Description

Moves the project management steering document from `.kiro/steering/project-management.md` to `.kiro/skills/github/SKILL.md`, converting it into a Kiro skill that activates only for GitHub-related tasks.

- Renamed and relocated the file to follow the skill convention
- Updated frontmatter from `inclusion: always` to skill metadata (`name`, `description`, `tools`)
- Renamed heading from "Project Management" to "GitHub Project Management"
- Merged "Commit Messages & PR Titles" section into "Pull Requests" section for clarity
- Minor wording tweaks (e.g., "Fixes" → "Resolves", added "and focused")

## Validation

- Verified the skill file is correctly structured with proper frontmatter
- No code changes; documentation/configuration only

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.