### PR TITLE
Set User-Agent header on all outbound proxy requests

### DIFF
--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -11,11 +11,14 @@ import { createLogger } from "./logging.js";
 const { default: fetch } = await import("node-fetch");
 const mockFetch = vi.mocked(fetch);
 
+const testVersion = "1.2.3";
+
 function createTestApp(configPath = ".") {
   const app = createApp({
     configPath,
     staticFilesVirtualPath: "/explorer",
     staticFilesPath: ".",
+    version: testVersion,
   });
   app.locals.logger = createLogger({
     HOST: "localhost",
@@ -650,6 +653,71 @@ describe("createApp", () => {
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
       expect(fetchOptions.service).toBe("neptune-graph");
+    });
+  });
+
+  // ── User-Agent header ───────────────────────────────────────────
+
+  describe("User-Agent header", () => {
+    it("sets User-Agent on outbound requests", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/sparql")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      const fetchOptions = mockFetch.mock.calls[0][1] as any;
+      expect(fetchOptions.headers["User-Agent"]).toBe(
+        `graph-explorer/${testVersion}`,
+      );
+    });
+
+    it("falls back to 'graph-explorer' when version is not provided", async () => {
+      mockFetchOnce();
+
+      const app = createApp({
+        configPath: ".",
+        staticFilesVirtualPath: "/explorer",
+        staticFilesPath: ".",
+      });
+      app.locals.logger = createLogger({
+        HOST: "localhost",
+        PROXY_SERVER_HTTPS_CONNECTION: false,
+        PROXY_SERVER_HTTPS_PORT: 443,
+        PROXY_SERVER_HTTP_PORT: 80,
+        LOG_LEVEL: "silent",
+        LOG_STYLE: "default",
+      });
+
+      await request(app)
+        .post("/sparql")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      const fetchOptions = mockFetch.mock.calls[0][1] as any;
+      expect(fetchOptions.headers["User-Agent"]).toBe("graph-explorer");
+    });
+
+    it("preserves User-Agent after IAM signing", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/sparql")
+        .set(
+          dbHeaders({
+            "aws-neptune-region": "us-east-1",
+            "service-type": "neptune-db",
+          }),
+        )
+        .send({ query: "SELECT 1" });
+
+      const fetchOptions = mockFetch.mock.calls[0][1] as any;
+      expect(fetchOptions.headers["User-Agent"]).toBe(
+        `graph-explorer/${testVersion}`,
+      );
     });
   });
 

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -66,12 +66,14 @@ interface CreateAppOptions {
   configPath: string;
   staticFilesVirtualPath: string;
   staticFilesPath: string;
+  version?: string;
 }
 
 export function createApp({
   configPath,
   staticFilesVirtualPath,
   staticFilesPath,
+  version,
 }: CreateAppOptions): express.Express {
   const app = express();
 
@@ -116,6 +118,8 @@ export function createApp({
 
     return headers;
   }
+
+  const userAgent = version ? `graph-explorer/${version}` : "graph-explorer";
 
   // Function to retry fetch requests with exponential backoff.
   const retryFetch = async (
@@ -202,7 +206,10 @@ export function createApp({
     try {
       const response = await retryFetch(
         new URL(url),
-        options,
+        {
+          ...options,
+          headers: { "User-Agent": userAgent, ...options.headers },
+        },
         isIamEnabled,
         region,
         serviceType,

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 
+import packageJson from "../package.json" with { type: "json" };
 import { createApp } from "./app.js";
 import { parseEnvironmentValues } from "./env.js";
 import { handleError } from "./error-handler.js";
@@ -48,7 +49,12 @@ const {
   useHttps,
 } = serverConfig;
 
-const app = createApp({ configPath, staticFilesVirtualPath, staticFilesPath });
+const app = createApp({
+  configPath,
+  staticFilesVirtualPath,
+  staticFilesPath,
+  version: packageJson.version,
+});
 
 // Store logger on app.locals for access in middleware and routes
 app.locals.logger = logger;


### PR DESCRIPTION
## Description

Sets a `User-Agent: graph-explorer/<version>` header on all outbound proxy requests to the graph database. This helps database operators identify Graph Explorer traffic in their server logs.

- Add optional `version` parameter to `createApp` to keep the app factory testable without coupling to `package.json`
- Inject `User-Agent` header in `fetchData` before calling `retryFetch`, so it is set once per request
- Fall back to `"graph-explorer"` when no version is provided
- Read version from `package.json` in `node-server.ts` and pass it through

## Validation

- Three new tests covering: versioned header, fallback without version, and preservation after IAM signing
- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes (60 proxy server tests, 1564 total)

## Related Issues

- Resolves #1078

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.