### PR TITLE
Add issue type REST API instructions to GitHub skill

### DIFF
--- a/.kiro/skills/github/SKILL.md
+++ b/.kiro/skills/github/SKILL.md
@@ -15,6 +15,10 @@ tools: ["git", "gh", "fs_read", "grep", "glob", "web_search", "web_fetch"]
 ## Issues
 
 - Always assign an issue type when creating issues: `Bug`, `Feature`, `Epic`, `Task`, or `Spike`
+- Set the issue type via the REST API after creation:
+  ```bash
+  gh api -X PATCH repos/{owner}/{repo}/issues/{number} --field type={type_name}
+  ```
 - Use the corresponding issue template for each type:
   - `Bug` → `.github/ISSUE_TEMPLATE/01-bug-report.md`
   - `Feature` → `.github/ISSUE_TEMPLATE/02-feature-request.md`


### PR DESCRIPTION
## Description

Adds instructions to the GitHub skill file for setting issue types via the REST API after creation. This documents the `gh api` command needed to assign issue types (`Bug`, `Feature`, `Epic`, `Task`, or `Spike`) since `gh issue create` does not support setting the type directly.

## Validation

- Verified setting the issue type this way works correctly

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.