### PR TITLE
Fail fast when HTTPS is requested but certificates are missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 # TypeScript build cache manifests
 *.tsbuildinfo
+
+# Local planning docs
+plans/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
+set -e
 
 ./process-environment.sh
 
 CONFIGURATION_FOLDER_PATH=${CONFIGURATION_FOLDER_PATH:-"./packages/graph-explorer/"}
-PROXY_SERVER_HTTPS_CONNECTION_VALUE=$(grep -e 'PROXY_SERVER_HTTPS_CONNECTION' $CONFIGURATION_FOLDER_PATH/.env | cut -d "=" -f 2)
 
-if [ -n "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" ] && [ "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" == "true" ]; then
+if [ ! -f "$CONFIGURATION_FOLDER_PATH/.env" ]; then
+    echo "Expected .env file not found at $CONFIGURATION_FOLDER_PATH/.env" >&2
+    exit 1
+fi
+
+PROXY_SERVER_HTTPS_CONNECTION_VALUE=$(grep -e '^PROXY_SERVER_HTTPS_CONNECTION=' "$CONFIGURATION_FOLDER_PATH/.env" | cut -d "=" -f 2 || true)
+
+if [ -n "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" ] && [ "$PROXY_SERVER_HTTPS_CONNECTION_VALUE" = "true" ]; then
     CERT_DIR=/graph-explorer/packages/graph-explorer-proxy-server/cert-info \
         HOST="$HOST" \
         ./setup-ssl.sh
@@ -14,4 +21,5 @@ else
 fi
 
 echo "Starting graph explorer..."
+# Stubbed in tests — update docker-entrypoint.test.ts if changing
 cd /graph-explorer/packages/graph-explorer-proxy-server && NODE_ENV=production node dist/node-server.js

--- a/packages/graph-explorer-proxy-server/cert-info/csr.conf
+++ b/packages/graph-explorer-proxy-server/cert-info/csr.conf
@@ -17,4 +17,4 @@ subjectAltName = @alt_names
 
 [ alt_names ]
 # Filled in by Dockerfile
-DNS.1 =
+DNS.1 = 

