### PR TITLE
Set explicit minimum permissions on GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -15,11 +15,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -6,11 +6,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-build-docker-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   install-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Set explicit minimum permissions (`contents: read`) at the workflow level on all three GitHub Actions workflows. This follows the principle of least privilege and ensures any future jobs inherit restricted token permissions by default.

- Add top-level `permissions: contents: read` to `unit.yml` (was missing entirely)
- Move `permissions` from job level to workflow level in `build_docker.yml`
- Move `permissions` from job level to workflow level in `test_build_docker.yml`

## Validation

- Verify each workflow file has `permissions: contents: read` at the top level
- Verify no job-level `permissions` blocks remain
- CI workflows should pass as before since no functional behavior changed

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have run `pnpm checks` to ensure code compiles and meets standards.
- [ ] I have run `pnpm test` to check if all tests are passing.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have added an entry in the `Changelog.md`.