### PR TITLE
Harden supply chain security settings

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -38,7 +38,7 @@ jobs:
           node-version-file: "package.json"
 
       - name: Install package and dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run type, lint, and format checks
         run: pnpm checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,10 @@ WORKDIR /
 COPY . /graph-explorer/
 WORKDIR /graph-explorer
 
-RUN pnpm install && \
+RUN pnpm install --frozen-lockfile && \
     pnpm build && \
     pnpm clean:dep && \
-    pnpm install --prod --ignore-scripts && \
+    pnpm install --prod --frozen-lockfile --ignore-scripts && \
     npm uninstall -g npm && \
     corepack disable && \
     rm -rf /usr/local/bin/pnpm* /usr/local/bin/corepack && \

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,17 @@ This repository is composed by 3 packages and a mono-repository structure itself
 
 Each of these `package.json` files has an independent `version` property. However, in this project we should keep them correlated. Therefore, when a new release version is being prepared, the version number should be increased in all 4 files. Regarding the version number displayed in the user interface, it is specifically extracted from the `<root>/packages/graph-explorer/package.json`. file
 
+### Supply chain security
+
+The `pnpm-workspace.yaml` file includes several settings that harden the project against supply chain attacks. These may cause `pnpm install` to fail when adding new dependencies, which is intentional.
+
+- **`minimumReleaseAge`** — Newly published package versions are blocked for 24 hours, giving the community time to discover and report compromised releases.
+- **`strictDepBuilds`** — Any dependency that tries to run a build script (e.g. `postinstall`) will cause installation to fail unless it is explicitly listed in `onlyBuiltDependencies` or `ignoredBuiltDependencies`.
+- **`blockExoticSubdeps`** — Transitive dependencies cannot resolve to git repositories or raw tarball URLs. Only direct dependencies in `package.json` may use exotic sources.
+- **`trustPolicy`** — Refuses to install a package version whose publish-time trust evidence (provenance, signatures) is weaker than a previously published version of that package.
+
+If `pnpm install` fails due to one of these checks, evaluate whether the dependency is safe and update `pnpm-workspace.yaml` accordingly.
+
 ### Local environment overrides
 
 Create a `.env.local` file in `packages/graph-explorer/` to override environment variables without modifying tracked files. This file is gitignored and will not be committed.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,10 @@ minimumReleaseAge: 1440
 ignoredBuiltDependencies:
   - core-js
 
+# Explicitly allow these packages to run build scripts
+onlyBuiltDependencies:
+  - esbuild
+
 # Fail if any dependency tries to run a build script that has not been allowed
 strictDepBuilds: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,17 @@ packages:
 # This prevents malicious packages from being installed by waiting 24 hours
 # after a package is published. See https://pnpm.io/settings#minimumreleaseage
 minimumReleaseAge: 1440
+
+# Silently block packages with unwanted build scripts
+ignoredBuiltDependencies:
+  - core-js
+
+# Fail if any dependency tries to run a build script that has not been allowed
+strictDepBuilds: true
+
+# Prevent transitive dependencies from using git or tarball URLs
+blockExoticSubdeps: true
+
+# Refuse to install a package version whose trust evidence is weaker than a
+# previously published version of that package
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Description

Adds pnpm supply chain hardening settings and tightens the Dockerfile and CI install steps based on a review of [npm security best practices](https://github.com/lirantal/npm-security-best-practices).

- **`strictDepBuilds: true`** — Fail `pnpm install` if any dependency tries to run a build script that hasn't been explicitly allowed. `core-js` is added to `ignoredBuiltDependencies` to suppress its sponsorship postinstall.
- **`onlyBuiltDependencies: [esbuild]`** — Explicitly allow the `esbuild` postinstall script, which installs the platform-specific binary.
- **`blockExoticSubdeps: true`** — Prevent transitive dependencies from resolving to git repos or raw tarball URLs.
- **`trustPolicy: no-downgrade`** — Refuse to install a package version whose publish-time trust evidence (provenance, signatures) is weaker than a previously published version.
- **`--frozen-lockfile`** on both Dockerfile install steps and the CI unit test workflow, ensuring deterministic installs.
- **`--ignore-scripts`** kept on the production install in the Dockerfile as defense-in-depth.
- **Documentation** added to `docs/development.md` explaining the supply chain settings and what to do when `pnpm install` rejects a dependency.

## Validation

- `pnpm install --frozen-lockfile` succeeds locally with all new settings
- No changes to application code or tests

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.