--- a/packages/graph-explorer-proxy-server/src/config-pipeline.test.ts
+++ b/packages/graph-explorer-proxy-server/src/config-pipeline.test.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "child_process";
+import dotenv from "dotenv";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { parseEnvironmentValues } from "./env.js";
+import { proxyServerRoot } from "./paths.js";
+import { resolveServerConfig, ServerConfigError } from "./server-config.js";
+
+const expectedKeyPath = path.join(proxyServerRoot, "cert-info/server.key");
+const expectedCertPath = path.join(proxyServerRoot, "cert-info/server.crt");
+
+const processEnvScriptPath = path.resolve(
+  import.meta.dirname,
+  "../../../process-environment.sh",
+);
+
+function runPipeline(
+  workDir: string,
+  env: Record<string, string> = {},
+  presetEnvVars: Record<string, string> = {},
+) {
+  const configFolder =
+    env.CONFIGURATION_FOLDER_PATH ?? "./packages/graph-explorer/";
+  const resolvedConfigFolder = path.resolve(workDir, configFolder);
+  fs.mkdirSync(resolvedConfigFolder, { recursive: true });
+
+  // Pre-seed .env with vars the shell script doesn't write
+  if (Object.keys(presetEnvVars).length > 0) {
+    const lines = Object.entries(presetEnvVars)
+      .map(([k, v]) => `${k}=${v}`)
+      .join("\n");
+    fs.writeFileSync(path.join(resolvedConfigFolder, ".env"), lines + "\n");
+  }
+
+  execFileSync("sh", [processEnvScriptPath], {
+    cwd: workDir,
+    env: { ...env, PATH: process.env.PATH },
+  });
+
+  const envFilePath = path.join(resolvedConfigFolder, ".env");
+  const envFileContent = fs.readFileSync(envFilePath, "utf-8");
+  const parsed = dotenv.parse(envFileContent);
+  return parseEnvironmentValues(parsed);
+}
+
+describe("config pipeline: shell → dotenv → Zod → server config", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "ge-pipeline-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("HTTPS enabled by default flows through to server config", () => {
+    const env = runPipeline(workDir);
+    expect(env.PROXY_SERVER_HTTPS_CONNECTION).toBe(true);
+
+    vi.spyOn(fs, "existsSync").mockImplementation(
+      p => p === expectedKeyPath || p === expectedCertPath,
+    );
+    const config = resolveServerConfig(env);
+    expect(config.useHttps).toBe(true);
+    expect(config.port).toBe(443);
+  });
+
+  it("HTTPS disabled flows through to HTTP config", () => {
+    const env = runPipeline(workDir, {
+      PROXY_SERVER_HTTPS_CONNECTION: "false",
+    });
+
+    const config = resolveServerConfig(env);
+    expect(config.useHttps).toBe(false);
+    expect(config.port).toBe(80);
+  });
+
+  it("Neptune Notebook forces HTTPS off", () => {
+    const env = runPipeline(workDir, { NEPTUNE_NOTEBOOK: "true" });
+
+    const config = resolveServerConfig(env);
+    expect(config.useHttps).toBe(false);
+  });
+
+  it("HTTPS enabled but certs missing throws ServerConfigError", () => {
+    const env = runPipeline(workDir);
+    expect(env.PROXY_SERVER_HTTPS_CONNECTION).toBe(true);
+
+    expect(() => resolveServerConfig(env)).toThrow(ServerConfigError);
+  });
+
+  it("custom HTTP port flows through", () => {
+    const env = runPipeline(
+      workDir,
+      { PROXY_SERVER_HTTPS_CONNECTION: "false" },
+      { PROXY_SERVER_HTTP_PORT: "8080" },
+    );
+
+    const config = resolveServerConfig(env);
+    expect(config.port).toBe(8080);
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/docker-entrypoint.test.ts
+++ b/packages/graph-explorer-proxy-server/src/docker-entrypoint.test.ts
@@ -1,0 +1,194 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const originalScriptPath = path.resolve(
+  import.meta.dirname,
+  "../../../docker-entrypoint.sh",
+);
+
+function setupWorkDir() {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "ge-entrypoint-test-"));
+  const configDir = path.join(workDir, "packages", "graph-explorer");
+  fs.mkdirSync(configDir, { recursive: true });
+
+  // Create modified entrypoint with stubbed last line
+  const script = fs.readFileSync(originalScriptPath, "utf-8");
+  const serverStartLine =
+    "cd /graph-explorer/packages/graph-explorer-proxy-server && NODE_ENV=production node dist/node-server.js";
+  if (!script.includes(serverStartLine)) {
+    throw new Error(
+      "docker-entrypoint.sh no longer contains the expected server start line. Update the test stub.",
+    );
+  }
+  const modifiedScript = script.replace(
+    serverStartLine,
+    'echo "SERVER_STARTED"',
+  );
+  const scriptPath = path.join(workDir, "docker-entrypoint.sh");
+  fs.writeFileSync(scriptPath, modifiedScript, { mode: 0o755 });
+
+  // Default stubs
+  fs.writeFileSync(
+    path.join(workDir, "process-environment.sh"),
+    "#!/bin/sh\nexit 0\n",
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(workDir, "setup-ssl.sh"),
+    '#!/bin/sh\ntouch ./ssl-called\necho "$HOST" > ./host-value\n',
+    { mode: 0o755 },
+  );
+
+  return { workDir, configDir, scriptPath };
+}
+
+function writeEnv(configDir: string, content: string) {
+  fs.writeFileSync(path.join(configDir, ".env"), content);
+}
+
+function runScript(
+  workDir: string,
+  scriptPath: string,
+  env: Record<string, string> = {},
+): { exitCode: number; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("sh", [scriptPath], {
+      cwd: workDir,
+      env: { PATH: process.env.PATH, ...env },
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { exitCode: 0, stdout, stderr: "" };
+  } catch (error: unknown) {
+    const e = error as { status: number; stdout: string; stderr: string };
+    return {
+      exitCode: e.status,
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+    };
+  }
+}
+
+describe("docker-entrypoint.sh", () => {
+  let workDir: string;
+  let configDir: string;
+  let scriptPath: string;
+
+  beforeEach(() => {
+    ({ workDir, configDir, scriptPath } = setupWorkDir());
+  });
+
+  afterEach(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("fails when .env file is missing", () => {
+    // Don't write any .env file
+
+    const { exitCode, stderr } = runScript(workDir, scriptPath);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(".env");
+  });
+
+  it("set -e propagates process-environment.sh failure", () => {
+    fs.writeFileSync(
+      path.join(workDir, "process-environment.sh"),
+      "#!/bin/sh\nexit 1\n",
+      { mode: 0o755 },
+    );
+
+    const { exitCode } = runScript(workDir, scriptPath);
+    expect(exitCode).not.toBe(0);
+  });
+
+  it("set -e propagates setup-ssl.sh failure", () => {
+    writeEnv(configDir, "PROXY_SERVER_HTTPS_CONNECTION=true\n");
+    fs.writeFileSync(
+      path.join(workDir, "setup-ssl.sh"),
+      "#!/bin/sh\nexit 1\n",
+      { mode: 0o755 },
+    );
+
+    const { exitCode, stdout } = runScript(workDir, scriptPath);
+    expect(exitCode).not.toBe(0);
+    expect(stdout).not.toContain("Starting graph explorer");
+  });
+
+  it("calls setup-ssl.sh when HTTPS is true", () => {
+    writeEnv(configDir, "PROXY_SERVER_HTTPS_CONNECTION=true\n");
+
+    const { exitCode } = runScript(workDir, scriptPath, {
+      HOST: "localhost",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(workDir, "ssl-called"))).toBe(true);
+  });
+
+  it("skips setup-ssl.sh when HTTPS is false", () => {
+    writeEnv(configDir, "PROXY_SERVER_HTTPS_CONNECTION=false\n");
+
+    const { exitCode, stdout } = runScript(workDir, scriptPath);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(workDir, "ssl-called"))).toBe(false);
+    expect(stdout).toContain("SSL disabled");
+  });
+
+  it("skips setup-ssl.sh when PROXY_SERVER_HTTPS_CONNECTION is absent", () => {
+    writeEnv(configDir, "LOG_LEVEL=info\n");
+
+    const { exitCode, stdout } = runScript(workDir, scriptPath);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(workDir, "ssl-called"))).toBe(false);
+    expect(stdout).toContain("SSL disabled");
+  });
+
+  it("grep ignores commented-out lines", () => {
+    writeEnv(configDir, "# PROXY_SERVER_HTTPS_CONNECTION=true\n");
+
+    const { exitCode } = runScript(workDir, scriptPath);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(workDir, "ssl-called"))).toBe(false);
+  });
+
+  it("grep ignores similarly-named variables", () => {
+    writeEnv(configDir, "GRAPH_EXP_PROXY_SERVER_HTTPS_CONNECTION=true\n");
+
+    const { exitCode } = runScript(workDir, scriptPath);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(workDir, "ssl-called"))).toBe(false);
+  });
+
+  it("passes HOST to setup-ssl.sh", () => {
+    writeEnv(configDir, "PROXY_SERVER_HTTPS_CONNECTION=true\n");
+
+    runScript(workDir, scriptPath, { HOST: "my-test-host" });
+
+    const hostValue = fs
+      .readFileSync(path.join(workDir, "host-value"), "utf-8")
+      .trim();
+    expect(hostValue).toBe("my-test-host");
+  });
+
+  it("uses custom CONFIGURATION_FOLDER_PATH", () => {
+    const customDir = path.join(workDir, "custom-config");
+    fs.mkdirSync(customDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(customDir, ".env"),
+      "PROXY_SERVER_HTTPS_CONNECTION=false\n",
+    );
+
+    const { exitCode, stdout } = runScript(workDir, scriptPath, {
+      CONFIGURATION_FOLDER_PATH: customDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("SSL disabled");
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -6,7 +6,7 @@ import { parseEnvironmentValues } from "./env.js";
 import { handleError } from "./error-handler.js";
 import { createLogger } from "./logging.js";
 import { clientRoot, isDirectory } from "./paths.js";
-import { resolveServerConfig } from "./server-config.js";
+import { resolveServerConfig, ServerConfigError } from "./server-config.js";
 import { createServer } from "./server.js";
 
 // Load .env files into process.env before parsing
@@ -27,6 +27,17 @@ const env = parseEnvironmentValues(process.env);
 const logger = createLogger(env);
 logger.info("Parsed environment values: %o", env);
 
+let serverConfig;
+try {
+  serverConfig = resolveServerConfig(env);
+} catch (error) {
+  if (error instanceof ServerConfigError) {
+    logger.fatal(error.message);
+    process.exit(1);
+  }
+  throw error;
+}
+
 const {
   port,
   baseUrl,
@@ -35,7 +46,7 @@ const {
   staticFilesVirtualPath,
   staticFilesPath,
   useHttps,
-} = resolveServerConfig(env);
+} = serverConfig;
 
 const app = createApp({ configPath, staticFilesVirtualPath, staticFilesPath });
 

--- a/packages/graph-explorer-proxy-server/src/process-environment.test.ts
+++ b/packages/graph-explorer-proxy-server/src/process-environment.test.ts
@@ -384,4 +384,26 @@ describe("process-environment.sh", () => {
       ]);
     });
   });
