### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Graph Explorer",
   "author": "amazon",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "main": "dist/node-server.js",
   "type": "module",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Graph Explorer",
   "engines": {
     "node": ">=24.13.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "2.6.0",
+  "version": "3.0.0",
   "description": "Shared types and functions across client and server.",
   "author": "amazon",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Bump version from 2.6.0 to 3.0.0 across all workspace packages.

## Validation

- Verified all four `package.json` files have consistent `3.0.0` version
- Verified app shows "v3.0.0"

## Related Issues

- Part of #685

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.