### PR TITLE
Improve CORS defaults and upstream header forwarding

### DIFF
--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -104,24 +104,25 @@ describe("createApp", () => {
       expect(response.headers["access-control-max-age"]).toBe("86400");
     });
 
-    it("does not forward upstream Access-Control headers", async () => {
+    it("only forwards content-type from upstream responses", async () => {
       mockFetchOnce(JSON.stringify({ results: [] }), 200, {
         "content-type": "application/json",
         "access-control-allow-origin": "https://upstream.example.com",
-        "access-control-allow-methods": "PUT,DELETE",
+        "transfer-encoding": "chunked",
+        server: "Neptune/1.0",
+        "x-request-id": "abc-123",
       });
 
       const app = createTestApp();
       const response = await request(app)
         .post("/sparql")
-        .set("Origin", "http://example.com")
         .set(dbHeaders())
         .send({ query: "SELECT 1" });
 
-      // The proxy's own CORS headers should be used, not the upstream ones
-      expect(response.headers["access-control-allow-origin"]).toBe(
-        "http://example.com",
-      );
+      expect(response.headers["content-type"]).toContain("application/json");
+      expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+      expect(response.headers["server"]).toBeUndefined();
+      expect(response.headers["x-request-id"]).toBeUndefined();
     });
   });
 

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -63,6 +63,30 @@ describe("createApp", () => {
     mockFetch.mockReset();
   });
 
+  // ── CORS ────────────────────────────────────────────────────────────
+
+  describe("CORS", () => {
+    it("does not forward upstream Access-Control headers", async () => {
+      mockFetchOnce(JSON.stringify({ results: [] }), 200, {
+        "content-type": "application/json",
+        "access-control-allow-origin": "https://upstream.example.com",
+        "access-control-allow-methods": "PUT,DELETE",
+      });
+
+      const app = createTestApp();
+      const response = await request(app)
+        .post("/sparql")
+        .set("Origin", "http://example.com")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      // The proxy's own CORS headers should be used, not the upstream ones
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "http://example.com",
+      );
+    });
+  });
+
   // ── Static routes ──────────────────────────────────────────────────
 
   it("GET /status returns 200 OK", async () => {

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -66,6 +66,44 @@ describe("createApp", () => {
   // ── CORS ────────────────────────────────────────────────────────────
 
   describe("CORS", () => {
+    it("reflects the request origin by default", async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .get("/status")
+        .set("Origin", "http://example.com");
+
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "http://example.com",
+      );
+    });
+
+    it("does not set origin header when request has no Origin", async () => {
+      const app = createTestApp();
+      const response = await request(app).get("/status");
+
+      expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+    });
+
+    it("only allows GET and POST methods", async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .options("/status")
+        .set("Origin", "http://example.com")
+        .set("Access-Control-Request-Method", "DELETE");
+
+      expect(response.headers["access-control-allow-methods"]).toBe("GET,POST");
+    });
+
+    it("sets preflight max-age cache header", async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .options("/status")
+        .set("Origin", "http://example.com")
+        .set("Access-Control-Request-Method", "POST");
+
+      expect(response.headers["access-control-max-age"]).toBe("86400");
+    });
+
     it("does not forward upstream Access-Control headers", async () => {
       mockFetchOnce(JSON.stringify({ results: [] }), 200, {
         "content-type": "application/json",

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -202,10 +202,13 @@ export function createApp({
         serviceType,
       );
 
-      // Set the headers from the fetch response to the client response
+      // Set the headers from the fetch response to the client response,
+      // skipping Access-Control headers to avoid clobbering the proxy's CORS config
       res.status(response.status);
       for (const [key, value] of response.headers.entries()) {
-        res.setHeader(key, value);
+        if (!key.toLowerCase().startsWith("access-control-")) {
+          res.setHeader(key, value);
+        }
       }
 
       // Pipe the raw fetch response body directly to the client response

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -77,7 +77,13 @@ export function createApp({
 
   app.use(requestLoggingMiddleware());
   app.use(compression());
-  app.use(cors());
+  app.use(
+    cors({
+      origin: true,
+      methods: ["GET", "POST"],
+      maxAge: 86400,
+    }),
+  );
   app.use(bodyParser.json({ limit: "50mb" }));
   app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
   app.use(

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -208,12 +208,14 @@ export function createApp({
         serviceType,
       );
 
-      // Set the headers from the fetch response to the client response,
-      // skipping Access-Control headers to avoid clobbering the proxy's CORS config
+      // Only forward content headers from the upstream response.
+      // All other headers (CORS, hop-by-hop, server info) are dropped
+      // to avoid conflicts with the proxy's own response handling.
       res.status(response.status);
-      for (const [key, value] of response.headers.entries()) {
-        if (!key.toLowerCase().startsWith("access-control-")) {
-          res.setHeader(key, value);
+      for (const header of ["content-type", "content-encoding"]) {
+        const value = response.headers.get(header);
+        if (value) {
+          res.setHeader(header, value);
         }
       }
 


### PR DESCRIPTION
## Description

Hardens the proxy server's CORS configuration and upstream response header handling.

- **Reflect request origin instead of wildcard** — `cors()` now uses `origin: true` instead of the default `*`. When no `Origin` header is present (same-origin or non-browser clients), no `Access-Control-Allow-Origin` header is set.
- **Restrict allowed methods** — Only `GET` and `POST` are advertised, matching the actual routes defined in the proxy.
- **Cache preflight responses** — `maxAge: 86400` reduces redundant OPTIONS requests in cross-origin scenarios (e.g., local development).
- **Allowlist upstream response headers** — Only `content-type` and `content-encoding` are forwarded from upstream database responses. Previously all headers were forwarded, which could clobber the proxy's own CORS headers and leak hop-by-hop headers that should not be forwarded by a proxy (RFC 7230 §6.1).

## Validation

- 5 new CORS tests in `app.test.ts` covering origin reflection, no-origin behavior, method restriction, preflight caching, and the upstream header allowlist
- All 1591 tests pass
- `pnpm checks` passes
- All standard deployments (SageMaker Notebook, EC2, ECS+ALB) are same-origin, so CORS headers are not evaluated by the browser — no behavioral change for production users

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.