### PR TITLE
Add PROXY_SERVER_CORS_ORIGIN env var to restrict allowed CORS origin

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -175,6 +175,16 @@ Uses the self-signed certificate to serve the proxy-server over https if true.
 - Default `false` in code, `true` in Docker via the entrypoint script
 - Type: `boolean`
 
+#### `PROXY_SERVER_CORS_ORIGIN`
+
+Restricts which origins are allowed to make cross-origin requests to the proxy server. When set, only requests from these exact origins will receive CORS headers. When not set, all origins are allowed. Each origin must include the scheme and must not have a trailing slash or path.
+
+Example: `https://my-app.example.com` or `https://app-a.example.com,https://app-b.example.com`
+
+- Optional
+- Default: all origins allowed
+- Type: `string` (comma-separated for multiple origins)
+
 #### `CONFIGURATION_FOLDER_PATH`
 
 Override path for the folder containing `.env` and `defaultConnection.json`. When set, replaces the default path entirely.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -61,6 +61,26 @@ When using the default self-signed certificate, your browser will show a securit
 > 
 > To get rid of the "Not Secure" warning, see [Using self-signed certificates on Chrome](../development.md#using-self-signed-certificates-on-chrome).
 
+## CORS
+
+To restrict cross-origin requests, set the `PROXY_SERVER_CORS_ORIGIN` environment variable to the origin you want to allow. The default option allows cross-origin requests from all origins.
+
+```bash
+PROXY_SERVER_CORS_ORIGIN=https://my-app.example.com
+```
+
+To allow multiple origins, separate them with commas:
+
+```bash
+PROXY_SERVER_CORS_ORIGIN=https://my-app.example.com,https://other-app.example.com
+```
+
+When set, browsers will block cross-origin requests from any other origin. This prevents malicious pages from making requests to the proxy server using a visitor's browser session.
+
+> [!NOTE]
+>
+> CORS headers only affect browser-initiated requests — direct API calls from scripts or other servers are not restricted by CORS. CORS is a defense-in-depth layer, not a substitute for authentication or network-level access controls. Ensure the proxy server is not exposed to untrusted networks.
+
 ## Permissions
 
 Graph Explorer does not provide any mechanisms for controlling user permissions. If you are using Graph Explorer with AWS, Neptune permissions can be controlled through IAM roles.

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -13,12 +13,13 @@ const mockFetch = vi.mocked(fetch);
 
 const testVersion = "1.2.3";
 
-function createTestApp(configPath = ".") {
+function createTestApp(configPath = ".", corsOrigin?: string[]) {
   const app = createApp({
     configPath,
     staticFilesVirtualPath: "/explorer",
     staticFilesPath: ".",
     version: testVersion,
+    corsOrigin,
   });
   app.locals.logger = createLogger({
     HOST: "localhost",
@@ -83,6 +84,69 @@ describe("createApp", () => {
     it("does not set origin header when request has no Origin", async () => {
       const app = createTestApp();
       const response = await request(app).get("/status");
+
+      expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+    });
+
+    it("sets the configured corsOrigin when provided", async () => {
+      const app = createTestApp(".", ["https://my-app.example.com"]);
+      const response = await request(app)
+        .get("/status")
+        .set("Origin", "https://my-app.example.com");
+
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "https://my-app.example.com",
+      );
+    });
+
+    it("returns the configured origin regardless of the requesting origin", async () => {
+      const app = createTestApp(".", ["https://my-app.example.com"]);
+      const response = await request(app)
+        .get("/status")
+        .set("Origin", "https://evil.example.com");
+
+      // The cors library sets a fixed Access-Control-Allow-Origin header
+      // when origin is a string. The browser enforces the mismatch by
+      // blocking the response when the header doesn't match the page origin.
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "https://my-app.example.com",
+      );
+    });
+
+    it("returns the configured origin on preflight regardless of the requesting origin", async () => {
+      const app = createTestApp(".", ["https://my-app.example.com"]);
+      const response = await request(app)
+        .options("/status")
+        .set("Origin", "https://evil.example.com")
+        .set("Access-Control-Request-Method", "POST");
+
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "https://my-app.example.com",
+      );
+    });
+
+    it("reflects the matching origin when multiple origins are configured", async () => {
+      const app = createTestApp(".", [
+        "https://app-a.example.com",
+        "https://app-b.example.com",
+      ]);
+      const response = await request(app)
+        .get("/status")
+        .set("Origin", "https://app-b.example.com");
+
+      expect(response.headers["access-control-allow-origin"]).toBe(
+        "https://app-b.example.com",
+      );
+    });
+
+    it("does not reflect a non-matching origin when multiple origins are configured", async () => {
+      const app = createTestApp(".", [
+        "https://app-a.example.com",
+        "https://app-b.example.com",
+      ]);
+      const response = await request(app)
+        .get("/status")
+        .set("Origin", "https://evil.example.com");
 
       expect(response.headers["access-control-allow-origin"]).toBeUndefined();
     });

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -67,6 +67,7 @@ interface CreateAppOptions {
   staticFilesVirtualPath: string;
   staticFilesPath: string;
   version?: string;
+  corsOrigin?: string[];
 }
 
 export function createApp({
@@ -74,6 +75,7 @@ export function createApp({
   staticFilesVirtualPath,
   staticFilesPath,
   version,
+  corsOrigin,
 }: CreateAppOptions): express.Express {
   const app = express();
 
@@ -81,7 +83,11 @@ export function createApp({
   app.use(compression());
   app.use(
     cors({
-      origin: true,
+      origin: corsOrigin
+        ? corsOrigin.length === 1
+          ? corsOrigin[0]
+          : corsOrigin
+        : true,
       methods: ["GET", "POST"],
       maxAge: 86400,
     }),

--- a/packages/graph-explorer-proxy-server/src/env.test.ts
+++ b/packages/graph-explorer-proxy-server/src/env.test.ts
@@ -85,6 +85,28 @@ describe("parseEnvironmentValues", () => {
       expect(process.exit).toHaveBeenCalledWith(1);
     });
 
+    it("exits process when PROXY_SERVER_CORS_ORIGIN is missing the scheme", () => {
+      parseEnvironmentValues({
+        PROXY_SERVER_CORS_ORIGIN: "my-app.example.com",
+      });
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("Must be an HTTP or HTTPS URL"),
+      );
+    });
+
+    it("exits process when PROXY_SERVER_CORS_ORIGIN is a wildcard", () => {
+      parseEnvironmentValues({ PROXY_SERVER_CORS_ORIGIN: "*" });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits process when PROXY_SERVER_CORS_ORIGIN has a trailing comma", () => {
+      parseEnvironmentValues({
+        PROXY_SERVER_CORS_ORIGIN: "https://example.com,",
+      });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
     it("logs error details on validation failure", () => {
       parseEnvironmentValues({ LOG_LEVEL: "verbose" });
       expect(console.error).toHaveBeenCalledWith(
@@ -101,5 +123,71 @@ describe("parseEnvironmentValues", () => {
 
     expect(result.HOST).toBe("my-server");
     expect(result).not.toHaveProperty("SOME_OTHER_VAR");
+  });
+
+  it("parses PROXY_SERVER_CORS_ORIGIN when provided", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_CORS_ORIGIN: "https://my-app.example.com",
+    });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toStrictEqual([
+      "https://my-app.example.com",
+    ]);
+  });
+
+  it("parses comma-separated PROXY_SERVER_CORS_ORIGIN values", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_CORS_ORIGIN:
+        "https://app-a.example.com,https://app-b.example.com",
+    });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toStrictEqual([
+      "https://app-a.example.com",
+      "https://app-b.example.com",
+    ]);
+  });
+
+  it("trims whitespace around comma-separated PROXY_SERVER_CORS_ORIGIN values", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_CORS_ORIGIN:
+        "https://app-a.example.com , https://app-b.example.com",
+    });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toStrictEqual([
+      "https://app-a.example.com",
+      "https://app-b.example.com",
+    ]);
+  });
+
+  it("defaults PROXY_SERVER_CORS_ORIGIN to undefined when not provided", () => {
+    const result = parseEnvironmentValues({});
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toBeUndefined();
+  });
+
+  it("treats empty PROXY_SERVER_CORS_ORIGIN as unset", () => {
+    const result = parseEnvironmentValues({ PROXY_SERVER_CORS_ORIGIN: "" });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toBeUndefined();
+  });
+
+  it("strips trailing slash from PROXY_SERVER_CORS_ORIGIN", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_CORS_ORIGIN: "https://my-app.example.com/",
+    });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toStrictEqual([
+      "https://my-app.example.com",
+    ]);
+  });
+
+  it("strips path from PROXY_SERVER_CORS_ORIGIN", () => {
+    const result = parseEnvironmentValues({
+      PROXY_SERVER_CORS_ORIGIN: "https://my-app.example.com/app",
+    });
+
+    expect(result.PROXY_SERVER_CORS_ORIGIN).toStrictEqual([
+      "https://my-app.example.com",
+    ]);
   });
 });

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -16,6 +16,23 @@ export const EnvironmentValuesSchema = z.object({
     .enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"])
     .default("debug"),
   LOG_STYLE: z.enum(["cloudwatch", "default"]).default("default"),
+  PROXY_SERVER_CORS_ORIGIN: z
+    .string()
+    .optional()
+    .transform(value => value || undefined)
+    .transform(value => value?.split(",").map(v => v.trim()))
+    .pipe(
+      z
+        .array(
+          z
+            .httpUrl({
+              message:
+                "Must be an HTTP or HTTPS URL (e.g. https://example.com)",
+            })
+            .transform(value => new URL(value).origin),
+        )
+        .optional(),
+    ),
 });
 
 export type EnvironmentValues = z.infer<typeof EnvironmentValuesSchema>;

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -54,6 +54,7 @@ const app = createApp({
   staticFilesVirtualPath,
   staticFilesPath,
   version: packageJson.version,
+  corsOrigin: env.PROXY_SERVER_CORS_ORIGIN,
 });
 
 // Store logger on app.locals for access in middleware and routes


### PR DESCRIPTION
## Description

Adds an optional `PROXY_SERVER_CORS_ORIGIN` environment variable that restricts which origins are allowed to make cross-origin requests to the proxy server. When not set, the existing behavior (all origins allowed) is preserved.

- Pass `corsOrigin` through to the `cors()` middleware, falling back to `origin: true` when unset
- Validate the env var with `z.httpUrl()` and normalize to a proper origin via `URL.origin`, stripping any trailing slash or path
- Support comma-separated values for multiple allowed origins (e.g. `https://a.example.com,https://b.example.com`)
- Add tests for matching origin, non-matching origin, multiple origins, and preflight behavior
- Add env var parsing tests for presence, absence, normalization, and validation failures
- Document the new variable in `docs/development.md` (env var reference)
- Document CORS configuration in `docs/references/security.md` (new CORS section)

## Validation

- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes
- Verified the `GRAPH_EXP` Vite `envPrefix` does not expose this variable to the client bundle

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.