### PR TITLE
Add v3.0.1 release notes and improve HTTPS documentation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,12 +2,12 @@
 
 ## Release 3.0.1
 
-This patch release hardens security, improves error handling, and refactors the proxy server for testability. Error messages surface richer diagnostics — status codes, response bodies, and cause chains — so troubleshooting is more useful. We also upgraded to Vite 8, cutting build time by 60% and bundle size by 5%.
+This patch release improves error handling, refactors the proxy server for testability, and hardens the application protection mechanisms. Error messages surface richer diagnostics — status codes, response bodies, and cause chains — so troubleshooting is more useful. We also upgraded to Vite 8, cutting build time by 60% and bundle size by 5%.
 
 - **Bug fixes** — new empty state when no connections are configured instead of misleading "No Schema Available", Docker entrypoint now respects custom config directories (thanks @theneelshah!), Podman container permissions fix
 - **Error handling** — the error details dialog now surfaces status codes, response bodies, and cause chains so you can diagnose issues without digging through logs. Invalid proxy requests return proper 400 errors instead of cryptic 500s. Connection failures and CORS mismatches get targeted error messages.
 - **Tooling & docs** — Vite 8 upgrade cuts build time by 60% and bundle size by 5%, reorganized docs into guides and references, updated README
-- **Security** — tighter CORS defaults, supply chain hardening, automated vulnerability scanning, least-privilege CI permissions, and a new security policy for reporting vulnerabilities
+- **Application hardening** — tighter CORS defaults, supply chain hardening, automated vulnerability scanning, least-privilege CI permissions, and a new security policy for reporting vulnerabilities
 - **Proxy server** — previously untestable parts of the proxy server now have 170+ tests (up from 56), making future changes safer and more reliable
 
 ### HTTPS Configuration

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,65 @@
 # Graph Explorer Change Log
 
