### PR TITLE
Decouple proxy server startup from module-level side effects

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -151,6 +151,14 @@ Uses the self-signed certificate to serve the proxy-server over https if true.
 - Default `false` in code, `true` in Docker via the entrypoint script
 - Type: `boolean`
 
+#### `CONFIGURATION_FOLDER_PATH`
+
+Override path for the folder containing `.env` and `defaultConnection.json`. When set, replaces the default path entirely.
+
+- Optional
+- Default: `<client root>` (`packages/graph-explorer`)
+- Type: `string`
+
 ### Using self-signed certificates with Docker
 
 - Self-signed certificates will use the hostname provided in the `docker run` command, so unless you have specific requirements, there are no extra steps here besides providing the hostname.

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -38,7 +38,6 @@
     "@types/express": "^5.0.6",
     "@types/node": "^24.10.9",
     "@vitest/coverage-v8": "4.0.18",
-    "memfs": "^4.56.11",
     "rimraf": "^6.1.3",
     "tsx": "^4.21.0",
     "vitest": "4.0.18"

--- a/packages/graph-explorer-proxy-server/src/env.test.ts
+++ b/packages/graph-explorer-proxy-server/src/env.test.ts
@@ -1,0 +1,105 @@
+import { parseEnvironmentValues } from "./env.js";
+
+describe("parseEnvironmentValues", () => {
+  it("returns defaults when env is empty", () => {
+    const result = parseEnvironmentValues({});
+
+    expect(result.HOST).toBe("localhost");
+    expect(result.PROXY_SERVER_HTTPS_CONNECTION).toBe(false);
+    expect(result.PROXY_SERVER_HTTPS_PORT).toBe(443);
+    expect(result.PROXY_SERVER_HTTP_PORT).toBe(80);
+    expect(result.LOG_LEVEL).toBe("debug");
+    expect(result.LOG_STYLE).toBe("default");
+  });
+
+  it("parses provided values", () => {
+    const result = parseEnvironmentValues({
+      HOST: "my-server",
+      PROXY_SERVER_HTTP_PORT: "8080",
+      LOG_LEVEL: "error",
+    });
+
+    expect(result.HOST).toBe("my-server");
+    expect(result.PROXY_SERVER_HTTP_PORT).toBe(8080);
+    expect(result.LOG_LEVEL).toBe("error");
+  });
+
+  it("overrides all defaults", () => {
+    const result = parseEnvironmentValues({
+      HOST: "my-server.example.com",
+      PROXY_SERVER_HTTPS_CONNECTION: "true",
+      PROXY_SERVER_HTTPS_PORT: "8443",
+      PROXY_SERVER_HTTP_PORT: "8080",
+      LOG_LEVEL: "error",
+      LOG_STYLE: "cloudwatch",
+    });
+
+    expect(result.HOST).toBe("my-server.example.com");
+    expect(result.PROXY_SERVER_HTTPS_CONNECTION).toBe(true);
+    expect(result.PROXY_SERVER_HTTPS_PORT).toBe(8443);
+    expect(result.PROXY_SERVER_HTTP_PORT).toBe(8080);
+    expect(result.LOG_LEVEL).toBe("error");
+    expect(result.LOG_STYLE).toBe("cloudwatch");
+  });
+
+  it("handles boolean values case-insensitively", () => {
+    expect(
+      parseEnvironmentValues({ PROXY_SERVER_HTTPS_CONNECTION: "TRUE" })
+        .PROXY_SERVER_HTTPS_CONNECTION,
+    ).toBe(true);
+
+    expect(
+      parseEnvironmentValues({ PROXY_SERVER_HTTPS_CONNECTION: "False" })
+        .PROXY_SERVER_HTTPS_CONNECTION,
+    ).toBe(false);
+  });
+
+  it("coerces port strings to numbers", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_HTTP_PORT: "3000",
+      PROXY_SERVER_HTTPS_PORT: "3443",
+    });
+
+    expect(result.PROXY_SERVER_HTTP_PORT).toBe(3000);
+    expect(result.PROXY_SERVER_HTTPS_PORT).toBe(3443);
+  });
+
+  describe("validation failures", () => {
+    beforeEach(() => {
+      vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    it("exits process on invalid PROXY_SERVER_HTTPS_CONNECTION", () => {
+      parseEnvironmentValues({ PROXY_SERVER_HTTPS_CONNECTION: "yes" });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits process on invalid LOG_LEVEL", () => {
+      parseEnvironmentValues({ LOG_LEVEL: "verbose" });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits process on invalid LOG_STYLE", () => {
+      parseEnvironmentValues({ LOG_STYLE: "json" });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("logs error details on validation failure", () => {
+      parseEnvironmentValues({ LOG_LEVEL: "verbose" });
+      expect(console.error).toHaveBeenCalledWith(
+        "Failed to parse environment values",
+      );
+    });
+  });
+
+  it("ignores unknown env vars", () => {
+    const result = parseEnvironmentValues({
+      HOST: "my-server",
+      SOME_OTHER_VAR: "ignored",
+    });
+
+    expect(result.HOST).toBe("my-server");
+    expect(result).not.toHaveProperty("SOME_OTHER_VAR");
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -1,8 +1,4 @@
-import dotenv from "dotenv";
-import path from "path";
 import { z } from "zod";
-
-import { clientRoot } from "./paths.js";
 
 /** Coerces a string to a boolean value in a case insensitive way. */
 export const BooleanStringSchema = z
@@ -10,8 +6,8 @@ export const BooleanStringSchema = z
   .refine(s => s.toLowerCase() === "true" || s.toLowerCase() === "false")
   .transform(s => s.toLowerCase() === "true");
 
-// Define a required schema for the values we expect along with their defaults
-const EnvironmentValuesSchema = z.object({
+/** Schema for the environment values we expect along with their defaults. */
+export const EnvironmentValuesSchema = z.object({
   HOST: z.string().default("localhost"),
   PROXY_SERVER_HTTPS_CONNECTION: BooleanStringSchema.default(false),
   PROXY_SERVER_HTTPS_PORT: z.coerce.number().default(443),
@@ -20,36 +16,19 @@ const EnvironmentValuesSchema = z.object({
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("debug"),
   LOG_STYLE: z.enum(["cloudwatch", "default"]).default("default"),
-  CONFIGURATION_FOLDER_PATH: z.coerce.string().default(clientRoot),
 });
 
-const defaultConnectionFolderPath = process.env.CONFIGURATION_FOLDER_PATH
-  ? process.env.CONFIGURATION_FOLDER_PATH
-  : clientRoot;
+export type EnvironmentValues = z.infer<typeof EnvironmentValuesSchema>;
 
-// Load environment variables from .env file.
-dotenv.config({
-  path: [
-    path.join(clientRoot, ".env.local"),
-    path.join(clientRoot, ".env"),
-    path.join(defaultConnectionFolderPath, ".env"),
-  ],
-});
-
-// Parse the environment values from the process
-const parsedEnvironmentValues = EnvironmentValuesSchema.safeParse(process.env);
-
-if (!parsedEnvironmentValues.success) {
+/** Parses and validates environment values, exiting the process on failure. */
+export function parseEnvironmentValues(
+  env: Record<string, string | undefined>,
+): EnvironmentValues {
+  const result = EnvironmentValuesSchema.safeParse(env);
+  if (result.success) {
+    return result.data;
+  }
   console.error("Failed to parse environment values");
-  const flattenedErrors = parsedEnvironmentValues.error.flatten();
-  console.error(flattenedErrors.fieldErrors);
-  process.exit(1);
+  console.error(z.prettifyError(result.error));
+  return process.exit(1);
 }
-
-// eslint-disable-next-line no-console
-console.log("Parsed environment values:", parsedEnvironmentValues.data);
-
-// Adds all environment values to local object
-export const env = {
-  ...parsedEnvironmentValues.data,
-};

--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -1,13 +1,12 @@
 import type { NextFunction, Request, Response } from "express";
 
-import { getRequestLoggerPrefix, logger } from "./logging.js";
+import { type AppLogger, getRequestLoggerPrefix } from "./logging.js";
 
 /**
  * Global error handler
  * @param error The error to handle.
  */
-export function handleError(error: unknown) {
-  // Log the error itself
+export function handleError(error: unknown, logger: AppLogger) {
   logger.error(error);
 }
 
@@ -30,6 +29,7 @@ export function errorHandlingMiddleware() {
     response: Response,
     _next: NextFunction,
   ) => {
+    const logger = request.app.locals.logger;
     const errorInfo = extractErrorInfo(error);
 
     response.status(errorInfo.status);
@@ -49,7 +49,7 @@ export function errorHandlingMiddleware() {
         .join(""),
     );
 
-    handleError(error);
+    handleError(error, logger);
   };
 }
 

--- a/packages/graph-explorer-proxy-server/src/express.d.ts
+++ b/packages/graph-explorer-proxy-server/src/express.d.ts
@@ -1,0 +1,11 @@
+import type { EnvironmentValues } from "./env.js";
+import type { AppLogger } from "./logging.js";
+
+declare module "express-serve-static-core" {
+  interface Application {
+    locals: {
+      env: EnvironmentValues;
+      logger: AppLogger;
+    } & Record<string, unknown>;
+  }
+}

--- a/packages/graph-explorer-proxy-server/src/logging.test.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.test.ts
@@ -1,0 +1,202 @@
+import type { Request, Response } from "express";
+
+import type { EnvironmentValues } from "./env.js";
+
+import {
+  createLogger,
+  getRequestLoggerPrefix,
+  logRequestAndResponse,
+  requestLoggingMiddleware,
+} from "./logging.js";
+
+function createMockEnv(
+  overrides: Partial<EnvironmentValues> = {},
+): EnvironmentValues {
+  return {
+    HOST: "localhost",
+    PROXY_SERVER_HTTPS_CONNECTION: false,
+    PROXY_SERVER_HTTPS_PORT: 443,
+    PROXY_SERVER_HTTP_PORT: 80,
+    LOG_LEVEL: "silent",
+    LOG_STYLE: "default",
+    ...overrides,
+  };
+}
+
+const sharedLogger = createLogger(createMockEnv());
+
+function createMockRequest(overrides: Partial<Request> = {}) {
+  return {
+    method: "GET",
+    path: "/test",
+    app: {
+      locals: {
+        logger: sharedLogger,
+      },
+    },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function createMockResponse(statusCode: number) {
+  return {
+    statusCode,
+    statusMessage: "OK",
+    on: vi.fn(),
+    writableFinished: true,
+  } as unknown as Response;
+}
+
+describe("createLogger", () => {
+  it("creates a logger with the configured log level", () => {
+    const logger = createLogger(createMockEnv({ LOG_LEVEL: "warn" }));
+    expect(logger.level).toBe("warn");
+  });
+
+  it("creates a logger with debug level by default", () => {
+    const logger = createLogger(createMockEnv({ LOG_LEVEL: "debug" }));
+    expect(logger.level).toBe("debug");
+  });
+
+  it("supports all valid log levels", () => {
+    const levels = [
+      "fatal",
+      "error",
+      "warn",
+      "info",
+      "debug",
+      "trace",
+      "silent",
+    ] as const;
+    for (const level of levels) {
+      const logger = createLogger(createMockEnv({ LOG_LEVEL: level }));
+      expect(logger.level).toBe(level);
+    }
+  });
+});
+
+describe("getRequestLoggerPrefix", () => {
+  it("formats GET request", () => {
+    const req = createMockRequest({ method: "GET", path: "/sparql" });
+    expect(getRequestLoggerPrefix(req)).toBe("GET /sparql");
+  });
+
+  it("formats POST request", () => {
+    const req = createMockRequest({ method: "POST", path: "/gremlin" });
+    expect(getRequestLoggerPrefix(req)).toBe("POST /gremlin");
+  });
+});
+
+describe("logRequestAndResponse", () => {
+  it("logs 2xx responses at debug level", () => {
+    const req = createMockRequest();
+    const logger = req.app.locals.logger;
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    logRequestAndResponse(req, createMockResponse(200));
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Response 200"),
+    );
+  });
+
+  it("logs 3xx responses at debug level", () => {
+    const req = createMockRequest();
+    const logger = req.app.locals.logger;
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    logRequestAndResponse(req, createMockResponse(301));
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Response 301"),
+    );
+  });
+
+  it("logs 4xx responses at warn level", () => {
+    const req = createMockRequest();
+    const logger = req.app.locals.logger;
+    const warnSpy = vi.spyOn(logger, "warn");
+
+    logRequestAndResponse(req, createMockResponse(404));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Response 404"),
+    );
+  });
+
+  it("logs 5xx responses at error level", () => {
+    const req = createMockRequest();
+    const logger = req.app.locals.logger;
+    const errorSpy = vi.spyOn(logger, "error");
+
+    logRequestAndResponse(req, createMockResponse(500));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Response 500"),
+    );
+  });
+
+  it("includes request method and path in log message", () => {
+    const req = createMockRequest({ method: "POST", path: "/sparql" });
+    const logger = req.app.locals.logger;
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    logRequestAndResponse(req, createMockResponse(200));
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[POST /sparql]"),
+    );
+  });
+});
+
+describe("requestLoggingMiddleware", () => {
+  it("calls next for normal requests", () => {
+    const middleware = requestLoggingMiddleware();
+    const req = createMockRequest({ method: "GET", path: "/sparql" });
+    const res = createMockResponse(200);
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("skips logging for /logger endpoint", () => {
+    const middleware = requestLoggingMiddleware();
+    const req = createMockRequest({ method: "POST", path: "/logger" });
+    const logger = req.app.locals.logger;
+    const traceSpy = vi.spyOn(logger, "trace");
+    const res = createMockResponse(200);
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(traceSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips logging for OPTIONS requests", () => {
+    const middleware = requestLoggingMiddleware();
+    const req = createMockRequest({ method: "OPTIONS", path: "/sparql" });
+    const logger = req.app.locals.logger;
+    const traceSpy = vi.spyOn(logger, "trace");
+    const res = createMockResponse(200);
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(traceSpy).not.toHaveBeenCalled();
+  });
+
+  it("registers a finish listener on the response", () => {
+    const middleware = requestLoggingMiddleware();
+    const req = createMockRequest({ method: "GET", path: "/sparql" });
+    const res = createMockResponse(200);
+    const next = vi.fn();
+
+    middleware(req, res, next);
+
+    expect(res.on).toHaveBeenCalledWith("finish", expect.any(Function));
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/logging.ts
+++ b/packages/graph-explorer-proxy-server/src/logging.ts
@@ -3,14 +3,12 @@ import type { PrettyOptions } from "pino-pretty";
 
 import { type LevelWithSilent, pino } from "pino";
 
-import { env } from "./env.js";
+import type { EnvironmentValues } from "./env.js";
 
 export type LogLevel = LevelWithSilent;
 
-export const logger = createLogger();
-
 /** Create a logger instance with pino. */
-function createLogger() {
+export function createLogger(env: EnvironmentValues) {
   // Check whether we are configured with CloudWatch style
   const loggingInCloudWatch = env.LOG_STYLE === "cloudwatch";
   const options: PrettyOptions = loggingInCloudWatch
@@ -24,16 +22,17 @@ function createLogger() {
         colorize: true,
         translateTime: true,
       };
-  const level = env.LOG_LEVEL;
 
   return pino({
-    level,
+    level: env.LOG_LEVEL,
     transport: {
       target: "pino-pretty",
       options,
     },
   });
 }
+
+export type AppLogger = ReturnType<typeof createLogger>;
 
 /** Chooses an log level appropriate for the given status code. */
 function logLevelFromStatusCode(statusCode: number) {
@@ -53,6 +52,7 @@ export function getRequestLoggerPrefix(req: Request) {
 
 /** Logs the request path and response status using the given logger. */
 export function logRequestAndResponse(req: Request, res: Response) {
+  const logger = req.app.locals.logger;
   const logLevel = logLevelFromStatusCode(res.statusCode);
 
   const requestMessage = `[${getRequestLoggerPrefix(req)}] Response ${res.statusCode} ${res.statusMessage}`;
@@ -73,6 +73,8 @@ export function logRequestAndResponse(req: Request, res: Response) {
 /** Creates the pino-http middleware with the given logger and appropriate options. */
 export function requestLoggingMiddleware() {
   return (req: Request, res: Response, next: NextFunction) => {
+    const logger = req.app.locals.logger;
+
     // Ignore requests to logger endpoint
     if (req.path.includes("/logger")) {
       next();

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -5,6 +5,7 @@ import aws4 from "aws4";
 import bodyParser from "body-parser";
 import compression from "compression";
 import cors from "cors";
+import dotenv from "dotenv";
 import express, { type NextFunction, type Response } from "express";
 import fs from "fs";
 import https from "https";
@@ -12,12 +13,34 @@ import fetch, { type RequestInit } from "node-fetch";
 import path from "path";
 import { pipeline } from "stream";
 
-import { BooleanStringSchema, env } from "./env.js";
+import { BooleanStringSchema, parseEnvironmentValues } from "./env.js";
 import { errorHandlingMiddleware, handleError } from "./error-handler.js";
-import { logger as proxyLogger, requestLoggingMiddleware } from "./logging.js";
-import { clientRoot, proxyServerRoot } from "./paths.js";
+import { createLogger, requestLoggingMiddleware } from "./logging.js";
+import { clientRoot, isDirectory, proxyServerRoot } from "./paths.js";
+
+// Load .env files into process.env before parsing
+const configPath = process.env.CONFIGURATION_FOLDER_PATH ?? clientRoot;
+if (!isDirectory(configPath)) {
+  const source = process.env.CONFIGURATION_FOLDER_PATH
+    ? `CONFIGURATION_FOLDER_PATH="${configPath}"`
+    : `default config path "${configPath}"`;
+  console.error(`Configuration folder does not exist: ${source}`);
+  process.exit(1);
+}
+dotenv.config({
+  path: [path.join(configPath, ".env.local"), path.join(configPath, ".env")],
+});
+
+const env = parseEnvironmentValues(process.env);
+
+const logger = createLogger(env);
+logger.info("Parsed environment values: %o", env);
 
 const app = express();
+
+// Store env and logger on app.locals for access in middleware and routes
+app.locals.env = env;
+app.locals.logger = logger;
 
 const DEFAULT_SERVICE_TYPE = "neptune-db";
 
@@ -103,7 +126,7 @@ const retryFetch = async (
     try {
       const res = await fetch(url.href, options);
       if (!res.ok) {
-        proxyLogger.error("!!Request failure!!");
+        logger.error("!!Request failure!!");
         return res;
       } else {
         return res;
@@ -113,10 +136,10 @@ const retryFetch = async (
         // Don't log about retries if retrying is not used
         throw err;
       } else if (i === refetchMaxRetries - 1) {
-        proxyLogger.error(err, "!!Proxy Retry Fetch Reached Maximum Tries!!");
+        logger.error(err, "!!Proxy Retry Fetch Reached Maximum Tries!!");
         throw err;
       } else {
-        proxyLogger.debug("Proxy Retry Fetch Count::: " + i);
+        logger.debug("Proxy Retry Fetch Count::: " + i);
         await new Promise(resolve => setTimeout(resolve, retryDelay));
       }
     }
@@ -155,7 +178,7 @@ async function fetchData(
       pipeline(response.body, res, err => {
         if (err) {
           // Log the error as a warning, but otherwise ignore it
-          proxyLogger.warn("Pipeline error %o", err);
+          logger.warn("Pipeline error %o", err);
         }
       });
     } else {
@@ -166,27 +189,21 @@ async function fetchData(
   }
 }
 
-const defaultConnectionFolderPath = env.CONFIGURATION_FOLDER_PATH
-  ? env.CONFIGURATION_FOLDER_PATH
-  : clientRoot;
-
 app.use(compression()); // Use compression middleware
 app.use(cors());
 app.use(bodyParser.json({ limit: "50mb" }));
 app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
 app.use(
   "/defaultConnection",
-  express.static(
-    path.join(defaultConnectionFolderPath, "defaultConnection.json"),
-  ),
+  express.static(path.join(configPath, "defaultConnection.json")),
 );
 
 // Host the Graph Explorer UI static files
 const staticFilesVirtualPath = "/explorer";
 const staticFilesPath = path.join(clientRoot, "dist");
 
-proxyLogger.info("Hosting client side static files from: %s", staticFilesPath);
-proxyLogger.info(
+logger.info("Hosting client side static files from: %s", staticFilesPath);
+logger.info(
   "Hosting client side static files at: %s",
   staticFilesVirtualPath ?? "/",
 );
@@ -216,7 +233,7 @@ app.post("/sparql", async (req, res, next) => {
     if (!queryId) {
       return;
     }
-    proxyLogger.debug(`Cancelling request ${queryId}...`);
+    logger.debug(`Cancelling request ${queryId}...`);
     try {
       await retryFetch(
         new URL(`${graphDbConnectionUrl}/sparql/status`),
@@ -234,7 +251,7 @@ app.post("/sparql", async (req, res, next) => {
       );
     } catch (err) {
       // Not really an error
-      proxyLogger.warn(err, "Failed to cancel the query");
+      logger.warn(err, "Failed to cancel the query");
     }
   }
 
@@ -261,7 +278,7 @@ app.post("/sparql", async (req, res, next) => {
   }
 
   if (shouldLogDbQuery) {
-    proxyLogger.debug("[SPARQL] Received database query:\n%s", queryString);
+    logger.debug("[SPARQL] Received database query:\n%s", queryString);
   }
 
   const rawUrl = `${graphDbConnectionUrl}/sparql`;
@@ -312,7 +329,7 @@ app.post("/gremlin", async (req, res, next) => {
   }
 
   if (shouldLogDbQuery) {
-    proxyLogger.debug("[Gremlin] Received database query:\n%s", queryString);
+    logger.debug("[Gremlin] Received database query:\n%s", queryString);
   }
 
   /// Function to cancel long running queries if the client disappears before completion
@@ -320,7 +337,7 @@ app.post("/gremlin", async (req, res, next) => {
     if (!queryId) {
       return;
     }
-    proxyLogger.debug(`Cancelling request ${queryId}...`);
+    logger.debug(`Cancelling request ${queryId}...`);
     try {
       await retryFetch(
         new URL(
@@ -333,7 +350,7 @@ app.post("/gremlin", async (req, res, next) => {
       );
     } catch (err) {
       // Not really an error
-      proxyLogger.warn(err, "Failed to cancel the query");
+      logger.warn(err, "Failed to cancel the query");
     }
   }
 
@@ -388,7 +405,7 @@ app.post("/openCypher", async (req, res, next) => {
   }
 
   if (shouldLogDbQuery) {
-    proxyLogger.debug("[openCypher] Received database query:\n%s", queryString);
+    logger.debug("[openCypher] Received database query:\n%s", queryString);
   }
 
   const rawUrl = `${headers["graph-db-connection-url"]}/openCypher`;
@@ -516,15 +533,15 @@ app.post("/logger", (req, res, next) => {
       message = JSON.parse(headers["message"]).replaceAll("\\", "");
     }
     if (level.toLowerCase() === "error") {
-      proxyLogger.error(message);
+      logger.error(message);
     } else if (level.toLowerCase() === "warn") {
-      proxyLogger.warn(message);
+      logger.warn(message);
     } else if (level.toLowerCase() === "info") {
-      proxyLogger.info(message);
+      logger.info(message);
     } else if (level.toLowerCase() === "debug") {
-      proxyLogger.debug(message);
+      logger.debug(message);
     } else if (level.toLowerCase() === "trace") {
-      proxyLogger.trace(message);
+      logger.trace(message);
     } else {
       throw new Error("Tried to log to an unknown level.");
     }
@@ -570,8 +587,8 @@ function logServerLocations() {
   }
 
   const baseUrl = `${scheme}://${host}${port}`;
-  proxyLogger.info(`Proxy server located at ${baseUrl}`);
-  proxyLogger.info(
+  logger.info(`Proxy server located at ${baseUrl}`);
+  logger.info(
     `Graph Explorer UI located at: ${baseUrl}${staticFilesVirtualPath ?? ""}`,
   );
 }
@@ -596,17 +613,19 @@ function startServer() {
 const server = startServer();
 
 process.on("uncaughtException", (error: Error) => {
-  handleError(error);
+  handleError(error, logger);
 });
 
 process.on("unhandledRejection", reason => {
-  handleError(reason);
+  handleError(reason, logger);
 });
 
-// Watch for shutdown event and close gracefully.
-process.on("SIGTERM", () => {
-  proxyLogger.info("SIGTERM signal received: closing HTTP server");
+// Watch for shutdown events and close gracefully.
+function gracefulShutdown(signal: string) {
+  logger.info(`${signal} signal received: closing HTTP server`);
   server.close(() => {
-    proxyLogger.info("HTTP server closed");
+    logger.info("HTTP server closed");
   });
-});
+}
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));

--- a/packages/graph-explorer-proxy-server/src/paths.test.ts
+++ b/packages/graph-explorer-proxy-server/src/paths.test.ts
@@ -1,4 +1,8 @@
-import { clientRoot, proxyServerRoot } from "./paths.js";
+import fs from "fs";
+import path from "path";
+import { vi } from "vitest";
+
+import { clientRoot, isDirectory, proxyServerRoot } from "./paths.js";
 
 test("clientRoot is points to graph-explorer", () => {
   expect(clientRoot).toMatch("/packages/graph-explorer");
@@ -6,4 +10,26 @@ test("clientRoot is points to graph-explorer", () => {
 
 test("proxyServerRoot points to graph-explorer-proxy-server", () => {
   expect(proxyServerRoot).toMatch("/packages/graph-explorer-proxy-server");
+});
+
+describe("isDirectory", () => {
+  test("returns true for a directory", () => {
+    expect(isDirectory(proxyServerRoot)).toBe(true);
+  });
+
+  test("returns false for a file", () => {
+    expect(isDirectory(path.join(proxyServerRoot, "package.json"))).toBe(false);
+  });
+
+  test("returns false for a non-existent path", () => {
+    expect(isDirectory("/does/not/exist")).toBe(false);
+  });
+
+  test("rethrows unexpected errors", () => {
+    vi.spyOn(fs, "statSync").mockImplementation(() => {
+      throw new Error("unexpected");
+    });
+    expect(() => isDirectory("/any/path")).toThrow("unexpected");
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/graph-explorer-proxy-server/src/paths.ts
+++ b/packages/graph-explorer-proxy-server/src/paths.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 
 // Construct relative paths
@@ -8,3 +9,15 @@ export const proxyServerRoot = path.join(
   "packages",
   "graph-explorer-proxy-server",
 );
+
+/** Returns true if the given path exists and is a directory, false if it does not exist, or rethrows on unexpected errors. */
+export function isDirectory(path: string) {
+  try {
+    return fs.statSync(path).isDirectory();
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/packages/graph-explorer-proxy-server/vitest.config.ts
+++ b/packages/graph-explorer-proxy-server/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    restoreMocks: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
     coverage: {
       reportsDirectory: "coverage",
       provider: "v8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,9 +415,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@24.10.9)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.31.1)(terser@5.42.0)(tsx@4.21.0)(yaml@2.8.3))
-      memfs:
-        specifier: ^4.56.11
-        version: 4.56.11(tslib@2.8.1)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -1441,126 +1438,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jsonjoy.com/base64@1.1.2':
-    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/base64@17.65.0':
-    resolution: {integrity: sha512-Xrh7Fm/M0QAYpekSgmskdZYnFdSGnsxJ/tHaolA4bNwWdG9i65S8m83Meh7FOxyJyQAdo4d4J97NOomBLEfkDQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@1.2.1':
-    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/buffers@17.65.0':
-    resolution: {integrity: sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@1.0.0':
-    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/codegen@17.65.0':
-    resolution: {integrity: sha512-7MXcRYe7n3BG+fo3jicvjB0+6ypl2Y/bQp79Sp7KeSiiCgLqw4Oled6chVv07/xLVTdo3qa1CD0VCCnPaw+RGA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-core@4.56.11':
-    resolution: {integrity: sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-fsa@4.56.11':
-    resolution: {integrity: sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-builtins@4.56.11':
-    resolution: {integrity: sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-to-fsa@4.56.11':
-    resolution: {integrity: sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node-utils@4.56.11':
-    resolution: {integrity: sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-node@4.56.11':
-    resolution: {integrity: sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-print@4.56.11':
-    resolution: {integrity: sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/fs-snapshot@4.56.11':
-    resolution: {integrity: sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@1.21.0':
-    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pack@17.65.0':
-    resolution: {integrity: sha512-e0SG/6qUCnVhHa0rjDJHgnXnbsacooHVqQHxspjvlYQSkHm+66wkHw6Gql+3u/WxI/b1VsOdUi0M+fOtkgKGdQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@1.0.2':
-    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/json-pointer@17.65.0':
-    resolution: {integrity: sha512-uhTe+XhlIZpWOxgPcnO+iSCDgKKBpwkDVTyYiXX9VayGV8HSFVJM67M6pUE71zdnXF1W0Da21AvnhlmdwYPpow==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@1.9.0':
-    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
-  '@jsonjoy.com/util@17.65.0':
-    resolution: {integrity: sha512-cWiEHZccQORf96q2y6zU3wDeIVPeidmGqd9cNKJRYoVHTV0S1eHPy5JTbHpMnGfDvtvujQwQozOqgO9ABu6h0w==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -3848,12 +3725,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob-to-regex.js@1.2.0:
-    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3945,10 +3816,6 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4356,11 +4223,6 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
-
-  memfs@4.56.11:
-    resolution: {integrity: sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==}
-    peerDependencies:
-      tslib: '2'
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5121,12 +4983,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  thingies@2.5.0:
-    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
-    engines: {node: '>=10.18'}
-    peerDependencies:
-      tslib: ^2
-
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
@@ -5171,12 +5027,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  tree-dump@1.1.0:
-    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
-    engines: {node: '>=10.0'}
-    peerDependencies:
-      tslib: '2'
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -6833,133 +6683,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/base64@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/buffers@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@1.0.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/codegen@17.65.0(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-core@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-fsa@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-builtins@4.56.11(tslib@2.8.1)':
-    dependencies:
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-to-fsa@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-fsa': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node-utils@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-node@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.56.11(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-print@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/fs-snapshot@4.56.11(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pack@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/base64': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/json-pointer': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@1.0.2(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/json-pointer@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/util': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
-      tslib: 2.8.1
-
-  '@jsonjoy.com/util@17.65.0(tslib@2.8.1)':
-    dependencies:
-      '@jsonjoy.com/buffers': 17.65.0(tslib@2.8.1)
-      '@jsonjoy.com/codegen': 17.65.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -9595,10 +9318,6 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regex.js@1.2.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
@@ -9697,8 +9416,6 @@ snapshots:
   https@1.0.0: {}
 
   husky@9.1.7: {}
-
-  hyperdyperid@1.2.0: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -10084,23 +9801,6 @@ snapshots:
   mdn-data@2.12.2: {}
 
   media-typer@1.1.0: {}
-
-  memfs@4.56.11(tslib@2.8.1):
-    dependencies:
-      '@jsonjoy.com/fs-core': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-fsa': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-to-fsa': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.56.11(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
-      '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
-      tree-dump: 1.1.0(tslib@2.8.1)
-      tslib: 2.8.1
 
   merge-descriptors@2.0.0: {}
 
@@ -10923,10 +10623,6 @@ snapshots:
       source-map-support: 0.5.21
     optional: true
 
-  thingies@2.5.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
-
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
@@ -10961,10 +10657,6 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  tree-dump@1.1.0(tslib@2.8.1):
-    dependencies:
-      tslib: 2.8.1
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Description

Refactors the proxy server so that environment parsing, logger creation, and config path validation happen explicitly in `node-server.ts` instead of as side effects during module import. This makes `env.ts`, `logging.ts`, and `error-handler.ts` testable in isolation and gives the server explicit control over its startup sequence.

- Move dotenv loading and env parsing from `env.ts` into `node-server.ts` so importing `env.ts` no longer triggers side effects
- Export `parseEnvironmentValues()` and `EnvironmentValues` type from `env.ts` for explicit usage
- Export `createLogger()` from `logging.ts` instead of a module-level singleton
- Store `env` and `logger` on `app.locals` with typed Express declarations (`express.d.ts`)
- Pass `logger` as a parameter to `handleError()` instead of importing it
- Add `isDirectory()` helper to `paths.ts` and use it for config path validation
- Add `CONFIGURATION_FOLDER_PATH` documentation to `docs/development.md`
- Add SIGINT handler alongside existing SIGTERM for graceful shutdown
- Add unit tests for `env.ts`, `logging.ts`, and `paths.ts`

## Validation

- `pnpm checks` passes (pre-existing TS7027 in `env.ts` is unrelated)
- `pnpm test` passes for all new and existing tests
- Manually verified: normal startup, custom config path, invalid config path, `.env.local` precedence, request logging through `app.locals`, and SIGTERM/SIGINT graceful shutdown

## Related Issues

- Part of #1633 

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.