+
+  describe("grep-safe .env output", () => {
+    it("PROXY_SERVER_HTTPS_CONNECTION is on its own line", () => {
+      const { envFile } = runScript(workDir);
+      expect(envFile).toMatch(/^PROXY_SERVER_HTTPS_CONNECTION=true$/m);
+    });
+
+    it("does not produce commented-out PROXY_SERVER_HTTPS_CONNECTION", () => {
+      const { envFile } = runScript(workDir);
+      expect(envFile).not.toContain("# PROXY_SERVER_HTTPS_CONNECTION");
+    });
+
+    it("value has no trailing whitespace", () => {
+      const { envFile } = runScript(workDir, {
+        PROXY_SERVER_HTTPS_CONNECTION: "false",
+      });
+      const line = envFile
+        .split("\n")
+        .find(l => l.startsWith("PROXY_SERVER_HTTPS_CONNECTION"));
+      expect(line).toBe("PROXY_SERVER_HTTPS_CONNECTION=false");
+    });
+  });
 });

--- a/packages/graph-explorer-proxy-server/src/server-config.test.ts
+++ b/packages/graph-explorer-proxy-server/src/server-config.test.ts
@@ -76,34 +76,43 @@ describe("resolveServerConfig", () => {
     expect(config.useHttps).toBe(false);
   });
 
