### PR TITLE
Prose wrap

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,8 +25,7 @@ Please read the [Code of Conduct](https://github.com/aws/graph-explorer/blob/mai
   You can check the items by adding an `x` between the brackets, like this: `[x]`
 -->
 
-- [ ] I confirm that my contribution is made under the terms of the Apache 2.0
-      license.
+- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
 - [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
 - [ ] I have run `pnpm test` to check if all tests are passing.
 - [ ] I have covered new added functionality with unit tests if necessary.

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -73,8 +73,7 @@ jobs:
           docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:sagemaker-$IMAGE_TAG
 
       - name: Update latest tag for release
-        if:
-          ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag ==
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag ==
           'release' }}
         env:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}

--- a/.kiro/skills/connectors/SKILL.md
+++ b/.kiro/skills/connectors/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: connectors
-description:
-  Database connector and explorer patterns for Gremlin, openCypher, and SPARQL,
-  including the query template tag and escapeString usage.
+description: Database connector and explorer patterns for Gremlin, openCypher, and SPARQL, including the query template tag and escapeString usage.
 tools: ["fs_read", "code", "grep", "glob", "web_search", "web_fetch"]
 ---
 
@@ -10,8 +8,7 @@ tools: ["fs_read", "code", "grep", "glob", "web_search", "web_fetch"]
 
 ## Connector Pattern
 
-- Database connectors are separated by query language (gremlin, openCypher,
-  sparql)
+- Database connectors are separated by query language (gremlin, openCypher, sparql)
 - Common interfaces are defined in `src/connector/index.ts`
 - Each connector implements the same interface for consistent API
 
@@ -21,17 +18,13 @@ tools: ["fs_read", "code", "grep", "glob", "web_search", "web_fetch"]
 - Each explorer provides a unified interface for a specific query language
 - Located in `src/connector/[query-language]/explorer/`
 - Explorers handle query construction, execution, and result transformation
-- They shield the application from query language specifics while providing
-  consistent data structures
+- They shield the application from query language specifics while providing consistent data structures
 
 ## Branded Types
 
-For branded type conventions and the full type reference table, refer to
-`.kiro/skills/typescript/SKILL.md`.
+For branded type conventions and the full type reference table, refer to `.kiro/skills/typescript/SKILL.md`.
 
 ## Database Queries
 
-- Use the `query` template tag from `@/utils` for all query strings (Gremlin,
-  openCypher, SPARQL) to ensure consistent formatting
-- For Gremlin queries, use `escapeString()` from `@/utils` to escape special
-  characters in string literals
+- Use the `query` template tag from `@/utils` for all query strings (Gremlin, openCypher, SPARQL) to ensure consistent formatting
+- For Gremlin queries, use `escapeString()` from `@/utils` to escape special characters in string literals

--- a/.kiro/skills/github/SKILL.md
+++ b/.kiro/skills/github/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: github
-description:
-  Handle management of any GitHub related tasks, including creating or modifying
-  issues, publishing a branch as a pull requests (or PRs), or creating or
-  modifying sub-issues or child issues.
+description: Handle management of any GitHub related tasks, including creating or modifying issues, publishing a branch as a pull requests (or PRs), or creating or modifying sub-issues or child issues.
 tools: ["git", "gh", "fs_read", "grep", "glob", "web_search", "web_fetch"]
 ---
 
@@ -12,18 +9,13 @@ tools: ["git", "gh", "fs_read", "grep", "glob", "web_search", "web_fetch"]
 ## General
 
 - Use the `gh` CLI for all GitHub operations when possible