+## Release 3.0.1
+
+This patch release hardens security, improves error handling, and refactors the proxy server for testability. Error messages surface richer diagnostics — status codes, response bodies, and cause chains — so troubleshooting is more useful. We also upgraded to Vite 8, cutting build time by 60% and bundle size by 5%.
+
+- **Bug fixes** — new empty state when no connections are configured instead of misleading "No Schema Available", Docker entrypoint now respects custom config directories (thanks @theneelshah!), Podman container permissions fix
+- **Error handling** — the error details dialog now surfaces status codes, response bodies, and cause chains so you can diagnose issues without digging through logs. Invalid proxy requests return proper 400 errors instead of cryptic 500s. Connection failures and CORS mismatches get targeted error messages.
+- **Tooling & docs** — Vite 8 upgrade cuts build time by 60% and bundle size by 5%, reorganized docs into guides and references, updated README
+- **Security** — tighter CORS defaults, supply chain hardening, automated vulnerability scanning, least-privilege CI permissions, and a new security policy for reporting vulnerabilities
+- **Proxy server** — previously untestable parts of the proxy server now have 170+ tests (up from 56), making future changes safer and more reliable
+
+### HTTPS Configuration
+
+Previous versions had a bug where the Docker entrypoint ignored custom config directory paths, which could cause your HTTPS settings to be silently skipped. While fixing this, we also discovered that when HTTPS was enabled but certificate generation or discovery failed, the server would silently fall back to HTTP instead of reporting the problem. The server now exits with a clear error in this scenario. If you were unknowingly relying on this fallback behavior, ensure your certificates are in place before upgrading or explicitly disable HTTPS. See the [HTTPS Connections](https://github.com/aws/graph-explorer/blob/v3.0.1/docs/references/security.md#https-connections) documentation for details.
+
+### New Contributors
+
+Welcome and thank you to our first-time contributor!
+
+- @theneelshah made their first contribution in https://github.com/aws/graph-explorer/pull/1598
+
+### All Changes
+
+- Update readme intro by @kmcginnes in https://github.com/aws/graph-explorer/pull/1567
+- Switch to proseWrap preserve by @kmcginnes in https://github.com/aws/graph-explorer/pull/1568
+- Use permalinks in the changelog by @kmcginnes in https://github.com/aws/graph-explorer/pull/1569
+- Rename additionaldocs directory to docs by @kmcginnes in https://github.com/aws/graph-explorer/pull/1570
+- Reorganize documentation into guides structure by @kmcginnes in https://github.com/aws/graph-explorer/pull/1571
+- Move reference documentation to docs/references/ by @kmcginnes in https://github.com/aws/graph-explorer/pull/1572
+- Set explicit minimum permissions on GitHub Actions workflows by @kmcginnes in https://github.com/aws/graph-explorer/pull/1573
+- Update dependencies and remove stale overrides by @kmcginnes in https://github.com/aws/graph-explorer/pull/1574
+- Bump version to 3.1.0 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1587
+- Fix air routes sample permission error on Podman by @kmcginnes in https://github.com/aws/graph-explorer/pull/1588
+- Rename issue templates for consistent ordering by @kmcginnes in https://github.com/aws/graph-explorer/pull/1591
+- Update GitHub issue and PR templates by @kmcginnes in https://github.com/aws/graph-explorer/pull/1592
+- Add issue type REST API instructions to GitHub skill by @kmcginnes in https://github.com/aws/graph-explorer/pull/1597
+- Fix: use CONFIGURATION_FOLDER_PATH in docker-entrypoint.sh for custom config directory by @theneelshah in https://github.com/aws/graph-explorer/pull/1598
+- Update dependencies and remove stale fast-xml-parser override by @kmcginnes in https://github.com/aws/graph-explorer/pull/1603
+- Add git conventions skill by @kmcginnes in https://github.com/aws/graph-explorer/pull/1606
+- Change version to 3.0.1 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1607
+- Clean up Docker image and add Trivy scan to CI by @kmcginnes in https://github.com/aws/graph-explorer/pull/1609
+- Show empty connection state instead of misleading 'No Schema Available' by @kmcginnes in https://github.com/aws/graph-explorer/pull/1611
+- Disable schema sync queries when no connection exists by @kmcginnes in https://github.com/aws/graph-explorer/pull/1612
+- Add GRAPH_EXP_DEV_PORT and .env.local documentation by @kmcginnes in https://github.com/aws/graph-explorer/pull/1613
+- Update dependencies to latest compatible versions by @kmcginnes in https://github.com/aws/graph-explorer/pull/1615
+- Decouple proxy server startup from module-level side effects by @kmcginnes in https://github.com/aws/graph-explorer/pull/1628
+- Add tests for process-environment.sh and fix POSIX compliance by @kmcginnes in https://github.com/aws/graph-explorer/pull/1629
+- Update lodash to latest version by @kmcginnes in https://github.com/aws/graph-explorer/pull/1631
+- Extract proxy server into testable modules by @kmcginnes in https://github.com/aws/graph-explorer/pull/1632
+- Extract SSL cert logic into testable setup-ssl.sh script by @kmcginnes in https://github.com/aws/graph-explorer/pull/1637
+- Validate graph database connection URL with Zod schema by @kmcginnes in https://github.com/aws/graph-explorer/pull/1639
+- Fail fast when HTTPS is requested but certificates are missing by @kmcginnes in https://github.com/aws/graph-explorer/pull/1640
+- Pin @tanstack/eslint-plugin-query to 5.96.2 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1641
+- Improve error details with richer diagnostic information by @kmcginnes in https://github.com/aws/graph-explorer/pull/1644
+- Add security policy and security audit workflow by @kmcginnes in https://github.com/aws/graph-explorer/pull/1648
+- Remove ExplorerInjector component by @kmcginnes in https://github.com/aws/graph-explorer/pull/1649
+- Improve error details and handle proxy connection errors by @kmcginnes in https://github.com/aws/graph-explorer/pull/1650
+- Update Vite to version 8 by @kmcginnes in https://github.com/aws/graph-explorer/pull/1651
+- Harden supply chain security settings by @kmcginnes in https://github.com/aws/graph-explorer/pull/1652
+- Improve CORS defaults and upstream header forwarding by @kmcginnes in https://github.com/aws/graph-explorer/pull/1653
+
 ## Release 3.0.0
 
 Graph Explorer 3.0 is here! This release brings one of the most requested features — the ability to visualize your graph database schema — along with a fresh navigation experience and a handful of quality-of-life improvements.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -6,7 +6,50 @@ Graph Explorer supports the HTTPS protocol by default and provides a self-signed
 
 ## HTTPS Connections
 
-If either Graph Explorer or the proxy-server are served over an HTTPS connection (which it is by default), you will have to bypass the warning message from the browser due to the included certificate being a self-signed certificate. You can bypass by manually ignoring them from the browser or downloading the correct certificate and configuring them to be trusted. Alternatively, you can provide your own certificate. The following instructions can be used as an example to bypass the warnings for Chrome, but note that different browsers and operating systems will have slightly different steps.
+Graph Explorer serves over HTTPS by default using a self-signed certificate. The `HOST` environment variable controls the hostname used in the certificate's Subject Alternative Name (SAN). When `HOST` is set, the entrypoint script generates a fresh self-signed certificate on container startup. When `HOST` is not set, the server expects to find existing certificate files.
+
+### Certificate files
+
+The proxy server reads certificates from the following location inside the container:
+
+```
+/graph-explorer/packages/graph-explorer-proxy-server/cert-info/
+├── rootCA.key    # Root CA private key
+├── rootCA.crt    # Root CA certificate
+├── server.key    # Server private key
+├── server.csr    # Server certificate signing request
+├── server.crt    # Server certificate
+├── csr.conf      # CSR configuration template
+└── cert.conf     # Certificate extensions configuration
+```
+
+If HTTPS is enabled and any of these files are missing, the server will exit with an error listing the missing files.
+
+### Using your own certificates
+
+To use your own certificates instead of the self-signed ones, mount your certificate files into the `cert-info` directory. All five certificate files must be present (`rootCA.key`, `rootCA.crt`, `server.key`, `server.csr`, `server.crt`).
+
+> [!IMPORTANT]
+>
+> Do not set the `HOST` environment variable, otherwise the entrypoint will overwrite your files with a new self-signed certificate.
+
+```bash
+docker run -p 443:443 \
+  -v /path/to/your/server.key:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/server.key \
+  -v /path/to/your/server.crt:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/server.crt \
+  -v /path/to/your/rootCA.crt:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt \
+  -v /path/to/your/rootCA.key:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.key \
+  -v /path/to/your/server.csr:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/server.csr \
+  public.ecr.aws/neptune/graph-explorer
+```
+
+### Disabling HTTPS
+
+To serve over HTTP instead, set `PROXY_SERVER_HTTPS_CONNECTION=false` in your environment or `.env` file.
+
+### Trusting the self-signed certificate
+
+When using the default self-signed certificate, your browser will show a security warning. You can bypass this by trusting the certificate:
 
 1. Download the certificate directly from the browser. For example, if using Google Chrome, click the "Not Secure" section on the left of the URL bar and select "Certificate is not valid" to show the certificate. Then click Details tab and click Export at the bottom.
 2. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.


### PR DESCRIPTION
## Description

Add release notes for v3.0.1 to the changelog and improve the HTTPS documentation in the security reference.

- Add v3.0.1 release notes covering app hardening, error handling improvements, proxy server testability, bug fixes, and the HTTPS configuration behavioral change
- Expand the HTTPS Connections section in `docs/references/security.md` with certificate file locations, instructions for mounting your own certificates, and how to disable HTTPS
- Add an important callout warning not to set `HOST` when providing custom certificates

## Validation

- Review the rendered changelog for accuracy and readability
- Review the HTTPS documentation for completeness
- Custom certificate mounting was tested locally with Finch

## Related Issues

*None*

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.