### PR TITLE
Fix edge and node labels disappearing at middle zoom levels

### DIFF
--- a/packages/graph-explorer/src/components/Graph/styles/defaultEdgeStyle.ts
+++ b/packages/graph-explorer/src/components/Graph/styles/defaultEdgeStyle.ts
@@ -25,7 +25,7 @@ const defaultEdgeStyle: EdgeStyle = {
     fontSize: 7,
     hAlign: "center",
     maxWidth: 80,
-    minZoomedFontSize: 6,
+    minZoomedFontSize: 0,
     opacity: 0.7,
     padding: 2,
     rotation: "autorotate",

--- a/packages/graph-explorer/src/components/Graph/styles/defaultNodeStyle.ts
+++ b/packages/graph-explorer/src/components/Graph/styles/defaultNodeStyle.ts
@@ -17,7 +17,7 @@ const defaultNodeStyle: NodeStyle = {
   shape: "ellipse",
   text: {
     fontSize: 7,
-    minZoomedFontSize: 6,
+    minZoomedFontSize: 0,
     rotation: "autorotate",
     vAlign: "bottom",
     vMargin: 0,


### PR DESCRIPTION
## Summary

Set `minZoomedFontSize` to `0` in both `defaultEdgeStyle.ts` and `defaultNodeStyle.ts`. The previous value of `6` interacted with `fontSize: 7` to create a narrow band at intermediate zoom levels where Cytoscape.js would hide labels unexpectedly.

## Changes

- `packages/graph-explorer/src/components/Graph/styles/defaultEdgeStyle.ts` -- `minZoomedFontSize: 6` to `0`
- `packages/graph-explorer/src/components/Graph/styles/defaultNodeStyle.ts` -- `minZoomedFontSize: 6` to `0`

Setting `minZoomedFontSize` to `0` disables the zoom threshold entirely, so labels stay visible at all zoom levels until they're naturally too small to render. This matches the expected behavior described in the issue.

## Testing

Verified the change is scoped to only the two style files referenced in the issue. The Cytoscape.js `min-zoomed-font-size` property at `0` means "always show the label" per the Cytoscape docs.

This contribution was developed with AI assistance (Codex).

Fixes #1600