### PR TITLE
Add explicit monorepo command instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,28 @@
 - For product overview and architecture, refer to
   `.kiro/skills/product/SKILL.md`
 
+## Monorepo Commands
+
+- **Always run commands from the project root** — never `cd` into a subfolder
+- Only use scripts defined in the root `package.json`
+- Use `pnpm` as the package manager
+
+### Examples
+
+```bash
+# All checks (lint, format, types)
+pnpm run checks
+
+# All tests
+pnpm test
+
+# Single test file
+pnpm test packages/graph-explorer/src/path/to/file.test.ts
+
+# Test name pattern match
+pnpm test -- -t "pattern"
+```
+
 # Project Organization
 
 ## Key Architectural Patterns


### PR DESCRIPTION
## Description

Previous attempts to reduce the scope of the AGENTS.md file did not help with AI agent behavior around running commands. Agents would continuously try to run tests using `npx vitest ...` instead of the correct `pnpm test` command. They would also attempt to check for type errors in non-standard ways rather than using the defined `pnpm run checks` script.

This change adds a dedicated "Monorepo Commands" section to AGENTS.md with explicit instructions:

- Always run commands from the project root, never from subfolders
- Only use scripts defined in the root `package.json`
- Use `pnpm` as the package manager
- Concrete examples for running checks, all tests, single test files, and test name pattern matching

## Validation

- Verify the new section appears between "Core Rules" and "Project Organization" in AGENTS.md
- Confirm examples match the scripts in the root `package.json`

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have run `pnpm checks` to ensure code compiles and meets standards.
- [x] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.