-  it("sets useHttps to false when HTTPS is enabled but cert files do not exist", () => {
+  it("throws when HTTPS is enabled but cert files do not exist", () => {
     vi.spyOn(fs, "existsSync").mockReturnValue(false);
 
-    const config = resolveServerConfig(
-      createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }),
+    expect(() =>
+      resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true })),
+    ).toThrow(
+      expect.objectContaining({
+        name: "ServerConfigError",
+        message: expect.stringContaining(expectedKeyPath),
+      }),
     );
-
-    expect(config.useHttps).toBe(false);
   });
 
-  it("sets useHttps to false when only the key file exists", () => {
+  it("throws when HTTPS is enabled but only the key file exists", () => {
     vi.spyOn(fs, "existsSync").mockImplementation(p => p === expectedKeyPath);
 
-    const config = resolveServerConfig(
-      createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }),
+    expect(() =>
+      resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true })),
+    ).toThrow(
+      expect.objectContaining({
+        name: "ServerConfigError",
+        message: expect.stringContaining(expectedCertPath),
+      }),
     );
-
-    expect(config.useHttps).toBe(false);
   });
 
-  it("sets useHttps to false when only the cert file exists", () => {
+  it("throws when HTTPS is enabled but only the cert file exists", () => {
     vi.spyOn(fs, "existsSync").mockImplementation(p => p === expectedCertPath);
 
-    const config = resolveServerConfig(
-      createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }),
+    expect(() =>
+      resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true })),
+    ).toThrow(
+      expect.objectContaining({
+        name: "ServerConfigError",
+        message: expect.stringContaining(expectedKeyPath),
+      }),
     );
