### PR TITLE
Move schema discovery message to sidebar alert

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,10 @@
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "rootFontSize": 14,
+        "classFunctions": ["cva", "cn"]
+      }
+    }
+  }
+}

--- a/packages/graph-explorer/src/components/EmptyState.tsx
+++ b/packages/graph-explorer/src/components/EmptyState.tsx
@@ -5,12 +5,15 @@ import { cn } from "@/utils";
 
 function EmptyState({
   className,
+  size = "default",
   ...props
-}: React.ComponentPropsWithRef<"div">) {
+}: React.ComponentPropsWithRef<"div"> & { size?: "default" | "small" }) {
   return (
     <div
+      data-slot="empty"
+      data-size={size}
       className={cn(
-        "flex h-full w-full flex-col items-center justify-center",
+        "group/empty flex h-full w-full flex-col items-center justify-center",
         className,
       )}
       {...props}
@@ -20,12 +23,13 @@ function EmptyState({
 EmptyState.displayName = "EmptyState";
 
 const emptyStateIconStyles = cva({
-  base: "mb-6 flex size-24 items-center justify-center rounded-full text-7xl text-white [&>svg]:size-1/2",
+  base: "mb-6 flex size-24 items-center justify-center rounded-full text-7xl text-white group-data-[size=small]/empty:mb-3 group-data-[size=small]/empty:size-10 [&>svg]:size-1/2",
   variants: {
     variant: {
-      info: "from-primary-main to-primary-light bg-gradient-to-b shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
+      info: "from-primary-main to-primary-light bg-linear-to-b shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
       error:
-        "from-error-main to-error-light bg-gradient-to-b shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
+        "from-error-main to-error-light bg-linear-to-b shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
+      subtle: "bg-muted text-muted-foreground rounded-lg",
     },
   },
   defaultVariants: {
@@ -70,7 +74,7 @@ function EmptyStateTitle({
   return (
     <h3
       className={cn(
-        "text-text-primary gx-wrap-break-word text-lg font-bold text-balance",
+        "text-text-primary gx-wrap-break-word text-lg font-bold text-balance group-data-[size=small]/empty:text-sm",
         className,
       )}
       {...props}
@@ -86,7 +90,7 @@ function EmptyStateDescription({
   return (
     <div
       className={cn(
-        "font-base text-text-primary/75 gx-wrap-break-word text-base",
+        "font-base text-text-primary/75 gx-wrap-break-word text-base group-data-[size=small]/empty:text-sm",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraphToolbar.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraphToolbar.tsx
@@ -2,7 +2,6 @@ import { RefreshCcwIcon } from "lucide-react";
 
 import {
   Button,
-  InfoTooltip,
   PanelHeader,
   PanelHeaderActions,
   PanelHeaderDivider,
@@ -26,13 +25,7 @@ import { schemaGraphLayoutAtom } from "./SchemaGraph";
 export function SchemaGraphToolbar() {
   return (
     <PanelHeader>
-      <PanelTitle>
-        Schema Graph{" "}
-        <InfoTooltip>
-          This schema was implicitly discovered by sampling the structure of the
-          data and may not represent the complete schema.
-        </InfoTooltip>
-      </PanelTitle>
+      <PanelTitle>Schema Graph</PanelTitle>
       <PanelHeaderActions className="gap-1.5">
         <SelectLayout
           className="max-w-64 min-w-auto"

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
@@ -68,14 +68,4 @@ describe("PropertiesDetails", () => {
 
     expect(screen.getByText("3")).toBeInTheDocument();
   });
-
-  test("renders description text", () => {
-    render(<PropertiesDetails attributes={[]} />);
-
-    expect(
-      screen.getByText(
-        /properties and their data types, which are inferred from query responses/i,
-      ),
-    ).toBeInTheDocument();
-  });
 });

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
@@ -7,6 +7,7 @@ import {
   EmptyState,
   EmptyStateContent,
   EmptyStateDescription,
+  EmptyStateIcon,
   EmptyStateTitle,
   toHumanString,
 } from "@/components";
@@ -24,7 +25,7 @@ import { ASCII, cn } from "@/utils";
 
 /** Container for a detail section with consistent vertical spacing. */
 export function Details({ className, ...props }: ComponentPropsWithRef<"div">) {
-  return <div className={cn("space-y-5", className)} {...props} />;
+  return <div className={cn("space-y-3", className)} {...props} />;
 }
 
 /** Groups a title and optional description or value with tight spacing. */
@@ -42,20 +43,7 @@ export function DetailsTitle({
 }: ComponentPropsWithRef<"h2">) {
   return (
     <h2
-      className={cn("text-text-primary text-base/7 font-bold", className)}
-      {...props}
-    />
-  );
-}
-
-/** Muted description text for a detail section. */
-export function DetailsDescription({
-  className,
-  ...props
-}: ComponentPropsWithRef<"p">) {
-  return (
-    <p
-      className={cn("text-muted-foreground text-sm/6 text-pretty", className)}
+      className={cn("text-foreground text-base/7 font-bold", className)}
       {...props}
     />
   );
@@ -91,21 +79,19 @@ export function PropertiesDetails({
   return (
     <Details>
       <DetailsHeader>
-        <DetailsTitle className="flex justify-between gap-2">
+        <DetailsTitle className="flex gap-2">
           {t("properties")}
-          <Chip variant="neutral-subtle">
+          <Chip variant="neutral-subtle" className="ml-auto">
             {toHumanString(attributes.length)}
           </Chip>
         </DetailsTitle>
-        <DetailsDescription>
-          {t("properties")} and their data types, which are inferred from query
-          responses.
-        </DetailsDescription>
       </DetailsHeader>
       <div>
         {attributes.length === 0 ? (
-          <EmptyState className="pt-8">
-            <ListIcon className="text-muted-foreground mb-4 size-8 opacity-50" />
+          <EmptyState className="pt-8" size="small">
+            <EmptyStateIcon variant="subtle">
+              <ListIcon />
+            </EmptyStateIcon>
             <EmptyStateContent>
               <EmptyStateTitle>No {t("properties")}</EmptyStateTitle>
               <EmptyStateDescription>

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/EdgeConnectionDetails.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/EdgeConnectionDetails.tsx
@@ -18,13 +18,13 @@ import { LABELS } from "@/utils";
 
 import {
   Details,
-  DetailsDescription,
   DetailsHeader,
   DetailsTitle,
   DetailsValue,
   EdgeConnectionRow,
   PropertiesDetails,
 } from "./Details";
+import { SchemaDiscoveryAlert } from "./SchemaDiscoveryAlert";
 
 export type EdgeConnectionDetailsProps = {
   edgeConnection: EdgeConnection;
@@ -65,14 +65,13 @@ export function EdgeConnectionDetails({
         <Details>
           <DetailsHeader>
             <DetailsTitle>{t("edge-connection")}</DetailsTitle>
-            <DetailsDescription>
-              The currently selected {t("edge-connection").toLowerCase()}.
-            </DetailsDescription>
           </DetailsHeader>
           <EdgeConnectionRow edgeConnection={edgeConnection} />
         </Details>
 
         <PropertiesDetails attributes={config.attributes} />
+
+        <SchemaDiscoveryAlert />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/NodeLabelDetails.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/NodeLabelDetails.tsx
@@ -20,13 +20,13 @@ import { LABELS } from "@/utils";
 
 import {
   Details,
-  DetailsDescription,
   DetailsHeader,
   DetailsTitle,
   DetailsValue,
   EdgeConnectionRow,
   PropertiesDetails,
 } from "./Details";
+import { SchemaDiscoveryAlert } from "./SchemaDiscoveryAlert";
 
 export type NodeLabelDetailsProps = {
   vertexType: VertexType;
@@ -69,10 +69,6 @@ export function NodeLabelDetails({
         <Details>
           <DetailsHeader>
             <DetailsTitle>{t("edge-connections")}</DetailsTitle>
-            <DetailsDescription>
-              All discovered {t("edge-connections").toLowerCase()} related to
-              this {t("node-type").toLowerCase()}.
-            </DetailsDescription>
           </DetailsHeader>
           <ul className="space-y-3">
             {edgeConnections?.map(edgeConnection => (
@@ -93,6 +89,8 @@ export function NodeLabelDetails({
         </Details>
 
         <PropertiesDetails attributes={config.attributes} />
+
+        <SchemaDiscoveryAlert />
       </PanelContent>
     </Panel>
   );

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaDiscoveryAlert.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaDiscoveryAlert.tsx
@@ -1,0 +1,14 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components";
+
+/** Informs the user that the schema was implicitly discovered and may be incomplete. */
+export function SchemaDiscoveryAlert() {
+  return (
+    <Alert>
+      <AlertTitle>Schema Discovery</AlertTitle>
+      <AlertDescription>
+        This schema was implicitly discovered by sampling the structure of the
+        data and may not represent the complete schema.
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Description

Move the implicit schema discovery message from a tooltip in the Schema Graph toolbar to an `Alert` component at the bottom of the sidebar detail panels. This makes the message more visible and contextually relevant when viewing node or edge details.

- Remove the `InfoTooltip` from the Schema Graph toolbar title for a cleaner header
- Add a `SchemaDiscoveryAlert` component that uses the existing `Alert` pattern to inform users the schema was implicitly discovered
- Place `SchemaDiscoveryAlert` at the bottom of `NodeLabelDetails` and `EdgeConnectionDetails` sidebars
- Remove per-section description text (`DetailsDescription`) to reduce visual noise
- Add `"small"` size variant and `"subtle"` icon variant to `EmptyState` for compact empty states in the sidebar
- Tighten vertical spacing in `Details` sections (`space-y-5` → `space-y-3`)

## Validation

- Open the Schema Graph view
- Select a node label or edge connection in the sidebar
- Verify the "Schema Discovery" alert appears at the bottom of the detail panel
- Verify the toolbar title no longer has a tooltip icon
- Verify empty property states render with the smaller, subtle icon style

| Node Label Details | Edge Label Details (with no properties) |
| --- | --- | 
| <img width="3358" height="2218" alt="CleanShot 2026-03-02 at 17 35 07@2x" src="https://github.com/user-attachments/assets/ab97d504-8d3e-491f-a725-95bc6bd1bed4" /> | <img width="3358" height="2218" alt="CleanShot 2026-03-02 at 17 35 40@2x" src="https://github.com/user-attachments/assets/e9598ef3-b900-467d-b6ee-aa3396123411" /> |


## Related Issues

- Resolves #1544 

## Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.