### PR TITLE
Extract SSL cert logic into testable setup-ssl.sh script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN pnpm install && \
     rm -rf $HOME/.local && \
     rm -rf $HOME/.cache && \
     chmod a+x ./process-environment.sh && \
+    chmod a+x ./setup-ssl.sh && \
     chmod a+x ./docker-entrypoint.sh
 
 EXPOSE 443

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,26 +6,9 @@ CONFIGURATION_FOLDER_PATH=${CONFIGURATION_FOLDER_PATH:-"./packages/graph-explore
 PROXY_SERVER_HTTPS_CONNECTION_VALUE=$(grep -e 'PROXY_SERVER_HTTPS_CONNECTION' $CONFIGURATION_FOLDER_PATH/.env | cut -d "=" -f 2)
 
 if [ -n "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" ] && [ "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" == "true" ]; then
-
-    if [ $HOST ]; then
-        echo "Generating new self-signed SSL cert using $HOST..."
-        cd /graph-explorer/packages/graph-explorer-proxy-server/cert-info/
-        sed -i "21s/$/ $HOST:*/" csr.conf
-        sed -i "8s/$/ $HOST:*/" cert.conf
-        openssl req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=Graph Explorer/C=US/L=Seattle" -keyout rootCA.key -out rootCA.crt
-        openssl genrsa -out ./server.key 2048
-        openssl req -new -key ./server.key -out ./server.csr -config ./csr.conf
-        openssl x509 -req -in ./server.csr -CA ./rootCA.crt -CAkey ./rootCA.key -CAcreateserial -out ./server.crt -days 365 -sha256 -extfile ./cert.conf
-    else
-        echo "No HOST environment variable specified."
-        if [ -f "./rootCA.key" ] && [ -f "./rootCA.crt" ] && [ -f "./rootCA.crt" ] && [ -f "./server.csr"] && [ -f "./server.crt"]; then
-            echo "Found existing self-signed SSL certificate. Re-using existing cert."
-        else
-            echo "No existing self-signed SSL certificate found. Please specify --env HOST=<hostname> during docker run command to create SSL cert."
-            exit 1
-        fi
-    fi
-
+    CERT_DIR=/graph-explorer/packages/graph-explorer-proxy-server/cert-info \
+        HOST="$HOST" \
+        ./setup-ssl.sh
 else
     echo "SSL disabled. Skipping self-signed certificate generation."
 fi

--- a/packages/graph-explorer-proxy-server/src/setup-ssl.test.ts
+++ b/packages/graph-explorer-proxy-server/src/setup-ssl.test.ts
@@ -1,0 +1,170 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const scriptPath = path.resolve(import.meta.dirname, "../../../setup-ssl.sh");
+
+const CERT_CONF_CONTENT = `authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+# Filled in by Dockerfile
+DNS.1 = `;
+
+const CSR_CONF_CONTENT = `[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+C = US
+ST = Washington
+L = Seattle
+O = Graph Explorer
+CN = Graph Explorer
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+# Filled in by Dockerfile
+DNS.1 = `;
+
+function runScript(
+  certDir: string,
+  env: Record<string, string> = {},
+): { exitCode: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("sh", [scriptPath], {
+      env: { CERT_DIR: certDir, PATH: process.env.PATH, ...env },
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { exitCode: 0, stdout, stderr: "" };
+  } catch (error: unknown) {
+    const e = error as {
+      status: number;
+      stdout: string;
+      stderr: string;
+    };
+    return {
+      exitCode: e.status,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+    };
+  }
+}
+
+/** Creates the cert config template files that openssl needs. */
+function seedCertConfigs(certDir: string) {
+  fs.writeFileSync(path.join(certDir, "cert.conf"), CERT_CONF_CONTENT);
+  fs.writeFileSync(path.join(certDir, "csr.conf"), CSR_CONF_CONTENT);
+}
+
+/** Creates placeholder cert files to simulate pre-existing certificates. */
+function seedAllCertFiles(certDir: string) {
+  for (const f of [
+    "rootCA.key",
+    "rootCA.crt",
+    "server.key",
+    "server.csr",
+    "server.crt",
+  ]) {
+    fs.writeFileSync(path.join(certDir, f), "placeholder");
+  }
+}
+
+describe("setup-ssl.sh", () => {
+  let certDir: string;
+
+  beforeEach(() => {
+    certDir = fs.mkdtempSync(path.join(os.tmpdir(), "ge-ssl-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(certDir, { recursive: true, force: true });
+  });
+
+  it("fails when CERT_DIR is not set", () => {
+    const { exitCode, stderr } = runScript("", { CERT_DIR: "" });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("CERT_DIR is required");
+  });
+
+  describe("with HOST set (generate new certs)", () => {
+    it("generates certificate files", () => {
+      seedCertConfigs(certDir);
+
+      const { exitCode } = runScript(certDir, { HOST: "localhost" });
+
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(path.join(certDir, "rootCA.key"))).toBe(true);
+      expect(fs.existsSync(path.join(certDir, "rootCA.crt"))).toBe(true);
+      expect(fs.existsSync(path.join(certDir, "server.key"))).toBe(true);
+      expect(fs.existsSync(path.join(certDir, "server.csr"))).toBe(true);
+      expect(fs.existsSync(path.join(certDir, "server.crt"))).toBe(true);
+    });
+
+    it("adds HOST to cert.conf SAN entries", () => {
+      seedCertConfigs(certDir);
+
+      runScript(certDir, { HOST: "my-host.example.com" });
+
+      const certConf = fs.readFileSync(
+        path.join(certDir, "cert.conf"),
+        "utf-8",
+      );
+      expect(certConf).toContain("my-host.example.com");
+    });
+
+    it("adds HOST to csr.conf SAN entries", () => {
+      seedCertConfigs(certDir);
+
+      runScript(certDir, { HOST: "my-host.example.com" });
+
+      const csrConf = fs.readFileSync(path.join(certDir, "csr.conf"), "utf-8");
+      expect(csrConf).toContain("my-host.example.com");
+    });
+  });
+
+  describe("without HOST (check existing certs)", () => {
+    it("succeeds when all cert files exist", () => {
+      seedAllCertFiles(certDir);
+
+      const { exitCode, stdout } = runScript(certDir);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Re-using existing cert");
+    });
+
+    it("fails when no cert files exist", () => {
+      const { exitCode, stdout } = runScript(certDir);
+
+      expect(exitCode).not.toBe(0);
+      expect(stdout).toContain("No existing self-signed SSL certificate found");
+    });
+
+    // BUG: The existence check has rootCA.crt listed twice and server.key is
+    // never checked. This means a missing server.key is not detected.
+    it("does not detect a missing server.key file", () => {
+      for (const f of [
+        "rootCA.key",
+        "rootCA.crt",
+        "server.csr",
+        "server.crt",
+      ]) {
+        fs.writeFileSync(path.join(certDir, f), "placeholder");
+      }
+
+      const { exitCode } = runScript(certDir);
+
+      // Should fail but passes due to the duplicate rootCA.crt check
+      expect(exitCode).toBe(0);
+    });
+  });
+});

--- a/setup-ssl.sh
+++ b/setup-ssl.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Generates or validates self-signed SSL certificates.
+#
+# Environment:
+#   CERT_DIR  – directory for certificate files (required)
+#   HOST      – hostname for SAN entries; when unset, expects existing certs
+#
+
+if [ -z "$CERT_DIR" ]; then
+    echo "CERT_DIR is required" >&2
+    exit 1
+fi
+
+if [ $HOST ]; then
+    echo "Generating new self-signed SSL cert using $HOST..."
+    sed -i'' -e "s/^DNS\.1 = .*/DNS.1 = $HOST:*/" "$CERT_DIR/csr.conf"
+    sed -i'' -e "s/^DNS\.1 = .*/DNS.1 = $HOST:*/" "$CERT_DIR/cert.conf"
+    openssl req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=Graph Explorer/C=US/L=Seattle" -keyout "$CERT_DIR/rootCA.key" -out "$CERT_DIR/rootCA.crt"
+    openssl genrsa -out "$CERT_DIR/server.key" 2048
+    openssl req -new -key "$CERT_DIR/server.key" -out "$CERT_DIR/server.csr" -config "$CERT_DIR/csr.conf"
+    openssl x509 -req -in "$CERT_DIR/server.csr" -CA "$CERT_DIR/rootCA.crt" -CAkey "$CERT_DIR/rootCA.key" -CAcreateserial -out "$CERT_DIR/server.crt" -days 365 -sha256 -extfile "$CERT_DIR/cert.conf"
+else
+    echo "No HOST environment variable specified."
+    if [ -f "$CERT_DIR/rootCA.key" ] && [ -f "$CERT_DIR/rootCA.crt" ] && [ -f "$CERT_DIR/rootCA.crt" ] && [ -f "$CERT_DIR/server.csr" ] && [ -f "$CERT_DIR/server.crt" ]; then
+        echo "Found existing self-signed SSL certificate. Re-using existing cert."
+    else
+        echo "No existing self-signed SSL certificate found. Please specify --env HOST=<hostname> during docker run command to create SSL cert."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Description

Extract the SSL certificate generation and validation logic from `docker-entrypoint.sh` into a standalone `setup-ssl.sh` script so it can be tested in isolation, following the same pattern used for `process-environment.sh`.

- Move cert generation and existing-cert validation into `setup-ssl.sh`, parameterized by `CERT_DIR` and `HOST` environment variables
- Use absolute paths with `CERT_DIR` instead of `cd` + relative paths
- Use portable `sed` pattern matching instead of hardcoded line numbers (necessary for cross-platform test execution)
- Preserve existing behavior including known bugs (duplicate `rootCA.crt` check that misses `server.key`)
- Add `chmod a+x ./setup-ssl.sh` to Dockerfile
- Add 7 tests covering cert generation, SAN injection, existing cert reuse, and missing file detection

This is a behavior-preserving extraction to enable a follow-up PR that fixes the bugs with test coverage already in place.

## Validation

- `pnpm checks` passes
- `pnpm test` passes (7 new tests in `setup-ssl.test.ts`)
- Bug test case documents the duplicate `rootCA.crt` / missing `server.key` defect
- Docker image built and tested with Finch across three scenarios:
  - **HTTPS disabled** — starts cleanly on HTTP ✅
  - **HTTPS enabled with HOST** — generates certs and starts on HTTPS ✅
  - **HTTPS enabled without HOST, no existing certs** — prints error but continues past `exit 1` due to missing `set -e` in `docker-entrypoint.sh`, silently falls back to HTTP. This is pre-existing behavior preserved by this PR and will be fixed in a follow-up.

## Related Issues

- Part of #1633 
- Part of #1634

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.