-
-    expect(config.useHttps).toBe(false);
   });
 
   it("sets useHttps to true when HTTPS is enabled and both cert files exist", () => {
@@ -114,6 +123,64 @@ describe("resolveServerConfig", () => {
     );
 
     expect(config.useHttps).toBe(true);
+  });
+
+  describe("ServerConfigError message content", () => {
+    it("both files missing: message contains both paths", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+      let message = "";
+      try {
+        resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }));
+      } catch (e) {
+        message = (e as Error).message;
+      }
+
+      expect(message).toContain("server.key");
+      expect(message).toContain("server.crt");
+    });
+
+    it("only key missing: message contains key path but not cert path", () => {
+      vi.spyOn(fs, "existsSync").mockImplementation(
+        p => p === expectedCertPath,
+      );
+
+      let message = "";
+      try {
+        resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }));
+      } catch (e) {
+        message = (e as Error).message;
+      }
+
+      expect(message).toContain("server.key");
+      expect(message).not.toContain("server.crt");
+    });
+
+    it("only cert missing: message contains cert path but not key path", () => {
+      vi.spyOn(fs, "existsSync").mockImplementation(p => p === expectedKeyPath);
+
+      let message = "";
+      try {
+        resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true }));
+      } catch (e) {
+        message = (e as Error).message;
+      }
+
+      expect(message).toContain("server.crt");
+      expect(message).not.toContain("server.key");
+    });
+
+    it("message includes the env var name", () => {
+      vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+      expect(() =>
+        resolveServerConfig(createEnv({ PROXY_SERVER_HTTPS_CONNECTION: true })),
+      ).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining("PROXY_SERVER_HTTPS_CONNECTION"),
+        }),
+      );
+    });
   });
 });
 

--- a/packages/graph-explorer-proxy-server/src/server-config.ts
+++ b/packages/graph-explorer-proxy-server/src/server-config.ts
@@ -5,6 +5,13 @@ import type { EnvironmentValues } from "./env.js";
 
 import { clientRoot, proxyServerRoot } from "./paths.js";
 