-- Never delete or change the status of issues or pull requests unless explicitly
-  requested
-- Never mention CVEs, security vulnerabilities, or security advisories in issues
-  or PRs. Instead, describe the change as a dependency update (e.g., "Update
-  fast-xml-parser to latest version" rather than "Fix CVE-2026-25896")
+- Never delete or change the status of issues or pull requests unless explicitly requested
+- Never mention CVEs, security vulnerabilities, or security advisories in issues or PRs. Instead, describe the change as a dependency update (e.g., "Update fast-xml-parser to latest version" rather than "Fix CVE-2026-25896")
 
 ## Issues
 
-- Always assign an issue type when creating issues: `Task`, `Bug`, `Feature`,
-  `Epic`, or `Spike`
-- Use context from the codebase or the web to fill in additional detail when
-  creating issues
+- Always assign an issue type when creating issues: `Task`, `Bug`, `Feature`, `Epic`, or `Spike`
+- Use context from the codebase or the web to fill in additional detail when creating issues
 - Only apply labels from the existing set; do not create new labels
 - Do not add or remove labels unless explicitly requested
 
@@ -39,15 +31,11 @@ gh api graphql \
   -f query="mutation { addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$CHILD_ID\" }) { issue { title } subIssue { title } } }"
 ```
 
-Note: `gh issue create` does not support `--parent`. Create the issue first,
-then link it via the GraphQL API as shown above.
+Note: `gh issue create` does not support `--parent`. Create the issue first, then link it via the GraphQL API as shown above.
 
 ## Related Issues
 
-When an issue or PR relates to another issue or PR, add a "Related Issues"
-section with a list of linked items. Always use a list format, even for a single
-item, because GitHub expands the reference number into the referenced item's
-title (e.g., `- Fixes #123` renders as "Fixes some bug #123").
+When an issue or PR relates to another issue or PR, add a "Related Issues" section with a list of linked items. Always use a list format, even for a single item, because GitHub expands the reference number into the referenced item's title (e.g., `- Fixes #123` renders as "Fixes some bug #123").
 
 Prefix each item with a brief relationship descriptor such as:
 
@@ -70,12 +58,9 @@ Example:
 
 - Always publish pull requests as drafts
 - Always setup tracking when publishing a branch to a remote
-- In the title, describe the changes conceptually (e.g., "Add vertex filtering
-  to graph view")
-- In the title, do not use conventional commit prefixes like `docs:`,
-  `feature:`, `refactor:`, `fix:`, etc
+- In the title, describe the changes conceptually (e.g., "Add vertex filtering to graph view")
+- In the title, do not use conventional commit prefixes like `docs:`, `feature:`, `refactor:`, `fix:`, etc
 - Follow the pull request template in `.github/pull_request_template.md`
 - Link to the corresponding issue when one exists (e.g., `Fixes #123`)
 - Keep descriptions concise and focused
-- Include a bulleted list of changes at the conceptual level with reasons for
-  each change so reviewers can scan quickly
+- Include a bulleted list of changes at the conceptual level with reasons for each change so reviewers can scan quickly

--- a/.kiro/skills/product/SKILL.md
+++ b/.kiro/skills/product/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: product
-description:
-  Graph Explorer product overview including supported graph types, query
-  languages, databases, key features, and high-level architecture.
+description: Graph Explorer product overview including supported graph types, query languages, databases, key features, and high-level architecture.
 tools: ["fs_read", "grep", "glob", "web_search"]
 ---
 
 # Graph Explorer Product Overview
 
-Graph Explorer is a React-based web application that enables users to visualize
-and explore graph data without writing queries. It supports multiple graph
-database types and query languages.
+Graph Explorer is a React-based web application that enables users to visualize and explore graph data without writing queries. It supports multiple graph database types and query languages.
 
 ## Core Purpose
 
@@ -22,17 +18,14 @@ database types and query languages.
 
 - **Property Graphs**: Gremlin, openCypher
 - **RDF Graphs**: SPARQL 1.1 protocol
-- **Databases**: Amazon Neptune, Amazon Neptune Analytics, Apache TinkerPop
-  Gremlin Server REST endpoints, JanusGraph
+- **Databases**: Amazon Neptune, Amazon Neptune Analytics, Apache TinkerPop Gremlin Server REST endpoints, JanusGraph
 
 ## Key Features
 
 - **Connections Management**: Create and manage database connections
-- **Graph Visualization**: Interactive graph view with search, custom queries,
-  and styling
+- **Graph Visualization**: Interactive graph view with search, custom queries, and styling
 - **Tabular View**: Show/hide nodes and edges, export to CSV/JSON
-- **Data Explorer**: List all nodes and properties for a specific node type and
-  send to graph view
+- **Data Explorer**: List all nodes and properties for a specific node type and send to graph view
 - **Schema Explorer**: View node types and their relationships as a graph
 - **Authentication**: AWS IAM authentication via SigV4 signing protocol
 
@@ -40,5 +33,4 @@ database types and query languages.
 
 - **Frontend**: TypeScript React application served via Vite
 - **Backend**: Express.js proxy server for authentication and request routing
-- **Deployment**: Docker containers, supports local and cloud deployment (EC2,
-  ECS)
+- **Deployment**: Docker containers, supports local and cloud deployment (EC2, ECS)

--- a/.kiro/skills/react/SKILL.md
+++ b/.kiro/skills/react/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: react
-description:
-  React component patterns, hooks, naming conventions, and the query-language
-  translation system for Graph Explorer.
+description: React component patterns, hooks, naming conventions, and the query-language translation system for Graph Explorer.
 tools:
   [
     "fs_read",
@@ -19,9 +17,7 @@ tools:
 ## React Version & Compiler
 
 - This project uses React 19
-- The React Compiler is enabled — it auto-memoizes components and hooks, so
-  manual `useMemo`, `useCallback`, and `React.memo` are unnecessary in most
-  cases and should be avoided unless profiling shows a specific need
+- The React Compiler is enabled — it auto-memoizes components and hooks, so manual `useMemo`, `useCallback`, and `React.memo` are unnecessary in most cases and should be avoided unless profiling shows a specific need
 - Official React docs: https://react.dev
 
 ## General
@@ -33,8 +29,7 @@ tools:
 
 ## Feature Modules
 
-- Feature modules in `src/modules/` contain all related components, hooks, and
-  utilities
+- Feature modules in `src/modules/` contain all related components, hooks, and utilities
 - Each module exports its public API through an index file
 - Modules should be self-contained with minimal dependencies on other modules
 
@@ -46,16 +41,11 @@ tools:
 
 ## Translations (Query-Language Labels)
 
-The translation system is not used for locale/language translations. Instead, it
-swaps UI labels based on the active connection's query language. Each query
-language (Gremlin, openCypher, SPARQL) has its own JSON file in
-`src/hooks/translations/` that maps keys to display strings (e.g., `"node-type"`
-→ `"Node Label"` in Gremlin vs `"Class"` in SPARQL).
+The translation system is not used for locale/language translations. Instead, it swaps UI labels based on the active connection's query language. Each query language (Gremlin, openCypher, SPARQL) has its own JSON file in `src/hooks/translations/` that maps keys to display strings (e.g., `"node-type"` → `"Node Label"` in Gremlin vs `"Class"` in SPARQL).
 
 Key files:
 
-- `src/hooks/useTranslations.ts` — `useTranslations()` hook returns a `t`
-  function scoped to the current query engine
+- `src/hooks/useTranslations.ts` — `useTranslations()` hook returns a `t` function scoped to the current query engine
 - `src/hooks/translations/gremlin-translations.json`
 - `src/hooks/translations/openCypher-translations.json`
 - `src/hooks/translations/sparql-translations.json`
@@ -71,7 +61,5 @@ Key naming conventions:
 
 - Lower-case kebab-case (e.g., `node-type`, `edge-connections`)
 - Keys should read naturally as stand-ins for the word they represent
-- Keys typically match one of the query language terms or the codebase
-  vocabulary
-- Nested keys use dot notation when accessed (e.g.,
-  `node-expand.no-selection-title`)
+- Keys typically match one of the query language terms or the codebase vocabulary
+- Nested keys use dot notation when accessed (e.g., `node-expand.no-selection-title`)

--- a/.kiro/skills/schema/SKILL.md
+++ b/.kiro/skills/schema/SKILL.md
@@ -1,49 +1,32 @@
 ---
 name: schema
-description:
-  Schema storage and discovery in Graph Explorer, including SchemaStorageModel
-  persistence, edge connections, incremental schema growth, and related Jotai
-  atoms.
+description: Schema storage and discovery in Graph Explorer, including SchemaStorageModel persistence, edge connections, incremental schema growth, and related Jotai atoms.
 tools: ["fs_read", "code", "grep", "glob", "web_search", "web_fetch"]
 ---
 
 # Schema Storage
 
-Schema discovery is expensive in both time and database compute, so the
-discovered schema is persisted in IndexedDB (via localforage) as a
-`SchemaStorageModel`. This acts as a persistent cache per connection.
+Schema discovery is expensive in both time and database compute, so the discovered schema is persisted in IndexedDB (via localforage) as a `SchemaStorageModel`. This acts as a persistent cache per connection.
 
 Key files:
 
-- `src/core/StateProvider/schema.ts` — `SchemaStorageModel` type, Jotai atoms,
-  and incremental update logic
-- `src/core/ConfigurationProvider/types.ts` — `EdgeConnection`,
-  `VertexTypeConfig`, `EdgeTypeConfig`, and related types
+- `src/core/StateProvider/schema.ts` — `SchemaStorageModel` type, Jotai atoms, and incremental update logic
+- `src/core/ConfigurationProvider/types.ts` — `EdgeConnection`, `VertexTypeConfig`, `EdgeTypeConfig`, and related types
 - `src/hooks/useSchemaSync.ts` — schema sync orchestration
 - `src/connector/queries/edgeConnectionsQuery.ts` — edge connection discovery
 
 ## Edge Connections
 
-Edge connections (`EdgeConnection[]`) describe relationships between vertex
-types and are used by the Schema Explorer feature. Because the edge connection
-query can be expensive and unreliable, it runs separately from the main schema
-sync so that a failure only affects Schema Explorer — all other features work
-without edge connections.
+Edge connections (`EdgeConnection[]`) describe relationships between vertex types and are used by the Schema Explorer feature. Because the edge connection query can be expensive and unreliable, it runs separately from the main schema sync so that a failure only affects Schema Explorer — all other features work without edge connections.
 
-The `edgeConnections` property on `SchemaStorageModel` has three meaningful
-states:
+The `edgeConnections` property on `SchemaStorageModel` has three meaningful states:
 
-- `undefined` — edge connections have not been successfully discovered (query
-  not run or errored)
+- `undefined` — edge connections have not been successfully discovered (query not run or errored)
 - `[]` (empty array) — query succeeded but no edge connections exist
 - populated array — query succeeded with results
 
-If the edge connection query fails, the error is stored in the schema via the
-`edgeConnectionDiscoveryFailed` flag.
+If the edge connection query fails, the error is stored in the schema via the `edgeConnectionDiscoveryFailed` flag.
 
 ## Incremental Schema Growth
 
-As users explore the graph, queries may return vertex/edge types or attributes
-not present in the initial schema sync. These are automatically merged into the
-stored schema via `updateSchemaFromEntities()`, causing the schema to grow more
-complete over time.
+As users explore the graph, queries may return vertex/edge types or attributes not present in the initial schema sync. These are automatically merged into the stored schema via `updateSchemaFromEntities()`, causing the schema to grow more complete over time.

--- a/.kiro/skills/tailwind/SKILL.md
+++ b/.kiro/skills/tailwind/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: tailwind
-description:
-  Tailwind CSS v4 styling rules, responsive design patterns, and data attribute
-  conventions for Graph Explorer.
+description: Tailwind CSS v4 styling rules, responsive design patterns, and data attribute conventions for Graph Explorer.
 tools:
   [
     "fs_read",
@@ -18,8 +16,6 @@ tools:
 
 - Use Tailwind v4 CSS syntax
 - The `tailwind.config.ts` file remains for legacy reasons
-- Prefer Tailwind responsive directives and container queries over
-  `ResizeObserver` for responsive layout changes whenever possible
-- Prefer using data attributes to deal within conditionally applied styles using
-  Tailwind
+- Prefer Tailwind responsive directives and container queries over `ResizeObserver` for responsive layout changes whenever possible
+- Prefer using data attributes to deal within conditionally applied styles using Tailwind
 - Lookup the latest Tailwind documentation from `https://tailwindcss.com/docs`

--- a/.kiro/skills/testing/SKILL.md
+++ b/.kiro/skills/testing/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: testing
-description:
-  Testing standards, patterns, and utilities for Graph Explorer including
-  Vitest, DbState, renderHookWithState, test data factories, SPARQL test
-  helpers, and backward compatibility testing for persisted data.
+description: Testing standards, patterns, and utilities for Graph Explorer including Vitest, DbState, renderHookWithState, test data factories, SPARQL test helpers, and backward compatibility testing for persisted data.
 tools: ["fs_read", "code", "grep", "glob", "web_search", "web_fetch"]
 ---
 
@@ -38,8 +35,7 @@ import { createRandomName, createRandomInteger } from "@shared/utils/testing";
 
 ### Random Data Factories
 
-Use the factory methods for random data generation to create test data that
-doesn't directly impact test results:
+Use the factory methods for random data generation to create test data that doesn't directly impact test results:
 
 - **Graph Explorer**: Use `@/utils/testing` for frontend-specific test data
 - **Shared**: Use `@shared/utils/testing` for common utilities
@@ -59,8 +55,7 @@ const randomColor = createRandomColor();
 
 ### Testable Entities
 
-Prefer `TestableVertex` and `TestableEdge` over raw vertex/edge types for more
-flexible test data:
+Prefer `TestableVertex` and `TestableEdge` over raw vertex/edge types for more flexible test data:
 
 ```typescript
 import { createTestableVertex, createTestableEdge } from "@/utils/testing";
@@ -85,8 +80,7 @@ const patchedVertex = vertex.asPatchedResult();
 
 ### Use renderHookWithState()
 
-For testing React hooks, always use `renderHookWithState()` instead of the
-standard `renderHook()`:
+For testing React hooks, always use `renderHookWithState()` instead of the standard `renderHook()`:
 
 ```typescript
 import { renderHookWithState, DbState } from "@/utils/testing";
@@ -136,16 +130,14 @@ test("should filter vertices by type", () => {
 
 ### Depend on setupTests.ts
 
-All tests automatically inherit the configuration from `setupTests.ts`, which
-provides:
+All tests automatically inherit the configuration from `setupTests.ts`, which provides:
 
 - **Consistent Environment**: UTC timezone, en-US locale
 - **Mocked Dependencies**: localforage, logger, query client with no retries
 - **Cleanup**: Automatic cleanup after each test
 - **Global Mocks**: Intl, environment variables
 
-Most tests require minimal additional setup beyond what's provided
-automatically.
+Most tests require minimal additional setup beyond what's provided automatically.
 
 ### Environment Variables
 
@@ -289,8 +281,7 @@ test("should render vertex correctly", () => {
 
 ### Use toStrictEqual() with Full Expected Arrays
 
-Instead of checking array length and individual indices, use `toStrictEqual()`
-with the complete expected array:
+Instead of checking array length and individual indices, use `toStrictEqual()` with the complete expected array:
 
 ```typescript
 // ❌ Avoid: Length check + individual index assertions
@@ -308,16 +299,14 @@ expect(result).toStrictEqual([
 **Benefits:**
 
 - **Cleaner**: Single assertion instead of multiple checks
-- **Stricter**: `toStrictEqual()` provides more thorough comparison than
-  `toEqual()`
+- **Stricter**: `toStrictEqual()` provides more thorough comparison than `toEqual()`
 - **Readable**: Expected results are clearly visible in the test
 - **Maintainable**: Changes only require updating one array
 - **Better Errors**: Failure messages show full expected vs actual arrays
 
 ### SPARQL Test Helpers
 
-For SPARQL-related tests, use the helper functions to create consistent test
-data:
+For SPARQL-related tests, use the helper functions to create consistent test data:
 
 ```typescript
 import {
@@ -397,8 +386,7 @@ test("should handle RDF construct query", async () => {
 
 ### Targeted Testing for Small Changes
 
-For small, isolated changes, run only the relevant tests instead of the full
-test suite:
+For small, isolated changes, run only the relevant tests instead of the full test suite:
 
 ```bash
 # Run tests for a specific file
@@ -417,21 +405,18 @@ Only run the full test suite (`pnpm test`) in these situations:
 
 - At the end of implementing a large feature or set of changes
 - Before creating a pull request
-- After making changes that could have wide-reaching effects (e.g., shared
-  utilities, core providers, type definitions)
+- After making changes that could have wide-reaching effects (e.g., shared utilities, core providers, type definitions)
 - When explicitly requested
 
 ### Quick Validation with pnpm checks
 
-For a quick validation of changes, run all static checks (type checking,
-linting, and formatting) in a single command:
+For a quick validation of changes, run all static checks (type checking, linting, and formatting) in a single command:
 
 ```bash
 pnpm checks
 ```
 
-This takes less than a minute and catches most issues without running the full
-test suite. Use this as your default validation for small changes.
+This takes less than a minute and catches most issues without running the full test suite. Use this as your default validation for small changes.
 
 ### Type Checking Only
 
@@ -441,8 +426,7 @@ For changes that don't have associated tests, verify type correctness:
 pnpm check:types
 ```
 
-This is faster than running the full test suite and catches most issues with
-styling, configuration, or type-only changes.
+This is faster than running the full test suite and catches most issues with styling, configuration, or type-only changes.
 
 ## Best Practices
 
@@ -470,14 +454,10 @@ styling, configuration, or type-only changes.
 
 ### Do Not Test Styling or Layout
 
-- Do not write tests that assert on CSS classes, HTML element types, or layout
-  structure
-- These tests are fragile and break on routine visual changes that have no
-  functional impact
-- Instead, test the behavioral logic: conditional rendering, data
-  transformations, user interactions, and state changes
-- If a component is purely presentational with no branching logic, it does not
-  need a test
+- Do not write tests that assert on CSS classes, HTML element types, or layout structure
+- These tests are fragile and break on routine visual changes that have no functional impact
+- Instead, test the behavioral logic: conditional rendering, data transformations, user interactions, and state changes
+- If a component is purely presentational with no branching logic, it does not need a test
 
 ### Performance
 
@@ -498,27 +478,19 @@ test("should handle errors gracefully", async () => {
 
 ## Persistent Storage Backward Compatibility
 
-Graph Explorer persists state to IndexedDB via localforage (managed through
-Jotai atoms). When a type used in persistent storage changes shape — for
-example, a property is added, removed, or renamed — previously stored data will
-still be loaded with the old shape. This can silently break logic that assumes
-the new shape.
+Graph Explorer persists state to IndexedDB via localforage (managed through Jotai atoms). When a type used in persistent storage changes shape — for example, a property is added, removed, or renamed — previously stored data will still be loaded with the old shape. This can silently break logic that assumes the new shape.
 
 ### Requirements
 
-Any type or object that is persisted through Jotai and localforage **must** have
-tests that exercise the old storage shape alongside the new one. These tests
-verify that:
+Any type or object that is persisted through Jotai and localforage **must** have tests that exercise the old storage shape alongside the new one. These tests verify that:
 
 1. Data in the old shape is accepted without errors
 2. Logic that consumes the data produces correct results with both shapes
-3. Old and new shapes can coexist (e.g., a mix of old and new entries in an
-   array)
+3. Old and new shapes can coexist (e.g., a mix of old and new entries in an array)
 
 ### Test Structure
 
-Group backward-compatibility tests in a dedicated `describe` block with a clear
-comment block explaining:
+Group backward-compatibility tests in a dedicated `describe` block with a clear comment block explaining:
 
 - What the old shape looked like
 - Why the tests exist
@@ -561,15 +533,13 @@ describe("backward compatibility: <brief description>", () => {
 
 ### Key Persisted Types
 
-These types are stored in IndexedDB and require backward-compatibility tests
-when modified:
+These types are stored in IndexedDB and require backward-compatibility tests when modified:
 
 - `SchemaStorageModel` — vertex/edge configs, prefixes, edge connections
 - `PrefixTypeConfig` — RDF namespace prefix definitions
 - `VertexTypeConfig` / `EdgeTypeConfig` — schema type configurations
 - `RawConfiguration` — connection and schema configuration
-- User preferences (`VertexPreferencesStorageModel`,
-  `EdgePreferencesStorageModel`)
+- User preferences (`VertexPreferencesStorageModel`, `EdgePreferencesStorageModel`)
 
 ### When to Add These Tests
 

--- a/.kiro/skills/typescript/SKILL.md
+++ b/.kiro/skills/typescript/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: typescript
-description:
-  TypeScript conventions and rules for Graph Explorer, including branded types,
-  function style preferences, and type safety patterns.
+description: TypeScript conventions and rules for Graph Explorer, including branded types, function style preferences, and type safety patterns.
 ---
 
 # TypeScript Conventions
@@ -10,18 +8,13 @@ description:
 ## General Rules
 
 - Do not change the VS Code setting `typescript.autoClosingTags`
-- Prefer named function syntax over anonymous arrow functions for module-level
-  declarations (e.g., `function handleClick() {}` over
-  `const handleClick = () => {}`). Arrow functions within function scope are
-  fine.
+- Prefer named function syntax over anonymous arrow functions for module-level declarations (e.g., `function handleClick() {}` over `const handleClick = () => {}`). Arrow functions within function scope are fine.
 - Every commit should have no type errors
-- Use explicit type aliases instead of `ReturnType<typeof ...>` when available
-  (e.g., use `AppStore` instead of `ReturnType<typeof getAppStore>`)
+- Use explicit type aliases instead of `ReturnType<typeof ...>` when available (e.g., use `AppStore` instead of `ReturnType<typeof getAppStore>`)
 
 ## Branded Types
 
-The project uses branded types from `@/utils` for type safety. These prevent
-accidental mixing of similar types at compile time.
+The project uses branded types from `@/utils` for type safety. These prevent accidental mixing of similar types at compile time.
 
 | Type                     | Creator Function             | Location                                |
 | ------------------------ | ---------------------------- | --------------------------------------- |
@@ -38,5 +31,4 @@ accidental mixing of similar types at compile time.
 | `RdfPrefix`              | `generatePrefix()`           | `@/utils/rdf`                           |
 | `NormalizedIriNamespace` | `normalizeNamespace()`       | `@/utils/rdf`                           |
 
-Always use the appropriate branded type instead of `string` when working with
-these identifiers.
+Always use the appropriate branded type instead of `string` when working with these identifiers.

--- a/.kiro/steering/documentation.md
+++ b/.kiro/steering/documentation.md
@@ -5,8 +5,7 @@ fileMatchPattern: "{**/*.md,additionaldocs/**}"
 
 # Project Documentation Standards
 
-- Be professional & clear; use straightforward language accessible to both
-  technical and non-technical users
+- Be professional & clear; use straightforward language accessible to both technical and non-technical users
 - Be concise; get to the point quickly without unnecessary explanations
 - Clearly state what users need to know or have before starting
 - Write from the user's perspective, addressing their goals and pain points

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "arrowParens": "avoid",
-  "proseWrap": "always",
+  "proseWrap": "preserve",
   "plugins": ["prettier-plugin-tailwindcss"],
   "tailwindFunctions": ["cva", "cn"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,21 +5,16 @@
 - Prefer descriptive variable and function names over code comments
 - Prefer simple to follow logic over clever concise code
 - Every commit should have no type errors, lint errors, or failing tests
-- When possible, create failing tests first then implement the logic to make the
-  tests pass
+- When possible, create failing tests first then implement the logic to make the tests pass
 - Add or update tests for the code you change, even if nobody asked
-- For TypeScript conventions and rules, refer to
-  `.kiro/skills/typescript/SKILL.md`
+- For TypeScript conventions and rules, refer to `.kiro/skills/typescript/SKILL.md`
 - For Tailwind style guidelines, refer to `.kiro/skills/tailwind/SKILL.md`
 - For testing patterns and examples, refer to `.kiro/skills/testing/SKILL.md`
-- For code organization patterns and conventions, refer to
-  `.kiro/skills/connectors/SKILL.md`
-- For React related patterns and conventions, refer to
-  `.kiro/skills/react/SKILL.md`
+- For code organization patterns and conventions, refer to `.kiro/skills/connectors/SKILL.md`
+- For React related patterns and conventions, refer to `.kiro/skills/react/SKILL.md`
 - For schema storage and discovery, refer to `.kiro/skills/schema/SKILL.md`
 - For GitHub issue and PR management, refer to `.kiro/skills/github/SKILL.md`
-- For product overview and architecture, refer to
-  `.kiro/skills/product/SKILL.md`
+- For product overview and architecture, refer to `.kiro/skills/product/SKILL.md`
 
 ## Monorepo Commands
 
@@ -50,16 +45,14 @@ pnpm test -- -t "pattern"
 - **State Management**: Use Jotai atoms for global state
 - **Data Fetching**: Use TanStack Query for remote data
 - **Graph Rendering**: Cytoscape.js with custom layout plugins
-- **Query Abstraction**: Explorers that provide unified interfaces for different
-  query languages
+- **Query Abstraction**: Explorers that provide unified interfaces for different query languages
 - **Configuration**: Environment variables and configuration providers
 - **Error Handling**: Error boundaries and consistent error display components
 - **State Persistence**: localforage for client-side persistence using IndexedDB
 
 ## Data Storage & Persistence
 
-- **Client-Side Only**: Graph Explorer stores all user data and preferences
-  client-side
+- **Client-Side Only**: Graph Explorer stores all user data and preferences client-side
 - **No Server Storage**: The backend proxy server does not store any user data
 - **IndexedDB**: Used as the primary storage mechanism via localforage
 - **Persistence Scope**:
@@ -68,5 +61,4 @@ pnpm test -- -t "pattern"
   - Query history
   - Visualization settings
   - Layout preferences
-- **External Data**: Graph data is queried directly from the connected graph
-  databases and is not owned or persisted by Graph Explorer
+- **External Data**: Graph data is queried directly from the connected graph databases and is not owned or persisted by Graph Explorer

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,3 @@
 ## Code of Conduct
 
-This project has adopted the
-[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For
-more information see the
-[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,14 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug
-report, new feature, correction, or additional documentation, we greatly value
-feedback and contributions from our community.
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional documentation, we greatly value feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests
-to ensure we have all the necessary information to effectively respond to your
-bug report or contribution.
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary information to effectively respond to your bug report or contribution.
 
 ## Reporting Bugs/Feature Requests
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest
-features.
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check existing open, or recently closed, issues to
-make sure somebody else hasn't already reported the issue. Please try to include
-as much information as you can. Details like these are incredibly useful:
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 - A reproducible test case or series of steps
 - The version of our code being used
@@ -24,55 +17,35 @@ as much information as you can. Details like these are incredibly useful:
 
 ## Contributing via Pull Requests
 
-Contributions via pull requests are much appreciated. Before sending us a pull
-request, please ensure that:
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
 1. You are working against the latest source on the _main_ branch.
-2. You check existing open, and recently merged, pull requests to make sure
-   someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your
-   time to be wasted.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing.
-   If you also reformat all the code, it will be hard for us to focus on your
-   change.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request
-   interface.
-6. Pay attention to any automated CI failures reported in the pull request, and
-   stay involved in the conversation.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional documentation on
-[forking a repository](https://help.github.com/articles/fork-a-repo/) and
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Finding contributions to work on
 
-Looking at the existing issues is a great way to find something to contribute
-on. As our projects, by default, use the default GitHub issue labels
-(enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any
-'help wanted' issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
 ## Code of Conduct
 
-This project has adopted the
-[Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For
-more information see the
-[Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 ## Security issue notifications
 
-If you discover a potential security issue in this project we ask that you
-notify AWS/Amazon Security via our
-[vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
-Please do **not** create a public github issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to
-confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,24 +2,15 @@
 
 ## Release 3.0.0
 
-Graph Explorer 3.0 is here! This release brings one of the most requested
-features — the ability to visualize your graph database schema — along with a
-fresh navigation experience and a handful of quality-of-life improvements.
+Graph Explorer 3.0 is here! This release brings one of the most requested features — the ability to visualize your graph database schema — along with a fresh navigation experience and a handful of quality-of-life improvements.
 
-If you're upgrading from a previous version, all your existing connections,
-preferences, and configuration data will carry over unchanged.
+If you're upgrading from a previous version, all your existing connections, preferences, and configuration data will carry over unchanged.
 
 ### Schema Explorer
 
-You can now see the shape of your graph at a glance. The new Schema Explorer
-renders your vertex types, edge types, and their connections as an interactive
-schema graph. Drill into any type from the sidebar to see property details and
-data types. Edge connection discovery maps out how your types relate, giving you
-a bird's-eye view of your entire graph structure.
+You can now see the shape of your graph at a glance. The new Schema Explorer renders your vertex types, edge types, and their connections as an interactive schema graph. Drill into any type from the sidebar to see property details and data types. Edge connection discovery maps out how your types relate, giving you a bird's-eye view of your entire graph structure.
 
-The schema is built by sampling your graph data, so it reflects what Graph
-Explorer has seen so far and may not capture every type or property in your
-database.
+The schema is built by sampling your graph data, so it reflects what Graph Explorer has seen so far and may not capture every type or property in your database.
 
 <div align="center">
   <img width="540" src="images/schema-explorer.png" />
@@ -27,10 +18,7 @@ database.
 
 ### Redesigned Navigation
 
-Getting around Graph Explorer just got easier. The navigation bar has been
-rebuilt as a clean, static top bar for moving between the Graph Explorer, Data
-Explorer, and Schema Explorer. Sidebar tabs have been refreshed to match the new
-look.
+Getting around Graph Explorer just got easier. The navigation bar has been rebuilt as a clean, static top bar for moving between the Graph Explorer, Data Explorer, and Schema Explorer. Sidebar tabs have been refreshed to match the new look.
 
 <div align="center">
   <img width="540" src="images/graph-explorer.png" />
@@ -38,8 +26,7 @@ look.
 
 ### Data Explorer Improvements
 
-The Data Explorer now includes a vertex type switcher for faster browsing across
-types and a new export button to download data as CSV or JSON (thanks @dwrth!).
+The Data Explorer now includes a vertex type switcher for faster browsing across types and a new export button to download data as CSV or JSON (thanks @dwrth!).
 
 <div align="center">
   <img width="540" src="images/data-explorer.png" />
@@ -56,173 +43,92 @@ types and a new export button to download data as CSV or JSON (thanks @dwrth!).
 
 Welcome and thank you to our first-time contributors! 🎉
 
-- @Eepsita12 made their first contribution in
-  https://github.com/aws/graph-explorer/pull/1483
-- @abhu85 made their first contribution in
-  https://github.com/aws/graph-explorer/pull/1525
+- @Eepsita12 made their first contribution in https://github.com/aws/graph-explorer/pull/1483
+- @abhu85 made their first contribution in https://github.com/aws/graph-explorer/pull/1525
 
 ### All Changes
 
-- Add & use Alert component for settings by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1394
-- Add vertex type switcher to Data Explorer by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1390
-- Remove less frequently used colors by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1397
-- Update roadmap by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1398
-- Update colors with semantic variables by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1400
-- Fix SPARQL query optimization issue (again) by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1402
-- Fix search result disclosure chevron state by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1414
-- Add patch release info to main by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1437
-- Bump version to 2.6.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1438
-- Breakdown Workspace components in to more flexible pieces by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1399
-- Remove explicitly set type names in tests by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1440
-- Update steering to prefer function syntax by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1439
-- Update to use map for counts by type by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1442
-- Use strongly typed VertexType and EdgeType by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1441
-- Update all dependencies by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1444
-- Fix button within button error by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1447
-- Migrate to jotai-family as suggested by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1446
-- Remove redundant schema type by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1450
-- Add EdgeConnection type for Schema Explorer by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1449
+- Add & use Alert component for settings by @kmcginnes in https://github.com/aws/graph-explorer/pull/1394
+- Add vertex type switcher to Data Explorer by @kmcginnes in https://github.com/aws/graph-explorer/pull/1390
+- Remove less frequently used colors by @kmcginnes in https://github.com/aws/graph-explorer/pull/1397
+- Update roadmap by @kmcginnes in https://github.com/aws/graph-explorer/pull/1398
+- Update colors with semantic variables by @kmcginnes in https://github.com/aws/graph-explorer/pull/1400
+- Fix SPARQL query optimization issue (again) by @kmcginnes in https://github.com/aws/graph-explorer/pull/1402
+- Fix search result disclosure chevron state by @kmcginnes in https://github.com/aws/graph-explorer/pull/1414
+- Add patch release info to main by @kmcginnes in https://github.com/aws/graph-explorer/pull/1437
+- Bump version to 2.6.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1438
+- Breakdown Workspace components in to more flexible pieces by @kmcginnes in https://github.com/aws/graph-explorer/pull/1399
+- Remove explicitly set type names in tests by @kmcginnes in https://github.com/aws/graph-explorer/pull/1440
+- Update steering to prefer function syntax by @kmcginnes in https://github.com/aws/graph-explorer/pull/1439
+- Update to use map for counts by type by @kmcginnes in https://github.com/aws/graph-explorer/pull/1442
+- Use strongly typed VertexType and EdgeType by @kmcginnes in https://github.com/aws/graph-explorer/pull/1441
+- Update all dependencies by @kmcginnes in https://github.com/aws/graph-explorer/pull/1444
+- Fix button within button error by @kmcginnes in https://github.com/aws/graph-explorer/pull/1447
+- Migrate to jotai-family as suggested by @kmcginnes in https://github.com/aws/graph-explorer/pull/1446
+- Remove redundant schema type by @kmcginnes in https://github.com/aws/graph-explorer/pull/1450
+- Add EdgeConnection type for Schema Explorer by @kmcginnes in https://github.com/aws/graph-explorer/pull/1449
 - Sort imports by @kmcginnes in https://github.com/aws/graph-explorer/pull/1452
-- Update number formatting to handle smaller numbers by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1460
-- Edge connection discovery queries by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1454
-- Fix Graph component styling by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1463
-- Add edgeConnectionsQuery React Query wrapper by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1464
-- Update Kiro steering instructions by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1465
-- Tweak navigation button UI & data explorer toolbar by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1459
-- Move graph toolbar buttons to shared components by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1466
-- Add basic schema explorer route by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1467
-- Cleanup Docker image and update dependencies by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1468
-- Add patch release to changelog by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1473
-- Consolidate duplicate labels by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1472
-- Standardize terminology across query languages by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1475
-- Refactor entity count formatting to support translations by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1477
-- Hide Display Name Property Selector for SPARQL Edge Styling by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1476
-- Update terminology: "Graph Type" → "Query Language" by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1474
-- Changed queries to get the explorer instance from Jotai by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1479
-- Add export button to Data Explorer by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1462
-- Ensure schema sync occurs when changing connection by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1482
-- Add edge connection discovery on schema refresh by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1484
-- Fix lint errors on save by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1489
-- Update keyword search labels to be more clear by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1488
-- Add SchemaGraph module and UI improvements by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1492
-- Update dependencies and enforce fast-xml-parser minimum version by @kmcginnes
-  in https://github.com/aws/graph-explorer/pull/1497
-- Fix Gremlin edge connection parsing to use key lookup instead of positional
-  destructuring by @kmcginnes in https://github.com/aws/graph-explorer/pull/1498
-- Fix table view to expand when graph view is hidden by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1499
-- Ensure using latest @isaacs/brace-expansion by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1500
-- Simplify TypeScript configuration by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1501
-- Cleanup button props and consolidate IconButton into Button by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1502
-- Add SchemaDiscoveryBoundary for per-route schema sync states by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1509
-- Static nav bar with responsive dropdown menu by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1511
-- Export placeholder missing values as empty in CSV/JSON by @Eepsita12 in
-  https://github.com/aws/graph-explorer/pull/1483
-- Update sidebar tab style to better match nav by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1513
-- fix: EdgeDiscoveryBoundary preserves children after initial edge discovery by
-  @kmcginnes in https://github.com/aws/graph-explorer/pull/1517
-- Show message when multiple items selected in schema graph by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1516
-- Improve SPARQL schema graph and update RDF terminology by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1524
-- Update steering docs with schema storage, related issues, and project
-  references by @kmcginnes in https://github.com/aws/graph-explorer/pull/1527
-- fix(infra): use cross-platform compatible checks script by @abhu85 in
-  https://github.com/aws/graph-explorer/pull/1525
-- docs: add translations section to steering docs by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1529
-- Update some key packages by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1531
-- Add data type descriptions to schema sidebar details by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1533
-- Consolidate edge discovery into SchemaDiscoveryBoundary by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1530
-- Move prefix utilities to utils/rdf/ directory by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1535
-- Update minimatch to latest version by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1536
-- Update eslint, ajv, and qs by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1537
-- Add branded types for RDF namespace and prefix identifiers by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1538
-- Add node and edge styling sidebar panels to Schema Explorer by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1540
-- Move the project management steering to a skill by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1543
-- Update documentation for schema view and navigation changes by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1545
-- Update fast-xml-parser to 5.3.5+ by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1549 (based on #1534 by @abhu85)
-- Bump rollup to 4.59.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1550
-- Migrate agent instructions from steering files to modular skills by @kmcginnes
-  in https://github.com/aws/graph-explorer/pull/1552
-- Bump version to 3.0.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1546
-- Preserve edgeConnections on errors and fix import drop by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1551
-- Add explicit monorepo command instructions to AGENTS.md by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1555
-- Enforce pnpm and fix husky pre-commit hook by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1554
-- Move schema discovery message to sidebar alert by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1553
-- Fix edge connection reset on schema sync by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1556 (based on #1548 by @abhu85)
-- Rewrite prefix generation and replacement logic by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1539
-- Fix documentation inaccuracies across the repository by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1559
+- Update number formatting to handle smaller numbers by @kmcginnes in https://github.com/aws/graph-explorer/pull/1460
+- Edge connection discovery queries by @kmcginnes in https://github.com/aws/graph-explorer/pull/1454
+- Fix Graph component styling by @kmcginnes in https://github.com/aws/graph-explorer/pull/1463
+- Add edgeConnectionsQuery React Query wrapper by @kmcginnes in https://github.com/aws/graph-explorer/pull/1464
+- Update Kiro steering instructions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1465
+- Tweak navigation button UI & data explorer toolbar by @kmcginnes in https://github.com/aws/graph-explorer/pull/1459
+- Move graph toolbar buttons to shared components by @kmcginnes in https://github.com/aws/graph-explorer/pull/1466
+- Add basic schema explorer route by @kmcginnes in https://github.com/aws/graph-explorer/pull/1467
+- Cleanup Docker image and update dependencies by @kmcginnes in https://github.com/aws/graph-explorer/pull/1468
+- Add patch release to changelog by @kmcginnes in https://github.com/aws/graph-explorer/pull/1473
+- Consolidate duplicate labels by @kmcginnes in https://github.com/aws/graph-explorer/pull/1472
+- Standardize terminology across query languages by @kmcginnes in https://github.com/aws/graph-explorer/pull/1475
+- Refactor entity count formatting to support translations by @kmcginnes in https://github.com/aws/graph-explorer/pull/1477
+- Hide Display Name Property Selector for SPARQL Edge Styling by @kmcginnes in https://github.com/aws/graph-explorer/pull/1476
+- Update terminology: "Graph Type" → "Query Language" by @kmcginnes in https://github.com/aws/graph-explorer/pull/1474
+- Changed queries to get the explorer instance from Jotai by @kmcginnes in https://github.com/aws/graph-explorer/pull/1479
+- Add export button to Data Explorer by @dwrth in https://github.com/aws/graph-explorer/pull/1462
+- Ensure schema sync occurs when changing connection by @kmcginnes in https://github.com/aws/graph-explorer/pull/1482
+- Add edge connection discovery on schema refresh by @kmcginnes in https://github.com/aws/graph-explorer/pull/1484
+- Fix lint errors on save by @kmcginnes in https://github.com/aws/graph-explorer/pull/1489
+- Update keyword search labels to be more clear by @kmcginnes in https://github.com/aws/graph-explorer/pull/1488
+- Add SchemaGraph module and UI improvements by @kmcginnes in https://github.com/aws/graph-explorer/pull/1492
+- Update dependencies and enforce fast-xml-parser minimum version by @kmcginnes in https://github.com/aws/graph-explorer/pull/1497
+- Fix Gremlin edge connection parsing to use key lookup instead of positional destructuring by @kmcginnes in https://github.com/aws/graph-explorer/pull/1498
+- Fix table view to expand when graph view is hidden by @kmcginnes in https://github.com/aws/graph-explorer/pull/1499
+- Ensure using latest @isaacs/brace-expansion by @kmcginnes in https://github.com/aws/graph-explorer/pull/1500
+- Simplify TypeScript configuration by @kmcginnes in https://github.com/aws/graph-explorer/pull/1501
+- Cleanup button props and consolidate IconButton into Button by @kmcginnes in https://github.com/aws/graph-explorer/pull/1502
+- Add SchemaDiscoveryBoundary for per-route schema sync states by @kmcginnes in https://github.com/aws/graph-explorer/pull/1509
+- Static nav bar with responsive dropdown menu by @kmcginnes in https://github.com/aws/graph-explorer/pull/1511
+- Export placeholder missing values as empty in CSV/JSON by @Eepsita12 in https://github.com/aws/graph-explorer/pull/1483
+- Update sidebar tab style to better match nav by @kmcginnes in https://github.com/aws/graph-explorer/pull/1513
+- fix: EdgeDiscoveryBoundary preserves children after initial edge discovery by @kmcginnes in https://github.com/aws/graph-explorer/pull/1517
+- Show message when multiple items selected in schema graph by @kmcginnes in https://github.com/aws/graph-explorer/pull/1516
+- Improve SPARQL schema graph and update RDF terminology by @kmcginnes in https://github.com/aws/graph-explorer/pull/1524
+- Update steering docs with schema storage, related issues, and project references by @kmcginnes in https://github.com/aws/graph-explorer/pull/1527
+- fix(infra): use cross-platform compatible checks script by @abhu85 in https://github.com/aws/graph-explorer/pull/1525
+- docs: add translations section to steering docs by @kmcginnes in https://github.com/aws/graph-explorer/pull/1529
+- Update some key packages by @kmcginnes in https://github.com/aws/graph-explorer/pull/1531
+- Add data type descriptions to schema sidebar details by @kmcginnes in https://github.com/aws/graph-explorer/pull/1533
+- Consolidate edge discovery into SchemaDiscoveryBoundary by @kmcginnes in https://github.com/aws/graph-explorer/pull/1530
+- Move prefix utilities to utils/rdf/ directory by @kmcginnes in https://github.com/aws/graph-explorer/pull/1535
+- Update minimatch to latest version by @kmcginnes in https://github.com/aws/graph-explorer/pull/1536
+- Update eslint, ajv, and qs by @kmcginnes in https://github.com/aws/graph-explorer/pull/1537
+- Add branded types for RDF namespace and prefix identifiers by @kmcginnes in https://github.com/aws/graph-explorer/pull/1538
+- Add node and edge styling sidebar panels to Schema Explorer by @kmcginnes in https://github.com/aws/graph-explorer/pull/1540
+- Move the project management steering to a skill by @kmcginnes in https://github.com/aws/graph-explorer/pull/1543
+- Update documentation for schema view and navigation changes by @kmcginnes in https://github.com/aws/graph-explorer/pull/1545
+- Update fast-xml-parser to 5.3.5+ by @kmcginnes in https://github.com/aws/graph-explorer/pull/1549 (based on #1534 by @abhu85)
+- Bump rollup to 4.59.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1550
+- Migrate agent instructions from steering files to modular skills by @kmcginnes in https://github.com/aws/graph-explorer/pull/1552
+- Bump version to 3.0.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1546
+- Preserve edgeConnections on errors and fix import drop by @kmcginnes in https://github.com/aws/graph-explorer/pull/1551
+- Add explicit monorepo command instructions to AGENTS.md by @kmcginnes in https://github.com/aws/graph-explorer/pull/1555
+- Enforce pnpm and fix husky pre-commit hook by @kmcginnes in https://github.com/aws/graph-explorer/pull/1554
+- Move schema discovery message to sidebar alert by @kmcginnes in https://github.com/aws/graph-explorer/pull/1553
+- Fix edge connection reset on schema sync by @kmcginnes in https://github.com/aws/graph-explorer/pull/1556 (based on #1548 by @abhu85)
+- Rewrite prefix generation and replacement logic by @kmcginnes in https://github.com/aws/graph-explorer/pull/1539
+- Fix documentation inaccuracies across the repository by @kmcginnes in https://github.com/aws/graph-explorer/pull/1559
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.5.2...v3.0.0
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.5.2...v3.0.0
 
 ## Release 2.5.2
 
@@ -230,107 +136,67 @@ This release bumps the Node & PNPM versions and cleans up the Docker image.
 
 ### All Changes
 
-- Cleanup Docker image and update dependencies by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1468
+- Cleanup Docker image and update dependencies by @kmcginnes in https://github.com/aws/graph-explorer/pull/1468
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.5.1...v2.5.2
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.5.1...v2.5.2
 
 ## Release 2.5.1
 
-This release includes a fix for a regression that caused neighbor expansion in
-SPARQL databases to perform poorly.
+This release includes a fix for a regression that caused neighbor expansion in SPARQL databases to perform poorly.
 
 ### All Changes
 
-- Fix SPARQL query optimization issue (again) by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1402
+- Fix SPARQL query optimization issue (again) by @kmcginnes in https://github.com/aws/graph-explorer/pull/1402
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.5.0...v2.5.1
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.5.0...v2.5.1
 
 ## Release 2.5.0
 
-This release focuses on improving the graph exploration experience with better
-debugging tools, enhanced node interactions, and performance optimizations.
+This release focuses on improving the graph exploration experience with better debugging tools, enhanced node interactions, and performance optimizations.
 
 ### New Features
 
-- **Raw JSON Response Viewer**: View query results as formatted JSON with syntax
-  highlighting and copy functionality for better debugging
-- **Enhanced Node Expansion**: Expand single or multiple selected nodes
-  simultaneously through an improved context menu
-- **Graph View Improvements**: Added toggle buttons to the empty state and
-  updated the re-layout button icon for clarity
+- **Raw JSON Response Viewer**: View query results as formatted JSON with syntax highlighting and copy functionality for better debugging
+- **Enhanced Node Expansion**: Expand single or multiple selected nodes simultaneously through an improved context menu
+- **Graph View Improvements**: Added toggle buttons to the empty state and updated the re-layout button icon for clarity
 
 ### Improvements
 
-- **Better Context Menu**: Reorganized options with new abilities to center/zoom
-  to selected items and remove all selected items
-- **Performance**: Faster app startup by lazy-loading Cytoscape and other heavy
-  dependencies (38% reduction in initial bundle size)
-- **UI Polish**: Updated table and notification styling, plus fixed node
-  stacking issues in graph rendering
-- **Stability**: Resolved race conditions that caused inconsistent behavior
-  during app initialization
+- **Better Context Menu**: Reorganized options with new abilities to center/zoom to selected items and remove all selected items
+- **Performance**: Faster app startup by lazy-loading Cytoscape and other heavy dependencies (38% reduction in initial bundle size)
+- **UI Polish**: Updated table and notification styling, plus fixed node stacking issues in graph rendering
+- **Stability**: Resolved race conditions that caused inconsistent behavior during app initialization
 
 ### All Changes
 
-- Change Prettier trailing comma option by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1340
-- Update dependencies to the latest versions by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1341
-- Update to Zod v4 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1342
-- Add basic raw response dialog by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1345
-- Change re-layout button icon by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1350
-- Add GraphContext to contain the graphRef by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1351
-- Rework context menu to make more sense by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1352
-- Use Monaco editor for raw response syntax highlighting and folding by
-  @kmcginnes in https://github.com/aws/graph-explorer/pull/1349
-- Add expand option to single target by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1354
-- Remove offset and edgeTypes from neighbor request by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1355
-- Allow expanding multiple nodes at once by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1357
-- Bump body-parser from 2.2.0 to 2.2.1 by @dependabot[bot] in
-  https://github.com/aws/graph-explorer/pull/1353
-- Bump the version to 2.5.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1359
-- Disable scroll pinning in raw response & fix property labels by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1361
-- Add toggle buttons to graph view empty state by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1366
-- Fix node stacking issue with graph canvas rendering by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1365
-- Migrate table components to Tailwind by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1368
-- Add search tokens constants by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1382
-- Move searchable attributes to a hook by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1383
-- Update prefixes to use specific hook by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1384
-- Switch notifications to use Sonner by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1385
-- Introduce code splitting by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1386
-- Move LocalForage preloading to before React is initialized by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1387
-- Fix explorer creation on app load by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1389
-- Fix HTML errors related to table by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1388
-- Update versions of GitHub actions by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1391
+- Change Prettier trailing comma option by @kmcginnes in https://github.com/aws/graph-explorer/pull/1340
+- Update dependencies to the latest versions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1341
+- Update to Zod v4 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1342
+- Add basic raw response dialog by @kmcginnes in https://github.com/aws/graph-explorer/pull/1345
+- Change re-layout button icon by @kmcginnes in https://github.com/aws/graph-explorer/pull/1350
+- Add GraphContext to contain the graphRef by @kmcginnes in https://github.com/aws/graph-explorer/pull/1351
+- Rework context menu to make more sense by @kmcginnes in https://github.com/aws/graph-explorer/pull/1352
+- Use Monaco editor for raw response syntax highlighting and folding by @kmcginnes in https://github.com/aws/graph-explorer/pull/1349
+- Add expand option to single target by @kmcginnes in https://github.com/aws/graph-explorer/pull/1354
+- Remove offset and edgeTypes from neighbor request by @kmcginnes in https://github.com/aws/graph-explorer/pull/1355
+- Allow expanding multiple nodes at once by @kmcginnes in https://github.com/aws/graph-explorer/pull/1357
+- Bump body-parser from 2.2.0 to 2.2.1 by @dependabot[bot] in https://github.com/aws/graph-explorer/pull/1353
+- Bump the version to 2.5.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1359
+- Disable scroll pinning in raw response & fix property labels by @kmcginnes in https://github.com/aws/graph-explorer/pull/1361
+- Add toggle buttons to graph view empty state by @kmcginnes in https://github.com/aws/graph-explorer/pull/1366
+- Fix node stacking issue with graph canvas rendering by @kmcginnes in https://github.com/aws/graph-explorer/pull/1365
+- Migrate table components to Tailwind by @kmcginnes in https://github.com/aws/graph-explorer/pull/1368
+- Add search tokens constants by @kmcginnes in https://github.com/aws/graph-explorer/pull/1382
+- Move searchable attributes to a hook by @kmcginnes in https://github.com/aws/graph-explorer/pull/1383
+- Update prefixes to use specific hook by @kmcginnes in https://github.com/aws/graph-explorer/pull/1384
+- Switch notifications to use Sonner by @kmcginnes in https://github.com/aws/graph-explorer/pull/1385
+- Introduce code splitting by @kmcginnes in https://github.com/aws/graph-explorer/pull/1386
+- Move LocalForage preloading to before React is initialized by @kmcginnes in https://github.com/aws/graph-explorer/pull/1387
+- Fix explorer creation on app load by @kmcginnes in https://github.com/aws/graph-explorer/pull/1389
+- Fix HTML errors related to table by @kmcginnes in https://github.com/aws/graph-explorer/pull/1388
+- Update versions of GitHub actions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1391
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.4.1...v2.5.0
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.4.1...v2.5.0
 
 ## Release v2.4.1
 
@@ -345,88 +211,50 @@ This release includes several important bug fixes and improvements, notably:
 
 ### All Changes
 
-- Update TypeScript configs for consistency by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1274
-- Use verbatimModuleSyntax and make imports consistent by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1278
-- Update dependencies post release by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1282
-- Use Activity for sidebar by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1290
-- Make style dialogs more global by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1291
-- Fix auto open details on selection issue in context menu actions by @kmcginnes
-  in https://github.com/aws/graph-explorer/pull/1292
-- Update Tailwind to v4 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1293
-- Bump version to 2.4.1 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1295
-- Remove forwardRef by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1296
-- Fix sidebar color issue by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1297
-- Fix layout issues by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1298
-- Fix container query issues by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1300
-- Cleanup from Tailwind upgrade by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1301
-- Fix handling of long labels across app UI by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1302
-- Update node & edge style dialogs by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1303
-- Add general steering rules for claude/q/kiro by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1305
-- Fix auto open details again by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1306
-- Fix null prefix by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1307
-- Remove `searchable` and `hidden` from `AttributeConfig` by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1311
-- Create schema entries for multi-label entities by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1312
-- Use default values for user preferences by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1313
-- Remove vertexTypes from expand neighbors request by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1314
-- Update canvas data to include label info by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1315
-- Add unit tests around connections by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1318
-- Use universal Jotai store by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1320
-- Update vertex and edge canvas state with query results by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1321
-- Update ESLint configuration by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1322
-- Fix re-renders in some core spots by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1324
-- Update atomWithLocalStorage to be cached and synchronous by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1323
-- Refactor schema, preferences, display types by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1316
-- Add refresh button for vertices and edges by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1325
-- Minor optimizations for refactored Jotai state by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1332
+- Update TypeScript configs for consistency by @kmcginnes in https://github.com/aws/graph-explorer/pull/1274
+- Use verbatimModuleSyntax and make imports consistent by @kmcginnes in https://github.com/aws/graph-explorer/pull/1278
+- Update dependencies post release by @kmcginnes in https://github.com/aws/graph-explorer/pull/1282
+- Use Activity for sidebar by @kmcginnes in https://github.com/aws/graph-explorer/pull/1290
+- Make style dialogs more global by @kmcginnes in https://github.com/aws/graph-explorer/pull/1291
+- Fix auto open details on selection issue in context menu actions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1292
+- Update Tailwind to v4 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1293
+- Bump version to 2.4.1 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1295
+- Remove forwardRef by @kmcginnes in https://github.com/aws/graph-explorer/pull/1296
+- Fix sidebar color issue by @kmcginnes in https://github.com/aws/graph-explorer/pull/1297
+- Fix layout issues by @kmcginnes in https://github.com/aws/graph-explorer/pull/1298
+- Fix container query issues by @kmcginnes in https://github.com/aws/graph-explorer/pull/1300
+- Cleanup from Tailwind upgrade by @kmcginnes in https://github.com/aws/graph-explorer/pull/1301
+- Fix handling of long labels across app UI by @kmcginnes in https://github.com/aws/graph-explorer/pull/1302
+- Update node & edge style dialogs by @kmcginnes in https://github.com/aws/graph-explorer/pull/1303
+- Add general steering rules for claude/q/kiro by @kmcginnes in https://github.com/aws/graph-explorer/pull/1305
+- Fix auto open details again by @kmcginnes in https://github.com/aws/graph-explorer/pull/1306
+- Fix null prefix by @kmcginnes in https://github.com/aws/graph-explorer/pull/1307
+- Remove `searchable` and `hidden` from `AttributeConfig` by @kmcginnes in https://github.com/aws/graph-explorer/pull/1311
+- Create schema entries for multi-label entities by @kmcginnes in https://github.com/aws/graph-explorer/pull/1312
+- Use default values for user preferences by @kmcginnes in https://github.com/aws/graph-explorer/pull/1313
+- Remove vertexTypes from expand neighbors request by @kmcginnes in https://github.com/aws/graph-explorer/pull/1314
+- Update canvas data to include label info by @kmcginnes in https://github.com/aws/graph-explorer/pull/1315
+- Add unit tests around connections by @kmcginnes in https://github.com/aws/graph-explorer/pull/1318
+- Use universal Jotai store by @kmcginnes in https://github.com/aws/graph-explorer/pull/1320
+- Update vertex and edge canvas state with query results by @kmcginnes in https://github.com/aws/graph-explorer/pull/1321
+- Update ESLint configuration by @kmcginnes in https://github.com/aws/graph-explorer/pull/1322
+- Fix re-renders in some core spots by @kmcginnes in https://github.com/aws/graph-explorer/pull/1324
+- Update atomWithLocalStorage to be cached and synchronous by @kmcginnes in https://github.com/aws/graph-explorer/pull/1323
+- Refactor schema, preferences, display types by @kmcginnes in https://github.com/aws/graph-explorer/pull/1316
+- Add refresh button for vertices and edges by @kmcginnes in https://github.com/aws/graph-explorer/pull/1325
+- Minor optimizations for refactored Jotai state by @kmcginnes in https://github.com/aws/graph-explorer/pull/1332
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.4.0...v2.4.1
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.4.0...v2.4.1
 
 ## Release v2.4.0
 
-This release introduces support for SPARQL queries within the query editor. Now,
-all three query engines are supported: Gremlin, openCypher, and SPARQL. This
-does not mean we are done with the query editor. We have many exciting ideas
-being considered for future releases.
+This release introduces support for SPARQL queries within the query editor. Now, all three query engines are supported: Gremlin, openCypher, and SPARQL. This does not mean we are done with the query editor. We have many exciting ideas being considered for future releases.
 
 ### SPARQL Query Support
 
 - Support for `SELECT`, `ASK`, `DESCRIBE`, and `CONSTRUCT` queries
-- `DESCRIBE` and `CONSTRUCT` queries will result in fully materialized vertex
-  and edge results
-- `SELECT` and `ASK` queries will result in raw statements, but do not
-  materialize results as vertices or edges
+- `DESCRIBE` and `CONSTRUCT` queries will result in fully materialized vertex and edge results
+- `SELECT` and `ASK` queries will result in raw statements, but do not materialize results as vertices or edges
 - Support for RDF resources without a defined `rdf:type`
 - Updated display name defaults to use `rdfs:label` if it is available
 
@@ -435,145 +263,81 @@ being considered for future releases.
 - Added support for vertices that have no label in openCypher
 - Hide properties that don't have a value for the given vertex or edge
 - Added confirmation dialog when deleting a connection (thanks @dwrth)
-- Added ability to horizontally scroll toolbars if space is limited (thanks
-  @Ansh2004P)
+- Added ability to horizontally scroll toolbars if space is limited (thanks @Ansh2004P)
 - Added zoom to fit toolbar button (thanks @cnaples79)
-- Updated the strings used to represent no value, no type, and empty value to be
-  more clear
-- Updated handling of neighbor counts when neighbors have more than one type or
-  label
+- Updated the strings used to represent no value, no type, and empty value to be more clear
+- Updated handling of neighbor counts when neighbors have more than one type or label
 - Updated handling of date values, specifically in openCypher connections
 - Updated behavior of auto open details panel when a node is selected
 - Fixed many bugs
 
 ### All Changes
 
-- Adjust styles in DialogFooter by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1147
-- Bump version to 2.4.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1132
-- Remove unused code by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1131
-- Use DialogFooter in LoadConfigButton dialog by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1148
-- Increase randomness in generated test strings by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1153
-- Add confirmation to deleting a connection by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1136
-- Update dependencies by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1155
-- Fix node icon color change by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1103
-- Add steering doc for documentation by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1164
-- Use consistent Spinner component across app by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1130
-- Update TypeScript config for Node 24 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1156
-- Migrate EdgeStyleDialog to tailwind by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1151
-- Migrate CreateConnection to Tailwind by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1150
-- Use verbatimModuleSyntax in proxy server by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1157
-- Clear graph restore progress notification by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1172
-- Fix input lag when changing node and edge colors by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1173
-- Update minor versions by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1181
-- Add testing steering document by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1182
-- Simplify vertex detail query by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1186
-- Fix neighbor expansion when no attributes by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1185
-- Remove old async relics by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1180
-- Streamline useGraphStyles hook by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1183
-- Simplify queryClient test setup by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1179
-- Include headers in IAM request signing by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1198
-- Disable retries for user query by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1201
-- Fix neighbor expansion in SPARQL by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1195
-- Add SPARQL support to user queries by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1199
-- Fix Panel header overflow causing canvas to scroll off-screen by @Ansh2004P in
-  https://github.com/aws/graph-explorer/pull/1142
-- Update documentation for SPARQL query editor by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1211
-- Reduce risk of malicious packages by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1215
-- Disable spell check, auto capitalize/complete by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1225
-- Use store for Jotai state in tests by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1216
-- Add date as entity property value by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1220
-- feat: add Zoom to Fit button to graph canvas toolbar by @cnaples79 in
-  https://github.com/aws/graph-explorer/pull/1229
-- Fix multi label/class support in neighbor counts by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1194
-- Fix keyword search when resource has no attributes by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1230
-- Update rawQuery tests to use sparql helpers by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1236
-- Fix bug in testable edge with rdf values by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1238
-- Switch vertex details to map quads by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1239
-- Update raw query with mapping logic by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1241
-- Bump happy-dom from 18.0.1 to 20.0.0 by @dependabot[bot] in
-  https://github.com/aws/graph-explorer/pull/1244
-- Execute neighbor count queries in parallel by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1243
-- Update tests for DisplayVertexTypeConfig by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1246
-- Update fetch neighbors to use quad mapping by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1240
-- Consolidate blank node mapping logic by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1245
-- Move ASCII constants to module by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1251
-- Move labels in to module by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1252
-- Fix scrollbar placement in `Tabular` by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1257
-- Minor tweaks for consolidated mapping logic by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1248
-- Ensure rdfs:label is first attribute by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1247
-- Update labels used when there is no value by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1253
-- Add check for empty string and use friendly string by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1254
-- Fix auto open details by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1262
-- Don’t add missing attributes to vertex or edge by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1255
-- Use shared filter helpers across queries by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1256
-- Support RDF resources that have no type or class defined by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1258
-- Bump happy-dom from 20.0.0 to 20.0.2 by @dependabot[bot] in
-  https://github.com/aws/graph-explorer/pull/1266
-- Save query state on every change by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1269
+- Adjust styles in DialogFooter by @kmcginnes in https://github.com/aws/graph-explorer/pull/1147
+- Bump version to 2.4.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1132
+- Remove unused code by @kmcginnes in https://github.com/aws/graph-explorer/pull/1131
+- Use DialogFooter in LoadConfigButton dialog by @kmcginnes in https://github.com/aws/graph-explorer/pull/1148
+- Increase randomness in generated test strings by @kmcginnes in https://github.com/aws/graph-explorer/pull/1153
+- Add confirmation to deleting a connection by @dwrth in https://github.com/aws/graph-explorer/pull/1136
+- Update dependencies by @kmcginnes in https://github.com/aws/graph-explorer/pull/1155
+- Fix node icon color change by @dwrth in https://github.com/aws/graph-explorer/pull/1103
+- Add steering doc for documentation by @kmcginnes in https://github.com/aws/graph-explorer/pull/1164
+- Use consistent Spinner component across app by @kmcginnes in https://github.com/aws/graph-explorer/pull/1130
+- Update TypeScript config for Node 24 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1156
+- Migrate EdgeStyleDialog to tailwind by @kmcginnes in https://github.com/aws/graph-explorer/pull/1151
+- Migrate CreateConnection to Tailwind by @kmcginnes in https://github.com/aws/graph-explorer/pull/1150
+- Use verbatimModuleSyntax in proxy server by @kmcginnes in https://github.com/aws/graph-explorer/pull/1157
+- Clear graph restore progress notification by @dwrth in https://github.com/aws/graph-explorer/pull/1172
+- Fix input lag when changing node and edge colors by @dwrth in https://github.com/aws/graph-explorer/pull/1173
+- Update minor versions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1181
+- Add testing steering document by @kmcginnes in https://github.com/aws/graph-explorer/pull/1182
+- Simplify vertex detail query by @kmcginnes in https://github.com/aws/graph-explorer/pull/1186
+- Fix neighbor expansion when no attributes by @kmcginnes in https://github.com/aws/graph-explorer/pull/1185
+- Remove old async relics by @kmcginnes in https://github.com/aws/graph-explorer/pull/1180
+- Streamline useGraphStyles hook by @kmcginnes in https://github.com/aws/graph-explorer/pull/1183
+- Simplify queryClient test setup by @kmcginnes in https://github.com/aws/graph-explorer/pull/1179
+- Include headers in IAM request signing by @kmcginnes in https://github.com/aws/graph-explorer/pull/1198
+- Disable retries for user query by @kmcginnes in https://github.com/aws/graph-explorer/pull/1201
+- Fix neighbor expansion in SPARQL by @kmcginnes in https://github.com/aws/graph-explorer/pull/1195
+- Add SPARQL support to user queries by @kmcginnes in https://github.com/aws/graph-explorer/pull/1199
+- Fix Panel header overflow causing canvas to scroll off-screen by @Ansh2004P in https://github.com/aws/graph-explorer/pull/1142
+- Update documentation for SPARQL query editor by @kmcginnes in https://github.com/aws/graph-explorer/pull/1211
+- Reduce risk of malicious packages by @kmcginnes in https://github.com/aws/graph-explorer/pull/1215
+- Disable spell check, auto capitalize/complete by @kmcginnes in https://github.com/aws/graph-explorer/pull/1225
+- Use store for Jotai state in tests by @kmcginnes in https://github.com/aws/graph-explorer/pull/1216
+- Add date as entity property value by @kmcginnes in https://github.com/aws/graph-explorer/pull/1220
+- feat: add Zoom to Fit button to graph canvas toolbar by @cnaples79 in https://github.com/aws/graph-explorer/pull/1229
+- Fix multi label/class support in neighbor counts by @kmcginnes in https://github.com/aws/graph-explorer/pull/1194
+- Fix keyword search when resource has no attributes by @kmcginnes in https://github.com/aws/graph-explorer/pull/1230
+- Update rawQuery tests to use sparql helpers by @kmcginnes in https://github.com/aws/graph-explorer/pull/1236
+- Fix bug in testable edge with rdf values by @kmcginnes in https://github.com/aws/graph-explorer/pull/1238
+- Switch vertex details to map quads by @kmcginnes in https://github.com/aws/graph-explorer/pull/1239
+- Update raw query with mapping logic by @kmcginnes in https://github.com/aws/graph-explorer/pull/1241
+- Bump happy-dom from 18.0.1 to 20.0.0 by @dependabot[bot] in https://github.com/aws/graph-explorer/pull/1244
+- Execute neighbor count queries in parallel by @kmcginnes in https://github.com/aws/graph-explorer/pull/1243
+- Update tests for DisplayVertexTypeConfig by @kmcginnes in https://github.com/aws/graph-explorer/pull/1246
+- Update fetch neighbors to use quad mapping by @kmcginnes in https://github.com/aws/graph-explorer/pull/1240
+- Consolidate blank node mapping logic by @kmcginnes in https://github.com/aws/graph-explorer/pull/1245
+- Move ASCII constants to module by @kmcginnes in https://github.com/aws/graph-explorer/pull/1251
+- Move labels in to module by @kmcginnes in https://github.com/aws/graph-explorer/pull/1252
+- Fix scrollbar placement in `Tabular` by @dwrth in https://github.com/aws/graph-explorer/pull/1257
+- Minor tweaks for consolidated mapping logic by @kmcginnes in https://github.com/aws/graph-explorer/pull/1248
+- Ensure rdfs:label is first attribute by @kmcginnes in https://github.com/aws/graph-explorer/pull/1247
+- Update labels used when there is no value by @kmcginnes in https://github.com/aws/graph-explorer/pull/1253
+- Add check for empty string and use friendly string by @kmcginnes in https://github.com/aws/graph-explorer/pull/1254
+- Fix auto open details by @kmcginnes in https://github.com/aws/graph-explorer/pull/1262
+- Don’t add missing attributes to vertex or edge by @kmcginnes in https://github.com/aws/graph-explorer/pull/1255
+- Use shared filter helpers across queries by @kmcginnes in https://github.com/aws/graph-explorer/pull/1256
+- Support RDF resources that have no type or class defined by @kmcginnes in https://github.com/aws/graph-explorer/pull/1258
+- Bump happy-dom from 20.0.0 to 20.0.2 by @dependabot[bot] in https://github.com/aws/graph-explorer/pull/1266
+- Save query state on every change by @kmcginnes in https://github.com/aws/graph-explorer/pull/1269
 
 ### New Contributors
 
-- @Ansh2004P made their first contribution in
-  https://github.com/aws/graph-explorer/pull/1142
-- @cnaples79 made their first contribution in
-  https://github.com/aws/graph-explorer/pull/1229
+- @Ansh2004P made their first contribution in https://github.com/aws/graph-explorer/pull/1142
+- @cnaples79 made their first contribution in https://github.com/aws/graph-explorer/pull/1229
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.3.1...v2.4.0
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.3.1...v2.4.0
 
 ## Release v2.3.1
 
@@ -581,24 +345,16 @@ This release resolves a few important issues from the previous release.
 
 ### All changes
 
-- Remove past roadmap items by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1116
-- Add OpenSSL back to Docker by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1137
-- Bump version to 2.3.1 for patch by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1138
-- Fix expand neighbor query when edge ID is UUID by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1140
+- Remove past roadmap items by @kmcginnes in https://github.com/aws/graph-explorer/pull/1116
+- Add OpenSSL back to Docker by @kmcginnes in https://github.com/aws/graph-explorer/pull/1137
+- Bump version to 2.3.1 for patch by @kmcginnes in https://github.com/aws/graph-explorer/pull/1138
+- Fix expand neighbor query when edge ID is UUID by @kmcginnes in https://github.com/aws/graph-explorer/pull/1140
 
-**Full Changelog**:
-https://github.com/aws/graph-explorer/compare/v2.3.0...v2.3.1
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v2.3.0...v2.3.1
 
 ## Release v2.3
 
-This release improves the accuracy when rendering query results by preserving
-result names, properly rendering grouped data structures like maps, embedding
-source and target node information within edge results, and refining the overall
-results interface for better clarity.
+This release improves the accuracy when rendering query results by preserving result names, properly rendering grouped data structures like maps, embedding source and target node information within edge results, and refining the overall results interface for better clarity.
 
 ### Major changes
 
@@ -607,364 +363,177 @@ results interface for better clarity.
 - **Added** nested source & target vertex results inside of edge results
 - **Added** support for grouped data structures like maps and paths
 - **Updated** vertex and edge results to highlight when added to the graph
-- **Fixed** table view filter and sort reset when toggled off/on (thanks @dwrth
-  🎉)
+- **Fixed** table view filter and sort reset when toggled off/on (thanks @dwrth 🎉)
 - **Updated** Gremlin expand neighbors query performance by removing sorting
 
 ### All changes
 
-- Add context for Kiro by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1063
-- Remove unused dependencies by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1076
-- Refactor entity logic and add scalar as entity by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1075
-- Update Node and use official binaries by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1077
-- Remove unused code by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1079
-- Remove all usages of Mantine by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1080
-- Update search result UI by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1081
-- Split queries in to multiple files by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1084
-- Use more conventional approach to React Router by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1083
-- Migrate manual query from a mutation to a query by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1082
-- Fixes render issue for vertex & edge properties by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1089
-- Use arrays instead of Map inside Entities by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1090
-- Simplify Scalar type by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1092
-- Remove vertex info from Edge type by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1096
-- Produce more accurate query results by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1091
-- Bump version to 2.3.0 by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1106
-- Persistent table filtering and sorting by @dwrth in
-  https://github.com/aws/graph-explorer/pull/1100
-- Remove order by ID in fetch neighbors by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1112
-- Add highlight to nodes/edges added to the graph by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1111
-- Fix result count alignment when nothing to add to graph by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1107
-- Reorganize result types in to connector namespace by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1114
-- Add results title for query results by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1115
-- Show no attributes when none exist by @kmcginnes in
-  https://github.com/aws/graph-explorer/pull/1113
+- Add context for Kiro by @kmcginnes in https://github.com/aws/graph-explorer/pull/1063
+- Remove unused dependencies by @kmcginnes in https://github.com/aws/graph-explorer/pull/1076
+- Refactor entity logic and add scalar as entity by @kmcginnes in https://github.com/aws/graph-explorer/pull/1075
+- Update Node and use official binaries by @kmcginnes in https://github.com/aws/graph-explorer/pull/1077
+- Remove unused code by @kmcginnes in https://github.com/aws/graph-explorer/pull/1079
+- Remove all usages of Mantine by @kmcginnes in https://github.com/aws/graph-explorer/pull/1080
+- Update search result UI by @kmcginnes in https://github.com/aws/graph-explorer/pull/1081
+- Split queries in to multiple files by @kmcginnes in https://github.com/aws/graph-explorer/pull/1084
+- Use more conventional approach to React Router by @kmcginnes in https://github.com/aws/graph-explorer/pull/1083
+- Migrate manual query from a mutation to a query by @kmcginnes in https://github.com/aws/graph-explorer/pull/1082
+- Fixes render issue for vertex & edge properties by @kmcginnes in https://github.com/aws/graph-explorer/pull/1089
+- Use arrays instead of Map inside Entities by @kmcginnes in https://github.com/aws/graph-explorer/pull/1090
+- Simplify Scalar type by @kmcginnes in https://github.com/aws/graph-explorer/pull/1092
+- Remove vertex info from Edge type by @kmcginnes in https://github.com/aws/graph-explorer/pull/1096
+- Produce more accurate query results by @kmcginnes in https://github.com/aws/graph-explorer/pull/1091
+- Bump version to 2.3.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1106
+- Persistent table filtering and sorting by @dwrth in https://github.com/aws/graph-explorer/pull/1100
+- Remove order by ID in fetch neighbors by @kmcginnes in https://github.com/aws/graph-explorer/pull/1112
+- Add highlight to nodes/edges added to the graph by @kmcginnes in https://github.com/aws/graph-explorer/pull/1111
+- Fix result count alignment when nothing to add to graph by @kmcginnes in https://github.com/aws/graph-explorer/pull/1107
+- Reorganize result types in to connector namespace by @kmcginnes in https://github.com/aws/graph-explorer/pull/1114
+- Add results title for query results by @kmcginnes in https://github.com/aws/graph-explorer/pull/1115
+- Show no attributes when none exist by @kmcginnes in https://github.com/aws/graph-explorer/pull/1113
 
 ### New Contributors
 
-- @dwrth made their first contribution in
-  https://github.com/aws/graph-explorer/pull/1100
+- @dwrth made their first contribution in https://github.com/aws/graph-explorer/pull/1100
 
 ## Release v2.2
 
-This release brings significant performance improvements for the query editor,
-restoring graph session, and other operations that typically need to query for
-details about many nodes & edges all at once.
+This release brings significant performance improvements for the query editor, restoring graph session, and other operations that typically need to query for details about many nodes & edges all at once.
 
-In prior releases, this would manifest in multiple queries per node or edge,
-which could bog down the browser and overload the servers. With this release,
-similar types of requests are now batched together to reduce the number of
-requests down to around 3 requests in typical situations. This leads to better
-utilization of network bandwidth, reduces the load on both browser and server,
-and results in a more responsive UI.
+In prior releases, this would manifest in multiple queries per node or edge, which could bog down the browser and overload the servers. With this release, similar types of requests are now batched together to reduce the number of requests down to around 3 requests in typical situations. This leads to better utilization of network bandwidth, reduces the load on both browser and server, and results in a more responsive UI.
 
 ### Major changes
 
-- **Updated** query logic to prefer batching similar requests in groups of 100
-  instead of individual requests
-  ([#1044](https://github.com/aws/graph-explorer/pull/1044),
-  [#1048](https://github.com/aws/graph-explorer/pull/1048),
-  [#1065](https://github.com/aws/graph-explorer/pull/1065),
-  [#1068](https://github.com/aws/graph-explorer/pull/1068))
+- **Updated** query logic to prefer batching similar requests in groups of 100 instead of individual requests ([#1044](https://github.com/aws/graph-explorer/pull/1044), [#1048](https://github.com/aws/graph-explorer/pull/1048), [#1065](https://github.com/aws/graph-explorer/pull/1065), [#1068](https://github.com/aws/graph-explorer/pull/1068))
 
 ### Other changes
 
-- **Updated** roadmap to move SPARQL query editor up in priority
-  ([#1066](https://github.com/aws/graph-explorer/pull/1066))
-- **Updated** imperative query logic to check for a cache value first
-  ([#1047](https://github.com/aws/graph-explorer/pull/1047))
-- **Updated** Tanstack Query logic to simplify query construction
-  ([#1015](https://github.com/aws/graph-explorer/pull/1015),
-  [#1040](https://github.com/aws/graph-explorer/pull/1040),
-  [#1042](https://github.com/aws/graph-explorer/pull/1042))
-- **Fixed** rendering boolean values for Gremlin connections
-  ([#1034](https://github.com/aws/graph-explorer/pull/1034))
-- **Added** troubleshooting steps for mismatched proxy server to documentation
-  ([#1062](https://github.com/aws/graph-explorer/pull/1062))
-- **Fixed** brittleness of some tests
-  ([#1070](https://github.com/aws/graph-explorer/pull/1070))
+- **Updated** roadmap to move SPARQL query editor up in priority ([#1066](https://github.com/aws/graph-explorer/pull/1066))
+- **Updated** imperative query logic to check for a cache value first ([#1047](https://github.com/aws/graph-explorer/pull/1047))
+- **Updated** Tanstack Query logic to simplify query construction ([#1015](https://github.com/aws/graph-explorer/pull/1015), [#1040](https://github.com/aws/graph-explorer/pull/1040), [#1042](https://github.com/aws/graph-explorer/pull/1042))
+- **Fixed** rendering boolean values for Gremlin connections ([#1034](https://github.com/aws/graph-explorer/pull/1034))
+- **Added** troubleshooting steps for mismatched proxy server to documentation ([#1062](https://github.com/aws/graph-explorer/pull/1062))
+- **Fixed** brittleness of some tests ([#1070](https://github.com/aws/graph-explorer/pull/1070))
 
 ## Release v2.1
 
-This release continues the momentum of the last release, **introducing query
-editor support for openCypher connections**. This enables the use of the query
-editor with Neptune Analytics for the first time.
+This release continues the momentum of the last release, **introducing query editor support for openCypher connections**. This enables the use of the query editor with Neptune Analytics for the first time.
 
-As before, if you are a Neptune user concerned about data integrity, check out
-the
-[instructions on configuring IAM permissions to restrict mutations](./README.md#permissions),
-ensuring that users can enforce read-only operations.
+As before, if you are a Neptune user concerned about data integrity, check out the [instructions on configuring IAM permissions to restrict mutations](./README.md#permissions), ensuring that users can enforce read-only operations.
 
 ### New features & major changes
 
-- **Added** support for openCypher in the query editor
-  ([#1016](https://github.com/aws/graph-explorer/pull/1016),
-  [#1024](https://github.com/aws/graph-explorer/pull/1024),
-  [#1035](https://github.com/aws/graph-explorer/pull/1035))
+- **Added** support for openCypher in the query editor ([#1016](https://github.com/aws/graph-explorer/pull/1016), [#1024](https://github.com/aws/graph-explorer/pull/1024), [#1035](https://github.com/aws/graph-explorer/pull/1035))
 
 ### Other changes
 
-- **Added** close button to table view
-  ([#1026](https://github.com/aws/graph-explorer/pull/1026))
-- **Updated** label for properties count in connection detail
-  ([#1030](https://github.com/aws/graph-explorer/pull/1030))
-- **Updated** dependencies to latest versions and some minor refactorings
-  ([#1014](https://github.com/aws/graph-explorer/pull/1014),
-  [#1023](https://github.com/aws/graph-explorer/pull/1023),
-  [#1025](https://github.com/aws/graph-explorer/pull/1025),
-  [#1027](https://github.com/aws/graph-explorer/pull/1027))
+- **Added** close button to table view ([#1026](https://github.com/aws/graph-explorer/pull/1026))
+- **Updated** label for properties count in connection detail ([#1030](https://github.com/aws/graph-explorer/pull/1030))
+- **Updated** dependencies to latest versions and some minor refactorings ([#1014](https://github.com/aws/graph-explorer/pull/1014), [#1023](https://github.com/aws/graph-explorer/pull/1023), [#1025](https://github.com/aws/graph-explorer/pull/1025), [#1027](https://github.com/aws/graph-explorer/pull/1027))
 
 ## Release v2.0
 
-Graph Explorer v2.0 marks a significant milestone with the introduction of the
-new
-[query editor for Gremlin connections](./additionaldocs/features/README.md#query-search).
-This powerful feature allows users to enter any valid Gremlin query and
-visualize the returned nodes, edges, and scalar values directly from the
-database. You can review the results in the sidebar and choose to add all nodes
-& edges to the graph or add results individually.
+Graph Explorer v2.0 marks a significant milestone with the introduction of the new [query editor for Gremlin connections](./additionaldocs/features/README.md#query-search). This powerful feature allows users to enter any valid Gremlin query and visualize the returned nodes, edges, and scalar values directly from the database. You can review the results in the sidebar and choose to add all nodes & edges to the graph or add results individually.
 
-For Neptune users concerned about data integrity, [the README](./README.md) now
-includes
-[instructions on configuring IAM permissions to restrict mutations](./README.md#permissions),
-ensuring users can enforce read-only operations.
+For Neptune users concerned about data integrity, [the README](./README.md) now includes [instructions on configuring IAM permissions to restrict mutations](./README.md#permissions), ensuring users can enforce read-only operations.
 
-The release also changes the default strategy for representing node & edge
-labels in the UI. The app no longer performs any transformations on these names,
-providing a more intuitive and accurate representation of your data. For RDF
-datasets, namespace prefixes will continue to be substituted.
+The release also changes the default strategy for representing node & edge labels in the UI. The app no longer performs any transformations on these names, providing a more intuitive and accurate representation of your data. For RDF datasets, namespace prefixes will continue to be substituted.
 
-Additionally, graph layout options now have a more intuitive organization, and
-new directions have been added for hierarchical, subway, and klay layouts.
+Additionally, graph layout options now have a more intuitive organization, and new directions have been added for hierarchical, subway, and klay layouts.
 
 ### New features & major changes
 
-- **Added** query editor for Gremlin connections
-  ([#686](https://github.com/aws/graph-explorer/issues/686),
-  [#949](https://github.com/aws/graph-explorer/pull/949),
-  [#947](https://github.com/aws/graph-explorer/pull/947),
-  [#956](https://github.com/aws/graph-explorer/pull/956),
-  [#957](https://github.com/aws/graph-explorer/pull/957),
-  [#974](https://github.com/aws/graph-explorer/pull/974),
-  [#958](https://github.com/aws/graph-explorer/pull/958),
-  [#989](https://github.com/aws/graph-explorer/pull/989),
-  [#991](https://github.com/aws/graph-explorer/pull/991))
-- **Changed** node & edge label strategy to better represent true database names
-  ([#996](https://github.com/aws/graph-explorer/pull/996))
-- **Updated** graph layout options to include better descriptions and new
-  directions for hierarchical and subway
-  ([#973](https://github.com/aws/graph-explorer/pull/973))
+- **Added** query editor for Gremlin connections ([#686](https://github.com/aws/graph-explorer/issues/686), [#949](https://github.com/aws/graph-explorer/pull/949), [#947](https://github.com/aws/graph-explorer/pull/947), [#956](https://github.com/aws/graph-explorer/pull/956), [#957](https://github.com/aws/graph-explorer/pull/957), [#974](https://github.com/aws/graph-explorer/pull/974), [#958](https://github.com/aws/graph-explorer/pull/958), [#989](https://github.com/aws/graph-explorer/pull/989), [#991](https://github.com/aws/graph-explorer/pull/991))
+- **Changed** node & edge label strategy to better represent true database names ([#996](https://github.com/aws/graph-explorer/pull/996))
+- **Updated** graph layout options to include better descriptions and new directions for hierarchical and subway ([#973](https://github.com/aws/graph-explorer/pull/973))
 
 ### Other changes
 
-- **Updated** too many requests error message for accuracy
-  ([#990](https://github.com/aws/graph-explorer/pull/990))
-- **Fixed** multiple selection box behavior
-  ([#987](https://github.com/aws/graph-explorer/pull/987))
-- **Fixed** resizing columns in table view
-  ([#988](https://github.com/aws/graph-explorer/pull/988))
-- **Fixed** search result row separators to ensure they are always rendered
-  properly ([#997](https://github.com/aws/graph-explorer/pull/997))
+- **Updated** too many requests error message for accuracy ([#990](https://github.com/aws/graph-explorer/pull/990))
+- **Fixed** multiple selection box behavior ([#987](https://github.com/aws/graph-explorer/pull/987))
+- **Fixed** resizing columns in table view ([#988](https://github.com/aws/graph-explorer/pull/988))
+- **Fixed** search result row separators to ensure they are always rendered properly ([#997](https://github.com/aws/graph-explorer/pull/997))
 
 ## Release v1.16.0
 
-This release of Graph Explorer introduces significant usability improvements and
-performance enhancements. Users now have greater control over their exploration
-experience with the ability to customize default neighbor expansion limits and
-resize the sidebar. The connection interface has been refined with more
-intuitive placement of the sync button near the last sync timestamp.
+This release of Graph Explorer introduces significant usability improvements and performance enhancements. Users now have greater control over their exploration experience with the ability to customize default neighbor expansion limits and resize the sidebar. The connection interface has been refined with more intuitive placement of the sync button near the last sync timestamp.
 
-Performance has been enhanced across multiple areas, particularly for RDF
-datasets where neighbor expansion is now faster. The openCypher expand neighbor
-query has been optimized for scenarios without limits, and the neighbor count
-query now shows the full count of neighbors without restrictions. Under the
-hood, the application has undergone significant architectural improvements,
-transitioning from Recoil to Jotai for state management and implementing the
-React Compiler to boost overall rendering performance. These technical updates,
-along with numerous dependency updates and bug fixes, result in a more
-responsive and reliable experience.
+Performance has been enhanced across multiple areas, particularly for RDF datasets where neighbor expansion is now faster. The openCypher expand neighbor query has been optimized for scenarios without limits, and the neighbor count query now shows the full count of neighbors without restrictions. Under the hood, the application has undergone significant architectural improvements, transitioning from Recoil to Jotai for state management and implementing the React Compiler to boost overall rendering performance. These technical updates, along with numerous dependency updates and bug fixes, result in a more responsive and reliable experience.
 
 ### New Features
 
-- **Added** ability to customize default neighbor expansion limit
-  ([#925](https://github.com/aws/graph-explorer/pull/925))
-- **Added** ability to resize the sidebar
-  ([#938](https://github.com/aws/graph-explorer/pull/938))
+- **Added** ability to customize default neighbor expansion limit ([#925](https://github.com/aws/graph-explorer/pull/925))
+- **Added** ability to resize the sidebar ([#938](https://github.com/aws/graph-explorer/pull/938))
 
 ### Other changes
 
-- **Improved** Improved connection details by moving the sync button near the
-  last sync timestamp (thanks @enumura1,
-  [#901](https://github.com/aws/graph-explorer/pull/901),
-  [#908](https://github.com/aws/graph-explorer/pull/908))
-- **Improved** performance of neighbor expansion in RDF datasets
-  ([#942](https://github.com/aws/graph-explorer/pull/942))
-- **Improved** openCypher expand neighbor query to be faster when no limit is
-  provided ([#924](https://github.com/aws/graph-explorer/pull/924))
-- **Removed** limit on neighbor count query in order to always show the full
-  count of neighbors ([#924](https://github.com/aws/graph-explorer/pull/924))
-- **Fixed** issue where a schema sync would not automatically run when a
-  connection was changed
-  ([#919](https://github.com/aws/graph-explorer/pull/919))
-- **Updated** localForage Recoil integration to be async and use Suspense
-  ([#883](https://github.com/aws/graph-explorer/pull/883))
-- **Removed** Recoil state debugging tool that was never used
-  ([#909](https://github.com/aws/graph-explorer/pull/909))
-- **Updated** the state management layer to use Jotai instead of Recoil
-  ([#896](https://github.com/aws/graph-explorer/pull/896),
-  [#920](https://github.com/aws/graph-explorer/pull/920),
-  [#934](https://github.com/aws/graph-explorer/pull/934))
-- **Updated** to use the React Compiler to improve performance and simplify code
-  ([#916](https://github.com/aws/graph-explorer/pull/916))
-- **Updated** dependencies and minor refactoring of code
-  ([#922](https://github.com/aws/graph-explorer/pull/922),
-  [#926](https://github.com/aws/graph-explorer/pull/926),
-  [#930](https://github.com/aws/graph-explorer/pull/930),
-  [#931](https://github.com/aws/graph-explorer/pull/931),
-  [#932](https://github.com/aws/graph-explorer/pull/932),
-  [#933](https://github.com/aws/graph-explorer/pull/933))
+- **Improved** Improved connection details by moving the sync button near the last sync timestamp (thanks @enumura1, [#901](https://github.com/aws/graph-explorer/pull/901), [#908](https://github.com/aws/graph-explorer/pull/908))
+- **Improved** performance of neighbor expansion in RDF datasets ([#942](https://github.com/aws/graph-explorer/pull/942))
+- **Improved** openCypher expand neighbor query to be faster when no limit is provided ([#924](https://github.com/aws/graph-explorer/pull/924))
+- **Removed** limit on neighbor count query in order to always show the full count of neighbors ([#924](https://github.com/aws/graph-explorer/pull/924))
+- **Fixed** issue where a schema sync would not automatically run when a connection was changed ([#919](https://github.com/aws/graph-explorer/pull/919))
+- **Updated** localForage Recoil integration to be async and use Suspense ([#883](https://github.com/aws/graph-explorer/pull/883))
+- **Removed** Recoil state debugging tool that was never used ([#909](https://github.com/aws/graph-explorer/pull/909))
+- **Updated** the state management layer to use Jotai instead of Recoil ([#896](https://github.com/aws/graph-explorer/pull/896), [#920](https://github.com/aws/graph-explorer/pull/920), [#934](https://github.com/aws/graph-explorer/pull/934))
+- **Updated** to use the React Compiler to improve performance and simplify code ([#916](https://github.com/aws/graph-explorer/pull/916))
+- **Updated** dependencies and minor refactoring of code ([#922](https://github.com/aws/graph-explorer/pull/922), [#926](https://github.com/aws/graph-explorer/pull/926), [#930](https://github.com/aws/graph-explorer/pull/930), [#931](https://github.com/aws/graph-explorer/pull/931), [#932](https://github.com/aws/graph-explorer/pull/932), [#933](https://github.com/aws/graph-explorer/pull/933))
 
 ## Release v1.15.0
 
-Graph Explorer now offers session persistence, allowing you to seamlessly
-continue your work. With a single click, you can restore your previous graph
-visualization instead of starting from scratch. This feature retrieves the most
-current information for all nodes and edges from your last session, ensuring
-you're working with up-to-date data.
+Graph Explorer now offers session persistence, allowing you to seamlessly continue your work. With a single click, you can restore your previous graph visualization instead of starting from scratch. This feature retrieves the most current information for all nodes and edges from your last session, ensuring you're working with up-to-date data.
 
-This release also resolves a couple of long standing issues. The first is that
-double click expansion is now much more reliable and consistent across all three
-query languages. The second is that SPARQL neighbor counts and expansion is much
-more accurate and reliable.
+This release also resolves a couple of long standing issues. The first is that double click expansion is now much more reliable and consistent across all three query languages. The second is that SPARQL neighbor counts and expansion is much more accurate and reliable.
 
 And as always, there are many additional small fixes and improvements.
 
 ### New Features
 
-- **Added** ability to restore the graph from the previous session
-  ([#826](https://github.com/aws/graph-explorer/pull/826),
-  [#840](https://github.com/aws/graph-explorer/pull/840))
-- **Added** add /status endpoint to verify proxy health (thanks @ssheladiya,
-  [#833](https://github.com/aws/graph-explorer/pull/833))
-- **Added** ability to see full error details from errors in the UI
-  ([#858](https://github.com/aws/graph-explorer/pull/858))
-- **Added** ability to cancel a long running schema sync
-  ([#869](https://github.com/aws/graph-explorer/pull/869))
+- **Added** ability to restore the graph from the previous session ([#826](https://github.com/aws/graph-explorer/pull/826), [#840](https://github.com/aws/graph-explorer/pull/840))
+- **Added** add /status endpoint to verify proxy health (thanks @ssheladiya, [#833](https://github.com/aws/graph-explorer/pull/833))
+- **Added** ability to see full error details from errors in the UI ([#858](https://github.com/aws/graph-explorer/pull/858))
+- **Added** ability to cancel a long running schema sync ([#869](https://github.com/aws/graph-explorer/pull/869))
 
 ### Other changes
 
-- **Updated** graph manipulation logic to lay foundations for query editor
-  ([#864](https://github.com/aws/graph-explorer/pull/864),
-  [#848](https://github.com/aws/graph-explorer/pull/848),
-  [#853](https://github.com/aws/graph-explorer/pull/853),
-  [#850](https://github.com/aws/graph-explorer/pull/850),
-  [#843](https://github.com/aws/graph-explorer/pull/843),
-  [#842](https://github.com/aws/graph-explorer/pull/842),
-  [#839](https://github.com/aws/graph-explorer/pull/839),
-  [#837](https://github.com/aws/graph-explorer/pull/837),
-  [#838](https://github.com/aws/graph-explorer/pull/838))
-- **Updated** styling of the connections screen
-  ([#828](https://github.com/aws/graph-explorer/pull/828))
-- **Updated** namespaces sidebar to use tabs instead of dropdown
-  ([#830](https://github.com/aws/graph-explorer/pull/830))
-- **Fixed** rendering performance issues adding to the graph and showing the
-  entity filters or node & edge style sidebars
-  ([#892](https://github.com/aws/graph-explorer/pull/892))
-- **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF
-  databases ([#870](https://github.com/aws/graph-explorer/pull/870))
-- **Fixed** issue representing metadata classes as valid instance types during
-  schema sync in RDF databases
-  ([#903](https://github.com/aws/graph-explorer/pull/903))
-- **Fixed** issue where double click expansion was inconsistent
-  ([#841](https://github.com/aws/graph-explorer/pull/841))
-- **Fixed** issue with table exports
-  ([#860](https://github.com/aws/graph-explorer/pull/860))
-- **Fixed** issue with long node titles or descriptions pushing the "add to
-  graph" button off the screen
-  ([#824](https://github.com/aws/graph-explorer/pull/824))
-- **Fixed** issue rendering search results with really long titles
-  ([#904](https://github.com/aws/graph-explorer/pull/904))
-- **Fixed** issue representing an edge connecting nodes with multiple labels
-  ([#839](https://github.com/aws/graph-explorer/pull/839))
-- **Fixed** proxy server error when a request is aborted mid-stream
-  ([#873](https://github.com/aws/graph-explorer/pull/873))
-- **Updated** icons in context menu to be more consistent
-  ([#906](https://github.com/aws/graph-explorer/pull/906))
-- **Updated** styling of buttons, input, textarea, and select fields
-  ([#847](https://github.com/aws/graph-explorer/pull/847),
-  [#832](https://github.com/aws/graph-explorer/pull/832),
-  [#834](https://github.com/aws/graph-explorer/pull/834))
-- **Updated** tests to be less fragile
-  ([865](https://github.com/aws/graph-explorer/pull/865))
-- **Updated** HMR behavior to ignore test files
-  ([#835](https://github.com/aws/graph-explorer/pull/835))
-- **Fixed** Docker build by not removing gzip
-  ([#868](https://github.com/aws/graph-explorer/pull/868))
-- **Updated** dependencies
-  ([#827](https://github.com/aws/graph-explorer/pull/827),
-  [#849](https://github.com/aws/graph-explorer/pull/849),
-  [#866](https://github.com/aws/graph-explorer/pull/866),
-  [#876](https://github.com/aws/graph-explorer/pull/876),
-  [#900](https://github.com/aws/graph-explorer/pull/900))
+- **Updated** graph manipulation logic to lay foundations for query editor ([#864](https://github.com/aws/graph-explorer/pull/864), [#848](https://github.com/aws/graph-explorer/pull/848), [#853](https://github.com/aws/graph-explorer/pull/853), [#850](https://github.com/aws/graph-explorer/pull/850), [#843](https://github.com/aws/graph-explorer/pull/843), [#842](https://github.com/aws/graph-explorer/pull/842), [#839](https://github.com/aws/graph-explorer/pull/839), [#837](https://github.com/aws/graph-explorer/pull/837), [#838](https://github.com/aws/graph-explorer/pull/838))
+- **Updated** styling of the connections screen ([#828](https://github.com/aws/graph-explorer/pull/828))
+- **Updated** namespaces sidebar to use tabs instead of dropdown ([#830](https://github.com/aws/graph-explorer/pull/830))
+- **Fixed** rendering performance issues adding to the graph and showing the entity filters or node & edge style sidebars ([#892](https://github.com/aws/graph-explorer/pull/892))
+- **Fixed** issues with filtered neighbor expansion and neighbor counts in RDF databases ([#870](https://github.com/aws/graph-explorer/pull/870))
+- **Fixed** issue representing metadata classes as valid instance types during schema sync in RDF databases ([#903](https://github.com/aws/graph-explorer/pull/903))
+- **Fixed** issue where double click expansion was inconsistent ([#841](https://github.com/aws/graph-explorer/pull/841))
+- **Fixed** issue with table exports ([#860](https://github.com/aws/graph-explorer/pull/860))
+- **Fixed** issue with long node titles or descriptions pushing the "add to graph" button off the screen ([#824](https://github.com/aws/graph-explorer/pull/824))
+- **Fixed** issue rendering search results with really long titles ([#904](https://github.com/aws/graph-explorer/pull/904))
+- **Fixed** issue representing an edge connecting nodes with multiple labels ([#839](https://github.com/aws/graph-explorer/pull/839))
+- **Fixed** proxy server error when a request is aborted mid-stream ([#873](https://github.com/aws/graph-explorer/pull/873))
+- **Updated** icons in context menu to be more consistent ([#906](https://github.com/aws/graph-explorer/pull/906))
+- **Updated** styling of buttons, input, textarea, and select fields ([#847](https://github.com/aws/graph-explorer/pull/847), [#832](https://github.com/aws/graph-explorer/pull/832), [#834](https://github.com/aws/graph-explorer/pull/834))
+- **Updated** tests to be less fragile ([865](https://github.com/aws/graph-explorer/pull/865))
+- **Updated** HMR behavior to ignore test files ([#835](https://github.com/aws/graph-explorer/pull/835))
+- **Fixed** Docker build by not removing gzip ([#868](https://github.com/aws/graph-explorer/pull/868))
+- **Updated** dependencies ([#827](https://github.com/aws/graph-explorer/pull/827), [#849](https://github.com/aws/graph-explorer/pull/849), [#866](https://github.com/aws/graph-explorer/pull/866), [#876](https://github.com/aws/graph-explorer/pull/876), [#900](https://github.com/aws/graph-explorer/pull/900))
 
 ## Release v1.14.1
 
-This release is a minor bug fix release, with a primary focus on surfacing
-schema sync errors to aid in diagnosing issues.
+This release is a minor bug fix release, with a primary focus on surfacing schema sync errors to aid in diagnosing issues.
 
-- **Improved** reliability of schema syncing, retrying on failure
-  ([#813](https://github.com/aws/graph-explorer/pull/813))
-- **Improved** handling of errors when fetching data from the database
-  ([#812](https://github.com/aws/graph-explorer/pull/812))
-- **Changed** to allow editing and deleting default connections
-  ([#801](https://github.com/aws/graph-explorer/pull/801),
-  [#821](https://github.com/aws/graph-explorer/pull/821))
-- **Changed** service type label to be "Neptune Analytics"
-  ([#811](https://github.com/aws/graph-explorer/pull/811))
-- **Fixed** issue where nodes and edges without any labels were causing the app
-  to crash ([#799](https://github.com/aws/graph-explorer/pull/799))
-- **Fixed** broken link in documentation (thanks @ssheladiya,
-  [#803](https://github.com/aws/graph-explorer/pull/803))
+- **Improved** reliability of schema syncing, retrying on failure ([#813](https://github.com/aws/graph-explorer/pull/813))
+- **Improved** handling of errors when fetching data from the database ([#812](https://github.com/aws/graph-explorer/pull/812))
+- **Changed** to allow editing and deleting default connections ([#801](https://github.com/aws/graph-explorer/pull/801), [#821](https://github.com/aws/graph-explorer/pull/821))
+- **Changed** service type label to be "Neptune Analytics" ([#811](https://github.com/aws/graph-explorer/pull/811))
+- **Fixed** issue where nodes and edges without any labels were causing the app to crash ([#799](https://github.com/aws/graph-explorer/pull/799))
+- **Fixed** broken link in documentation (thanks @ssheladiya, [#803](https://github.com/aws/graph-explorer/pull/803))
 
 ## Release v1.14.0
 
-This release includes a major new feature: the ability to load and save graphs.
-It required a massive effort to update the data management logic to allow this
-feature to exist. Some of these changes made the graph rendering logic slightly
-more efficient, so you may notice some small performance improvements.
+This release includes a major new feature: the ability to load and save graphs. It required a massive effort to update the data management logic to allow this feature to exist. Some of these changes made the graph rendering logic slightly more efficient, so you may notice some small performance improvements.
 
 ### Saving and Loading Graphs
 
-Graph Explorer now supports saving and loading graphs as files. To save the
-current graph, click the "Save graph to file" button in the graph toolbar. You
-can load a previously saved graph file by clicking the "Load graph from file"
-button in the graph toolbar and choosing the file to load.
+Graph Explorer now supports saving and loading graphs as files. To save the current graph, click the "Save graph to file" button in the graph toolbar. You can load a previously saved graph file by clicking the "Load graph from file" button in the graph toolbar and choosing the file to load.
 
-Graph Explorer will verify that you are currently connected to the right
-database and then read all the node & edge IDs in the file. It will then execute
-the required queries to get up to date information from the database and load
-the nodes & edges in to the graph. Any existing nodes & edges in your graph will
-be unchanged.
+Graph Explorer will verify that you are currently connected to the right database and then read all the node & edge IDs in the file. It will then execute the required queries to get up to date information from the database and load the nodes & edges in to the graph. Any existing nodes & edges in your graph will be unchanged.
 
 #### File Contents
 
@@ -976,372 +545,191 @@ The saved graph file contains the following information in plain JSON format:
 
 ### All Changes
 
-- **Added** ability to save the rendered graph to a file, allowing for reloading
-  the graph later or sharing the graph with other users who have the same
-  connection ([#756](https://github.com/aws/graph-explorer/pull/756),
-  [#758](https://github.com/aws/graph-explorer/pull/758),
-  [#761](https://github.com/aws/graph-explorer/pull/761),
-  [#762](https://github.com/aws/graph-explorer/pull/762),
-  [#767](https://github.com/aws/graph-explorer/pull/767),
-  [#768](https://github.com/aws/graph-explorer/pull/768),
-  [#769](https://github.com/aws/graph-explorer/pull/769),
-  [#770](https://github.com/aws/graph-explorer/pull/770),
-  [#775](https://github.com/aws/graph-explorer/pull/775),
-  [#781](https://github.com/aws/graph-explorer/pull/781),
-  [#786](https://github.com/aws/graph-explorer/pull/786),
-  [#793](https://github.com/aws/graph-explorer/pull/793))
-- **Updated** UI labels to refer to node & edge "labels" instead of "types"
-  ([#766](https://github.com/aws/graph-explorer/pull/766))
-- **Improved** neighbor count retrieval to be more efficient
-  ([#744](https://github.com/aws/graph-explorer/pull/744))
-- **Removed** unused `hidden` flag from schema types
-  ([#737](https://github.com/aws/graph-explorer/pull/737))
-- **Improved** entity filtering logic reducing re-renders
-  ([#739](https://github.com/aws/graph-explorer/pull/739),
-  [741](https://github.com/aws/graph-explorer/pull/741))
-- **Added** attribute count to node labels list in the connection screen
-  ([#743](https://github.com/aws/graph-explorer/pull/743))
-- **Improved** pagination controls by using a single shared component
-  ([#742](https://github.com/aws/graph-explorer/pull/742))
-- **Updated** styling across the app
-  ([#777](https://github.com/aws/graph-explorer/pull/777),
-  [#743](https://github.com/aws/graph-explorer/pull/743),
-  [#780](https://github.com/aws/graph-explorer/pull/780))
+- **Added** ability to save the rendered graph to a file, allowing for reloading the graph later or sharing the graph with other users who have the same connection ([#756](https://github.com/aws/graph-explorer/pull/756), [#758](https://github.com/aws/graph-explorer/pull/758), [#761](https://github.com/aws/graph-explorer/pull/761), [#762](https://github.com/aws/graph-explorer/pull/762), [#767](https://github.com/aws/graph-explorer/pull/767), [#768](https://github.com/aws/graph-explorer/pull/768), [#769](https://github.com/aws/graph-explorer/pull/769), [#770](https://github.com/aws/graph-explorer/pull/770), [#775](https://github.com/aws/graph-explorer/pull/775), [#781](https://github.com/aws/graph-explorer/pull/781), [#786](https://github.com/aws/graph-explorer/pull/786), [#793](https://github.com/aws/graph-explorer/pull/793))
+- **Updated** UI labels to refer to node & edge "labels" instead of "types" ([#766](https://github.com/aws/graph-explorer/pull/766))
+- **Improved** neighbor count retrieval to be more efficient ([#744](https://github.com/aws/graph-explorer/pull/744))
+- **Removed** unused `hidden` flag from schema types ([#737](https://github.com/aws/graph-explorer/pull/737))
+- **Improved** entity filtering logic reducing re-renders ([#739](https://github.com/aws/graph-explorer/pull/739), [741](https://github.com/aws/graph-explorer/pull/741))
+- **Added** attribute count to node labels list in the connection screen ([#743](https://github.com/aws/graph-explorer/pull/743))
+- **Improved** pagination controls by using a single shared component ([#742](https://github.com/aws/graph-explorer/pull/742))
+- **Updated** styling across the app ([#777](https://github.com/aws/graph-explorer/pull/777), [#743](https://github.com/aws/graph-explorer/pull/743), [#780](https://github.com/aws/graph-explorer/pull/780))
   - Rounded style for search inputs, panels, toast notifications, and more
   - Searchable list items style consistent with connection style
   - Softer grays
   - More consistent shadows
   - More consistent menus (context menus, select dropdowns, etc.)
   - Graph legend is now consistent with other panels
-- **Updated** dependencies and remove unused dependencies
-  ([#764](https://github.com/aws/graph-explorer/pull/764),
-  [#776](https://github.com/aws/graph-explorer/pull/776),
-  [#782](https://github.com/aws/graph-explorer/pull/782),
-  [#783](https://github.com/aws/graph-explorer/pull/783))
+- **Updated** dependencies and remove unused dependencies ([#764](https://github.com/aws/graph-explorer/pull/764), [#776](https://github.com/aws/graph-explorer/pull/776), [#782](https://github.com/aws/graph-explorer/pull/782), [#783](https://github.com/aws/graph-explorer/pull/783))
 
 ## Release 1.13.0
 
-This release is a maintenance release with improvements to app startup, default
-connection handling, and Neptune error handling.
+This release is a maintenance release with improvements to app startup, default connection handling, and Neptune error handling.
 
-- **Removed** URL parameter `configFile` support for the default connection
-  ([#724](https://github.com/aws/graph-explorer/pull/724))
-- **Improved** app startup UI to be more consistent
-  ([#723](https://github.com/aws/graph-explorer/pull/723))
-- **Improved** error logs in the browser console
-  ([#721](https://github.com/aws/graph-explorer/pull/721))
-- **Improved** default connection handling, including fallbacks for invalid data
-  ([#734](https://github.com/aws/graph-explorer/pull/734))
-- **Updated** dependencies
-  ([#718](https://github.com/aws/graph-explorer/pull/718),
-  [#720](https://github.com/aws/graph-explorer/pull/720))
+- **Removed** URL parameter `configFile` support for the default connection ([#724](https://github.com/aws/graph-explorer/pull/724))
+- **Improved** app startup UI to be more consistent ([#723](https://github.com/aws/graph-explorer/pull/723))
+- **Improved** error logs in the browser console ([#721](https://github.com/aws/graph-explorer/pull/721))
+- **Improved** default connection handling, including fallbacks for invalid data ([#734](https://github.com/aws/graph-explorer/pull/734))
+- **Updated** dependencies ([#718](https://github.com/aws/graph-explorer/pull/718), [#720](https://github.com/aws/graph-explorer/pull/720))
 
 ## Release 1.12.1
 
-- **Fixed** issue where the edge's display name value was not being displayed
-  properly ([#716](https://github.com/aws/graph-explorer/pull/716))
+- **Fixed** issue where the edge's display name value was not being displayed properly ([#716](https://github.com/aws/graph-explorer/pull/716))
 
 ## Release 1.12.0
 
-This release is mostly a maintenance release, with a few new features and bug
-fixes.
+This release is mostly a maintenance release, with a few new features and bug fixes.
 
 ### Consistent node and edge information
 
-The biggest noticeable change is the consistency of node and edge information
-across the app. Previously, the node and edge information was rendered
-differently in the search results, node details, edge details, and expand
-options. Now, they are all consistent, with the same information displayed.
+The biggest noticeable change is the consistency of node and edge information across the app. Previously, the node and edge information was rendered differently in the search results, node details, edge details, and expand options. Now, they are all consistent, with the same information displayed.
 
-These changes improve the support for multiple node labels and date values in
-Gremlin.
+These changes improve the support for multiple node labels and date values in Gremlin.
 
 ### All changes
 
-- **Improved** consistency of rendering node information across search results,
-  node details header, edge details header, and expand options header
-  ([#697](https://github.com/aws/graph-explorer/pull/697))
-- **Improved** edge properties in the details sidebar, which now includes the
-  source and target vertex IDs and types
-  ([#698](https://github.com/aws/graph-explorer/pull/698))
-- **Fixed** date rendering on Gremlin connections
-  ([#698](https://github.com/aws/graph-explorer/pull/698))
-- **Fixed** a bug where the automatic open details feature would not open the
-  details sidebar when selecting nodes
-  ([#679](https://github.com/aws/graph-explorer/pull/679))
-- **Improved** styling on checkboxes across the app, and specifically the export
-  options popover and entity filters sidebar
-  ([#676](https://github.com/aws/graph-explorer/pull/676))
-- **Improved** styling on icon buttons
-  ([#674](https://github.com/aws/graph-explorer/pull/674),
-  [#675](https://github.com/aws/graph-explorer/pull/675),
-  [#683](https://github.com/aws/graph-explorer/pull/683))
-- **Improved** styling & behavior on tooltips
-  ([#709](https://github.com/aws/graph-explorer/pull/709))
-- **Improved** styling & behavior color inputs
-  ([#707](https://github.com/aws/graph-explorer/pull/707))
-- **Updated** documentation to reorganize and extend the troubleshooting tips
-  ([#681](https://github.com/aws/graph-explorer/pull/681))
-- **Updated** documentation to add a roadmap outline
-  ([#696](https://github.com/aws/graph-explorer/pull/696))
-- **Consolidated** logic around the display of nodes and edges to a single
-  location for simplicity and consistency
-  ([#698](https://github.com/aws/graph-explorer/pull/698))
-- **Updated** dependencies, including Node v22
-  ([#680](https://github.com/aws/graph-explorer/pull/680))
+- **Improved** consistency of rendering node information across search results, node details header, edge details header, and expand options header ([#697](https://github.com/aws/graph-explorer/pull/697))
+- **Improved** edge properties in the details sidebar, which now includes the source and target vertex IDs and types ([#698](https://github.com/aws/graph-explorer/pull/698))
+- **Fixed** date rendering on Gremlin connections ([#698](https://github.com/aws/graph-explorer/pull/698))
+- **Fixed** a bug where the automatic open details feature would not open the details sidebar when selecting nodes ([#679](https://github.com/aws/graph-explorer/pull/679))
+- **Improved** styling on checkboxes across the app, and specifically the export options popover and entity filters sidebar ([#676](https://github.com/aws/graph-explorer/pull/676))
+- **Improved** styling on icon buttons ([#674](https://github.com/aws/graph-explorer/pull/674), [#675](https://github.com/aws/graph-explorer/pull/675), [#683](https://github.com/aws/graph-explorer/pull/683))
+- **Improved** styling & behavior on tooltips ([#709](https://github.com/aws/graph-explorer/pull/709))
+- **Improved** styling & behavior color inputs ([#707](https://github.com/aws/graph-explorer/pull/707))
+- **Updated** documentation to reorganize and extend the troubleshooting tips ([#681](https://github.com/aws/graph-explorer/pull/681))
+- **Updated** documentation to add a roadmap outline ([#696](https://github.com/aws/graph-explorer/pull/696))
+- **Consolidated** logic around the display of nodes and edges to a single location for simplicity and consistency ([#698](https://github.com/aws/graph-explorer/pull/698))
+- **Updated** dependencies, including Node v22 ([#680](https://github.com/aws/graph-explorer/pull/680))
 
 ## Release 1.11.0
 
-This release includes a big change to search, improvements to the Docker image
-size and security, and as always, there are many additional small fixes and
-improvements.
+This release includes a big change to search, improvements to the Docker image size and security, and as always, there are many additional small fixes and improvements.
 
 ### Search Sidebar
 
-With this release, we've moved search out of the top navigation bar and in to
-the sidebar. When new users open Graph Explorer for the first time, they will be
-greeted with a set of search results ready to be added to the graph and
-explored.
+With this release, we've moved search out of the top navigation bar and in to the sidebar. When new users open Graph Explorer for the first time, they will be greeted with a set of search results ready to be added to the graph and explored.
 
-For existing users, you'll benefit from a better experience with search. Your
-filters will remain active as you navigate around and it will do its best to
-keep your attribute selection when you change the node type. There's also a new
-"Add All" button, when you want to add all the search results to the graph with
-a single click.
+For existing users, you'll benefit from a better experience with search. Your filters will remain active as you navigate around and it will do its best to keep your attribute selection when you change the node type. There's also a new "Add All" button, when you want to add all the search results to the graph with a single click.
 
 ### All Changes
 
-- **Improved** search discoverability and ergonomics by moving the UI in to the
-  sidebar ([#665](https://github.com/aws/graph-explorer/pull/665),
-  [#669](https://github.com/aws/graph-explorer/pull/669),
-  [#670](https://github.com/aws/graph-explorer/pull/670))
-- **Improved** UI responsiveness by using map instead of array for large data
-  sets ([#658](https://github.com/aws/graph-explorer/pull/658))
-- **Improved** connection selection can now happen on any part of the connection
-  row ([#657](https://github.com/aws/graph-explorer/pull/657))
-- **Improved** style for the sidebar buttons
-  ([#651](https://github.com/aws/graph-explorer/pull/651))
-- **Improved** styles in the context menu to be easier to read
-  ([#670](https://github.com/aws/graph-explorer/pull/670))
-- **Improved** Docker image size, reducing it by 196 MB
-  ([#619](https://github.com/aws/graph-explorer/pull/619))
-- **Improved** query when searching across all node types
-  ([#607](https://github.com/aws/graph-explorer/pull/607))
-- **Improved** query generation by removing empty lines
-  ([#608](https://github.com/aws/graph-explorer/pull/608))
-- **Fixed** scrolling on search result details
-  [#657](https://github.com/aws/graph-explorer/pull/657)
-- **Fixed** Docker image containing more files than necessary.
-  ([#613](https://github.com/aws/graph-explorer/pull/613))
-- **Fixed** conflict when a node has a property named "id" that prevented
-  changing the display attribute.
-  ([#626](https://github.com/aws/graph-explorer/pull/626))
-- **Fixed** style issue where buttons have a halo around them after being
-  clicked ([#650](https://github.com/aws/graph-explorer/pull/650))
-- **Fixed** security vulnerabilities in the Docker image from dev dependencies
-  remaining in the image
-  ([#616](https://github.com/aws/graph-explorer/pull/616))
-- **Fixed** minor layout issue on connections screen
-  ([#648](https://github.com/aws/graph-explorer/pull/648),
-  [#670](https://github.com/aws/graph-explorer/pull/670))
-- **Updated** multiple dependencies
-  ([#611](https://github.com/aws/graph-explorer/pull/611),
-  [#614](https://github.com/aws/graph-explorer/pull/614),
-  [#616](https://github.com/aws/graph-explorer/pull/616),
-  [#624](https://github.com/aws/graph-explorer/pull/624))
+- **Improved** search discoverability and ergonomics by moving the UI in to the sidebar ([#665](https://github.com/aws/graph-explorer/pull/665), [#669](https://github.com/aws/graph-explorer/pull/669), [#670](https://github.com/aws/graph-explorer/pull/670))
+- **Improved** UI responsiveness by using map instead of array for large data sets ([#658](https://github.com/aws/graph-explorer/pull/658))
+- **Improved** connection selection can now happen on any part of the connection row ([#657](https://github.com/aws/graph-explorer/pull/657))
+- **Improved** style for the sidebar buttons ([#651](https://github.com/aws/graph-explorer/pull/651))
+- **Improved** styles in the context menu to be easier to read ([#670](https://github.com/aws/graph-explorer/pull/670))
+- **Improved** Docker image size, reducing it by 196 MB ([#619](https://github.com/aws/graph-explorer/pull/619))
+- **Improved** query when searching across all node types ([#607](https://github.com/aws/graph-explorer/pull/607))
+- **Improved** query generation by removing empty lines ([#608](https://github.com/aws/graph-explorer/pull/608))
+- **Fixed** scrolling on search result details [#657](https://github.com/aws/graph-explorer/pull/657)
+- **Fixed** Docker image containing more files than necessary. ([#613](https://github.com/aws/graph-explorer/pull/613))
+- **Fixed** conflict when a node has a property named "id" that prevented changing the display attribute. ([#626](https://github.com/aws/graph-explorer/pull/626))
+- **Fixed** style issue where buttons have a halo around them after being clicked ([#650](https://github.com/aws/graph-explorer/pull/650))
+- **Fixed** security vulnerabilities in the Docker image from dev dependencies remaining in the image ([#616](https://github.com/aws/graph-explorer/pull/616))
+- **Fixed** minor layout issue on connections screen ([#648](https://github.com/aws/graph-explorer/pull/648), [#670](https://github.com/aws/graph-explorer/pull/670))
+- **Updated** multiple dependencies ([#611](https://github.com/aws/graph-explorer/pull/611), [#614](https://github.com/aws/graph-explorer/pull/614), [#616](https://github.com/aws/graph-explorer/pull/616), [#624](https://github.com/aws/graph-explorer/pull/624))
 
 ## Release 1.10.1
 
-- **Improved** support for databases with thousands of node & edge types
-  ([#599](https://github.com/aws/graph-explorer/pull/599))
-- **Improved** logging on server and around schema sync
-  ([#604](https://github.com/aws/graph-explorer/pull/604))
-- **Fixed** context menu styles
-  ([#600](https://github.com/aws/graph-explorer/pull/600))
-- **Fixed** alignment of close button in search panel
-  ([#603](https://github.com/aws/graph-explorer/pull/603))
+- **Improved** support for databases with thousands of node & edge types ([#599](https://github.com/aws/graph-explorer/pull/599))
+- **Improved** logging on server and around schema sync ([#604](https://github.com/aws/graph-explorer/pull/604))
+- **Fixed** context menu styles ([#600](https://github.com/aws/graph-explorer/pull/600))
+- **Fixed** alignment of close button in search panel ([#603](https://github.com/aws/graph-explorer/pull/603))
 
 ## Release 1.10.0
 
-This release includes some new features to make managing and supporting Graph
-Explorer more friendly.
+This release includes some new features to make managing and supporting Graph Explorer more friendly.
 
 **Major Changes**
 
-- **Added** backup & restore options for Graph Explorer local data
-  ([#549](https://github.com/aws/graph-explorer/pull/549))
-- **Added** about screen that includes a link to submit feedback
-  ([#549](https://github.com/aws/graph-explorer/pull/549))
+- **Added** backup & restore options for Graph Explorer local data ([#549](https://github.com/aws/graph-explorer/pull/549))
+- **Added** about screen that includes a link to submit feedback ([#549](https://github.com/aws/graph-explorer/pull/549))
 - **Improved** logging & error handling to aid in support
-  - **Added** global error page if the React app crashes
-    ([#547](https://github.com/aws/graph-explorer/pull/547))
-  - **Added** optional server logging of database queries when using the proxy
-    server which can be enabled within settings
-    ([#574](https://github.com/aws/graph-explorer/pull/574),
-    [#575](https://github.com/aws/graph-explorer/pull/575))
-  - **Improved** handling of server errors with more consistent logging
-    ([#557](https://github.com/aws/graph-explorer/pull/557))
-  - **Improved** SageMaker Lifecycle script handling of CloudWatch log driver
-    failures ([#550](https://github.com/aws/graph-explorer/pull/550))
-  - **Improved** parsing of environment values in proxy server resulting in an
-    error when the values are invalid
-    ([#574](https://github.com/aws/graph-explorer/pull/574))
+  - **Added** global error page if the React app crashes ([#547](https://github.com/aws/graph-explorer/pull/547))
+  - **Added** optional server logging of database queries when using the proxy server which can be enabled within settings ([#574](https://github.com/aws/graph-explorer/pull/574), [#575](https://github.com/aws/graph-explorer/pull/575))
+  - **Improved** handling of server errors with more consistent logging ([#557](https://github.com/aws/graph-explorer/pull/557))
+  - **Improved** SageMaker Lifecycle script handling of CloudWatch log driver failures ([#550](https://github.com/aws/graph-explorer/pull/550))
+  - **Improved** parsing of environment values in proxy server resulting in an error when the values are invalid ([#574](https://github.com/aws/graph-explorer/pull/574))
 
 **Bug Fixes and Minor Changes**
 
-- **Fixed** performance issue in styling sidebar panels when many node & edge
-  types exist ([#542](https://github.com/aws/graph-explorer/pull/542))
-- **Fixed** issue with upper case characters in RDF URIs
-  ([#544](https://github.com/aws/graph-explorer/pull/544))
-- **Improved** app styles
-  ([#543](https://github.com/aws/graph-explorer/pull/543),
-  [#548](https://github.com/aws/graph-explorer/pull/548))
-- **Changed** Node to run in production mode
-  ([#558](https://github.com/aws/graph-explorer/pull/558))
-- **Removed** hosting production server using the client side Vite
-  configuration, requiring the use of the proxy server
-  ([#565](https://github.com/aws/graph-explorer/pull/565))
-- **Transition** to Tailwind instead of EmotionCSS for styles, which should make
-  updating the UI much simpler
-  ([#543](https://github.com/aws/graph-explorer/pull/543))
-- **Updated** multiple dependencies
-  ([#555](https://github.com/aws/graph-explorer/pull/555),
-  [#557](https://github.com/aws/graph-explorer/pull/557))
+- **Fixed** performance issue in styling sidebar panels when many node & edge types exist ([#542](https://github.com/aws/graph-explorer/pull/542))
+- **Fixed** issue with upper case characters in RDF URIs ([#544](https://github.com/aws/graph-explorer/pull/544))
+- **Improved** app styles ([#543](https://github.com/aws/graph-explorer/pull/543), [#548](https://github.com/aws/graph-explorer/pull/548))
+- **Changed** Node to run in production mode ([#558](https://github.com/aws/graph-explorer/pull/558))
+- **Removed** hosting production server using the client side Vite configuration, requiring the use of the proxy server ([#565](https://github.com/aws/graph-explorer/pull/565))
+- **Transition** to Tailwind instead of EmotionCSS for styles, which should make updating the UI much simpler ([#543](https://github.com/aws/graph-explorer/pull/543))
+- **Updated** multiple dependencies ([#555](https://github.com/aws/graph-explorer/pull/555), [#557](https://github.com/aws/graph-explorer/pull/557))
 
 ## Release 1.9.0
 
-This release includes many fixes and enhancements that make using Graph Explorer
-a more pleasant experience, especially for users with larger databases.
+This release includes many fixes and enhancements that make using Graph Explorer a more pleasant experience, especially for users with larger databases.
 
 **Major Changes**
 
-- **Improved** error experience in search and Data Explorer UI that includes a
-  retry button ([#477](https://github.com/aws/graph-explorer/pull/477))
-- **Improved** empty state experience in Data Explorer UI
-  ([#477](https://github.com/aws/graph-explorer/pull/477))
-- **Improved** search using openCypher which will now execute a single request
-  when searching across all labels
-  ([#493](https://github.com/aws/graph-explorer/pull/493),
-  [#532](https://github.com/aws/graph-explorer/pull/532))
-- **Improved** error messages for node expansion
-  ([#502](https://github.com/aws/graph-explorer/pull/502))
-- **Improved** Gremlin schema sync performance on larger databases, thanks to
-  @dsaban-lightricks for his great suggestion in issue #225
-  ([#498](https://github.com/aws/graph-explorer/pull/498))
-- **Reduced** chance of throttling issues when a large amount of requests are
-  executed in parallel by batching requests in groups of 10
-  ([#489](https://github.com/aws/graph-explorer/pull/489))
-- **Reduced** unnecessary search queries when no search term is provided by
-  ignoring attribute and exact match changes
-  ([#473](https://github.com/aws/graph-explorer/pull/473))
-- **Improved** diagnostic logging in Neptune Notebooks by adding CloudWatch logs
-  ([#517](https://github.com/aws/graph-explorer/pull/517))
-  - Check out the example
-    [lifecycle script](additionaldocs/sagemaker/install-graph-explorer-lc.sh)
-    and IAM policies for
-    [Neptune](additionaldocs/sagemaker/graph-explorer-neptune-db-policy.json)
-    and
-    [Neptune Analytics](additionaldocs/sagemaker/graph-explorer-neptune-analytics-policy.json)
+- **Improved** error experience in search and Data Explorer UI that includes a retry button ([#477](https://github.com/aws/graph-explorer/pull/477))
+- **Improved** empty state experience in Data Explorer UI ([#477](https://github.com/aws/graph-explorer/pull/477))
+- **Improved** search using openCypher which will now execute a single request when searching across all labels ([#493](https://github.com/aws/graph-explorer/pull/493), [#532](https://github.com/aws/graph-explorer/pull/532))
+- **Improved** error messages for node expansion ([#502](https://github.com/aws/graph-explorer/pull/502))
+- **Improved** Gremlin schema sync performance on larger databases, thanks to @dsaban-lightricks for his great suggestion in issue #225 ([#498](https://github.com/aws/graph-explorer/pull/498))
+- **Reduced** chance of throttling issues when a large amount of requests are executed in parallel by batching requests in groups of 10 ([#489](https://github.com/aws/graph-explorer/pull/489))
+- **Reduced** unnecessary search queries when no search term is provided by ignoring attribute and exact match changes ([#473](https://github.com/aws/graph-explorer/pull/473))
+- **Improved** diagnostic logging in Neptune Notebooks by adding CloudWatch logs ([#517](https://github.com/aws/graph-explorer/pull/517))
+  - Check out the example [lifecycle script](additionaldocs/sagemaker/install-graph-explorer-lc.sh) and IAM policies for [Neptune](additionaldocs/sagemaker/graph-explorer-neptune-db-policy.json) and [Neptune Analytics](additionaldocs/sagemaker/graph-explorer-neptune-analytics-policy.json)
 
 **Bug Fixes and Minor Changes**
 
-- **Fixed** issue with default connections when Neptune Notebook instance is
-  restarted ([#508](https://github.com/aws/graph-explorer/pull/508))
-- **Fixed** expanding a node on old versions of Gremlin
-  ([#503](https://github.com/aws/graph-explorer/pull/503))
-- **Fixed** default selection of expand type to be the first available type for
-  expansion ([#501](https://github.com/aws/graph-explorer/pull/501))
-- **Fixed** some SPARQL endpoints by using `application/sparql-results+json`
-  accept header for SPARQL requests
-  ([#499](https://github.com/aws/graph-explorer/pull/499))
-- **Fixed** CORS issue for some SPARQL and Gremlin endpoints due to `queryId` in
-  the request headers ([#529](https://github.com/aws/graph-explorer/pull/529))
-  ([#499](https://github.com/aws/graph-explorer/pull/499))
-- **Fixed** text wrapping for labels in edge styling sidebar
-  ([#499](https://github.com/aws/graph-explorer/pull/499))
-- **Fixed** potential error when the request body is very large by increasing
-  the body size limit for proxy server
-  ([#488](https://github.com/aws/graph-explorer/pull/488))
-- **Fixed** issue when selecting an item in search results that resulted in
-  errors in the browser console
-  ([#474](https://github.com/aws/graph-explorer/pull/474))
-- **Added** type checking and linting to server code
-  (<https://github.com/aws/graph-explorer/pull/522>)
-- **Added** environment values to override HTTP and HTTPS ports for proxy server
-  ([#500](https://github.com/aws/graph-explorer/pull/500))
+- **Fixed** issue with default connections when Neptune Notebook instance is restarted ([#508](https://github.com/aws/graph-explorer/pull/508))
+- **Fixed** expanding a node on old versions of Gremlin ([#503](https://github.com/aws/graph-explorer/pull/503))
+- **Fixed** default selection of expand type to be the first available type for expansion ([#501](https://github.com/aws/graph-explorer/pull/501))
+- **Fixed** some SPARQL endpoints by using `application/sparql-results+json` accept header for SPARQL requests ([#499](https://github.com/aws/graph-explorer/pull/499))
+- **Fixed** CORS issue for some SPARQL and Gremlin endpoints due to `queryId` in the request headers ([#529](https://github.com/aws/graph-explorer/pull/529)) ([#499](https://github.com/aws/graph-explorer/pull/499))
+- **Fixed** text wrapping for labels in edge styling sidebar ([#499](https://github.com/aws/graph-explorer/pull/499))
+- **Fixed** potential error when the request body is very large by increasing the body size limit for proxy server ([#488](https://github.com/aws/graph-explorer/pull/488))
+- **Fixed** issue when selecting an item in search results that resulted in errors in the browser console ([#474](https://github.com/aws/graph-explorer/pull/474))
+- **Added** type checking and linting to server code (<https://github.com/aws/graph-explorer/pull/522>)
+- **Added** environment values to override HTTP and HTTPS ports for proxy server ([#500](https://github.com/aws/graph-explorer/pull/500))
   - `PROXY_SERVER_HTTP_PORT` default is 80
   - `PROXY_SERVER_HTTPS_PORT` default is 443
-- **Updated** development scripts updated to be more consistent with the
-  industry ([#487](https://github.com/aws/graph-explorer/pull/487),
-  [#525](https://github.com/aws/graph-explorer/pull/525))
+- **Updated** development scripts updated to be more consistent with the industry ([#487](https://github.com/aws/graph-explorer/pull/487), [#525](https://github.com/aws/graph-explorer/pull/525))
   - Run the dev environment `pnpm dev`
   - Build & run the production environment `pnpm build && pnpm start`
   - Clean build artifacts with `pnpm clean`
-- **Fixed** running in production mode locally with Node
-  ([#500](https://github.com/aws/graph-explorer/pull/500))
-- **Updated** multiple dependencies
-  ([#475](https://github.com/aws/graph-explorer/pull/475),
-  [#486](https://github.com/aws/graph-explorer/pull/486),
-  [#490](https://github.com/aws/graph-explorer/pull/490),
-  [#492](https://github.com/aws/graph-explorer/pull/492),
-  [#491](https://github.com/aws/graph-explorer/pull/491),
-  [#522](https://github.com/aws/graph-explorer/pull/522),
-  [#523](https://github.com/aws/graph-explorer/pull/523))
+- **Fixed** running in production mode locally with Node ([#500](https://github.com/aws/graph-explorer/pull/500))
+- **Updated** multiple dependencies ([#475](https://github.com/aws/graph-explorer/pull/475), [#486](https://github.com/aws/graph-explorer/pull/486), [#490](https://github.com/aws/graph-explorer/pull/490), [#492](https://github.com/aws/graph-explorer/pull/492), [#491](https://github.com/aws/graph-explorer/pull/491), [#522](https://github.com/aws/graph-explorer/pull/522), [#523](https://github.com/aws/graph-explorer/pull/523))
 
 ## Release 1.8.0
 
 **Major Changes**
 
 - Better UX around neighbor expansion
-  - Expand up to 10 additional neighbors when double clicking a node
-    (<https://github.com/aws/graph-explorer/pull/455>,
-    <https://github.com/aws/graph-explorer/pull/465>)
-  - Improved reliability of node double click detection
-    (<https://github.com/aws/graph-explorer/pull/453>)
-  - Progress and errors are reported in notifications
-    (<https://github.com/aws/graph-explorer/pull/434>)
-  - Added ability to set a max limit for neighbor expansion per connection
-    (<https://github.com/aws/graph-explorer/pull/447>)
-  - Improved scrolling behavior in expand sidebar
-    (<https://github.com/aws/graph-explorer/pull/436>)
-  - Added caching and retries for failed requests
-    (<https://github.com/aws/graph-explorer/pull/434>)
+  - Expand up to 10 additional neighbors when double clicking a node (<https://github.com/aws/graph-explorer/pull/455>, <https://github.com/aws/graph-explorer/pull/465>)
+  - Improved reliability of node double click detection (<https://github.com/aws/graph-explorer/pull/453>)
+  - Progress and errors are reported in notifications (<https://github.com/aws/graph-explorer/pull/434>)
+  - Added ability to set a max limit for neighbor expansion per connection (<https://github.com/aws/graph-explorer/pull/447>)
+  - Improved scrolling behavior in expand sidebar (<https://github.com/aws/graph-explorer/pull/436>)
+  - Added caching and retries for failed requests (<https://github.com/aws/graph-explorer/pull/434>)
 
 - Better UX around node counts
-  - Progress and errors are reported in notifications when any are happening
-    (<https://github.com/aws/graph-explorer/pull/434>)
-  - Progress and errors are shown for selected node in the expand side bar
-    (<https://github.com/aws/graph-explorer/pull/463>)
-  - Added caching and retries for failed requests
-    (<https://github.com/aws/graph-explorer/pull/434>)
+  - Progress and errors are reported in notifications when any are happening (<https://github.com/aws/graph-explorer/pull/434>)
+  - Progress and errors are shown for selected node in the expand side bar (<https://github.com/aws/graph-explorer/pull/463>)
+  - Added caching and retries for failed requests (<https://github.com/aws/graph-explorer/pull/434>)
 
-- Added support for Gremlin Server 3.7
-  (<https://github.com/aws/graph-explorer/pull/411>)
+- Added support for Gremlin Server 3.7 (<https://github.com/aws/graph-explorer/pull/411>)
 
 **Bug Fixes and Minor Changes**
 
-- Fixed many bugs around neighbor expansion and counts for openCypher
-  (<https://github.com/aws/graph-explorer/pull/449>)
+- Fixed many bugs around neighbor expansion and counts for openCypher (<https://github.com/aws/graph-explorer/pull/449>)
   - Fixed expand limit to be type based when expanding from sidebar
-  - Fixed expand query to respect limit and offset properly so multiple
-    expansions return unique results
+  - Fixed expand query to respect limit and offset properly so multiple expansions return unique results
   - Fixed expand query so all edges are returned between source and target nodes
-- Improved performance and reliability of Gremlin neighbor expansion query
-  (<https://github.com/aws/graph-explorer/pull/454>)
-- Remove extraneous openCypher query when expanding nodes
-  (<https://github.com/aws/graph-explorer/pull/431>)
-- Fixed edge case where node badges are stale
-  (<https://github.com/aws/graph-explorer/pull/427>)
-- Fixed server starting log message
-  (<https://github.com/aws/graph-explorer/pull/416>)
-- Refactored several graph views for readability
-  (<https://github.com/aws/graph-explorer/pull/419>)
-- Improved testing coverage by having less mocked logic
-  (<https://github.com/aws/graph-explorer/pull/421>)
-- Fixed issue where the connection's fetch timeout input would disappear when
-  string is empty (<https://github.com/aws/graph-explorer/pull/445>)
-- Fixed issue where long connection URLs had no vertical padding
-  (<https://github.com/aws/graph-explorer/pull/445>)
+- Improved performance and reliability of Gremlin neighbor expansion query (<https://github.com/aws/graph-explorer/pull/454>)
+- Remove extraneous openCypher query when expanding nodes (<https://github.com/aws/graph-explorer/pull/431>)
+- Fixed edge case where node badges are stale (<https://github.com/aws/graph-explorer/pull/427>)
+- Fixed server starting log message (<https://github.com/aws/graph-explorer/pull/416>)
+- Refactored several graph views for readability (<https://github.com/aws/graph-explorer/pull/419>)
+- Improved testing coverage by having less mocked logic (<https://github.com/aws/graph-explorer/pull/421>)
+- Fixed issue where the connection's fetch timeout input would disappear when string is empty (<https://github.com/aws/graph-explorer/pull/445>)
+- Fixed issue where long connection URLs had no vertical padding (<https://github.com/aws/graph-explorer/pull/445>)
 - Updated to TypeScript 5.5 (<https://github.com/aws/graph-explorer/pull/451>)
 
 ## Release 1.7.0
@@ -1350,45 +738,23 @@ This release includes the following feature enhancements and bug fixes:
 
 **Major Changes**
 
-- Updated to Node v20 & React v18
-  (<https://github.com/aws/graph-explorer/pull/330>)
-  (<https://github.com/aws/graph-explorer/pull/345>)
-  (<https://github.com/aws/graph-explorer/pull/352>)
-- Added schema updating automatically when an unknown attribute is discovered
-  (<https://github.com/aws/graph-explorer/pull/356>)
-- Improved error handling on the client and server side
-  (<https://github.com/aws/graph-explorer/pull/283>)
-  (<https://github.com/aws/graph-explorer/pull/288>)
-- Removed fetch caching options
-  (<https://github.com/aws/graph-explorer/pull/280>)
+- Updated to Node v20 & React v18 (<https://github.com/aws/graph-explorer/pull/330>) (<https://github.com/aws/graph-explorer/pull/345>) (<https://github.com/aws/graph-explorer/pull/352>)
+- Added schema updating automatically when an unknown attribute is discovered (<https://github.com/aws/graph-explorer/pull/356>)
+- Improved error handling on the client and server side (<https://github.com/aws/graph-explorer/pull/283>) (<https://github.com/aws/graph-explorer/pull/288>)
+- Removed fetch caching options (<https://github.com/aws/graph-explorer/pull/280>)
 
 **Bug Fixes and Minor Changes**
 
-- Fixed node and edge filter behavior
-  (<https://github.com/aws/graph-explorer/pull/289>)
-- Fixed error on CSV export when "keep filtering and sorting"
-  (<https://github.com/aws/graph-explorer/pull/297>)
-- Fixed uploaded SVG rendering in graph
-  (<https://github.com/aws/graph-explorer/pull/296>)
-- Fixed search bar hover color
-  (<https://github.com/aws/graph-explorer/pull/293>)
-- Fixed Docker image tagging in GitHub workflows
-  (<https://github.com/aws/graph-explorer/pull/320>)
-- Fixed non-JSON response from SwissLipids
-  (<https://github.com/aws/graph-explorer/pull/395>)
-- Improved monorepo configuration
-  (<https://github.com/aws/graph-explorer/pull/305>)
-- Updated database query abstractions
-  (<https://github.com/aws/graph-explorer/pull/366>)
-  (<https://github.com/aws/graph-explorer/pull/367>)
-  (<https://github.com/aws/graph-explorer/pull/365>)
-- Improved the GitHub templates for issues and pull requests
-  (<https://github.com/aws/graph-explorer/pull/281>)
-  (<https://github.com/aws/graph-explorer/pull/332>)
-  (<https://github.com/aws/graph-explorer/pull/362>)
-- Various dependency upgrades (<https://github.com/aws/graph-explorer/pull/295>)
-  (<https://github.com/aws/graph-explorer/pull/306>)
-  (<https://github.com/aws/graph-explorer/pull/360>)
+- Fixed node and edge filter behavior (<https://github.com/aws/graph-explorer/pull/289>)
+- Fixed error on CSV export when "keep filtering and sorting" (<https://github.com/aws/graph-explorer/pull/297>)
+- Fixed uploaded SVG rendering in graph (<https://github.com/aws/graph-explorer/pull/296>)
+- Fixed search bar hover color (<https://github.com/aws/graph-explorer/pull/293>)
+- Fixed Docker image tagging in GitHub workflows (<https://github.com/aws/graph-explorer/pull/320>)
+- Fixed non-JSON response from SwissLipids (<https://github.com/aws/graph-explorer/pull/395>)
+- Improved monorepo configuration (<https://github.com/aws/graph-explorer/pull/305>)
+- Updated database query abstractions (<https://github.com/aws/graph-explorer/pull/366>) (<https://github.com/aws/graph-explorer/pull/367>) (<https://github.com/aws/graph-explorer/pull/365>)
+- Improved the GitHub templates for issues and pull requests (<https://github.com/aws/graph-explorer/pull/281>) (<https://github.com/aws/graph-explorer/pull/332>) (<https://github.com/aws/graph-explorer/pull/362>)
+- Various dependency upgrades (<https://github.com/aws/graph-explorer/pull/295>) (<https://github.com/aws/graph-explorer/pull/306>) (<https://github.com/aws/graph-explorer/pull/360>)
 
 ## Release 1.6.0
 
@@ -1396,48 +762,27 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Added support for Neptune Analytics
-  (<https://github.com/aws/graph-explorer/pull/241>)
-- Added auto-cancellation of previous queries on new SPARQL/Gremlin search
-  (<https://github.com/aws/graph-explorer/pull/259>)
-- Added search cancellation button
-  (<https://github.com/aws/graph-explorer/pull/265>)
-- Added additional PNPM checks to GitHub CI
-  (<https://github.com/aws/graph-explorer/pull/268>)
-- Improved keyword search performance
-  (<https://github.com/aws/graph-explorer/pull/243>)
-- Updated proxy URL generation in SageMaker Lifecycle
-  (<https://github.com/aws/graph-explorer/pull/279>)
-- Updated PropertyGraph Summary API routes in proxy server
-  (<https://github.com/aws/graph-explorer/pull/250>)
-- Updated SageMaker documentation for Neptune Analytics
-  (<https://github.com/aws/graph-explorer/pull/282>)
+- Added support for Neptune Analytics (<https://github.com/aws/graph-explorer/pull/241>)
+- Added auto-cancellation of previous queries on new SPARQL/Gremlin search (<https://github.com/aws/graph-explorer/pull/259>)
+- Added search cancellation button (<https://github.com/aws/graph-explorer/pull/265>)
+- Added additional PNPM checks to GitHub CI (<https://github.com/aws/graph-explorer/pull/268>)
+- Improved keyword search performance (<https://github.com/aws/graph-explorer/pull/243>)
+- Updated proxy URL generation in SageMaker Lifecycle (<https://github.com/aws/graph-explorer/pull/279>)
+- Updated PropertyGraph Summary API routes in proxy server (<https://github.com/aws/graph-explorer/pull/250>)
+- Updated SageMaker documentation for Neptune Analytics (<https://github.com/aws/graph-explorer/pull/282>)
 
 **Bug Fixes and Minor Changes**
 
-- Fixed escaping of quote characters in keyword search
-  (<https://github.com/aws/graph-explorer/pull/242>)
-- Fixed edge retrieval for legacy schema sync on openCypher
-  (<https://github.com/aws/graph-explorer/pull/245>)
-- Fixed default connections for Neptune Analytics
-  (<https://github.com/aws/graph-explorer/pull/254>)
-- Fixed formatting of search UI footer
-  (<https://github.com/aws/graph-explorer/pull/260>)
-- Fixed handling of query cancellation on unsupported databases
-  (<https://github.com/aws/graph-explorer/pull/276>)
-- Fixed rotation of sync progress indicator
-  (<https://github.com/aws/graph-explorer/pull/278>)
-- Additional config adjustments for ESLint and Prettier
-  (<https://github.com/aws/graph-explorer/pull/255>)
-- Removed `__all` predicate filter from SPARQL search queries
-  (<https://github.com/aws/graph-explorer/pull/270>)
-- Various formatting improvements
-  (<https://github.com/aws/graph-explorer/pull/251>)
-  (<https://github.com/aws/graph-explorer/pull/266>)
-  (<https://github.com/aws/graph-explorer/pull/267>)
-- Various dependency upgrades (<https://github.com/aws/graph-explorer/pull/248>)
-  (<https://github.com/aws/graph-explorer/pull/246>)
-  (<https://github.com/aws/graph-explorer/pull/286>)
+- Fixed escaping of quote characters in keyword search (<https://github.com/aws/graph-explorer/pull/242>)
+- Fixed edge retrieval for legacy schema sync on openCypher (<https://github.com/aws/graph-explorer/pull/245>)
+- Fixed default connections for Neptune Analytics (<https://github.com/aws/graph-explorer/pull/254>)
+- Fixed formatting of search UI footer (<https://github.com/aws/graph-explorer/pull/260>)
+- Fixed handling of query cancellation on unsupported databases (<https://github.com/aws/graph-explorer/pull/276>)
+- Fixed rotation of sync progress indicator (<https://github.com/aws/graph-explorer/pull/278>)
+- Additional config adjustments for ESLint and Prettier (<https://github.com/aws/graph-explorer/pull/255>)
+- Removed `__all` predicate filter from SPARQL search queries (<https://github.com/aws/graph-explorer/pull/270>)
+- Various formatting improvements (<https://github.com/aws/graph-explorer/pull/251>) (<https://github.com/aws/graph-explorer/pull/266>) (<https://github.com/aws/graph-explorer/pull/267>)
+- Various dependency upgrades (<https://github.com/aws/graph-explorer/pull/248>) (<https://github.com/aws/graph-explorer/pull/246>) (<https://github.com/aws/graph-explorer/pull/286>)
 
 ## Release 1.5.1
 
@@ -1445,10 +790,8 @@ This release includes the following feature enhancements and bug fixes:
 
 **Bug fixes**
 
-- Refactored API request options for non-IAM endpoints
-  (<https://github.com/aws/graph-explorer/pull/230>)
-- Enforced JSON response format for SPARQL queries
-  (<https://github.com/aws/graph-explorer/pull/230>)
+- Refactored API request options for non-IAM endpoints (<https://github.com/aws/graph-explorer/pull/230>)
+- Enforced JSON response format for SPARQL queries (<https://github.com/aws/graph-explorer/pull/230>)
 - Bumped `vite` to `4.5.2` (<https://github.com/aws/graph-explorer/pull/233>)
 
 ## Release 1.5.0
@@ -1457,21 +800,15 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Added new Fetch Timeout option to the Connections UI
-  (<https://github.com/aws/graph-explorer/pull/199>)
+- Added new Fetch Timeout option to the Connections UI (<https://github.com/aws/graph-explorer/pull/199>)
 
 **Bug fixes**
 
-- Fixed synchronization with high number of labels with long strings
-  (<https://github.com/aws/graph-explorer/pull/206>)
-- Fixed loading spinner rotation when synchronizing schema
-  (<https://github.com/aws/graph-explorer/pull/207>)
-- Fixed node and edge counts not updating on connection re-synchronization
-  (<https://github.com/aws/graph-explorer/pull/209>)
-- Fixed issue with Transition2 findDOMNode deprecation
-  (<https://github.com/aws/graph-explorer/pull/211>)
-- Fixed highlight not persisting on selected graph element
-  (<https://github.com/aws/graph-explorer/pull/187>)
+- Fixed synchronization with high number of labels with long strings (<https://github.com/aws/graph-explorer/pull/206>)
+- Fixed loading spinner rotation when synchronizing schema (<https://github.com/aws/graph-explorer/pull/207>)
+- Fixed node and edge counts not updating on connection re-synchronization (<https://github.com/aws/graph-explorer/pull/209>)
+- Fixed issue with Transition2 findDOMNode deprecation (<https://github.com/aws/graph-explorer/pull/211>)
+- Fixed highlight not persisting on selected graph element (<https://github.com/aws/graph-explorer/pull/187>)
 - Bumped `@types/semver` to `7.5.2`
 - Bumped `babel`, `postcss`, and `vite` to latest
 - Bumped `crypto-js` to `4.2.0`
@@ -1483,37 +820,22 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Added SageMaker Notebook support
-  (<https://github.com/aws/graph-explorer/pull/178>)
-- Added Default Connection support
-  (<https://github.com/aws/graph-explorer/pull/108>)
-- Added query language indicators to created connections
-  (<https://github.com/aws/graph-explorer/pull/164>)
-- Added match precision option to keyword search
-  (<https://github.com/aws/graph-explorer/pull/175>)
-- Added toggle for limit on retrieved vertex neighbors
-  (<https://github.com/aws/graph-explorer/pull/176>)
-- Added SageMaker Notebook hosting documentation
-  (<https://github.com/aws/graph-explorer/pull/183>)
-- Added ECS hosting documentation
-  (<https://github.com/aws/graph-explorer/pull/174>)
-- Updated Dockerfile base image to AL2022
-  (<https://github.com/aws/graph-explorer/pull/190>)
+- Added SageMaker Notebook support (<https://github.com/aws/graph-explorer/pull/178>)
+- Added Default Connection support (<https://github.com/aws/graph-explorer/pull/108>)
+- Added query language indicators to created connections (<https://github.com/aws/graph-explorer/pull/164>)
+- Added match precision option to keyword search (<https://github.com/aws/graph-explorer/pull/175>)
+- Added toggle for limit on retrieved vertex neighbors (<https://github.com/aws/graph-explorer/pull/176>)
+- Added SageMaker Notebook hosting documentation (<https://github.com/aws/graph-explorer/pull/183>)
+- Added ECS hosting documentation (<https://github.com/aws/graph-explorer/pull/174>)
+- Updated Dockerfile base image to AL2022 (<https://github.com/aws/graph-explorer/pull/190>)
 
 **Bug fixes**
 
-- Fixed search UI crashing on node select/preview
-  (<https://github.com/aws/graph-explorer/pull/177>)
-- Fixed Gremlin/openCypher matching ID property on all keyword searches
-  (<https://github.com/aws/graph-explorer/pull/169>)
-- Fixed default connections failing on SageMaker for certain instance names
-  (<https://github.com/aws/graph-explorer/pull/188>)
-- Resolved deprecation warnings in GitHub workflows
-  (<https://github.com/aws/graph-explorer/pull/181>)
-- Patched vulnerable dependencies
-  ([1](https://github.com/aws/graph-explorer/pull/182))
-  ([2](https://github.com/aws/graph-explorer/pull/189))
-  ([3](https://github.com/aws/graph-explorer/pull/191))
+- Fixed search UI crashing on node select/preview (<https://github.com/aws/graph-explorer/pull/177>)
+- Fixed Gremlin/openCypher matching ID property on all keyword searches (<https://github.com/aws/graph-explorer/pull/169>)
+- Fixed default connections failing on SageMaker for certain instance names (<https://github.com/aws/graph-explorer/pull/188>)
+- Resolved deprecation warnings in GitHub workflows (<https://github.com/aws/graph-explorer/pull/181>)
+- Patched vulnerable dependencies ([1](https://github.com/aws/graph-explorer/pull/182)) ([2](https://github.com/aws/graph-explorer/pull/189)) ([3](https://github.com/aws/graph-explorer/pull/191))
 
 ## Release 1.3.1
 
@@ -1521,8 +843,7 @@ This patch release includes bugfixes for Release 1.3.0.
 
 **Bug fixes**
 
-- Fix proxy issue with non-IAM Neptune requests
-  (<https://github.com/aws/graph-explorer/pull/166>)
+- Fix proxy issue with non-IAM Neptune requests (<https://github.com/aws/graph-explorer/pull/166>)
 
 ## Release 1.3.0
 
@@ -1530,28 +851,19 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Support openCypher-based graph databases
-  (<https://github.com/aws/graph-explorer/pull/129>)
-- Added ability to search by vertex ID for Gremlin
-  (<https://github.com/aws/graph-explorer/pull/113>)
-- Improved logging visibility and user control
-  (<https://github.com/aws/graph-explorer/pull/114>)
-- Upgraded various dependencies to resolve Docker build warnings
-  (<https://github.com/aws/graph-explorer/pull/118>)
-- Improved synchronization interface in Connections UI
-  (<https://github.com/aws/graph-explorer/pull/120>)
-- Added coverage tests for the UI client package
-  (<https://github.com/aws/graph-explorer/pull/130>)
+- Support openCypher-based graph databases (<https://github.com/aws/graph-explorer/pull/129>)
+- Added ability to search by vertex ID for Gremlin (<https://github.com/aws/graph-explorer/pull/113>)
+- Improved logging visibility and user control (<https://github.com/aws/graph-explorer/pull/114>)
+- Upgraded various dependencies to resolve Docker build warnings (<https://github.com/aws/graph-explorer/pull/118>)
+- Improved synchronization interface in Connections UI (<https://github.com/aws/graph-explorer/pull/120>)
+- Added coverage tests for the UI client package (<https://github.com/aws/graph-explorer/pull/130>)
 
 **Bug fixes**
 
 - Fix Expand Module scrollbar (<https://github.com/aws/graph-explorer/pull/131>)
-- Fixed header generation for IAM authenticated Neptune requests
-  (<https://github.com/aws/graph-explorer/pull/140>)
-- Fixed calculation of neighbors count in Expand View sidebar
-  (<https://github.com/aws/graph-explorer/pull/121>)
-- Fixed proxy server not respecting `GRAPH_EXP_ENV_ROOT_FOLDER` value in .env
-  (<https://github.com/aws/graph-explorer/pull/125>)
+- Fixed header generation for IAM authenticated Neptune requests (<https://github.com/aws/graph-explorer/pull/140>)
+- Fixed calculation of neighbors count in Expand View sidebar (<https://github.com/aws/graph-explorer/pull/121>)
+- Fixed proxy server not respecting `GRAPH_EXP_ENV_ROOT_FOLDER` value in .env (<https://github.com/aws/graph-explorer/pull/125>)
 
 ## Release 1.2.0
 
@@ -1559,23 +871,16 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Significantly reduced size of Docker image
-  (<https://github.com/aws/graph-explorer/pull/104>)
-- Improved schema synchronization performance via Summary API integration
-  (<https://github.com/aws/graph-explorer/pull/80>)
-- Improved error messaging when no/insufficient IAM role is found
-  (<https://github.com/aws/graph-explorer/pull/81>)
-- Updated Connections UI documentation for single server changes
-  (<https://github.com/aws/graph-explorer/pull/59>)
-- Added manual trigger for ECR updates
-  (<https://github.com/aws/graph-explorer/pull/68>)
+- Significantly reduced size of Docker image (<https://github.com/aws/graph-explorer/pull/104>)
+- Improved schema synchronization performance via Summary API integration (<https://github.com/aws/graph-explorer/pull/80>)
+- Improved error messaging when no/insufficient IAM role is found (<https://github.com/aws/graph-explorer/pull/81>)
+- Updated Connections UI documentation for single server changes (<https://github.com/aws/graph-explorer/pull/59>)
+- Added manual trigger for ECR updates (<https://github.com/aws/graph-explorer/pull/68>)
 
 **Bug fixes**
 
-- Fixed incorrect display of non-string IDs for Gremlin
-  (<https://github.com/aws/graph-explorer/pull/60>)
-- Fixed a database synchronization error caused by white spaces in labels for
-  Gremlin requests (<https://github.com/aws/graph-explorer/pull/84>)
+- Fixed incorrect display of non-string IDs for Gremlin (<https://github.com/aws/graph-explorer/pull/60>)
+- Fixed a database synchronization error caused by white spaces in labels for Gremlin requests (<https://github.com/aws/graph-explorer/pull/84>)
 
 ## Release 1.1.0
 
@@ -1583,39 +888,24 @@ This release includes the following feature enhancements and bug fixes:
 
 **Features**
 
-- Support for blank nodes when visualizing graphs using the RDF data model
-  (<https://github.com/aws/graph-explorer/pull/48>)
-- Enable Caching feature in the Connections UI which allows you to temporarily
-  store data in the browser between sessions
-  (<https://github.com/aws/graph-explorer/pull/48>)
-- Simplify the setup by consolidating the build and serving the graph-explorer
-  through port (<https://github.com/aws/graph-explorer/pull/52>)
-- Moved self-signed SSL certificate creation to Docker entrypoint script
-  (<https://github.com/aws/graph-explorer/pull/56>)
+- Support for blank nodes when visualizing graphs using the RDF data model (<https://github.com/aws/graph-explorer/pull/48>)
+- Enable Caching feature in the Connections UI which allows you to temporarily store data in the browser between sessions (<https://github.com/aws/graph-explorer/pull/48>)
+- Simplify the setup by consolidating the build and serving the graph-explorer through port (<https://github.com/aws/graph-explorer/pull/52>)
+- Moved self-signed SSL certificate creation to Docker entrypoint script (<https://github.com/aws/graph-explorer/pull/56>)
 
 **Bug fixes**
 
-- Fix an issue where the Graph Explorer is stuck in a loading state indefinitely
-  due to expired credentials by refreshing credentials and retrying requests
-  automatically (<https://github.com/aws/graph-explorer/pull/49>)
+- Fix an issue where the Graph Explorer is stuck in a loading state indefinitely due to expired credentials by refreshing credentials and retrying requests automatically (<https://github.com/aws/graph-explorer/pull/49>)
 
 ## Release 1.0.0
 
-The first release of Graph Explorer, an Apache 2.0 React-based web application
-that enables users to visualize both property graph and RDF data and explore
-connections between data without having to write graph queries. Major features
-include:
+The first release of Graph Explorer, an Apache 2.0 React-based web application that enables users to visualize both property graph and RDF data and explore connections between data without having to write graph queries. Major features include:
 
-- Ability to connect to graph databases like Amazon Neptune, or open-source
-  endpoints like Gremlin Server or Blazegraph
+- Ability to connect to graph databases like Amazon Neptune, or open-source endpoints like Gremlin Server or Blazegraph
 - Search and preview starting nodes once connected to a graph database
 - Visualize results in the Graph View & expand to view neighbors
-- Customize the Graph View with preferred layouts, colors, icons, labels, and
-  more
-- Use Expand filters to customize the result set by filter text or count of
-  results when expanding
-- Scroll through the Table View to view the data in the Graph View in tabular
-  format
+- Customize the Graph View with preferred layouts, colors, icons, labels, and more
+- Use Expand filters to customize the result set by filter text or count of results when expanding
+- Scroll through the Table View to view the data in the Graph View in tabular format
 - Use Table View filters when you need to highlight a subset of the data
-- Download a CSV or JSON of the nodes and edges in visualization, or download as
-  a PNG file
+- Download a CSV or JSON of the nodes and edges in visualization, or download as a PNG file

--- a/README.md
+++ b/README.md
@@ -1,147 +1,95 @@
 # Graph Explorer
 
-Graph Explorer is a React-based web application that makes it easy to visualize
-and explore graph data, no query language knowledge required. Search for nodes,
-expand connections, and discover relationships across your graph database
-through an intuitive visual interface.
+Graph Explorer is a React-based web application that makes it easy to visualize and explore graph data, no query language knowledge required. Search for nodes, expand connections, and discover relationships across your graph database through an intuitive visual interface.
 
-Connect to graph databases that support
-[Apache TinkerPop Gremlin](https://tinkerpop.apache.org/) or
-[W3C RDF/SPARQL](https://www.w3.org/TR/sparql11-overview/) over HTTP, or
-[openCypher](https://opencypher.org) via
-[Amazon Neptune](https://aws.amazon.com/neptune/).
+Connect to graph databases that support [Apache TinkerPop Gremlin](https://tinkerpop.apache.org/) or [W3C RDF/SPARQL](https://www.w3.org/TR/sparql11-overview/) over HTTP, or [openCypher](https://opencypher.org) via [Amazon Neptune](https://aws.amazon.com/neptune/).
 
 ## Explore Your Data
 
-Graph Explorer provides three integrated views for working with your graph
-database, all in one app.
+Graph Explorer provides three integrated views for working with your graph database, all in one app.
 
 ### Graph View
 
-Search, visualize, and explore connections between nodes with an interactive
-graph layout. Expand neighbors, filter by type, and run custom queries, all from
-a single view.
+Search, visualize, and explore connections between nodes with an interactive graph layout. Expand neighbors, filter by type, and run custom queries, all from a single view.
 
 ![Graph Explorer showing an interactive visualization of airport routes with search, table view, and node details](./images/graph-explorer.png)
 
 ### Data Explorer
 
-Browse all nodes for a given type in a paginated table. View every property at a
-glance and send nodes directly to the graph view for further exploration.
+Browse all nodes for a given type in a paginated table. View every property at a glance and send nodes directly to the graph view for further exploration.
 
 ![Data Explorer showing a tabular view of airport nodes with properties like city, code, and coordinates](./images/data-explorer.png)
 
 ### Schema Explorer
 
-Understand your data model at a glance. See node types, their relationships, and
-property details rendered as an interactive schema graph.
+Understand your data model at a glance. See node types, their relationships, and property details rendered as an interactive schema graph.
 
 ![Schema Explorer showing the relationships between airport, country, continent, and version node types](./images/schema-explorer.png)
 
 ### Flexible Deployment
 
-Run Graph Explorer wherever it fits your workflow: as a Docker container, on an
-Amazon EC2 instance, through Amazon SageMaker, or locally from source during
-development. Configure multiple connections to different databases and switch
-between them seamlessly. See [Getting Started](#getting-started) for setup
-guides.
+Run Graph Explorer wherever it fits your workflow: as a Docker container, on an Amazon EC2 instance, through Amazon SageMaker, or locally from source during development. Configure multiple connections to different databases and switch between them seamlessly. See [Getting Started](#getting-started) for setup guides.
 
 ## Learn More
 
-- [Getting Started](./additionaldocs/getting-started/README.md) - Set up Graph
-  Explorer with Docker, EC2, or from source
-- [Features Overview](./additionaldocs/features/README.md) - Detailed guide to
-  all features and functionality
+- [Getting Started](./additionaldocs/getting-started/README.md) - Set up Graph Explorer with Docker, EC2, or from source
+- [Features Overview](./additionaldocs/features/README.md) - Detailed guide to all features and functionality
 - [Roadmap](./ROADMAP.md) - See what's planned for future releases
-- [Discussions](https://github.com/aws/graph-explorer/discussions) - Ask
-  questions, share ideas, and connect with the community
-- [Submit an Issue](https://github.com/aws/graph-explorer/issues/new/choose) -
-  Report bugs or request new features
+- [Discussions](https://github.com/aws/graph-explorer/discussions) - Ask questions, share ideas, and connect with the community
+- [Submit an Issue](https://github.com/aws/graph-explorer/issues/new/choose) - Report bugs or request new features
 - [Contributing](./CONTRIBUTING.md) - Learn how to contribute to Graph Explorer
 - [Changelog](./Changelog.md) - See what's changed in recent releases
 
 ## Getting Started
 
-There are many ways to deploy and run Graph Explorer. If you are new to graph
-databases and Graph Explorer, we recommend that you check out the
-[Getting Started](./additionaldocs/getting-started/README.md) guide.
+There are many ways to deploy and run Graph Explorer. If you are new to graph databases and Graph Explorer, we recommend that you check out the [Getting Started](./additionaldocs/getting-started/README.md) guide.
 
-- [Local Docker Setup](./additionaldocs/getting-started/README.md#local-docker-setup) -
-  A quick start guide to deploying Graph Explorer locally using the official
-  Docker image.
-- [Amazon EC2 Setup](./additionaldocs/getting-started/README.md#amazon-ec2-setup) -
-  A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
-- [Local Development](./additionaldocs/getting-started/README.md#local-development-setup) -
-  A quick start guide building the Docker image from source code.
-- [Troubleshooting](./additionaldocs/troubleshooting.md) - A collection of
-  helpful tips if you run in to issues while setting up Graph Explorer.
-- [Samples](./samples) - A collection of Docker Compose files that show various
-  ways to configure and use Graph Explorer.
+- [Local Docker Setup](./additionaldocs/getting-started/README.md#local-docker-setup) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
+- [Amazon EC2 Setup](./additionaldocs/getting-started/README.md#amazon-ec2-setup) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
+- [Local Development](./additionaldocs/getting-started/README.md#local-development-setup) - A quick start guide building the Docker image from source code.
+- [Troubleshooting](./additionaldocs/troubleshooting.md) - A collection of helpful tips if you run in to issues while setting up Graph Explorer.
+- [Samples](./samples) - A collection of Docker Compose files that show various ways to configure and use Graph Explorer.
 
 ### Minimum Recommended Versions
 
-Graph Explorer does not block any particular versions of graph databases, but
-the queries used may or may not succeed based on the version of the query
-engine.
+Graph Explorer does not block any particular versions of graph databases, but the queries used may or may not succeed based on the version of the query engine.
 
-For Neptune databases, we recommend
-[version 1.2.1.0](https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases-1.2.1.0.html)
-or above, which include the summary API and TinkerPop 3.6.2.
+For Neptune databases, we recommend [version 1.2.1.0](https://docs.aws.amazon.com/neptune/latest/userguide/engine-releases-1.2.1.0.html) or above, which include the summary API and TinkerPop 3.6.2.
 
 For non-Neptune databases, we recommend at least TinkerPop 3.6.
 
 ## Connections
 
-Graph Explorer supports visualizing both **property graphs** and **RDF graphs**.
-You can connect to Amazon Neptune or you can also connect to open graph
-databases that implement an Apache TinkerPop Gremlin endpoint or the SPARQL 1.1
-protocol, such as Blazegraph. For additional details on connecting to different
-graph databases, see [Connections](./additionaldocs/connections.md).
+Graph Explorer supports visualizing both **property graphs** and **RDF graphs**. You can connect to Amazon Neptune or you can also connect to open graph databases that implement an Apache TinkerPop Gremlin endpoint or the SPARQL 1.1 protocol, such as Blazegraph. For additional details on connecting to different graph databases, see [Connections](./additionaldocs/connections.md).
 
 ### Providing a Default Connection
 
-To provide a default connection such that initial loads of Graph Explorer always
-result with the same starting connection, modify the `docker run ...` command to
-either take in a JSON configuration or runtime environment variables. If you
-provide both a JSON configuration and environmental variables, the JSON will be
-prioritized.
+To provide a default connection such that initial loads of Graph Explorer always result with the same starting connection, modify the `docker run ...` command to either take in a JSON configuration or runtime environment variables. If you provide both a JSON configuration and environmental variables, the JSON will be prioritized.
 
 #### Environment Variables
 
-These are the valid environment variables used for the default connection, their
-defaults, and their descriptions.
+These are the valid environment variables used for the default connection, their defaults, and their descriptions.
 
 - Required:
-  - `PUBLIC_OR_PROXY_ENDPOINT` - `None` - See
-    [Add a New Connection](#connections-ui)
+  - `PUBLIC_OR_PROXY_ENDPOINT` - `None` - See [Add a New Connection](#connections-ui)
 - Optional
-  - `GRAPH_TYPE` - `None` - If not specified, multiple connections will be
-    created for every available query language. See
-    [Add a New Connection](#connections-ui)
+  - `GRAPH_TYPE` - `None` - If not specified, multiple connections will be created for every available query language. See [Add a New Connection](#connections-ui)
   - `USING_PROXY_SERVER` - `False` - See [Add a New Connection](#connections-ui)
   - `IAM` - `False` - See [Add a New Connection](#connections-ui)
-  - `GRAPH_EXP_HTTPS_CONNECTION` - `True` - Controls whether Graph Explorer uses
-    SSL or not
-  - `PROXY_SERVER_HTTPS_CONNECTION` - `True` - Controls whether the server uses
-    SSL or not
-  - `GRAPH_EXP_FETCH_REQUEST_TIMEOUT` - `240000` - Controls the timeout for the
-    fetch request. Measured in milliseconds (i.e. 240000 is 240 seconds or 4
-    minutes).
-  - `GRAPH_EXP_NODE_EXPANSION_LIMIT` - `None` - Controls the limit for node
-    counts and expansion queries.
+  - `GRAPH_EXP_HTTPS_CONNECTION` - `True` - Controls whether Graph Explorer uses SSL or not
+  - `PROXY_SERVER_HTTPS_CONNECTION` - `True` - Controls whether the server uses SSL or not
+  - `GRAPH_EXP_FETCH_REQUEST_TIMEOUT` - `240000` - Controls the timeout for the fetch request. Measured in milliseconds (i.e. 240000 is 240 seconds or 4 minutes).
+  - `GRAPH_EXP_NODE_EXPANSION_LIMIT` - `None` - Controls the limit for node counts and expansion queries.
 - Conditionally Required:
   - Required if `USING_PROXY_SERVER=True`
-    - `GRAPH_CONNECTION_URL` - `None` - See
-      [Add a New Connection](#connections-ui)
+    - `GRAPH_CONNECTION_URL` - `None` - See [Add a New Connection](#connections-ui)
   - Required if `USING_PROXY_SERVER=True` and `IAM=True`
     - `AWS_REGION` - `None` - See [Add a New Connection](#connections-ui)
-    - `SERVICE_TYPE` - `neptune-db`, Set this as `neptune-db` for Neptune
-      database or `neptune-graph` for Neptune Analytics.
+    - `SERVICE_TYPE` - `neptune-db`, Set this as `neptune-db` for Neptune database or `neptune-graph` for Neptune Analytics.
 
 #### JSON Configuration Approach
 
-First, create a `config.json` file containing values for the connection
-attributes:
+First, create a `config.json` file containing values for the connection attributes:
 
 ```js
 {
@@ -172,8 +120,7 @@ docker run -p 80:80 -p 443:443 \
 
 #### Environment Variable Approach
 
-Provide the desired connection variables directly to the `docker run` command,
-as follows:
+Provide the desired connection variables directly to the `docker run` command, as follows:
 
 ```bash
 docker run -p 80:80 -p 443:443 \
@@ -197,58 +144,29 @@ For development guidance, see [Development](./additionaldocs/development.md).
 
 ## Security
 
-You can use Graph Explorer to connect to a publicly accessible graph database
-endpoint, or connect to a proxy endpoint that redirects to a private graph
-database endpoint.
+You can use Graph Explorer to connect to a publicly accessible graph database endpoint, or connect to a proxy endpoint that redirects to a private graph database endpoint.
 
-Graph Explorer supports the HTTPS protocol by default and provides a self-signed
-certificate as part of the Docker image. You can choose to use HTTP instead by
-changing the
-[environment variable default settings](./additionaldocs/development.md#environment-variables).
+Graph Explorer supports the HTTPS protocol by default and provides a self-signed certificate as part of the Docker image. You can choose to use HTTP instead by changing the [environment variable default settings](./additionaldocs/development.md#environment-variables).
 
 ### HTTPS Connections
 
-If either Graph Explorer or the proxy-server are served over an HTTPS connection
-(which it is by default), you will have to bypass the warning message from the
-browser due to the included certificate being a self-signed certificate. You can
-bypass by manually ignoring them from the browser or downloading the correct
-certificate and configuring them to be trusted. Alternatively, you can provide
-your own certificate. The following instructions can be used as an example to
-bypass the warnings for Chrome, but note that different browsers and operating
-systems will have slightly different steps.
+If either Graph Explorer or the proxy-server are served over an HTTPS connection (which it is by default), you will have to bypass the warning message from the browser due to the included certificate being a self-signed certificate. You can bypass by manually ignoring them from the browser or downloading the correct certificate and configuring them to be trusted. Alternatively, you can provide your own certificate. The following instructions can be used as an example to bypass the warnings for Chrome, but note that different browsers and operating systems will have slightly different steps.
 
-1. Download the certificate directly from the browser. For example, if using
-   Google Chrome, click the “Not Secure” section on the left of the URL bar and
-   select “Certificate is not valid” to show the certificate. Then click Details
-   tab and click Export at the bottom.
-2. Once you have the certificate, you will need to trust it on your machine. For
-   MacOS, you can open the Keychain Access app. Select System under System
-   Keychains. Then go to File > Import Items... and import the certificate you
-   downloaded in the previous step.
-3. Once imported, select the certificate and right-click to select "Get Info".
-   Expand the Trust section, and change the value of "When using this
-   certificate" to "Always Trust".
-4. You should now refresh the browser and see that you can proceed to open the
-   application. For Chrome, the application will remain “Not Secure” due to the
-   fact that this is a self-signed certificate. If you have trouble accessing
-   Graph Explorer after completing the previous step and reloading the browser,
-   consider running a docker restart command and refreshing the browser again.
+1. Download the certificate directly from the browser. For example, if using Google Chrome, click the “Not Secure” section on the left of the URL bar and select “Certificate is not valid” to show the certificate. Then click Details tab and click Export at the bottom.
+2. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
+3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
+4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain “Not Secure” due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
 
 <!-- prettier-ignore -->
 > [!TIP] 
 > 
-> To get rid of the “Not Secure” warning, see
-[Using self-signed certificates on Chrome](./additionaldocs/development.md#using-self-signed-certificates-on-chrome).
+> To get rid of the “Not Secure” warning, see [Using self-signed certificates on Chrome](./additionaldocs/development.md#using-self-signed-certificates-on-chrome).
 
 ## Permissions
 
-Graph Explorer does not provide any mechanisms for controlling user permissions.
-If you are using Graph Explorer with AWS, Neptune permissions can be controlled
-through IAM roles.
+Graph Explorer does not provide any mechanisms for controlling user permissions. If you are using Graph Explorer with AWS, Neptune permissions can be controlled through IAM roles.
 
-For information about what permissions Graph Explorer requires check out the
-documentation on
-[SageMaker configuration](./additionaldocs/sagemaker/README.md#minimum-database-permissions).
+For information about what permissions Graph Explorer requires check out the documentation on [SageMaker configuration](./additionaldocs/sagemaker/README.md#minimum-database-permissions).
 
 <!-- prettier-ignore -->
 > [!CAUTION] 
@@ -257,69 +175,37 @@ documentation on
 
 ## Authentication
 
-Authentication for Amazon Neptune connections is enabled using the
-[SigV4 signing protocol](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
+Authentication for Amazon Neptune connections is enabled using the [SigV4 signing protocol](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html).
 
-To use AWS IAM authentication, you must run requests through a proxy endpoint,
-such as an EC2 instance, where credentials are resolved and where requests are
-signed.
+To use AWS IAM authentication, you must run requests through a proxy endpoint, such as an EC2 instance, where credentials are resolved and where requests are signed.
 
-To set up a connection in Graph Explorer UI with AWS IAM auth enabled on
-Neptune, check Using Proxy-Server, then check AWS IAM Auth Enabled and type in
-the AWS Region where the Neptune cluster is hosted (e.g., us-east-1).
+To set up a connection in Graph Explorer UI with AWS IAM auth enabled on Neptune, check Using Proxy-Server, then check AWS IAM Auth Enabled and type in the AWS Region where the Neptune cluster is hosted (e.g., us-east-1).
 
-For further information on how AWS credentials are resolved in Graph Explorer,
-refer to this
-[documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html).
+For further information on how AWS credentials are resolved in Graph Explorer, refer to this [documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html).
 
 ## Health Check Status
 
-The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring
-its health and readiness. This endpoint is crucial for ensuring reliable service
-operation and can be utilized in various deployment scenarios.
+The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring its health and readiness. This endpoint is crucial for ensuring reliable service operation and can be utilized in various deployment scenarios.
 
 **Key Features:**
 
-- **Health Check:** The `/status` endpoint serves as a basic health check,
-  confirming that the Express server is running and responding. This is
-  essential for load balancers (like AWS ALB) to determine if the server is
-  operational and should receive traffic.
-- **Readiness Probe:** It also functions as a readiness probe in container
-  orchestration systems (like Kubernetes). This allows the orchestrator to know
-  when the server is ready to accept requests, preventing traffic from being
-  routed to instances that are still starting up or experiencing issues.
-- **Expected Response:** A successful health check or readiness probe will
-  result in an HTTP `200 OK` response with the body containing `OK`.
+- **Health Check:** The `/status` endpoint serves as a basic health check, confirming that the Express server is running and responding. This is essential for load balancers (like AWS ALB) to determine if the server is operational and should receive traffic.
+- **Readiness Probe:** It also functions as a readiness probe in container orchestration systems (like Kubernetes). This allows the orchestrator to know when the server is ready to accept requests, preventing traffic from being routed to instances that are still starting up or experiencing issues.
+- **Expected Response:** A successful health check or readiness probe will result in an HTTP `200 OK` response with the body containing `OK`.
 
 ## Logging
 
-Logs are, by default, sent to the console and will be visible as output to the
-docker logs. If you want to access the full set of logs, you can run
-`docker logs {container name or id}`.
+Logs are, by default, sent to the console and will be visible as output to the docker logs. If you want to access the full set of logs, you can run `docker logs {container name or id}`.
 
-The log level will be set via the `LOG_LEVEL` env variable at
-`/packages/graph-explorer/.env` where the possible options, from highest to
-lowest, are `fatal`, `error`, `warn`, `info`, `debug`, `trace`, and `silent`
-such that `fatal` is the highest level and will only include logs labeled as
-fatal and `trace` the lowest and will include any type of log. The `silent`
-level disables all logging.
+The log level will be set via the `LOG_LEVEL` env variable at `/packages/graph-explorer/.env` where the possible options, from highest to lowest, are `fatal`, `error`, `warn`, `info`, `debug`, `trace`, and `silent` such that `fatal` is the highest level and will only include logs labeled as fatal and `trace` the lowest and will include any type of log. The `silent` level disables all logging.
 
-By default, the log level is set to `info` and the only type of logs generated
-are those of `error`, `info`, or `debug`. If you need more detailed logs, you
-can change the log level from `info` in the default .env file to `debug` and the
-logs will begin printing the error's stack trace.
+By default, the log level is set to `info` and the only type of logs generated are those of `error`, `info`, or `debug`. If you need more detailed logs, you can change the log level from `info` in the default .env file to `debug` and the logs will begin printing the error's stack trace.
 
 The proxy server logging is split across a few key modules:
 
-1. `logging.ts` - Contains the `logger` instance (using pino) that is
-   responsible for actually recording the logs.
-2. `error-handler.ts` - Contains `errorHandlingMiddleware` which catches errors
-   thrown within Express routes, logs whitelisted request headers, and sends
-   appropriate error responses. It also contains a `handleError` function used
-   for global error handling.
-3. An endpoint called `/logger` in `node-server.ts` - This is how you would log
-   things from the browser. It needs a log level and message header passed and
-   you can then expect to see the message logged at the provided log level.
+1. `logging.ts` - Contains the `logger` instance (using pino) that is responsible for actually recording the logs.
+2. `error-handler.ts` - Contains `errorHandlingMiddleware` which catches errors thrown within Express routes, logs whitelisted request headers, and sends appropriate error responses. It also contains a `handleError` function used for global error handling.
+3. An endpoint called `/logger` in `node-server.ts` - This is how you would log things from the browser. It needs a log level and message header passed and you can then expect to see the message logged at the provided log level.
 
 ## Contributing Guidelines
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,7 @@
 
 This document describes the future roadmap for Graph Explorer.
 
-We encourage you to participate in the discussion within the individual roadmap
-issues linked below.
+We encourage you to participate in the discussion within the individual roadmap issues linked below.
 
 <!-- prettier-ignore -->
 > [!IMPORTANT]

--- a/additionaldocs/connections.md
+++ b/additionaldocs/connections.md
@@ -1,19 +1,15 @@
 ## Connections
 
-This section contains detailed instructions that help when configuring Graph
-Explorer with different graph database engines.
+This section contains detailed instructions that help when configuring Graph Explorer with different graph database engines.
 
 ### Connecting to Neptune
 
-- Ensure that Graph Explorer has access to the Neptune instance by being in the
-  same VPC or VPC peering.
-- If authentication is enabled, read query privileges are needed (See
-  [ReadDataViaQuery managed policy](https://docs.aws.amazon.com/neptune/latest/userguide/iam-data-access-examples.html#iam-auth-data-policy-example-read-query)).
+- Ensure that Graph Explorer has access to the Neptune instance by being in the same VPC or VPC peering.
+- If authentication is enabled, read query privileges are needed (See [ReadDataViaQuery managed policy](https://docs.aws.amazon.com/neptune/latest/userguide/iam-data-access-examples.html#iam-auth-data-policy-example-read-query)).
 
 ### Connecting to Gremlin-Server
 
-If you are using the default Gremlin Server docker image, you can get the server
-running with the following commands:
+If you are using the default Gremlin Server docker image, you can get the server running with the following commands:
 
 ```
 docker pull tinkerpop/gremlin-server:latest
@@ -24,10 +20,7 @@ docker run -p 8182:8182 \
 
 #### Enable REST
 
-Graph Explorer only supports HTTP(S) connections. When connecting to
-Gremlin-Server, ensure it is configured with a channelizer that supports HTTP(S)
-(i.e.
-[Channelizer Documentation](https://tinkerpop.apache.org/javadocs/current/full/org/apache/tinkerpop/gremlin/server/Channelizer.html)).
+Graph Explorer only supports HTTP(S) connections. When connecting to Gremlin-Server, ensure it is configured with a channelizer that supports HTTP(S) (i.e. [Channelizer Documentation](https://tinkerpop.apache.org/javadocs/current/full/org/apache/tinkerpop/gremlin/server/Channelizer.html)).
 
 <!-- prettier-ignore -->
 > [!TIP] 
@@ -39,21 +32,13 @@ Gremlin-Server, ensure it is configured with a channelizer that supports HTTP(S)
 
 #### Versions Prior to 3.7
 
-If you have a version of Gremlin Server prior to 3.7, you will need to make the
-following changes:
+If you have a version of Gremlin Server prior to 3.7, you will need to make the following changes:
 
-- **Enable property returns** - Remove
-  “.withStrategies(ReferenceElementStrategy)” from
-  `/scripts/generate-modern.groovy` so that properties are returned.
-- **Enable string IDs** - Change `gremlin.tinkergraph.vertexIdManager` and
-  `gremlin.tinkergraph.edgeIdManager` in `/conf/tinkergraph-empty.properties` to
-  support string ids. You can use `ANY`.
+- **Enable property returns** - Remove “.withStrategies(ReferenceElementStrategy)” from `/scripts/generate-modern.groovy` so that properties are returned.
+- **Enable string IDs** - Change `gremlin.tinkergraph.vertexIdManager` and `gremlin.tinkergraph.edgeIdManager` in `/conf/tinkergraph-empty.properties` to support string ids. You can use `ANY`.
 - Build and run the Docker container as normal.
 
 ### Connecting to BlazeGraph
 
-- Build and run the Docker container as normal and connect the proxy-server to
-  BlazeGraph and your workbench to the proxy-server.
-- If using Docker, ensure that the container running the workbench can properly
-  access the container running BlazeGraph. You can find documentation on how to
-  connect containers via [Docker networks](https://docs.docker.com/network/).
+- Build and run the Docker container as normal and connect the proxy-server to BlazeGraph and your workbench to the proxy-server.
+- If using Docker, ensure that the container running the workbench can properly access the container running BlazeGraph. You can find documentation on how to connect containers via [Docker networks](https://docs.docker.com/network/).

--- a/additionaldocs/development.md
+++ b/additionaldocs/development.md
@@ -1,8 +1,6 @@
 ## Development
 
-This developer README details instructions for building on top of the
-graph-explorer application, or for configuring advanced settings, like using
-environment variables to switch to HTTP.
+This developer README details instructions for building on top of the graph-explorer application, or for configuring advanced settings, like using environment variables to switch to HTTP.
 
 ### Requirements
 
@@ -11,20 +9,17 @@ environment variables to switch to HTTP.
 
 #### Node Version
 
-Ensure you are running the correct Node version. If you are using
-[NVM](https://github.com/nvm-sh/nvm), you can simply do:
+Ensure you are running the correct Node version. If you are using [NVM](https://github.com/nvm-sh/nvm), you can simply do:
 
 ```bash
 nvm use
 ```
 
-Otherwise, use whatever method you use to install
-[Node v24.13.0](https://nodejs.org/en/download).
+Otherwise, use whatever method you use to install [Node v24.13.0](https://nodejs.org/en/download).
 
 #### Node Corepack
 
-[Corepack](https://nodejs.org/api/corepack.html) is used to ensure the package
-manager used for the project is consistent.
+[Corepack](https://nodejs.org/api/corepack.html) is used to ensure the package manager used for the project is consistent.
 
 ```bash
 corepack enable
@@ -55,8 +50,7 @@ Launch your web browser of choice and navigate to
 http://localhost:5173
 ```
 
-At this point, Graph Explorer should be successfully running and it is asking
-you for connection details. This part is specific to your personal setup.
+At this point, Graph Explorer should be successfully running and it is asking you for connection details. This part is specific to your personal setup.
 
 ### Build for production
 
@@ -67,8 +61,7 @@ pnpm install
 pnpm build
 ```
 
-This will run the build across the both the client code and the proxy server
-code. You'll end up with two `dist` folders:
+This will run the build across the both the client code and the proxy server code. You'll end up with two `dist` folders:
 
 ```
 {ROOT_PATH}/packages/graph-explorer/dist/
@@ -83,8 +76,7 @@ pnpm start
 
 ### Managing dependencies
 
-If you need to add, remove, or update a dependency you can easily do so from the
-root folder in the CLI:
+If you need to add, remove, or update a dependency you can easily do so from the root folder in the CLI:
 
 ```bash
 # Adding a package for the react app
@@ -96,25 +88,14 @@ pnpm add -D vitest --filter graph-explorer-proxy-server
 
 #### Preparation of a release
 
-This repository is composed by 3 packages and a mono-repository structure
-itself. Then, you need to take into account 4 different `package.json` files:
+This repository is composed by 3 packages and a mono-repository structure itself. Then, you need to take into account 4 different `package.json` files:
 
-- `<root>/package.json` is intended to keep the dependencies for managing the
-  repository. It has utilities like linter, code formatter, or git checks.
-- `<root>/packages/graph-explorer/package.json` is the package file that
-  describes the UI client package.
-- `<root>/packages/graph-explorer-proxy-server/package.json` is the package file
-  for the node server which is in charge of authentication and redirection of
-  requests.
-- `<root>/packages/shared/package.json` is the package file for shared code
-  between the client and server packages.
+- `<root>/package.json` is intended to keep the dependencies for managing the repository. It has utilities like linter, code formatter, or git checks.
+- `<root>/packages/graph-explorer/package.json` is the package file that describes the UI client package.
+- `<root>/packages/graph-explorer-proxy-server/package.json` is the package file for the node server which is in charge of authentication and redirection of requests.
+- `<root>/packages/shared/package.json` is the package file for shared code between the client and server packages.
 
-Each of these `package.json` files has an independent `version` property.
-However, in this project we should keep them correlated. Therefore, when a new
-release version is being prepared, the version number should be increased in all
-4 files. Regarding the version number displayed in the user interface, it is
-specifically extracted from the `<root>/packages/graph-explorer/package.json`.
-file
+Each of these `package.json` files has an independent `version` property. However, in this project we should keep them correlated. Therefore, when a new release version is being prepared, the version number should be increased in all 4 files. Regarding the version number displayed in the user interface, it is specifically extracted from the `<root>/packages/graph-explorer/package.json`. file
 
 ### Environment variables
 
@@ -130,8 +111,7 @@ Example: `/explorer`
 
 #### `HOST`
 
-The public hostname of the server. This is used to generate the SSL certificate
-during the Docker build.
+The public hostname of the server. This is used to generate the SSL certificate during the Docker build.
 
 Example: `localhost`
 
@@ -141,8 +121,7 @@ Example: `localhost`
 
 #### `GRAPH_EXP_HTTPS_CONNECTION`
 
-Uses the self-signed certificate to serve Graph Explorer over https if true.
-Only used in Docker via the entrypoint script.
+Uses the self-signed certificate to serve Graph Explorer over https if true. Only used in Docker via the entrypoint script.
 
 - Optional
 - Default `true` in Docker, not set otherwise
@@ -174,64 +153,27 @@ Uses the self-signed certificate to serve the proxy-server over https if true.
 
 ### Using self-signed certificates with Docker
 
-- Self-signed certificates will use the hostname provided in the `docker run`
-  command, so unless you have specific requirements, there are no extra steps
-  here besides providing the hostname.
-- If you would like to modify the certificate files, be aware that the
-  Dockerfile will make automatic modifications on run in the
-  [entrypoint script](https://github.com/aws/graph-explorer/blob/main/docker-entrypoint.sh),
-  so you will need to remove these lines.
-- If you only serve one of either the proxy server or Graph Explorer UI over an
-  HTTPS connection and wish to download from the browser, you should navigate to
-  the one served over HTTPS to download the certificate.
-- The other certificate files can also be found at
-  /packages/graph-explorer-proxy-server/cert-info/ on the Docker container that
-  is created.
+- Self-signed certificates will use the hostname provided in the `docker run` command, so unless you have specific requirements, there are no extra steps here besides providing the hostname.
+- If you would like to modify the certificate files, be aware that the Dockerfile will make automatic modifications on run in the [entrypoint script](https://github.com/aws/graph-explorer/blob/main/docker-entrypoint.sh), so you will need to remove these lines.
+- If you only serve one of either the proxy server or Graph Explorer UI over an HTTPS connection and wish to download from the browser, you should navigate to the one served over HTTPS to download the certificate.
+- The other certificate files can also be found at /packages/graph-explorer-proxy-server/cert-info/ on the Docker container that is created.
 
 ### Using Self-signed certificates on Chrome
 
-For browsers like Safari and Firefox,
-[trusting the certificate from the browser](../README.md/#https-connections) is
-enough to bypass the “Not Secure” warning. However, Chrome treats self-signed
-certificates differently. If you want to use a self-signed certificate on Chrome
-**without** the “Not Secure” warning and you do not have your own certificate,
-or one provided by Let’s Encrypt, you can use the following instructions to add
-the root certificate and remove the warning. These instructions assume you’re
-using an EC2 instance to run the Docker container for Graph Explorer.
+For browsers like Safari and Firefox, [trusting the certificate from the browser](../README.md/#https-connections) is enough to bypass the “Not Secure” warning. However, Chrome treats self-signed certificates differently. If you want to use a self-signed certificate on Chrome **without** the “Not Secure” warning and you do not have your own certificate, or one provided by Let’s Encrypt, you can use the following instructions to add the root certificate and remove the warning. These instructions assume you’re using an EC2 instance to run the Docker container for Graph Explorer.
 
-1. After the Docker container is built and running, open a terminal prompt and
-   SSH into your proxy server instance (e.g., EC2).
+1. After the Docker container is built and running, open a terminal prompt and SSH into your proxy server instance (e.g., EC2).
 2. Get the container ID by running `sudo docker ps`
-3. Copy the root certificate file (rootCA.crt) from the container to EC2:
-   `sudo docker cp {container_id}:~/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt ~/rootCA.crt`
+3. Copy the root certificate file (rootCA.crt) from the container to EC2: `sudo docker cp {container_id}:~/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt ~/rootCA.crt`
 4. Exit SSH session
-5. Copy the root certificate file from EC2 to your local machine (where you
-   would run Graph Explorer on Chrome):
-   `scp -i {path_to_pem_file} {EC2_login}:~/rootCA.crt {path_on_local_to_place_file}`
-   For example,
-   `scp -i /Users/user1/EC2.pem ec2-user@XXX.XXX.XXX.XXX:~/rootCA.crt /Users/user1/downloads`
-6. After copying the certificate from the container to your local machine’s file
-   system, you can delete the rootCA.crt file from the EC2 file store with
-   `rm -rf ~/rootCA.crt`
-7. Once you have the certificate, you will need to trust it on your machine. For
-   MacOS, you can open the Keychain Access app. Select System under System
-   Keychains. Then go to File > Import Items... and import the certificate you
-   downloaded in the previous step.
-8. Once imported, select the certificate and right-click to select "Get Info".
-   Expand the Trust section, and change the value of "When using this
-   certificate" to "Always Trust".
-9. You should now refresh the browser and see that you can proceed to open the
-   application. For Chrome, the application will remain “Not Secure” due to the
-   fact that this is a self-signed certificate. If you have trouble accessing
-   Graph Explorer after completing the previous step and reloading the browser,
-   consider running a docker restart command and refreshing the browser again.
+5. Copy the root certificate file from EC2 to your local machine (where you would run Graph Explorer on Chrome): `scp -i {path_to_pem_file} {EC2_login}:~/rootCA.crt {path_on_local_to_place_file}` For example, `scp -i /Users/user1/EC2.pem ec2-user@XXX.XXX.XXX.XXX:~/rootCA.crt /Users/user1/downloads`
+6. After copying the certificate from the container to your local machine’s file system, you can delete the rootCA.crt file from the EC2 file store with `rm -rf ~/rootCA.crt`
+7. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
+8. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
+9. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain “Not Secure” due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
 
 ### Troubleshooting
 
-- If you need more detailed logs, you can change the log level from `info` in
-  the default .env file to `debug`. The logs will begin printing the error's
-  stack trace.
+- If you need more detailed logs, you can change the log level from `info` in the default .env file to `debug`. The logs will begin printing the error's stack trace.
 - If Graph Explorer crashes, you can recreate the container or run `pnpm start`
-- If Graph Explorer fails to start, check that the provided endpoint is properly
-  spelled and that you have access to from the environment you are trying to run
-  in. If you are in a different VPC, consider VPC Peering.
+- If Graph Explorer fails to start, check that the provided endpoint is properly spelled and that you have access to from the environment you are trying to run in. If you are in a different VPC, consider VPC Peering.

--- a/additionaldocs/ecs/ECS_FARGATE_DEPLOYMENT.md
+++ b/additionaldocs/ecs/ECS_FARGATE_DEPLOYMENT.md
@@ -1,28 +1,18 @@
 # Running Graph Explorer on AWS Fargate + Amazon ECS
 
-The following steps will allow you set up Graph Explorer on AWS Fargate in
-Amazon ECS, and connect to a running Neptune database.
+The following steps will allow you set up Graph Explorer on AWS Fargate in Amazon ECS, and connect to a running Neptune database.
 
 ### Create a new IAM role and permission policies
 
 1. Open the IAM console at https://console.aws.amazon.com/iam/.
 2. In the navigation pane, click **Roles**, and then click **Create role**.
-3. Choose **AWS service** as the role type. Under **Use cases for other AWS
-   services**, choose **Elastic Container Service** in the dropdown, then select
-   the **Elastic Container Service Task** option.
+3. Choose **AWS service** as the role type. Under **Use cases for other AWS services**, choose **Elastic Container Service** in the dropdown, then select the **Elastic Container Service Task** option.
 4. Click **Next**.
-5. Under **Permissions policies**, search for and select the AWS managed
-   policies
-   [AmazonECSTaskExecutionRolePolicy](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy)
-   and
-   [CloudWatchLogsFullAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/CloudWatchLogsFullAccess).
+5. Under **Permissions policies**, search for and select the AWS managed policies [AmazonECSTaskExecutionRolePolicy](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy) and [CloudWatchLogsFullAccess](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/CloudWatchLogsFullAccess).
 6. Click **Next**.
-7. For **Role name**, set the value to `GraphExplorer_ECS_Role`. Optionally, you
-   can enter a description.
-8. For **Add tags (optional)**, enter any custom tags to associate with the
-   policy.
-9. Click **Create role** to finish, and keep the role name handy to use in the
-   next steps.
+7. For **Role name**, set the value to `GraphExplorer_ECS_Role`. Optionally, you can enter a description.
+8. For **Add tags (optional)**, enter any custom tags to associate with the policy.
+9. Click **Create role** to finish, and keep the role name handy to use in the next steps.
 
 ![image](./images/iam-role.png)
 
@@ -31,25 +21,18 @@ Amazon ECS, and connect to a running Neptune database.
 1. Open the ECS console at https://console.aws.amazon.com/ecs/v2.
 2. In the left hand navigation pane, click **Clusters**.
 3. On the Clusters page, click **Create cluster**.
-4. Under **Cluster configuration**, for **Cluster name**, enter a unique
-   identifier.
-   - The name can contain up to 255 letters (uppercase and lowercase), numbers,
-     and hyphens.
-   - (Optional) If you would like to use a namespace different from the cluster
-     name, modify the value of **Default namespace**.
+4. Under **Cluster configuration**, for **Cluster name**, enter a unique identifier.
+   - The name can contain up to 255 letters (uppercase and lowercase), numbers, and hyphens.
+   - (Optional) If you would like to use a namespace different from the cluster name, modify the value of **Default namespace**.
 5. Under **Infrastructure**, select only **AWS Fargate**.
-6. (Optional) To turn on Container Insights, expand **Monitoring**, and then
-   turn on **Use Container Insights**.
-7. (Optional) To help identify your cluster, expand **Tags**, and then configure
-   your tags.
+6. (Optional) To turn on Container Insights, expand **Monitoring**, and then turn on **Use Container Insights**.
+7. (Optional) To help identify your cluster, expand **Tags**, and then configure your tags.
    - [Add a tag] Choose **Add tag and** do the following:
      - For **Key**, enter the key name.
      - For **Value**, enter the key value.
 8. Click **Create**.
 
-After the cluster has finished creation, you can create task definitions for
-your applications, which can then be run as standalone tasks, or as part of a
-service.
+After the cluster has finished creation, you can create task definitions for your applications, which can then be run as standalone tasks, or as part of a service.
 
 ![image](./images/ecs-cluster.png)
 
@@ -60,44 +43,25 @@ service.
 3. Under **Certificate type**, choose **Request a public certificate**.
 4. Click **Next**.
 5. In the **Domain names** section, enter your desired domain name.
-   - You can use a fully qualified domain name (FQDN), such as
-     `graphexplorer.example.com`, or a bare or apex domain name such as
-     `example.com`. You can also use an asterisk (\*) as a wild card in the
-     leftmost position to protect several site names in the same domain.
-6. In the **Validation method** section, choose either **DNS validation –
-   `recommended`** or **Email validation**, depending on your needs.
-   - Before ACM issues a certificate, it validates that you own or control the
-     domain names in your certificate request.
-   - If you choose **email validation**, ACM sends validation email to three
-     contact addresses registered in the WHOIS database, and up to five common
-     system administration addresses for each domain name. You or an authorized
-     representative must reply to one of these email messages. For more
-     information, see
-     [Email validation](https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html).
-   - If you use **DNS validation**, you simply add a CNAME record provided by
-     ACM to your DNS configuration. For more information about DNS validation,
-     see
-     [DNS validation](https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html).
-7. In the **Key algorithm** section, choose one of the three available
-   algorithms:
+   - You can use a fully qualified domain name (FQDN), such as `graphexplorer.example.com`, or a bare or apex domain name such as `example.com`. You can also use an asterisk (\*) as a wild card in the leftmost position to protect several site names in the same domain.
+6. In the **Validation method** section, choose either **DNS validation – `recommended`** or **Email validation**, depending on your needs.
+   - Before ACM issues a certificate, it validates that you own or control the domain names in your certificate request.
+   - If you choose **email validation**, ACM sends validation email to three contact addresses registered in the WHOIS database, and up to five common system administration addresses for each domain name. You or an authorized representative must reply to one of these email messages. For more information, see [Email validation](https://docs.aws.amazon.com/acm/latest/userguide/email-validation.html).
+   - If you use **DNS validation**, you simply add a CNAME record provided by ACM to your DNS configuration. For more information about DNS validation, see [DNS validation](https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html).
+7. In the **Key algorithm** section, choose one of the three available algorithms:
    - RSA 2048 (default)
    - ECDSA P 256
    - ECDSA P 384
 8. (Optional) Under the **Tags** section, you can add tags for your certificate.
 9. Click **Request**.
 
-After the request is processed, the console will return you to your certificate
-list, where information about the certificate will be displayed. The newly
-requested certificate will initially display the status `Pending validation`.
-Once the verification is successful, ACM will issue the SSL/TLS certificate for
-the specified domain names.
+After the request is processed, the console will return you to your certificate list, where information about the certificate will be displayed. The newly requested certificate will initially display the status `Pending validation`. Once the verification is successful, ACM will issue the SSL/TLS certificate for the specified domain names.
 
 ### Creating an ECS Task Definition
 
 1. Open the ECS console at https://console.aws.amazon.com/ecs/v2.
 2. In the left hand navigation pane, choose **Task definitions**.
-3. Click **Create new task definition** -> **Create new task definition with
-   JSON**.
+3. Click **Create new task definition** -> **Create new task definition with JSON**.
 4. In the JSON editor box, copy in the following template.
    ```json
    {
@@ -192,80 +156,54 @@ the specified domain names.
    }
    ```
 5. In the JSON template, update the following fields:
-   - `taskRoleArn` and `executionRoleArn`: The ARN of the IAM role created in
-     step "Create a new IAM role and permission policies".
-   - `environment` variables section (see
-     [Default Connections](https://github.com/aws/graph-explorer#providing-a-default-connection)
-     for more details):
+   - `taskRoleArn` and `executionRoleArn`: The ARN of the IAM role created in step "Create a new IAM role and permission policies".
+   - `environment` variables section (see [Default Connections](https://github.com/aws/graph-explorer#providing-a-default-connection) for more details):
      - `AWS_REGION`: The AWS region in which your Neptune cluster is located.
      - `GRAPH_TYPE`: The query language for your initial connection.
-     - `IAM`: Set this to `true` to use SigV4 signed requests, if your Neptune
-       cluster has IAM db authentication enabled.
+     - `IAM`: Set this to `true` to use SigV4 signed requests, if your Neptune cluster has IAM db authentication enabled.
      - `GRAPH_CONNECTION_URL`: Set this as `https://{NEPTUNE_ENDPOINT}:8182`.
-     - `PUBLIC_OR_PROXY_ENDPOINT`: Set this as
-       `https://{Domain name set in Step 5 of "Request an ACM Public Certificate"}`.
-     - `SERVICE_TYPE`: Set this as `neptune-db` for Neptune database or
-       `neptune-graph` for Neptune Analytics.
+     - `PUBLIC_OR_PROXY_ENDPOINT`: Set this as `https://{Domain name set in Step 5 of "Request an ACM Public Certificate"}`.
+     - `SERVICE_TYPE`: Set this as `neptune-db` for Neptune database or `neptune-graph` for Neptune Analytics.
 6. Click **Create**.
 
 ### Create a Fargate Service
 
 1. Open the ECS console at https://console.aws.amazon.com/ecs/v2.
 2. In the left hand navigation pane, choose **Clusters**.
-3. On the Clusters page, select the cluster that was created in step "Create the
-   Amazon ECS Cluster".
+3. On the Clusters page, select the cluster that was created in step "Create the Amazon ECS Cluster".
 4. Under the **Services** tab, click **Create**.
-5. Under the **Environment** section, expand **Compute configuration** and
-   configure the options with the values:
+5. Under the **Environment** section, expand **Compute configuration** and configure the options with the values:
    - **Compute options**: `Launch type`
    - **Launch type**: `FARGATE`
    - **Platform Version**: `LATEST`
 6. Under the **Deployment configuration** section, set the following:
    - **Application type**: Choose **Task**.
-   - **Task definition**: Choose the task definition created in step "Creating
-     an ECS Task Definition", and select the latest revision.
-   - **Service name**: Enter a name for your service, ex.
-     `svc-graphexplorer-demo`.
+   - **Task definition**: Choose the task definition created in step "Creating an ECS Task Definition", and select the latest revision.
+   - **Service name**: Enter a name for your service, ex. `svc-graphexplorer-demo`.
    - **Service type**: Choose **Replica**.
-   - **Desired tasks**: Enter the number of tasks to launch and maintain in the
-     service.
+   - **Desired tasks**: Enter the number of tasks to launch and maintain in the service.
 7. Expand the **Networking** section, and set the following:
    - **VPC**: Select the VPC where your Neptune database is located.
-   - **Subnets**: Select all of the public subnets for that VPC, and remove any
-     unassociated subnets.
-   - **Security group**: Select **Create a new security group**, and set the
-     fields as:
+   - **Subnets**: Select all of the public subnets for that VPC, and remove any unassociated subnets.
+   - **Security group**: Select **Create a new security group**, and set the fields as:
      - **Security group name**: `graphexplorer-demo`
-     - **Security group description**:
-       `Security group for access to graph-explorer`
-     - **Inbound rules**: Add two rules, one with type `HTTPS` and port range
-       `443`, and the second with type `HTTP` and port range `80`. Preferably,
-       authorize only a specific IP address range to access your instances.
+     - **Security group description**: `Security group for access to graph-explorer`
+     - **Inbound rules**: Add two rules, one with type `HTTPS` and port range `443`, and the second with type `HTTP` and port range `80`. Preferably, authorize only a specific IP address range to access your instances.
 8. Expand the **Load balancing** section.
-9. Select **Application load balancer**, and create a new load balancer with the
-   configuration:
+9. Select **Application load balancer**, and create a new load balancer with the configuration:
    - **Load balancer name**: `lb-graph-explorer-demo`
    - **Choose container to load balance**: `graph-explorer 443:443`.
-   - **Listener**: Select **Create New listener**, then set **Port** as `443`
-     and **Protocol** as `HTTPS`.
-   - **Certificate**: Select **Choose from ACM certificates**, then select the
-     domain name created in step "Request an ACM Public Certificate".
-   - **Target group**: Select **Create new target group**, with the options set
-     to:
-     - **Target group name**: `tg-graphexplorer-demo` with **Protocol** as
-       `HTTPS`.
-     - **Health check path**: `/explorer/` with **Health check protocol** as
-       `HTTPS`.
+   - **Listener**: Select **Create New listener**, then set **Port** as `443` and **Protocol** as `HTTPS`.
+   - **Certificate**: Select **Choose from ACM certificates**, then select the domain name created in step "Request an ACM Public Certificate".
+   - **Target group**: Select **Create new target group**, with the options set to:
+     - **Target group name**: `tg-graphexplorer-demo` with **Protocol** as `HTTPS`.
+     - **Health check path**: `/explorer/` with **Health check protocol** as `HTTPS`.
 
       <img width="720" alt="image" src="./images/target-group.png">
 
-10. (Optional) Under section **Service auto scaling**, specify the desired
-    scaling configuration.
-11. (Optional) To help identify your service and tasks, expand the **Tags**
-    section, then configure your desired tags.
-    - **Tip**: To have Amazon ECS automatically tag all newly launched tasks
-      with the cluster name and the task definition tags, select **Turn on
-      Amazon ECS managed tags**, and then select **Task definitions**.
+10. (Optional) Under section **Service auto scaling**, specify the desired scaling configuration.
+11. (Optional) To help identify your service and tasks, expand the **Tags** section, then configure your desired tags.
+    - **Tip**: To have Amazon ECS automatically tag all newly launched tasks with the cluster name and the task definition tags, select **Turn on Amazon ECS managed tags**, and then select **Task definitions**.
 12. Click **Create**.
 
 After few minutes, the Fargate service will be created and ready.
@@ -276,36 +214,19 @@ After few minutes, the Fargate service will be created and ready.
 
 1. Open the Route 53 console at https://console.aws.amazon.com/route53/.
 2. In the left hand navigation pane, click **Hosted zones**.
-3. Under **Hosted zones**, click the name of the hosted zone that you want to
-   create records in.
-   - If you do not have a hosted zone yet, create one with the **Domain name**
-     as the base for the domain created in section "Request an ACM Public
-     Certificate". For example, if the full domain is
-     `graphexplorer.example.com`, the hosted zone domain name should be
-     `example.com`.
+3. Under **Hosted zones**, click the name of the hosted zone that you want to create records in.
+   - If you do not have a hosted zone yet, create one with the **Domain name** as the base for the domain created in section "Request an ACM Public Certificate". For example, if the full domain is `graphexplorer.example.com`, the hosted zone domain name should be `example.com`.
 4. Under the **Records** tab, click **Create record**.
-5. Under the record displayed in the **Quick create record** section, set the
-   following configuration:
-   - **Record name**: Enter the subdomain name that you want to use to route
-     traffic to your Application load balancer. This subdomain in conjunction
-     with the hosted zone domain name should be your full domain as defined for
-     the ACM certificate. For example, if your full domain is
-     `graphexplorer.example.com`, and the hosted zone domain is `example.com`,
-     then the Record name should be `graphexplorer`.
+5. Under the record displayed in the **Quick create record** section, set the following configuration:
+   - **Record name**: Enter the subdomain name that you want to use to route traffic to your Application load balancer. This subdomain in conjunction with the hosted zone domain name should be your full domain as defined for the ACM certificate. For example, if your full domain is `graphexplorer.example.com`, and the hosted zone domain is `example.com`, then the Record name should be `graphexplorer`.
    - **Alias**: Enable this option, and configure in order:
-     - **Choose endpoint**: Select
-       `Alias to Application and Classic Load Balancer`.
+     - **Choose endpoint**: Select `Alias to Application and Classic Load Balancer`.
      - **Choose region**: Select the AWS region that the endpoint is from.
-     - **Choose load balancer**: Choose the name that you assigned to the load
-       balancer when you created the ECS Fargate Service.
+     - **Choose load balancer**: Choose the name that you assigned to the load balancer when you created the ECS Fargate Service.
 6. Leave everything else default, and click **Create records**.
 
-Changes generally propagate to all Route 53 servers within 60 seconds. When
-propagation is done, you'll be able to route traffic to your load balancer by
-using the name of the alias record that you created in the above step.
+Changes generally propagate to all Route 53 servers within 60 seconds. When propagation is done, you'll be able to route traffic to your load balancer by using the name of the alias record that you created in the above step.
 
 ### Accessing Graph Explorer
 
-Enter the URL you created in the Route53 section into a browser to access the
-endpoint for Graph Explorer (ex.`https://graphexplorer.example.com/explorer`).
-You should now be connected.
+Enter the URL you created in the Route53 section into a browser to access the endpoint for Graph Explorer (ex.`https://graphexplorer.example.com/explorer`). You should now be connected.

--- a/additionaldocs/features/README.md
+++ b/additionaldocs/features/README.md
@@ -1,27 +1,14 @@
 # Features
 
-If you are interested in where Graph Explorer is headed in the future then check
-out our [roadmap](../../ROADMAP.md) and
-[participate in the discussions](https://github.com/aws/graph-explorer/discussions).
+If you are interested in where Graph Explorer is headed in the future then check out our [roadmap](../../ROADMAP.md) and [participate in the discussions](https://github.com/aws/graph-explorer/discussions).
 
 ## Settings UI
 
 ### General Settings
 
-- **Default Neighbor Expansion Limit:** This setting will allow you to enable or
-  disable the default limit applied during neighbor expansion. This applies to
-  both double click expansion and the expand sidebar. This setting can be
-  overridden by a similar setting on the connection itself.
-- **Save Configuration:** This action will export all the configuration data
-  within the Graph Explorer local database. This will not store any data from
-  the connected graph databases. However, the export may contain the shape of
-  the schema for your databases and the connection URL.
-- **Load Configuration:** This action will replace all the Graph Explorer
-  configuration data you currently have with the data in the provided
-  configuration file. This is a destructive act and can not be undone. It is
-  **strongly** suggested that you perform a **Save Configuration** action before
-  performing a **Load Configuration** action to preserve any existing
-  configuration data.
+- **Default Neighbor Expansion Limit:** This setting will allow you to enable or disable the default limit applied during neighbor expansion. This applies to both double click expansion and the expand sidebar. This setting can be overridden by a similar setting on the connection itself.
+- **Save Configuration:** This action will export all the configuration data within the Graph Explorer local database. This will not store any data from the connected graph databases. However, the export may contain the shape of the schema for your databases and the connection URL.
+- **Load Configuration:** This action will replace all the Graph Explorer configuration data you currently have with the data in the provided configuration file. This is a destructive act and can not be undone. It is **strongly** suggested that you perform a **Save Configuration** action before performing a **Load Configuration** action to preserve any existing configuration data.
 
 ### About
 
@@ -29,109 +16,59 @@ In the _About_ page you can see the version number and submit any feedback.
 
 ## Connections UI
 
-You can create and manage connections to graph databases using this feature.
-Connections is accessible as the first screen after deploying the application or
-by clicking `Connections` in the navigation bar. Click `+` on the top-right to
-add a new connection. You can also edit and delete connections.
+You can create and manage connections to graph databases using this feature. Connections is accessible as the first screen after deploying the application or by clicking `Connections` in the navigation bar. Click `+` on the top-right to add a new connection. You can also edit and delete connections.
 
 - **Add a new connection:**
   - **Name:** Enter a name for your connection (e.g., `MyNeptuneCluster`).
-  - **Query Language:** Choose a query language that corresponds to your graph
-    database.
-  - **Public or proxy endpoint:** Provide the publicly accessible endpoint URL
-    for a graph database, e.g., Gremlin Server. If connecting to Amazon Neptune,
-    then provide a proxy endpoint URL that is accessible from outside the VPC,
-    e.g., EC2.
-    - **Note:** For connecting to Amazon Neptune, ensure that the graph
-      connection URL is in the format `https://[NEPTUNE_ENDPOINT]:8182`, and
-      that the proxy endpoint URL is either `https://[EC2_PUBLIC_HOSTNAME]:443`
-      or `http://[EC2_PUBLIC_HOSTNAME]:80`, depending on the protocol used.
-      Ensure that you don't end either of the URLs with `/`.
+  - **Query Language:** Choose a query language that corresponds to your graph database.
+  - **Public or proxy endpoint:** Provide the publicly accessible endpoint URL for a graph database, e.g., Gremlin Server. If connecting to Amazon Neptune, then provide a proxy endpoint URL that is accessible from outside the VPC, e.g., EC2.
+    - **Note:** For connecting to Amazon Neptune, ensure that the graph connection URL is in the format `https://[NEPTUNE_ENDPOINT]:8182`, and that the proxy endpoint URL is either `https://[EC2_PUBLIC_HOSTNAME]:443` or `http://[EC2_PUBLIC_HOSTNAME]:80`, depending on the protocol used. Ensure that you don't end either of the URLs with `/`.
   - **Using proxy server:** Check this box if using a proxy endpoint.
   - **Graph connection URL:** Provide the endpoint for the graph database
-  - **AWS IAM Auth Enabled:** Check this box if connecting to Amazon Neptune
-    using IAM Auth and SigV4 signed requests
+  - **AWS IAM Auth Enabled:** Check this box if connecting to Amazon Neptune using IAM Auth and SigV4 signed requests
   - **Service Type:** Choose the service type
-  - **AWS Region:** Specify the AWS region where the Neptune cluster is hosted
-    (e.g., us-east-1)
+  - **AWS Region:** Specify the AWS region where the Neptune cluster is hosted (e.g., us-east-1)
   - **Fetch Timeout:** Specify the timeout for the fetch request
-  - **Neighbor Expansion Limit:** Specify the default limit for neighbor
-    expansion. This will override the app setting for neighbor expansion.
+  - **Neighbor Expansion Limit:** Specify the default limit for neighbor expansion. This will override the app setting for neighbor expansion.
 
-- **Available Connections:** Once a connection is created, this section will
-  appear as a left-hand pane. When you create more than one connection to a
-  graph database, you can only connect to and visualize from one graph database
-  endpoint at a time. To select the active database, toggle the "Active" switch.
+- **Available Connections:** Once a connection is created, this section will appear as a left-hand pane. When you create more than one connection to a graph database, you can only connect to and visualize from one graph database endpoint at a time. To select the active database, toggle the "Active" switch.
 
-- **Connection Details:** Once a connection is created, this section will appear
-  as a right-hand information pane for a selected connection. It shows details
-  such as the connection name, query language, endpoint and a summary of the
-  graph data, such as the count of nodes, edges, and a list of node types.
-- **Last Synchronization:** When a connection is created, Graph Explorer will
-  perform a scan of the graph to provide summary data. To re-synchronize after
-  data has changed on your graph, select a connection, and then click the
-  "refresh" button next to "Last Synchronization" text.
-- **Data Table:** Under a listed node type, you can click on the ">" arrow to
-  get to the "Data Table" view. This allows you to see a sample list of nodes
-  under this type and choose one or more nodes to "Send to Explorer" for getting
-  started quickly if you are new to the data. You can also navigate directly to
-  the Data Table view using the "Data Table" link in the navigation bar.
+- **Connection Details:** Once a connection is created, this section will appear as a right-hand information pane for a selected connection. It shows details such as the connection name, query language, endpoint and a summary of the graph data, such as the count of nodes, edges, and a list of node types.
+- **Last Synchronization:** When a connection is created, Graph Explorer will perform a scan of the graph to provide summary data. To re-synchronize after data has changed on your graph, select a connection, and then click the "refresh" button next to "Last Synchronization" text.
+- **Data Table:** Under a listed node type, you can click on the ">" arrow to get to the "Data Table" view. This allows you to see a sample list of nodes under this type and choose one or more nodes to "Send to Explorer" for getting started quickly if you are new to the data. You can also navigate directly to the Data Table view using the "Data Table" link in the navigation bar.
 
 ## Graph View
 
-You can search, browse, expand, customize views of your graph data using the
-Graph view, which is the main view of this application. Once you create a
-connection, you can click "Graph" in the navigation bar to navigate here. There
-are several key features on this UI:
+You can search, browse, expand, customize views of your graph data using the Graph view, which is the main view of this application. Once you create a connection, you can click "Graph" in the navigation bar to navigate here. There are several key features on this UI:
 
-- **Toggle view visibility** The graph and table views can be hidden to allow
-  the other to expand.
+- **Toggle view visibility** The graph and table views can be hidden to allow the other to expand.
 
 ### Graph View UI
 
-The graph visualization canvas that you can interact with. Double-click to
-expand the first-order neighbors of a node.
+The graph visualization canvas that you can interact with. Double-click to expand the first-order neighbors of a node.
 
-- **Layout drop-down & reset:** You can display graph data using standard graph
-  layouts in the Graph View. You can use the circular arrow to reset the physics
-  of a layout.
+- **Layout drop-down & reset:** You can display graph data using standard graph layouts in the Graph View. You can use the circular arrow to reset the physics of a layout.
 - **Screenshot:** Download a picture of the current window in Graph View.
-- **Save Graph:** Save the current rendered graph as a JSON file that can be
-  shared with others having the same connection or reloaded at a later time.
+- **Save Graph:** Save the current rendered graph as a JSON file that can be shared with others having the same connection or reloaded at a later time.
 - **Load Graph:** Load a previously saved graph from a JSON file.
-- **Zoom In/Out & Clear:** To help users quickly zoom in/out or clear the whole
-  canvas in the Graph View.
-- **Legend (i):** This displays an informational list of icons, colors, and
-  display names available.
+- **Zoom In/Out & Clear:** To help users quickly zoom in/out or clear the whole canvas in the Graph View.
+- **Legend (i):** This displays an informational list of icons, colors, and display names available.
 
 ### Sidebar Panel UI
 
-The panel on the right of the graph provides various actions, configuration, and
-details about the open graph.
+The panel on the right of the graph provides various actions, configuration, and details about the open graph.
 
-- [**Search panel**](#search-panel) allows you to search for specific nodes by
-  filtering on node types & attributes or executing a database query then adding
-  nodes & edges to the graph panel.
-- [**Details panel**](#details-panel) shows details about a selected node/edge
-  such as properties etc.
-- [**Entities filter panel**](#entities-filter-panel) is used to control the
-  display of nodes and edges that are already expanded in the Graph View; click
-  to hide or show nodes/edges.
-- [**Expand panel**](#expand-panel) provides controls and filters to help focus
-  large neighbor expansions.
-- [**Node styling panel**](#node-styling-panel) of node display options (e.g.,
-  color, icon, the property to use for the displayed name).
-- [**Edge styling panel**](#edge-styling-panel) of edge display options (e.g.,
-  color, icon, the property to use for the displayed name).
-- [**Namespaces panel (RDF only)**](#namespace-panel) allows you to shorten the
-  display of Resource URIs within the app based on auto-generated prefixes,
-  commonly-used prefix libraries, or custom prefixes set by the user. Order of
-  priority is set to Custom > Common > Auto-generated.
+- [**Search panel**](#search-panel) allows you to search for specific nodes by filtering on node types & attributes or executing a database query then adding nodes & edges to the graph panel.
+- [**Details panel**](#details-panel) shows details about a selected node/edge such as properties etc.
+- [**Entities filter panel**](#entities-filter-panel) is used to control the display of nodes and edges that are already expanded in the Graph View; click to hide or show nodes/edges.
+- [**Expand panel**](#expand-panel) provides controls and filters to help focus large neighbor expansions.
+- [**Node styling panel**](#node-styling-panel) of node display options (e.g., color, icon, the property to use for the displayed name).
+- [**Edge styling panel**](#edge-styling-panel) of edge display options (e.g., color, icon, the property to use for the displayed name).
+- [**Namespaces panel (RDF only)**](#namespace-panel) allows you to shorten the display of Resource URIs within the app based on auto-generated prefixes, commonly-used prefix libraries, or custom prefixes set by the user. Order of priority is set to Custom > Common > Auto-generated.
 
 #### Search Panel
 
-The Search UI provides two powerful ways to search and interact with your graph
-database:
+The Search UI provides two powerful ways to search and interact with your graph database:
 
 ##### Filter Search
 
@@ -171,31 +108,24 @@ Provides fine grained control over neighbor expansions
 
 #### Entities Filter Panel
 
-Provides the ability to filter nodes or edges from the visualization by label
-(or rdf:type for RDF databases)
+Provides the ability to filter nodes or edges from the visualization by label (or rdf:type for RDF databases)
 
 #### Node Styling Panel
 
 Each node type can be customized in a variety of ways.
 
-- **Display label** allows you to change how the node label (or rdf:type) is
-  represented
-- **Display name attribute** allows you to choose the attribute on the node that
-  is used to uniquely label the node in the graph visualization and search
-- **Display description attribute** allows you to choose the attribute on the
-  node that is used to describe the node in search
+- **Display label** allows you to change how the node label (or rdf:type) is represented
+- **Display name attribute** allows you to choose the attribute on the node that is used to uniquely label the node in the graph visualization and search
+- **Display description attribute** allows you to choose the attribute on the node that is used to describe the node in search
 - **Custom symbol** can be uploaded in the form of an SVG icon
-- **Colors and borders** can be customized to visually distinguish from other
-  node types
+- **Colors and borders** can be customized to visually distinguish from other node types
 
 #### Edge Styling Panel
 
 Each edge type can be customized in a variety of ways.
 
-- **Display label** allows you to change how the edge label (or predicate in RDF
-  databases) is represented
-- **Display name attribute** allows you to choose the attribute on the edge that
-  is used to uniquely label the edge in the graph visualization and search
+- **Display label** allows you to change how the edge label (or predicate in RDF databases) is represented
+- **Display name attribute** allows you to choose the attribute on the edge that is used to uniquely label the edge in the graph visualization and search
 - **Arrow symbol** can be chosen for both source and target variations
 - **Colors and borders** can be customized for the edge label and the line
 - **Line style** can be solid, dotted, or dashed
@@ -209,12 +139,9 @@ Each edge type can be customized in a variety of ways.
 
 ### Table View UI
 
-This collapsible view shows a row-column display of the data in the Graph View.
-You can use filters in the Table to show/hide elements in the Graph View, and
-you can export the table view into a CSV or JSON file.
+This collapsible view shows a row-column display of the data in the Graph View. You can use filters in the Table to show/hide elements in the Graph View, and you can export the table view into a CSV or JSON file.
 
-The following columns are available for filtering on property graphs (RDF graphs
-in parentheses):
+The following columns are available for filtering on property graphs (RDF graphs in parentheses):
 
 - Node ID (Resource URI)
 - Node Type (Class)
@@ -230,19 +157,14 @@ in parentheses):
 #### Additional Table View UI Features
 
 - **Visibility** - manually show or hide nodes or edges
-- **All Nodes / All Edges (or All Resources / All Predicates) dropdown** -
-  allows you to display a list of either nodes or edges and control
-  display/filter on them
-- **Download** - You can download the current Table View as a CSV or JSON file
-  with additional customization options
+- **All Nodes / All Edges (or All Resources / All Predicates) dropdown** - allows you to display a list of either nodes or edges and control display/filter on them
+- **Download** - You can download the current Table View as a CSV or JSON file with additional customization options
 - **Default columns** - You can set which columns you want to display
 - Paging of rows
 
 ## Data Table View
 
-You can use the Data Table view to view the data for the selected node type. You
-can open the Data Table view by clicking "Data Table" in the navigation bar or
-by clicking the node type row in the connection details pane.
+You can use the Data Table view to view the data for the selected node type. You can open the Data Table view by clicking "Data Table" in the navigation bar or by clicking the node type row in the connection details pane.
 
 - Select a node type from the dropdown to view its data
 - View tabular data for the selected node type
@@ -252,9 +174,7 @@ by clicking the node type row in the connection details pane.
 
 ## Schema View
 
-The Schema view visualizes the schema of your graph database as an interactive
-graph. Node types are displayed as nodes and their relationships (edge
-connections) are displayed as edges between them.
+The Schema view visualizes the schema of your graph database as an interactive graph. Node types are displayed as nodes and their relationships (edge connections) are displayed as edges between them.
 
 You can open the Schema view by clicking "Schema" in the navigation bar.
 
@@ -266,7 +186,4 @@ You can open the Schema view by clicking "Schema" in the navigation bar.
 
 > [!NOTE]
 >
-> The schema and data types shown in the Schema view are inferred from samples
-> of nodes and edges returned by queries. They may not be 100% accurate or
-> complete, especially for large or diverse datasets. As you explore more data,
-> the schema will grow more complete over time.
+> The schema and data types shown in the Schema view are inferred from samples of nodes and edges returned by queries. They may not be 100% accurate or complete, especially for large or diverse datasets. As you explore more data, the schema will grow more complete over time.

--- a/additionaldocs/getting-started/README.md
+++ b/additionaldocs/getting-started/README.md
@@ -1,20 +1,14 @@
 # Getting Started
 
-This project contains the code needed to create a Docker image of the Graph
-Explorer. The image will create the Graph Explorer application and proxy server
-that will be served over the standard HTTP or HTTPS ports (HTTPS by default).
+This project contains the code needed to create a Docker image of the Graph Explorer. The image will create the Graph Explorer application and proxy server that will be served over the standard HTTP or HTTPS ports (HTTPS by default).
 
-The proxy server will be created automatically, but will only be necessary if
-you are connecting to Neptune. Gremlin-Server and BlazeGraph can be connected to
-directly. Additionally, the image will create a self-signed certificate that can
-be optionally used.
+The proxy server will be created automatically, but will only be necessary if you are connecting to Neptune. Gremlin-Server and BlazeGraph can be connected to directly. Additionally, the image will create a self-signed certificate that can be optionally used.
 
 ## Examples
 
 ### Local Docker Setup
 
-The quickest way to get started with Graph Explorer is to use the official
-Docker image. You can find the latest version of the image on  
+The quickest way to get started with Graph Explorer is to use the official Docker image. You can find the latest version of the image on  
 [Amazon's ECR Public Registry](https://gallery.ecr.aws/neptune/graph-explorer).
 
 <!-- prettier-ignore -->
@@ -25,13 +19,11 @@ Docker image. You can find the latest version of the image on
 #### Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed on your machine
-- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
-  installed on your machine
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed on your machine
 
 #### Steps
 
-1. Authenticate with the Amazon ECR Public Registry.
-   [More information](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
+1. Authenticate with the Amazon ECR Public Registry. [More information](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
 
    ```
    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
@@ -52,9 +44,7 @@ Docker image. You can find the latest version of the image on
     public.ecr.aws/neptune/graph-explorer
    ```
 
-   The `HOST` environment variable is used for SSL certificates generation since
-   HTTPS is the default. If you are hosting this on a public domain, you should
-   replace `HOST=localhost` with your domain name.
+   The `HOST` environment variable is used for SSL certificates generation since HTTPS is the default. If you are hosting this on a public domain, you should replace `HOST=localhost` with your domain name.
 
 4. Open a browser and type in the URL of the Graph Explorer server instance
 
@@ -62,27 +52,18 @@ Docker image. You can find the latest version of the image on
    https://localhost/explorer
    ```
 
-5. You will receive a warning as the SSL certificate used is self-signed. Since
-   the application is set to use HTTPS by default and contains a self-signed
-   certificate, you will need to add the Graph Explorer certificates to the
-   trusted certificates directory and manually trust them. See the
-   [HTTPS Connections](../troubleshooting.md#https-connections) section.
-6. After completing the trusted certification step and refreshing the browser,
-   you should now see the Connections UI. See below description on Connections
-   UI to configure your first connection to Amazon Neptune.
+5. You will receive a warning as the SSL certificate used is self-signed. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See the [HTTPS Connections](../troubleshooting.md#https-connections) section.
+6. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI. See below description on Connections UI to configure your first connection to Amazon Neptune.
 
 #### Gremlin Server Database
 
-Gremlin Server is an easy way to get started with graph databases. This example
-will configure a simple Gremlin Server instance to be used with Graph Explorer.
-It comes with a very small graph dataset.
+Gremlin Server is an easy way to get started with graph databases. This example will configure a simple Gremlin Server instance to be used with Graph Explorer. It comes with a very small graph dataset.
 
 1. Pull the latest Gremlin Server image from Docker Hub.
    ```
    docker pull tinkerpop/gremlin-server:latest
    ```
-2. Create and run the Gremlin Server container using the HTTP REST modern
-   configuration.
+2. Create and run the Gremlin Server container using the HTTP REST modern configuration.
    ```
    docker run -p 8182:8182 \
      --name gremlin-server \
@@ -98,9 +79,7 @@ It comes with a very small graph dataset.
 
 ## Amazon EC2 Setup
 
-The following instructions detail how to deploy graph-explorer onto an Amazon
-EC2 instance and use it as a proxy server with SSH tunneling to connect to
-Amazon Neptune.
+The following instructions detail how to deploy graph-explorer onto an Amazon EC2 instance and use it as a proxy server with SSH tunneling to connect to Amazon Neptune.
 
 <!-- prettier-ignore -->
 > [!NOTE]
@@ -111,21 +90,15 @@ of the VPC, such as setting up a load balancer or VPC peering.
 
 ### Prerequisites
 
-- Provision an Amazon EC2 instance that will be used to host the application and
-  connect to Neptune as a proxy server. For more details, see instructions
-  [here](https://github.com/aws/graph-notebook/tree/main/additional-databases/neptune).
-- Ensure the Amazon EC2 instance can send and receive on ports `22` (SSH),
-  `8182` (Neptune), and `443` or `80` depending on protocol used
-  (graph-explorer).
+- Provision an Amazon EC2 instance that will be used to host the application and connect to Neptune as a proxy server. For more details, see instructions [here](https://github.com/aws/graph-notebook/tree/main/additional-databases/neptune).
+- Ensure the Amazon EC2 instance can send and receive on ports `22` (SSH), `8182` (Neptune), and `443` or `80` depending on protocol used (graph-explorer).
 
 ### Steps
 
 These steps describe how to install Graph Explorer on your Amazon EC2 instance.
 
 1. Open an SSH client and connect to the EC2 instance.
-2. Download and install the necessary command line tools such as
-   [Git](https://git-scm.com/downloads) and
-   [Docker](https://docs.docker.com/get-docker/).
+2. Download and install the necessary command line tools such as [Git](https://git-scm.com/downloads) and [Docker](https://docs.docker.com/get-docker/).
 3. Clone the repository
    ```
    git clone https://github.com/aws/graph-explorer.git
@@ -145,25 +118,18 @@ These steps describe how to install Graph Explorer on your Amazon EC2 instance.
 > If you receive an error relating to the docker service not running, run
 > `service docker start`.
 
-4. Run the container substituting the `{hostname-or-ip-address}` with the
-   hostname or IP address of the EC2 instance.
+4. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance.
    ```
    docker run -p 80:80 -p 443:443 \
     --env HOST={hostname-or-ip-address} \
     graph-explorer
    ```
-5. Navigate to the public URL of your EC2 instance accessing the `/explorer`
-   endpoint. You will receive a warning as the SSL certificate used is
-   self-signed. The URL will look like this:
+5. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
    ```
    https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
    ```
-6. Since the application is set to use HTTPS by default and contains a
-   self-signed certificate, you will need to add the Graph Explorer certificates
-   to the trusted certificates directory and manually trust them. See
-   [HTTPS Connections](../troubleshooting.md#https-connections) section.
-7. After completing the trusted certification step and refreshing the browser,
-   you should now see the Connections UI.
+6. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](../troubleshooting.md#https-connections) section.
+7. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.
 
 ## Local Development Setup
 
@@ -203,6 +169,4 @@ You can build the Docker image locally by following the steps below.
 
 ## Troubleshooting
 
-If the instructions above do not work for you, please see the
-[Troubleshooting](../troubleshooting.md) page for more information. It contains
-workarounds for common issues and information on how to diagnose other issues.
+If the instructions above do not work for you, please see the [Troubleshooting](../troubleshooting.md) page for more information. It contains workarounds for common issues and information on how to diagnose other issues.

--- a/additionaldocs/sagemaker/README.md
+++ b/additionaldocs/sagemaker/README.md
@@ -1,28 +1,12 @@
 # Launching Graph Explorer using Amazon SageMaker
 
-Graph Explorer can be hosted and launched on Amazon SageMaker Notebooks via a
-lifecycle configuration script. To learn more about lifecycle configurations and
-how to create one, see the
-[documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).
+Graph Explorer can be hosted and launched on Amazon SageMaker Notebooks via a lifecycle configuration script. To learn more about lifecycle configurations and how to create one, see the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).
 
-You can use the provided sample lifecycle configuration,
-[`install-graph-explorer-lc.sh`](install-graph-explorer-lc.sh), or create your
-own shell script. If using the sample lifecycle, you should also create an IAM
-role with a policy containing the permissions described in either
-[`graph-explorer-neptune-db-policy.json`](graph-explorer-neptune-db-policy.json)
-or
-[`graph-explorer-neptune-analytics-policy.json`](graph-explorer-neptune-analytics-policy.json),
-depending on the service used.
+You can use the provided sample lifecycle configuration, [`install-graph-explorer-lc.sh`](install-graph-explorer-lc.sh), or create your own shell script. If using the sample lifecycle, you should also create an IAM role with a policy containing the permissions described in either [`graph-explorer-neptune-db-policy.json`](graph-explorer-neptune-db-policy.json) or [`graph-explorer-neptune-analytics-policy.json`](graph-explorer-neptune-analytics-policy.json), depending on the service used.
 
-After you have created the lifecycle configuration and IAM role, you can attach
-them to a new or existing SageMaker notebook instance, under
-`Notebook instance settings` -> `Additional configuration` ->
-`Lifecycle configuration` and `Permission and encryption` -> `IAM role`,
-respectively.
+After you have created the lifecycle configuration and IAM role, you can attach them to a new or existing SageMaker notebook instance, under `Notebook instance settings` -> `Additional configuration` -> `Lifecycle configuration` and `Permission and encryption` -> `IAM role`, respectively.
 
-When the notebook has been started and is in "Ready" state, you can access Graph
-Explorer by adding the `/proxy/9250/explorer/` extension to the base notebook
-URL. The Graph Explorer link should look something like:
+When the notebook has been started and is in "Ready" state, you can access Graph Explorer by adding the `/proxy/9250/explorer/` extension to the base notebook URL. The Graph Explorer link should look something like:
 
 ```
 https://graph-explorer-notebook-name.notebook.us-west-2.sagemaker.aws/proxy/9250/explorer/
@@ -30,12 +14,9 @@ https://graph-explorer-notebook-name.notebook.us-west-2.sagemaker.aws/proxy/9250
 
 ## Minimum Database Permissions
 
-By default, the permission policy for the IAM role of the SageMaker instance
-will have full access to the Neptune Database or Neptune Analytics instance.
-This means queries executed within Graph Explorer could contain mutations.
+By default, the permission policy for the IAM role of the SageMaker instance will have full access to the Neptune Database or Neptune Analytics instance. This means queries executed within Graph Explorer could contain mutations.
 
-To restrict Graph Explorer access for its most basic functionality you can use
-these minimum permissions.
+To restrict Graph Explorer access for its most basic functionality you can use these minimum permissions.
 
 - Read data via queries
 - Get the graph summary information (used for schema sync)
@@ -46,9 +27,7 @@ these minimum permissions.
 > 
 > If you are using the standard notebook setup, these policies will apply to both the Jupyter graph notebooks as well as Graph Explorer.
 
-If a user attempts to execute a mutation query inside of Graph Explorer, they
-will be presented with an error that informs them they are not authorized for
-that request.
+If a user attempts to execute a mutation query inside of Graph Explorer, they will be presented with an error that informs them they are not authorized for that request.
 
 **Neptune DB**
 

--- a/additionaldocs/troubleshooting.md
+++ b/additionaldocs/troubleshooting.md
@@ -1,7 +1,6 @@
 # Troubleshooting
 
-This page contains workarounds for common issues and information on how to
-diagnose other issues.
+This page contains workarounds for common issues and information on how to diagnose other issues.
 
 - [Docker Container Issues](#docker-container-issues)
 - [Schema Sync Fails](#schema-sync-fails)
@@ -10,23 +9,14 @@ diagnose other issues.
 
 ## Docker Container Issues
 
-1. If the container does not start, or immediately stops, use
-   `docker logs graph-explorer` to check the container console logs for any
-   related error messages that might provide guidance on why graph-explorer did
-   not start.
-2. If you are having issues connecting graph-explorer to your graph database,
-   use your browser's Developer Tools feature to monitor both the browser
-   console and network calls to determine if here are any errors related to
-   connectivity.
+1. If the container does not start, or immediately stops, use `docker logs graph-explorer` to check the container console logs for any related error messages that might provide guidance on why graph-explorer did not start.
+2. If you are having issues connecting graph-explorer to your graph database, use your browser's Developer Tools feature to monitor both the browser console and network calls to determine if here are any errors related to connectivity.
 
 ### Ports in Use
 
-If the default ports of 80 and 443 are already in use, you can use the `-p` flag
-to change the ports to something else. The host machine ports are the first of
-the two numbers. You can change those to whatever you want.
+If the default ports of 80 and 443 are already in use, you can use the `-p` flag to change the ports to something else. The host machine ports are the first of the two numbers. You can change those to whatever you want.
 
-For example, if you want to use port 8080 and 4431, you can use the following
-command:
+For example, if you want to use port 8080 and 4431, you can use the following command:
 
 ```
 docker run -p 8080:80 -p 4431:443 \
@@ -42,9 +32,7 @@ Which will result in the following URLs:
 
 ### HTTP Only
 
-If you do not want to use SSL and HTTPS, you can disable it by setting the
-following
-[environment variables](/additionaldocs/development.md#environment-variables):
+If you do not want to use SSL and HTTPS, you can disable it by setting the following [environment variables](/additionaldocs/development.md#environment-variables):
 
 ```
 PROXY_SERVER_HTTPS_CONNECTION=false
@@ -63,35 +51,16 @@ docker run -p 80:80 \
 
 ### HTTPS Connections
 
-If either of the Graph Explorer or the proxy-server are served over an HTTPS
-connection (which it is by default), you will have to bypass the warning message
-from the browser due to the included certificate being a self-signed
-certificate.
+If either of the Graph Explorer or the proxy-server are served over an HTTPS connection (which it is by default), you will have to bypass the warning message from the browser due to the included certificate being a self-signed certificate.
 
-You can bypass by manually ignoring them from the browser or downloading the
-correct certificate and configuring them to be trusted. Alternatively, you can
-provide your own certificate.
+You can bypass by manually ignoring them from the browser or downloading the correct certificate and configuring them to be trusted. Alternatively, you can provide your own certificate.
 
-The following instructions can be used as an example to bypass the warnings for
-Chrome, but note that different browsers and operating systems will have
-slightly different steps.
+The following instructions can be used as an example to bypass the warnings for Chrome, but note that different browsers and operating systems will have slightly different steps.
 
-1. Download the certificate directly from the browser. For example, if using
-   Google Chrome, click the “Not Secure” section on the left of the URL bar and
-   select “Certificate is not valid” to show the certificate. Then click Details
-   tab and click Export at the bottom.
-2. Once you have the certificate, you will need to trust it on your machine. For
-   MacOS, you can open the Keychain Access app. Select System under System
-   Keychains. Then go to File > Import Items... and import the certificate you
-   downloaded in the previous step.
-3. Once imported, select the certificate and right-click to select "Get Info".
-   Expand the Trust section, and change the value of "When using this
-   certificate" to "Always Trust".
-4. You should now refresh the browser and see that you can proceed to open the
-   application. For Chrome, the application will remain “Not Secure” due to the
-   fact that this is a self-signed certificate. If you have trouble accessing
-   Graph Explorer after completing the previous step and reloading the browser,
-   consider running a docker restart command and refreshing the browser again.
+1. Download the certificate directly from the browser. For example, if using Google Chrome, click the “Not Secure” section on the left of the URL bar and select “Certificate is not valid” to show the certificate. Then click Details tab and click Export at the bottom.
+2. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
+3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
+4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain “Not Secure” due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
 
 <!-- prettier-ignore -->
 > [!TIP]
@@ -104,22 +73,14 @@ This can happen for many reasons. Below are a few of the common ones.
 
 ### Mismatched Proxy Server URL
 
-When running a schema sync, a common cause of failures is a mismatch between the
-proxy server URL in your connection settings and the URL currently loaded in
-your browser. This mismatch can trigger a "Connection Error" message in Graph
-Explorer.
+When running a schema sync, a common cause of failures is a mismatch between the proxy server URL in your connection settings and the URL currently loaded in your browser. This mismatch can trigger a "Connection Error" message in Graph Explorer.
 
-Modern browsers enforce a security policy called
-[Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy),
-which requires API requests to be sent to the same domain as the page you're
-viewing. If your connection settings specify a different domain than your
-current browser URL, the request will be blocked.
+Modern browsers enforce a security policy called [Same-Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy), which requires API requests to be sent to the same domain as the page you're viewing. If your connection settings specify a different domain than your current browser URL, the request will be blocked.
 
 To resolve this issue:
 
 1. Check your connection settings
-2. Ensure the proxy server URL matches the domain portion of your current
-   browser URL
+2. Ensure the proxy server URL matches the domain portion of your current browser URL
 3. Update the connection if necessary
 
 For example:
@@ -141,46 +102,33 @@ There are multiple sources of timeouts.
 - Browser
 - Graph Explorer connection configuration
 
-The error you receive in Graph Explorer can interpret Neptune timeout errors and
-timeouts from Graph Explorer's configuration.
+The error you receive in Graph Explorer can interpret Neptune timeout errors and timeouts from Graph Explorer's configuration.
 
 ### Out of Memory
 
-This can happen when your database is very large. Graph Explorer does its best
-to support larger databases and is always improving. Please
-[file an issue](https://github.com/aws/graph-explorer/issues/new/choose) if you
-encounter this situation.
+This can happen when your database is very large. Graph Explorer does its best to support larger databases and is always improving. Please [file an issue](https://github.com/aws/graph-explorer/issues/new/choose) if you encounter this situation.
 
 ### Proxy Server Cannot Be Reached
 
-Communication between the client and proxy server can be configured in different
-ways. When Graph Explorer proxy server starts up it will print out its best
-approximation of the correct public proxy server address.
+Communication between the client and proxy server can be configured in different ways. When Graph Explorer proxy server starts up it will print out its best approximation of the correct public proxy server address.
 
-This can manifest as different types of errors depending on the root cause. You
-may receive 404 not found responses or get connection refused errors.
+This can manifest as different types of errors depending on the root cause. You may receive 404 not found responses or get connection refused errors.
 
 - The proxy server can be hosting HTTP or HTTPS
-- The port of the proxy server could be the default (i.e. 80 or 443 with SSL) or
-  a specific port provided through environment values
-- The proxy server paths are not exposed by the networking layer (load balancer,
-  proxy, firewall, etc)
+- The port of the proxy server could be the default (i.e. 80 or 443 with SSL) or a specific port provided through environment values
+- The proxy server paths are not exposed by the networking layer (load balancer, proxy, firewall, etc)
   - The client is hosted at `/explorer` by default, which is configurable
   - Queries are handled via `/gremlin`, `/opencypher`, `/sparql`
-  - Summary APIs are handled via `/summary`, `/pg/statistics/summary`,
-    `/rdf/statistics/summary`
+  - Summary APIs are handled via `/summary`, `/pg/statistics/summary`, `/rdf/statistics/summary`
   - Logging is handled by `/logger`
   - Default connection is handled by `/defaultConnection`
 
 > [!IMPORTANT]  
-> The paths listed here could always change in the future. If they do change, we
-> will note that in the release notes.
+> The paths listed here could always change in the future. If they do change, we will note that in the release notes.
 
 ## Backup Graph Explorer Data
 
-Inside of Graph Explorer there is an option to export all the configuration data
-that Graph Explorer uses. This data is local to the user’s browser and does not
-exist on the server.
+Inside of Graph Explorer there is an option to export all the configuration data that Graph Explorer uses. This data is local to the user’s browser and does not exist on the server.
 
 To gather the config data:
 
@@ -191,14 +139,11 @@ To gather the config data:
 5. Press the “Save Configuration” button
 6. Choose where to save the exported file
 
-This backup can be restored using the “Load Configuration” button in the same
-settings page.
+This backup can be restored using the “Load Configuration” button in the same settings page.
 
 ## Gathering SageMaker Logs
 
-The Graph Explorer proxy server outputs log statements to standard out. By
-default, these logs will be forwarded to CloudWatch if the Notebook has the
-proper permissions.
+The Graph Explorer proxy server outputs log statements to standard out. By default, these logs will be forwarded to CloudWatch if the Notebook has the proper permissions.
 
 To gather these logs:
 
@@ -208,22 +153,15 @@ To gather these logs:
 4. Find the Notebook hosting Graph Explorer
 5. Open the details screen for that Notebook
 6. In the “Actions” menu, choose “View Details in SageMaker”
-7. Press the “View Logs” link in the SageMaker details screen under the field
-   titled “Lifecycle configuration”
-8. Scroll down to the “Log Streams” panel in the CloudWatch details where you
-   should find multiple log streams
-9. For each log stream related to Graph Explorer (LifecycleConfigOnStart.log,
-   graph-explorer.log)
+7. Press the “View Logs” link in the SageMaker details screen under the field titled “Lifecycle configuration”
+8. Scroll down to the “Log Streams” panel in the CloudWatch details where you should find multiple log streams
+9. For each log stream related to Graph Explorer (LifecycleConfigOnStart.log, graph-explorer.log)
    1. Open the log stream
    2. In the “Actions” menu, choose “Download search results (CSV)”
 
 ### Graph Explorer Log Stream Does Not Exist
 
-New Neptune Notebooks automatically apply the correct IAM permissions to write
-to CloudWatch. If your Notebook does not automatically create a
-graph-explorer.log in the CloudWatch Log Streams, then it is possible that the
-Neptune Notebook was created before those IAM permissions were added. You’ll
-need to add those permissions manually.
+New Neptune Notebooks automatically apply the correct IAM permissions to write to CloudWatch. If your Notebook does not automatically create a graph-explorer.log in the CloudWatch Log Streams, then it is possible that the Neptune Notebook was created before those IAM permissions were added. You’ll need to add those permissions manually.
 
 Below are examples of which IAM permissions you need for Graph Explorer.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,12 +1,9 @@
 # Samples
 
-These samples are intended to show possible configuration of Graph Explorer
-using open source databases.
+These samples are intended to show possible configuration of Graph Explorer using open source databases.
 
 ## Air Routes with Gremlin Server
 
-This sample uses Gremlin Server as the database pre-loaded with the air routes
-sample data and shows how to configure Graph Explorer to connect to it
-automatically with a default connection.
+This sample uses Gremlin Server as the database pre-loaded with the air routes sample data and shows how to configure Graph Explorer to connect to it automatically with a default connection.
 
 [Air Routes](./air_routes/readme.md)

--- a/samples/air_routes/readme.md
+++ b/samples/air_routes/readme.md
@@ -4,15 +4,11 @@
 | ---------------- | -------------- | ------------ |
 | [Gremlin Server] | [Gremlin]      | [Air Routes] |
 
-[Air Routes]:
-  https://github.com/krlawrence/graph/blob/main/sample-data/air-routes-latest.graphml
+[Air Routes]: https://github.com/krlawrence/graph/blob/main/sample-data/air-routes-latest.graphml
 [Gremlin]: https://tinkerpop.apache.org/gremlin.html
-[Gremlin Server]:
-  https://tinkerpop.apache.org/docs/current/reference/#gremlin-server
+[Gremlin Server]: https://tinkerpop.apache.org/docs/current/reference/#gremlin-server
 
-This sample uses Gremlin Server as the database pre-loaded with the air routes
-sample data and shows how to configure Graph Explorer to connect to it
-automatically with a default connection.
+This sample uses Gremlin Server as the database pre-loaded with the air routes sample data and shows how to configure Graph Explorer to connect to it automatically with a default connection.
 
 > [!NOTE]  
 > The data is not persisted between restarts of the Docker container.
@@ -32,5 +28,4 @@ automatically with a default connection.
    ```
    docker compose up
    ```
-4. Open the browser and navigate to:
-   [http://localhost:8080/explorer](http://localhost:8080/explorer)
+4. Open the browser and navigate to: [http://localhost:8080/explorer](http://localhost:8080/explorer)


### PR DESCRIPTION
## Description

Change Prettier to turn off automatic wrapping of prose in markdown files.

## Validation

- Validate only whitespace and line ending changes, not content

## Related Issues

- Follows #1567

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.
