### PR TITLE
Update dompurify to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "pnpm": {
     "overrides": {
       "brace-expansion@>=5.0.0 <5.0.5": ">=5.0.5",
-      "dompurify@>=3.1.3 <3.3.2": ">=3.3.2",
+      "dompurify@<=3.3.3": ">=3.4.0",
       "fast-xml-parser@<5.5.7": ">=5.5.7",
       "flatted@<3.4.2": ">=3.4.2",
       "minimatch@<10.2.3": ">=10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   brace-expansion@>=5.0.0 <5.0.5: '>=5.0.5'
-  dompurify@>=3.1.3 <3.3.2: '>=3.3.2'
+  dompurify@<=3.3.3: '>=3.4.0'
   fast-xml-parser@<5.5.7: '>=5.5.7'
   flatted@<3.4.2: '>=3.4.2'
   minimatch@<10.2.3: '>=10.2.3'
@@ -3434,9 +3434,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.3.2:
-    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
-    engines: {node: '>=20'}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -8929,7 +8928,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
-  dompurify@3.3.2:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9927,7 +9926,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.3.2
+      dompurify: 3.4.0
       marked: 14.0.0
 
   motion-dom@12.35.2:


### PR DESCRIPTION
## Description

- Update the `dompurify` pnpm override to resolve to `>=3.4.0`, bringing in the latest version of the dependency

## Validation

- `pnpm audit` reports no known vulnerabilities
- `pnpm run checks` passes (lint, format, types)

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.