### PR TITLE
Disable schema sync queries when no connection exists

### DIFF
--- a/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
@@ -65,7 +65,10 @@ export function edgeConnectionsQuery(
 
         // Update the cached schema for the schema sync query
         const newSchema = store.get(activeSchemaAtom);
-        client.setQueryData(schemaSyncQuery(activeSchema).queryKey, newSchema);
+        client.setQueryData(
+          schemaSyncQuery({ activeSchema, hasConnection: true }).queryKey,
+          newSchema,
+        );
 
         return results.edgeConnections;
       } catch (error) {

--- a/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
+++ b/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
@@ -50,7 +50,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    const result = await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     expect(result.vertices).toHaveLength(1);
     expect(result.vertices[0].type).toBe("Person");
@@ -69,7 +71,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     const activeConfigId = store.get(activeConfigurationAtom);
     const storedSchema = store.get(schemaAtom).get(activeConfigId!);
@@ -101,7 +105,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     // Verify old schema was replaced
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
@@ -112,7 +118,9 @@ describe("schemaSyncQuery", () => {
   it("should return empty schema when no data exists", async () => {
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    const result = await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     expect(result.vertices).toStrictEqual([]);
     expect(result.edges).toStrictEqual([]);
@@ -129,7 +137,9 @@ describe("schemaSyncQuery", () => {
     });
 
     await expect(
-      queryClient.fetchQuery(schemaSyncQuery(undefined)),
+      queryClient.fetchQuery(
+        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      ),
     ).rejects.toThrow("Network error");
 
     const activeConfigId = store.get(activeConfigurationAtom);
@@ -151,7 +161,9 @@ describe("schemaSyncQuery", () => {
     });
 
     const queryClient = createQueryClient();
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
     expect(storedSchema?.edgeConnections).toBeUndefined();
@@ -171,7 +183,9 @@ describe("schemaSyncQuery", () => {
     });
 
     const queryClient = createQueryClient();
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
     expect(storedSchema?.lastSyncFail).toBe(false);
@@ -200,7 +214,9 @@ describe("schemaSyncQuery", () => {
     });
 
     await expect(
-      queryClient.fetchQuery(schemaSyncQuery(undefined)),
+      queryClient.fetchQuery(
+        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      ),
     ).rejects.toThrow("Network error");
 
     // Verify existing data was preserved
@@ -226,7 +242,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     const activeConfigId = store.get(activeConfigurationAtom);
     const storedSchema = store.get(schemaAtom).get(activeConfigId!);
@@ -241,7 +259,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     expect(fetchSchemaSpy).toHaveBeenCalledWith(
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -271,7 +291,9 @@ describe("schemaSyncQuery", () => {
       queries: { ...queryClient.getDefaultOptions().queries, retry: false },
     });
 
-    const queryPromise = queryClient.fetchQuery(schemaSyncQuery(undefined));
+    const queryPromise = queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     // Cancel the query
     await queryClient.cancelQueries({ queryKey: ["schema"] });
@@ -287,7 +309,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    const result = await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     expect(result.vertices.length).toBeGreaterThanOrEqual(2);
     expect(result.totalVertices).toBe(2);
@@ -307,7 +331,9 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(schemaSyncQuery(undefined));
+    const result = await queryClient.fetchQuery(
+      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+    );
 
     expect(result.totalVertices).toBe(100);
     expect(result.totalEdges).toBe(50);
@@ -336,7 +362,9 @@ describe("schemaSyncQuery", () => {
     });
 
     await expect(
-      queryClient.fetchQuery(schemaSyncQuery(undefined)),
+      queryClient.fetchQuery(
+        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      ),
     ).rejects.toThrow("Network error");
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);

--- a/packages/graph-explorer/src/connector/queries/schemaSyncQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/schemaSyncQuery.ts
@@ -27,13 +27,18 @@ import { getExplorer, getStore } from "./helpers";
  * On failure, persists `lastSyncFail` so the UI can show the failure after
  * a browser refresh and automatic retry is suppressed.
  */
-export function schemaSyncQuery(activeSchema: SchemaStorageModel | undefined) {
+export function schemaSyncQuery({
+  activeSchema,
+  hasConnection,
+}: {
+  activeSchema: SchemaStorageModel | undefined;
+  hasConnection: boolean;
+}) {
   return queryOptions({
     queryKey: ["schema", "discovery"],
     staleTime: Infinity,
     initialData: activeSchema,
-    // Don't automatically retry if the last sync failed (persisted across sessions)
-    enabled: !activeSchema?.lastSyncFail,
+    enabled: hasConnection && !activeSchema?.lastSyncFail,
     queryFn: async ({ signal, meta }) => {
       const explorer = getExplorer(meta);
       const store = getStore(meta);

--- a/packages/graph-explorer/src/hooks/useSchemaSync.test.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.test.ts
@@ -2,9 +2,12 @@ import { act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  activeConfigurationAtom,
+  configurationAtom,
   createEdgeType,
   createVertexType,
   type EdgeConnection,
+  explorerForTestingAtom,
   schemaAtom,
 } from "@/core";
 import { getAppStore } from "@/core/StateProvider/appStore";
@@ -13,6 +16,7 @@ import {
   createRandomVertexTypeConfig,
   DbState,
   FakeExplorer,
+  renderHookWithJotai,
   renderHookWithState,
 } from "@/utils/testing";
 
@@ -43,6 +47,47 @@ describe("useSchemaSync", () => {
     state.activeSchema.edgeConnections = undefined;
     return state;
   }
+
+  describe("no active connection", () => {
+    function renderWithNoConnection() {
+      return renderHookWithJotai(
+        () => useSchemaSync(),
+        store => {
+          store.set(activeConfigurationAtom, null);
+          store.set(configurationAtom, new Map());
+          store.set(schemaAtom, new Map());
+          store.set(explorerForTestingAtom, explorer);
+        },
+      );
+    }
+
+    it("should not fetch schema when no connection exists", () => {
+      const fetchSchemaSpy = vi.spyOn(explorer, "fetchSchema");
+
+      const { result } = renderWithNoConnection();
+
+      expect(fetchSchemaSpy).not.toHaveBeenCalled();
+      expect(result.current.schemaDiscoveryQuery.fetchStatus).toBe("idle");
+    });
+
+    it("should not fetch edge connections when no connection exists", () => {
+      const fetchEdgeConnectionsSpy = vi.spyOn(
+        explorer,
+        "fetchEdgeConnections",
+      );
+
+      const { result } = renderWithNoConnection();
+
+      expect(fetchEdgeConnectionsSpy).not.toHaveBeenCalled();
+      expect(result.current.edgeDiscoveryQuery.fetchStatus).toBe("idle");
+    });
+
+    it("should report isFetching as false when no connection exists", () => {
+      const { result } = renderWithNoConnection();
+
+      expect(result.current.isFetching).toBe(false);
+    });
+  });
 
   describe("schemaDiscoveryQuery", () => {
     it("should use initialData from active schema without fetching", () => {

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -1,7 +1,7 @@
 import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { edgeConnectionsQuery, schemaSyncQuery } from "@/connector";
-import { useMaybeActiveSchema } from "@/core";
+import { useConfiguration, useMaybeActiveSchema } from "@/core";
 import { logger } from "@/utils";
 
 /** Returns true if any schema sync query is running. Will not trigger the query to run. */
@@ -30,9 +30,12 @@ export function useCancelSchemaSync() {
  * - On refetch failure, TanStack Query preserves the previous successful data.
  */
 export function useSchemaSync() {
+  const config = useConfiguration();
   const activeSchema = useMaybeActiveSchema();
 
-  const schemaDiscoveryQuery = useQuery(schemaSyncQuery(activeSchema));
+  const schemaDiscoveryQuery = useQuery(
+    schemaSyncQuery({ activeSchema, hasConnection: config != null }),
+  );
   const edgeDiscoveryQuery = useQuery(
     edgeConnectionsQuery(schemaDiscoveryQuery.data),
   );


### PR DESCRIPTION
## Description

When no active connection is configured, `schemaSyncQuery` still fires because its `enabled` check (`!activeSchema?.lastSyncFail`) evaluates to `true` when `activeSchema` is `undefined`. This causes unnecessary network calls that fail silently.

- `schemaSyncQuery` now accepts an options object `{ activeSchema, hasConnection }` instead of positional params, making call sites self-documenting
- `useSchemaSync` passes `hasConnection: config != null` so both schema discovery and edge connection queries stay idle when no connection exists

## Validation

- Schema sync queries remain idle (fetchStatus `"idle"`) when no connection is configured
- All existing sync behavior is preserved when connections are configured
- No network calls are made on fresh install with no connections

## Related Issues

- Part of #1610

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.