### PR TITLE
fix(schema): persist empty edgeConnections array when database has no edges

### DIFF
--- a/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.test.ts
+++ b/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.test.ts
@@ -221,40 +221,32 @@ describe("edgeConnectionsQuery", () => {
     ]);
   });
 
-  it("should not update store when query returns early with empty edge types", async () => {
+  it("should set empty array in store when query has no edge types", async () => {
     const explorer = new FakeExplorer();
     const state = new DbState(explorer);
     const store = getAppStore();
+
+    // Explicitly set edgeConnections to undefined to test the fix
+    state.activeSchema.edgeConnections = undefined;
     state.applyTo(store);
 
-    // Set up initial edge connection
-    const sourceType = createVertexType("Person");
-    const targetType = createVertexType("Company");
-    const source = createTestableVertex().with({ types: [sourceType] });
-    const target = createTestableVertex().with({ types: [targetType] });
-    const edge = createTestableEdge().withSource(source).withTarget(target);
-    explorer.addTestableEdge(edge);
+    // Verify initial state has undefined edge connections
+    let schemaMap = store.get(schemaAtom);
+    let activeSchema = schemaMap.get(state.activeConfig.id);
+    expect(activeSchema?.edgeConnections).toBeUndefined();
 
     const queryClient = createQueryClient();
 
-    // First query to populate edge connections
-    await queryClient.fetchQuery(edgeConnectionsQuery([edge.type]));
-
-    // Verify initial state has edge connections
-    let schemaMap = store.get(schemaAtom);
-    let activeSchema = schemaMap.get(state.activeConfig.id);
-    expect(activeSchema?.edgeConnections).toHaveLength(1);
-
-    // Query with empty edge types returns early without updating store
+    // Query with empty edge types should persist empty array
     const result = await queryClient.fetchQuery(edgeConnectionsQuery([]));
 
     // Query returns empty array
     expect(result).toStrictEqual([]);
 
-    // But store is not updated - existing edge connections remain
+    // Store is updated with empty array to indicate "discovered but no connections"
     schemaMap = store.get(schemaAtom);
     activeSchema = schemaMap.get(state.activeConfig.id);
-    expect(activeSchema?.edgeConnections).toHaveLength(1);
+    expect(activeSchema?.edgeConnections).toStrictEqual([]);
   });
 
   it("should set lastEdgeConnectionSyncFail when query fails", async () => {
@@ -307,6 +299,34 @@ describe("edgeConnectionsQuery", () => {
     const activeSchema = schemaMap.get(state.activeConfig.id);
     expect(activeSchema?.lastEdgeConnectionSyncFail).toBe(false);
     expect(activeSchema?.edgeConnections).toHaveLength(1);
+  });
+
+  it("should distinguish between undefined (not discovered) and empty array (no connections)", async () => {
+    const explorer = new FakeExplorer();
+    const state = new DbState(explorer);
+    const store = getAppStore();
+
+    // Start with undefined edgeConnections (not yet discovered)
+    state.activeSchema.edgeConnections = undefined;
+    state.applyTo(store);
+
+    let schemaMap = store.get(schemaAtom);
+    let activeSchema = schemaMap.get(state.activeConfig.id);
+
+    // undefined means edge connections have not been discovered yet
+    expect(activeSchema?.edgeConnections).toBeUndefined();
+
+    const queryClient = createQueryClient();
+
+    // Query with empty edge types (empty database scenario)
+    await queryClient.fetchQuery(edgeConnectionsQuery([]));
+
+    schemaMap = store.get(schemaAtom);
+    activeSchema = schemaMap.get(state.activeConfig.id);
+
+    // Empty array means discovery succeeded but found no connections
+    expect(activeSchema?.edgeConnections).toStrictEqual([]);
+    expect(activeSchema?.edgeConnections).not.toBeUndefined();
   });
 
   it("should preserve existing edgeConnections when query fails", async () => {

--- a/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
@@ -34,6 +34,8 @@ export function edgeConnectionsQuery(edgeTypes: EdgeType[]) {
       const store = getStore(meta);
 
       if (sortedEdgeTypes.length === 0) {
+        // Still persist empty array to distinguish "no connections found" from "not yet discovered"
+        store.set(setEdgeConnectionsAtom, []);
         return [];
       }
 


### PR DESCRIPTION
## Summary

- Fix schema sync setting `edgeConnections` to `undefined` instead of `[]` when database has no nodes/edges
- Add test coverage for the semantic distinction between undefined (not discovered) and empty array (no connections found)

## Problem

When a database has no edges, the edge connections query was returning an empty array but not persisting it to the store. This meant `edgeConnections` remained `undefined`, which is indistinguishable from the case where edge connection discovery has not yet run or has failed.

## Root Cause

In `edgeConnectionsQuery.ts`, when `sortedEdgeTypes.length === 0`, the function returned `[]` early without calling `store.set(setEdgeConnectionsAtom, [])`. This meant the store was never updated, leaving `edgeConnections` as `undefined`.

## Solution

Added a call to persist the empty array to the store even when there are no edge types to query:

```typescript
if (sortedEdgeTypes.length === 0) {
  // Still persist empty array to distinguish "no connections found" from "not yet discovered"
  store.set(setEdgeConnectionsAtom, []);
  return [];
}
```

## Tests Run

```bash
pnpm vitest run packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.test.ts
# 11 tests pass

pnpm vitest run packages/graph-explorer/src/hooks/useSchemaSync.test.ts
# 18 tests pass

pnpm vitest run packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
# 13 tests pass

pnpm vitest run packages/graph-explorer/src/core/StateProvider/schema.test.ts
# 37 tests pass
```

## Test Plan

- [x] Verify that when a database has no edges, `edgeConnections` is set to `[]` (not `undefined`)
- [x] Verify that existing edge connections behavior is preserved when edges exist
- [x] Verify that the semantic distinction between "not discovered" and "no connections" is maintained

Fixes #1547

---
Generated with [Claude Code](https://claude.ai/code)