### PR TITLE
feat: make SPARQL endpoint path configurable

### DIFF
--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -27,6 +27,7 @@ interface DbQueryIncomingHttpHeaders extends IncomingHttpHeaders {
   "aws-neptune-region"?: string;
   "service-type"?: string;
   "db-query-logging-enabled"?: string;
+  "sparql-endpoint-path"?: string;
 }
 
 interface LoggerIncomingHttpHeaders extends IncomingHttpHeaders {
@@ -202,6 +203,7 @@ app.post("/sparql", async (req, res, next) => {
   const headers = req.headers as DbQueryIncomingHttpHeaders;
   const queryId = headers["queryid"];
   const graphDbConnectionUrl = headers["graph-db-connection-url"];
+  const sparqlEndpointPath = headers["sparql-endpoint-path"] || "/sparql";
   const shouldLogDbQuery = BooleanStringSchema.default(false).parse(
     headers["db-query-logging-enabled"],
   );
@@ -219,7 +221,7 @@ app.post("/sparql", async (req, res, next) => {
     proxyLogger.debug(`Cancelling request ${queryId}...`);
     try {
       await retryFetch(
-        new URL(`${graphDbConnectionUrl}/sparql/status`),
+        new URL(`${graphDbConnectionUrl}${sparqlEndpointPath}/status`),
         {
           method: "POST",
           headers: {
@@ -264,7 +266,7 @@ app.post("/sparql", async (req, res, next) => {
     proxyLogger.debug("[SPARQL] Received database query:\n%s", queryString);
   }
 
-  const rawUrl = `${graphDbConnectionUrl}/sparql`;
+  const rawUrl = `${graphDbConnectionUrl}${sparqlEndpointPath}`;
   let body = `query=${encodeURIComponent(queryString)}`;
   if (queryId) {
     body += `&queryId=${encodeURIComponent(queryId)}`;

--- a/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
+++ b/packages/graph-explorer/src/connector/fetchDatabaseRequest.ts
@@ -69,6 +69,9 @@ function getAuthHeaders(
     headers["db-query-logging-enabled"] = String(
       featureFlags.allowLoggingDbQuery,
     );
+    if (connection.sparqlEndpointPath) {
+      headers["sparql-endpoint-path"] = connection.sparqlEndpointPath;
+    }
   }
   if (connection.awsAuthEnabled) {
     headers["aws-neptune-region"] = connection.awsRegion || "";

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -54,7 +54,7 @@ function _sparqlFetch(
     return fetchDatabaseRequest(
       connection,
       featureFlags,
-      `${connection.url}/sparql`,
+      `${connection.url}${connection.sparqlEndpointPath ?? "/sparql"}`,
       {
         method: "POST",
         headers,

--- a/packages/graph-explorer/src/core/defaultConnection.ts
+++ b/packages/graph-explorer/src/core/defaultConnection.ts
@@ -21,6 +21,8 @@ export const DefaultConnectionDataSchema = z.object({
     .enum(neptuneServiceTypeOptions)
     .default(DEFAULT_SERVICE_TYPE)
     .catch(DEFAULT_SERVICE_TYPE),
+  // SPARQL options
+  GRAPH_EXP_SPARQL_ENDPOINT_PATH: z.string().optional(),
   // Connection options
   GRAPH_EXP_FETCH_REQUEST_TIMEOUT: z.number().default(240000),
   GRAPH_EXP_NODE_EXPANSION_LIMIT: z.number().optional(),
@@ -116,6 +118,7 @@ export function mapToConnection(data: DefaultConnectionData): RawConfiguration {
       awsAuthEnabled: data.GRAPH_EXP_IAM,
       awsRegion: data.GRAPH_EXP_AWS_REGION,
       serviceType: data.GRAPH_EXP_SERVICE_TYPE,
+      sparqlEndpointPath: data.GRAPH_EXP_SPARQL_ENDPOINT_PATH,
       fetchTimeoutMs: data.GRAPH_EXP_FETCH_REQUEST_TIMEOUT,
       nodeExpansionLimit: data.GRAPH_EXP_NODE_EXPANSION_LIMIT,
     },

--- a/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
+++ b/packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx
@@ -43,6 +43,7 @@ type ConnectionForm = {
   awsAuthEnabled?: boolean;
   serviceType?: NeptuneServiceType;
   awsRegion?: string;
+  sparqlEndpointPath?: string;
   fetchTimeoutEnabled: boolean;
   fetchTimeoutMs?: number;
   nodeExpansionLimitEnabled: boolean;
@@ -72,6 +73,7 @@ function mapToConnection(data: Required<ConnectionForm>): ConnectionConfig {
     awsAuthEnabled: data.awsAuthEnabled,
     serviceType: data.serviceType,
     awsRegion: data.awsRegion,
+    sparqlEndpointPath: data.sparqlEndpointPath || undefined,
     fetchTimeoutMs: data.fetchTimeoutEnabled ? data.fetchTimeoutMs : undefined,
     nodeExpansionLimit: data.nodeExpansionLimitEnabled
       ? data.nodeExpansionLimit
@@ -275,6 +277,25 @@ const CreateConnection = ({
             disabled={form.serviceType === "neptune-graph"}
           />
         </FormItem>
+        {form.queryEngine === "sparql" && (
+          <FormItem>
+            <Label>
+              SPARQL Endpoint Path
+              <InfoTooltip>
+                The path appended to the connection URL for SPARQL queries.
+                Defaults to &quot;/sparql&quot;. Some triple stores use
+                different paths, e.g., Apache Jena Fuseki uses
+                &quot;/query&quot;.
+              </InfoTooltip>
+            </Label>
+            <InputField
+              aria-label="SPARQL Endpoint Path"
+              value={form.sparqlEndpointPath ?? ""}
+              onChange={onFormChange("sparqlEndpointPath")}
+              placeholder="/sparql"
+            />
+          </FormItem>
+        )}
         <FormItem>
           <Label>
             Public or Proxy Endpoint

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -40,6 +40,12 @@ export type ConnectionConfig = {
    */
   awsRegion?: string;
   /**
+   * Custom SPARQL endpoint path appended to the connection URL.
+   * By default, "/sparql". Some triple stores use different paths,
+   * e.g., Apache Jena Fuseki uses "/query".
+   */
+  sparqlEndpointPath?: string;
+  /**
    * Number of milliseconds before aborting a request.
    * By default, undefined.
    */


### PR DESCRIPTION
## Summary

Adds a configurable `sparqlEndpointPath` field to `ConnectionConfig`, allowing users to specify the SPARQL query endpoint path for their triple store. Defaults to `"/sparql"` for full backward compatibility.

Closes #23

## Motivation

Graph Explorer currently hardcodes `/sparql` as the SPARQL endpoint path. This works for Amazon Neptune and Blazegraph, but many popular triple stores use different paths:

| Triple Store | SPARQL Path |
|---|---|
| Amazon Neptune | `/sparql` |
| Blazegraph | `/sparql` |
| Apache Jena Fuseki | `/query` |
| Virtuoso | `/sparql` |
| GraphDB | `/repositories/{repo}` |

Without this change, users of Fuseki, GraphDB, and other non-standard-path stores cannot use Graph Explorer at all.

## Changes

- **`packages/shared/src/types/index.ts`** — Add optional `sparqlEndpointPath` to `ConnectionConfig`
- **`packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts`** — Use `connection.sparqlEndpointPath ?? "/sparql"` instead of hardcoded `"/sparql"`
- **`packages/graph-explorer/src/connector/fetchDatabaseRequest.ts`** — Forward `sparql-endpoint-path` header to proxy when set
- **`packages/graph-explorer-proxy-server/src/node-server.ts`** — Read `sparql-endpoint-path` header, default to `"/sparql"`
- **`packages/graph-explorer/src/modules/CreateConnection/CreateConnection.tsx`** — Add "SPARQL Endpoint Path" input field (shown only when SPARQL is selected)
- **`packages/graph-explorer/src/core/defaultConnection.ts`** — Add `GRAPH_EXP_SPARQL_ENDPOINT_PATH` to default connection schema

## Backward compatibility

- The field is optional everywhere — existing connections without it behave identically to before
- Default value is `"/sparql"` in both the frontend connector and the proxy server
- The UI field only appears when SPARQL query language is selected
- No changes to Gremlin or OpenCypher paths

## Testing

Tested with Apache Jena Fuseki (which uses `/query`) against a knowledge graph with 4.7M triples — schema synchronization, node exploration, and graph visualization all work correctly with the custom path.