### PR TITLE
Show empty connection state instead of misleading 'No Schema Available'

### DIFF
--- a/packages/graph-explorer/src/components/SchemaDiscoveryBoundary.test.tsx
+++ b/packages/graph-explorer/src/components/SchemaDiscoveryBoundary.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import { describe, expect, test, vi } from "vitest";
 
 import { SchemaDiscoveryBoundary } from "./SchemaDiscoveryBoundary";
@@ -9,6 +10,7 @@ vi.mock("@/core", async () => {
     ...actual,
     useHasActiveSchema: vi.fn(),
     useMaybeActiveSchema: vi.fn(),
+    useConfiguration: vi.fn(),
   };
 });
 
@@ -25,10 +27,15 @@ vi.mock("@/hooks", async () => {
   };
 });
 
-import { useHasActiveSchema, useMaybeActiveSchema } from "@/core";
+import {
+  useConfiguration,
+  useHasActiveSchema,
+  useMaybeActiveSchema,
+} from "@/core";
 import { useSchemaSync } from "@/hooks/useSchemaSync";
 import { createRandomEdgeConnection } from "@/utils/testing/randomData";
 
+const mockedUseConfiguration = vi.mocked(useConfiguration);
 const mockedUseHasActiveSchema = vi.mocked(useHasActiveSchema);
 const mockedUseMaybeActiveSchema = vi.mocked(useMaybeActiveSchema);
 const mockedUseSchemaSync = vi.mocked(useSchemaSync);