+export class ServerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ServerConfigError";
+  }
+}
+
 export function resolveServerConfig(env: EnvironmentValues) {
   const certificateKeyFilePath = path.join(
     proxyServerRoot,
@@ -15,10 +22,18 @@ export function resolveServerConfig(env: EnvironmentValues) {
     "cert-info/server.crt",
   );
 
-  const useHttps =
-    env.PROXY_SERVER_HTTPS_CONNECTION &&
-    fs.existsSync(certificateKeyFilePath) &&
-    fs.existsSync(certificateFilePath);
+  const useHttps = env.PROXY_SERVER_HTTPS_CONNECTION;
+
+  if (useHttps) {
+    const missingFiles = [certificateKeyFilePath, certificateFilePath].filter(
+      f => !fs.existsSync(f),
+    );
+    if (missingFiles.length > 0) {
+      throw new ServerConfigError(
+        `PROXY_SERVER_HTTPS_CONNECTION is true but certificate files are missing: ${missingFiles.join(", ")}`,
+      );
+    }
+  }
 
   const port = useHttps
     ? env.PROXY_SERVER_HTTPS_PORT

--- a/packages/graph-explorer-proxy-server/src/setup-ssl.test.ts
+++ b/packages/graph-explorer-proxy-server/src/setup-ssl.test.ts
@@ -4,36 +4,17 @@ import os from "os";
 import path from "path";
 
 const scriptPath = path.resolve(import.meta.dirname, "../../../setup-ssl.sh");
+const certInfoDir = path.resolve(import.meta.dirname, "../cert-info");
 
-const CERT_CONF_CONTENT = `authorityKeyIdentifier=keyid,issuer
-basicConstraints=CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-subjectAltName = @alt_names
-
-[alt_names]
-# Filled in by Dockerfile
-DNS.1 = `;
-
-const CSR_CONF_CONTENT = `[ req ]
-default_bits = 2048
-prompt = no
-default_md = sha256
-req_extensions = req_ext
-distinguished_name = dn
-
-[ dn ]
-C = US
-ST = Washington
-L = Seattle
-O = Graph Explorer
-CN = Graph Explorer
-
-[ req_ext ]
-subjectAltName = @alt_names
-
-[ alt_names ]
-# Filled in by Dockerfile
-DNS.1 = `;
+/** Read the real config files so tests break if they change. */
+const CERT_CONF_CONTENT = fs.readFileSync(
+  path.join(certInfoDir, "cert.conf"),
+  "utf-8",
+);
+const CSR_CONF_CONTENT = fs.readFileSync(
+  path.join(certInfoDir, "csr.conf"),
+  "utf-8",
+);
 
 function runScript(
   certDir: string,
@@ -130,6 +111,16 @@ describe("setup-ssl.sh", () => {
       const csrConf = fs.readFileSync(path.join(certDir, "csr.conf"), "utf-8");
       expect(csrConf).toContain("my-host.example.com");
     });
+
+    it("exits immediately when openssl fails due to invalid config", () => {
+      fs.writeFileSync(path.join(certDir, "cert.conf"), "INVALID");
+      fs.writeFileSync(path.join(certDir, "csr.conf"), "INVALID");
+
+      const { exitCode } = runScript(certDir, { HOST: "localhost" });
+
+      expect(exitCode).not.toBe(0);
+      expect(fs.existsSync(path.join(certDir, "server.crt"))).toBe(false);
+    });
   });
 
   describe("without HOST (check existing certs)", () => {
@@ -143,15 +134,13 @@ describe("setup-ssl.sh", () => {
     });
 
     it("fails when no cert files exist", () => {
-      const { exitCode, stdout } = runScript(certDir);
+      const { exitCode, stderr } = runScript(certDir);
 
       expect(exitCode).not.toBe(0);
-      expect(stdout).toContain("No existing self-signed SSL certificate found");
+      expect(stderr).toContain("Missing certificate files");
     });
 
-    // BUG: The existence check has rootCA.crt listed twice and server.key is
-    // never checked. This means a missing server.key is not detected.
-    it("does not detect a missing server.key file", () => {
+    it("fails when server.key is missing", () => {
       for (const f of [
         "rootCA.key",
         "rootCA.crt",
@@ -161,10 +150,24 @@ describe("setup-ssl.sh", () => {
         fs.writeFileSync(path.join(certDir, f), "placeholder");
       }
 
-      const { exitCode } = runScript(certDir);
+      const { exitCode, stderr } = runScript(certDir);
 
-      // Should fail but passes due to the duplicate rootCA.crt check
-      expect(exitCode).toBe(0);
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("server.key");
+    });
+
+    it("reports each missing file individually", () => {
+      // Only rootCA.key exists
+      fs.writeFileSync(path.join(certDir, "rootCA.key"), "placeholder");
+
+      const { exitCode, stderr } = runScript(certDir);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("rootCA.crt");
+      expect(stderr).toContain("server.key");
+      expect(stderr).toContain("server.csr");
+      expect(stderr).toContain("server.crt");
+      expect(stderr).not.toContain("rootCA.key");
     });
   });
 });

--- a/setup-ssl.sh
+++ b/setup-ssl.sh
@@ -6,13 +6,14 @@
 #   CERT_DIR  – directory for certificate files (required)
 #   HOST      – hostname for SAN entries; when unset, expects existing certs
 #
+set -e
 
 if [ -z "$CERT_DIR" ]; then
     echo "CERT_DIR is required" >&2
     exit 1
 fi
 
-if [ $HOST ]; then
+if [ -n "$HOST" ]; then
     echo "Generating new self-signed SSL cert using $HOST..."
     sed -i'' -e "s/^DNS\.1 = .*/DNS.1 = $HOST:*/" "$CERT_DIR/csr.conf"
     sed -i'' -e "s/^DNS\.1 = .*/DNS.1 = $HOST:*/" "$CERT_DIR/cert.conf"
@@ -22,10 +23,16 @@ if [ $HOST ]; then
     openssl x509 -req -in "$CERT_DIR/server.csr" -CA "$CERT_DIR/rootCA.crt" -CAkey "$CERT_DIR/rootCA.key" -CAcreateserial -out "$CERT_DIR/server.crt" -days 365 -sha256 -extfile "$CERT_DIR/cert.conf"
 else
     echo "No HOST environment variable specified."
-    if [ -f "$CERT_DIR/rootCA.key" ] && [ -f "$CERT_DIR/rootCA.crt" ] && [ -f "$CERT_DIR/rootCA.crt" ] && [ -f "$CERT_DIR/server.csr" ] && [ -f "$CERT_DIR/server.crt" ]; then
-        echo "Found existing self-signed SSL certificate. Re-using existing cert."
-    else
-        echo "No existing self-signed SSL certificate found. Please specify --env HOST=<hostname> during docker run command to create SSL cert."
+    MISSING=""
+    for f in rootCA.key rootCA.crt server.key server.csr server.crt; do
+        if [ ! -f "$CERT_DIR/$f" ]; then
+            MISSING="$MISSING $f"
+        fi
+    done
+    if [ -n "$MISSING" ]; then
+        echo "Missing certificate files in $CERT_DIR:$MISSING" >&2
+        echo "Please specify --env HOST=<hostname> during docker run command to create SSL cert." >&2
         exit 1
     fi
+    echo "Found existing self-signed SSL certificate. Re-using existing cert."
 fi


### PR DESCRIPTION
## Description

When `PROXY_SERVER_HTTPS_CONNECTION` is `true` but the certificate files are missing, the server silently falls back to HTTP. This is a security concern — the user explicitly requested HTTPS but gets unencrypted traffic with no warning.

This PR makes the server fail fast with a clear error message instead of silently downgrading.

### Server config

- Add `ServerConfigError` that is thrown when HTTPS is enabled but cert files are missing, with a message listing exactly which files are absent
- Catch `ServerConfigError` in `node-server.ts` with a `logger.fatal` and `process.exit(1)`

### Shell scripts

- Fix `setup-ssl.sh`: add `set -e`, use POSIX `[ -n "$HOST" ]`, fix the duplicate `rootCA.crt` check bug (was missing `server.key`), and report each missing file individually to stderr
- Fix `docker-entrypoint.sh`: add `set -e`, validate `.env` file exists, anchor the grep pattern with `^` to ignore comments and similarly-named vars, and use POSIX `=` instead of `==`

### Tests

- New `docker-entrypoint.test.ts` — tests the entrypoint shell script in isolation with stubbed dependencies
- New `config-pipeline.test.ts` — end-to-end tests from shell script through Zod parsing to server config
- New tests in `process-environment.test.ts` verifying grep-safe `.env` output
- Updated `server-config.test.ts` to assert the new throwing behavior including error messages with specific missing file paths
- Updated `setup-ssl.test.ts` to read real config files instead of duplicating them, and test individual missing file reporting

## Validation

- `pnpm run checks` passes with no errors
- `pnpm test` — all 70 tests across the 5 affected test files pass
- Manual validation using docker locally

## Related Issues

- Fixes #1634

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.