### PR TITLE
Enforce pnpm and fix husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -6,13 +6,25 @@
   "license": "Apache-2.0",
   "type": "module",
   "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24.13.0",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=10.28.1",
+      "onFail": "error"
+    }
+  },
   "engines": {
-    "node": ">=24.13.0"
+    "node": ">=24.13.0",
+    "pnpm": ">=10.28.1"
   },
   "private": true,
   "scripts": {
-    "prepare": "husky install",
-    "precommit": "lint-staged && pnpm check:types",
+    "prepare": "husky",
     "lint": "eslint --fix --concurrency=auto",
     "check:lint": "eslint --concurrency=auto",
     "format": "prettier --write .",
@@ -50,10 +62,11 @@
     "vitest": "4.0.10"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": [
-      "eslint --fix"
-    ],
-    "**/*": "prettier --write --ignore-unknown"
+    "!(**/*.{js,ts,tsx})": "prettier --ignore-unknown --write",
+    "**/*.{js,ts,tsx}": [
+      "eslint --fix",
+      "prettier --ignore-unknown --write"
+    ]
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Description

- Enforce pnpm as the only allowed package manager using `devEngines` in `package.json`, `engines.pnpm` constraint, and `engine-strict=true` in `.npmrc`
- Migrate from the deprecated `husky install` API to the modern `husky` v9 command
- Add the missing `.husky/pre-commit` hook that runs `pnpm lint-staged`
- Remove the unused `precommit` script (intentionally dropping `check:types` from the pre-commit flow)
- Restructure the `lint-staged` config to use full glob paths and include `--ignore-unknown` on prettier commands

## Validation

- Run `npm install` or `yarn install` and verify it is blocked
- Run `pnpm install` and verify it succeeds and the `prepare` script sets up husky
- Stage a `.ts` file and a `.md` file, then run `pnpm lint-staged` to confirm both eslint and prettier run on the `.ts` file and only prettier runs on the `.md` file
- Commit and verify the pre-commit hook fires

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0
      license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.