@@ -57,11 +64,16 @@ function createMockSchemaSync(
 
 function mockSchema({
   hasSchema = false,
+  hasConnection = true,
   edgeConnections,
 }: {
   hasSchema?: boolean;
+  hasConnection?: boolean;
   edgeConnections?: ReturnType<typeof createRandomEdgeConnection>[];
 } = {}) {
+  mockedUseConfiguration.mockReturnValue(
+    hasConnection ? ({} as ReturnType<typeof useConfiguration>) : undefined,
+  );
   mockedUseHasActiveSchema.mockReturnValue(hasSchema);
   mockedUseMaybeActiveSchema.mockReturnValue(
     hasSchema ? { vertices: [], edges: [], edgeConnections } : undefined,
@@ -69,18 +81,47 @@ function mockSchema({
 }
 
 describe("SchemaDiscoveryBoundary", () => {
+  function renderBoundary(props: { requireEdgeConnections?: boolean } = {}) {
+    return render(
+      <MemoryRouter>
+        <SchemaDiscoveryBoundary {...props}>
+          <div>Children</div>
+        </SchemaDiscoveryBoundary>
+      </MemoryRouter>,
+    );
+  }
+
+  describe("no active connection", () => {
+    test("renders no-connection state when no connection is configured", () => {
+      mockSchema({ hasConnection: false });
+      mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+      renderBoundary();
+
+      expect(screen.getByText("No Connection")).toBeInTheDocument();
+      expect(screen.queryByText("No Schema Available")).not.toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
+    });
+
+    test("renders no-connection state even with requireEdgeConnections", () => {
+      mockSchema({ hasConnection: false });
+      mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
+
+      renderBoundary({ requireEdgeConnections: true });
+
+      expect(screen.getByText("No Connection")).toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
+    });
+  });
+
   describe("schema only (default)", () => {
     test("renders children when schema is available", () => {
       mockSchema({ hasSchema: true });
       mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
 
-      render(
-        <SchemaDiscoveryBoundary>
-          <div>Schema content</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary();
 
-      expect(screen.getByText("Schema content")).toBeInTheDocument();
+      expect(screen.getByText("Children")).toBeInTheDocument();
     });
 
     test("renders loading state when schema is syncing", () => {
@@ -89,14 +130,10 @@ describe("SchemaDiscoveryBoundary", () => {
         createMockSchemaSync({ isFetching: true }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary>
-          <div>Schema content</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary();
 
       expect(screen.getByText("Synchronizing...")).toBeInTheDocument();
-      expect(screen.queryByText("Schema content")).not.toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
     });
 
     test("renders loading state when isFetching with existing schema", () => {
@@ -105,14 +142,10 @@ describe("SchemaDiscoveryBoundary", () => {
         createMockSchemaSync({ isFetching: true }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary>
-          <div>Schema content</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary();
 
       expect(screen.getByText("Synchronizing...")).toBeInTheDocument();
-      expect(screen.queryByText("Schema content")).not.toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
     });
 
     test("renders error state when schema sync fails", () => {
@@ -129,27 +162,19 @@ describe("SchemaDiscoveryBoundary", () => {
         }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary>
-          <div>Schema content</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary();
 
-      expect(screen.queryByText("Schema content")).not.toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
     });
 
     test("renders no-schema state when no schema exists", () => {
       mockSchema();
       mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
 
-      render(
-        <SchemaDiscoveryBoundary>
-          <div>Schema content</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary();
 
       expect(screen.getByText("No Schema Available")).toBeInTheDocument();
-      expect(screen.queryByText("Schema content")).not.toBeInTheDocument();
+      expect(screen.queryByText("Children")).not.toBeInTheDocument();
     });
   });
 
@@ -161,11 +186,7 @@ describe("SchemaDiscoveryBoundary", () => {
       });
       mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.getByText("Children")).toBeInTheDocument();
     });
@@ -187,11 +208,7 @@ describe("SchemaDiscoveryBoundary", () => {
         }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.getByText("Children")).toBeInTheDocument();
     });
@@ -202,11 +219,7 @@ describe("SchemaDiscoveryBoundary", () => {
         createMockSchemaSync({ isFetching: true }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.getByText("Synchronizing...")).toBeInTheDocument();
       expect(screen.queryByText("Children")).not.toBeInTheDocument();
@@ -226,11 +239,7 @@ describe("SchemaDiscoveryBoundary", () => {
         }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.queryByText("Children")).not.toBeInTheDocument();
       expect(
@@ -252,11 +261,7 @@ describe("SchemaDiscoveryBoundary", () => {
         }),
       );
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.queryByText("Children")).not.toBeInTheDocument();
       expect(
@@ -268,11 +273,7 @@ describe("SchemaDiscoveryBoundary", () => {
       mockSchema({ hasSchema: true, edgeConnections: undefined });
       mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(
         screen.getByText("No edge-connections Available"),
@@ -284,11 +285,7 @@ describe("SchemaDiscoveryBoundary", () => {
       mockSchema();
       mockedUseSchemaSync.mockReturnValue(createMockSchemaSync());
 
-      render(
-        <SchemaDiscoveryBoundary requireEdgeConnections>
-          <div>Children</div>
-        </SchemaDiscoveryBoundary>,
-      );
+      renderBoundary({ requireEdgeConnections: true });
 
       expect(screen.getByText("No Schema Available")).toBeInTheDocument();
       expect(screen.queryByText("Children")).not.toBeInTheDocument();

--- a/packages/graph-explorer/src/components/SchemaDiscoveryBoundary.tsx
+++ b/packages/graph-explorer/src/components/SchemaDiscoveryBoundary.tsx
@@ -1,6 +1,15 @@
 import type { PropsWithChildren } from "react";
 
+import { ArrowRightIcon, DatabaseIcon } from "lucide-react";
+
 import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateIcon,
+  EmptyStateTitle,
+  NavButton,
   Panel,
   PanelContent,
   PanelEmptyState,
@@ -10,7 +19,11 @@ import {
   PanelTitle,
   SyncIcon,
 } from "@/components";
-import { useHasActiveSchema, useMaybeActiveSchema } from "@/core";
+import {
+  useConfiguration,
+  useHasActiveSchema,
+  useMaybeActiveSchema,
+} from "@/core";
 import { useTranslations } from "@/hooks";
 import { useCancelSchemaSync, useSchemaSync } from "@/hooks/useSchemaSync";
 
@@ -28,6 +41,7 @@ export function SchemaDiscoveryBoundary({
   children,
   requireEdgeConnections = false,
 }: SchemaDiscoveryBoundaryProps) {
+  const config = useConfiguration();
   const {
     schemaDiscoveryQuery,
     edgeDiscoveryQuery,
@@ -38,6 +52,30 @@ export function SchemaDiscoveryBoundary({
   const schema = useMaybeActiveSchema();
   const cancel = useCancelSchemaSync();
   const t = useTranslations();
+
+  // 0. If no connection is configured, show no-connection state
+  if (!config) {
+    return (
+      <Layout>
+        <EmptyState className="p-6">
+          <EmptyStateIcon>
+            <DatabaseIcon />
+          </EmptyStateIcon>
+          <EmptyStateContent>
+            <EmptyStateTitle>No Connection</EmptyStateTitle>
+            <EmptyStateDescription>
+              Add a connection to start exploring your graph data.
+            </EmptyStateDescription>
+            <EmptyStateActions>
+              <NavButton to="/connections" variant="primary">
+                Go to Connections <ArrowRightIcon />
+              </NavButton>
+            </EmptyStateActions>
+          </EmptyStateContent>
+        </EmptyState>
+      </Layout>
+    );
+  }
 
   // 1. If loading/fetching, show loading state
   if (isFetching) {

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.test.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { TooltipProvider } from "@/components";
+import { configurationAtom, getAppStore } from "@/core";
+import { createQueryClient } from "@/core/queryClient";
+import { TestProvider } from "@/utils/testing";
+
+import AvailableConnections from "./AvailableConnections";
+
+vi.mock("@/modules/CreateConnection", () => ({
+  default: () => <div>CreateConnection</div>,
+}));
+
+describe("AvailableConnections", () => {
+  test("renders empty state when there are no connections", () => {
+    const store = getAppStore();
+    store.set(configurationAtom, new Map());
+    const queryClient = createQueryClient();
+
+    render(
+      <TestProvider client={queryClient} store={store}>
+        <TooltipProvider>
+          <AvailableConnections isSync={false} />
+        </TooltipProvider>
+      </TestProvider>,
+    );
+
+    expect(screen.getByText("No Connections")).toBeInTheDocument();
+  });
+});

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -1,9 +1,17 @@
 import { useAtomValue } from "jotai";
+import { DatabaseIcon } from "lucide-react";
+import { useState } from "react";
 import { Virtuoso } from "react-virtuoso";
 
 import {
   AddIcon,
   Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateIcon,
+  EmptyStateTitle,
   FileButton,
   Panel,
   PanelContent,
@@ -20,6 +28,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@/components/Dialog";
 import { activeConfigurationAtom, configurationAtom } from "@/core";
 import CreateConnection from "@/modules/CreateConnection";
@@ -28,91 +37,112 @@ import { cn } from "@/utils";
 import { ConnectionRow } from "./ConnectionRow";
 import { useImportConnectionFile } from "./useImportConnectionFile";
 
-export type ConnectionDetailProps = {
+export type AvailableConnectionsProps = {
   isSync: boolean;
-  isModalOpen: boolean;
-  onModalChange(isOpen: boolean): void;
 };
 
-const AvailableConnections = ({
-  isSync,
-  isModalOpen,
-  onModalChange,
-}: ConnectionDetailProps) => {
+const AvailableConnections = ({ isSync }: AvailableConnectionsProps) => {
   const activeConnectionId = useAtomValue(activeConfigurationAtom);
   const allConnections = useAllConnections();
   const importConnectionFile = useImportConnectionFile();
+  const [isDialogOpen, setDialogOpen] = useState(false);
 
   return (
-    <Panel>
-      <PanelHeader>
-        <PanelTitle>Available connections</PanelTitle>
-        <PanelHeaderActions>
-          <FileButton
-            onChange={payload => payload && importConnectionFile(payload)}
-            accept="application/json"
-            asChild
-          >
-            <Button
-              tooltip="Import Connection"
-              variant="ghost"
-              size="icon"
-              disabled={isSync}
+    <Dialog open={isDialogOpen} onOpenChange={setDialogOpen}>
+      <Panel>
+        <PanelHeader>
+          <PanelTitle>Available connections</PanelTitle>
+          <PanelHeaderActions>
+            <FileButton
+              onChange={payload => payload && importConnectionFile(payload)}
+              accept="application/json"
+              asChild
             >
-              <TrayArrowIcon style={{ transform: "rotate(180deg)" }} />
-            </Button>
-          </FileButton>
-          <PanelHeaderDivider />
-          <Button
-            tooltip="Add New Connection"
-            variant="ghost"
-            size="icon"
-            onClick={() => onModalChange(true)}
-          >
-            <AddIcon />
-          </Button>
-        </PanelHeaderActions>
-      </PanelHeader>
-
-      <PanelContent>
-        <Virtuoso
-          data={allConnections}
-          itemContent={(index, connection) => (
-            <div
-              className={cn(
-                "px-3 py-1.5",
-                index === 0 && "pt-3",
-                index === allConnections.length - 1 && "pb-3",
-              )}
-            >
-              <div
-                key={connection.id}
-                className="has-[:checked]:bg-secondary-subtle group has-[:checked]:ring-primary-main rounded-lg ring-1 ring-gray-200 has-[:checked]:ring-2"
+              <Button
+                tooltip="Import Connection"
+                variant="ghost"
+                size="icon"
+                disabled={isSync}
               >
-                <ConnectionRow
-                  connection={connection}
-                  isSelected={activeConnectionId === connection.id}
-                  isDisabled={isSync}
-                />
-              </div>
-            </div>
+                <TrayArrowIcon style={{ transform: "rotate(180deg)" }} />
+              </Button>
+            </FileButton>
+            <PanelHeaderDivider />
+            <DialogTrigger asChild>
+              <Button tooltip="Add New Connection" variant="ghost" size="icon">
+                <AddIcon />
+              </Button>
+            </DialogTrigger>
+          </PanelHeaderActions>
+        </PanelHeader>
+
+        <PanelContent>
+          {allConnections.length === 0 ? (
+            <EmptyState>
+              <EmptyStateIcon>
+                <DatabaseIcon />
+              </EmptyStateIcon>
+              <EmptyStateContent>
+                <EmptyStateTitle>No Connections</EmptyStateTitle>
+                <EmptyStateDescription>
+                  Get started by adding or importing a connection.
+                </EmptyStateDescription>
+                <EmptyStateActions>
+                  <DialogTrigger asChild>
+                    <Button variant="primary">Add New Connection</Button>
+                  </DialogTrigger>
+                  <FileButton
+                    onChange={payload =>
+                      payload && importConnectionFile(payload)
+                    }
+                    accept="application/json"
+                    asChild
+                  >
+                    <Button>Import Connection</Button>
+                  </FileButton>
+                </EmptyStateActions>
+              </EmptyStateContent>
+            </EmptyState>
+          ) : (
+            <Virtuoso
+              data={allConnections}
+              itemContent={(index, connection) => (
+                <div
+                  className={cn(
+                    "px-3 py-1.5",
+                    index === 0 && "pt-3",
+                    index === allConnections.length - 1 && "pb-3",
+                  )}
+                >
+                  <div
+                    key={connection.id}
+                    className="has-[:checked]:bg-secondary-subtle group has-[:checked]:ring-primary-main rounded-lg ring-1 ring-gray-200 has-[:checked]:ring-2"
+                  >
+                    <ConnectionRow
+                      connection={connection}
+                      isSelected={activeConnectionId === connection.id}
+                      isDisabled={isSync}
+                    />
+                  </div>
+                </div>
+              )}
+            />
           )}
-        />
-        <Dialog open={isModalOpen} onOpenChange={onModalChange}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Add New Connection</DialogTitle>
-              <DialogDescription>
-                Enter the details of the new connection.
-              </DialogDescription>
-            </DialogHeader>
-            <DialogBody>
-              <CreateConnection onClose={() => onModalChange(false)} />
-            </DialogBody>
-          </DialogContent>
-        </Dialog>
-      </PanelContent>
-    </Panel>
+        </PanelContent>
+      </Panel>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add New Connection</DialogTitle>
+          <DialogDescription>
+            Enter the details of the new connection.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <CreateConnection onClose={() => setDialogOpen(false)} />
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
   );
 };
 

--- a/packages/graph-explorer/src/modules/AvailableConnections/index.ts
+++ b/packages/graph-explorer/src/modules/AvailableConnections/index.ts
@@ -1,2 +1,1 @@
 export { default } from "./AvailableConnections";
-export type { ConnectionDetailProps } from "./AvailableConnections";

--- a/packages/graph-explorer/src/routes/Connections/Connections.tsx
+++ b/packages/graph-explorer/src/routes/Connections/Connections.tsx
@@ -1,6 +1,3 @@
-import { useAtomValue } from "jotai";
-import { useState } from "react";
-
 import {
   NavBar,
   NavBarContent,
@@ -14,15 +11,13 @@ import {
   WorkspaceContent,
 } from "@/components";
 import GraphExplorerIcon from "@/components/icons/GraphExplorerIcon";
-import { configurationAtom, useConfiguration } from "@/core";
+import { useConfiguration } from "@/core";
 import { useIsSyncing } from "@/hooks/useSchemaSync";
 import AvailableConnections from "@/modules/AvailableConnections";
 import ConnectionDetail from "@/modules/ConnectionDetail";
 
 export default function Connections() {
   const config = useConfiguration();
-  const configuration = useAtomValue(configurationAtom);
-  const [isModalOpen, setModal] = useState(configuration.size === 0);
   const isSyncing = useIsSyncing();
 
   return (
@@ -39,11 +34,7 @@ export default function Connections() {
       <WorkspaceContent>
         <PanelGroup className="grid grid-cols-2 gap-2">
           <div className="h-full grow">
-            <AvailableConnections
-              isSync={isSyncing}
-              isModalOpen={isModalOpen}
-              onModalChange={setModal}
-            />
+            <AvailableConnections isSync={isSyncing} />
           </div>
           {config ? (
             <div className="h-full grow">


### PR DESCRIPTION
## Description

When Graph Explorer launches with no configured connections, all views (Graph, Data Explorer, Schema Explorer) show "No Schema Available" with a "Synchronize" button that fails. The Connections page auto-opens the "Add New Connection" dialog with no visible empty state behind it.

This PR fixes both issues:

- **SchemaDiscoveryBoundary**: Added a no-connection check as the first priority. When `useConfiguration()` returns undefined, it renders a "No Connection" empty state with a "Go to Connections" button instead of falling through to "No Schema Available".
- **AvailableConnections**: Shows an empty state with "Add New Connection" and "Import Connection" buttons when no connections exist, instead of an empty list.
- **Connections page**: Removed the auto-open dialog behavior (`useState(configuration.size === 0)` → removed). Dialog state is now fully owned by `AvailableConnections` using Radix `DialogTrigger`.
- **Cleanup**: Removed lifted modal state props from `AvailableConnections`, removed unused type export, removed unused imports from `Connections.tsx`.

## Validation

- All three views (Graph, Data, Schema) show "No Connection" with a link to Connections when no connections are configured
- Connections page shows an empty state with add/import buttons instead of auto-opening the dialog
- All existing behavior is preserved when connections are configured

<img width="1469" height="1051" alt="CleanShot 2026-03-26 at 20 58 01@2x" src="https://github.com/user-attachments/assets/e7a914a5-1536-4753-8ed0-80eff415f570" />
<img width="1469" height="1051" alt="CleanShot 2026-03-26 at 20 58 07@2x" src="https://github.com/user-attachments/assets/300c838d-52bf-4d41-8e94-974a3f42fdda" />

## Related Issues

- Fixes #1610

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.