### PR TITLE
Include connection ID in schema sync query key

### DIFF
--- a/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/edgeConnectionsQuery.ts
@@ -35,6 +35,7 @@ export function edgeConnectionsQuery(
   return queryOptions({
     queryKey: ["schema", "edgeConnections", sortedEdgeTypes],
     staleTime: Infinity,
+    retryOnMount: false,
     enabled: activeSchema != null && !activeSchema.lastEdgeConnectionSyncFail,
     initialData: activeSchema?.edgeConnections,
     queryFn: async ({ signal, meta, client }) => {
@@ -65,7 +66,8 @@ export function edgeConnectionsQuery(
 
         // Update the cached schema for the schema sync query
         const newSchema = store.get(activeSchemaAtom);
-        client.setQueryData(schemaSyncQueryKey, newSchema);
+        const connectionId = store.get(activeConfigurationAtom);
+        client.setQueryData(schemaSyncQueryKey(connectionId), newSchema);
 
         return results.edgeConnections;
       } catch (error) {

--- a/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
+++ b/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
@@ -51,7 +51,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     const result = await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     expect(result.vertices).toHaveLength(1);
@@ -72,7 +76,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     const activeConfigId = store.get(activeConfigurationAtom);
@@ -106,7 +114,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     // Verify old schema was replaced
@@ -119,11 +131,35 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     const result = await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     expect(result.vertices).toStrictEqual([]);
     expect(result.edges).toStrictEqual([]);
+  });
+
+  it("should be disabled when hasConnection is false", () => {
+    const options = schemaSyncQuery({
+      connectionId: store.get(activeConfigurationAtom),
+      activeSchema: undefined,
+      hasConnection: false,
+    });
+
+    expect(options.enabled).toBe(false);
+  });
+
+  it("should be disabled when lastSyncFail is true", () => {
+    const options = schemaSyncQuery({
+      connectionId: store.get(activeConfigurationAtom),
+      activeSchema: { vertices: [], edges: [], lastSyncFail: true },
+      hasConnection: true,
+    });
+
+    expect(options.enabled).toBe(false);
   });
 
   it("should set lastSyncFail when fetch fails", async () => {
@@ -138,7 +174,11 @@ describe("schemaSyncQuery", () => {
 
     await expect(
       queryClient.fetchQuery(
-        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+        schemaSyncQuery({
+          connectionId: store.get(activeConfigurationAtom),
+          activeSchema: undefined,
+          hasConnection: true,
+        }),
       ),
     ).rejects.toThrow("Network error");
 
@@ -162,7 +202,11 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
@@ -184,7 +228,11 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
@@ -215,7 +263,11 @@ describe("schemaSyncQuery", () => {
 
     await expect(
       queryClient.fetchQuery(
-        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+        schemaSyncQuery({
+          connectionId: store.get(activeConfigurationAtom),
+          activeSchema: undefined,
+          hasConnection: true,
+        }),
       ),
     ).rejects.toThrow("Network error");
 
@@ -243,7 +295,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     const activeConfigId = store.get(activeConfigurationAtom);
@@ -260,7 +316,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     expect(fetchSchemaSpy).toHaveBeenCalledWith(
@@ -292,7 +352,11 @@ describe("schemaSyncQuery", () => {
     });
 
     const queryPromise = queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     // Cancel the query
@@ -310,7 +374,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     const result = await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     expect(result.vertices.length).toBeGreaterThanOrEqual(2);
@@ -332,7 +400,11 @@ describe("schemaSyncQuery", () => {
     const queryClient = createQueryClient();
 
     const result = await queryClient.fetchQuery(
-      schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+      schemaSyncQuery({
+        connectionId: store.get(activeConfigurationAtom),
+        activeSchema: undefined,
+        hasConnection: true,
+      }),
     );
 
     expect(result.totalVertices).toBe(100);
@@ -363,7 +435,11 @@ describe("schemaSyncQuery", () => {
 
     await expect(
       queryClient.fetchQuery(
-        schemaSyncQuery({ activeSchema: undefined, hasConnection: true }),
+        schemaSyncQuery({
+          connectionId: store.get(activeConfigurationAtom),
+          activeSchema: undefined,
+          hasConnection: true,
+        }),
       ),
     ).rejects.toThrow("Network error");
 

--- a/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
+++ b/packages/graph-explorer/src/connector/queries/schemaSyncQuery.test.ts
@@ -42,6 +42,17 @@ describe("schemaSyncQuery", () => {
     store.set(explorerForTestingAtom, explorer);
   });
 
+  function defaultOptions(
+    overrides?: Partial<Parameters<typeof schemaSyncQuery>[0]>,
+  ) {
+    return schemaSyncQuery({
+      connectionId: store.get(activeConfigurationAtom),
+      activeSchema: undefined,
+      hasConnection: true,
+      ...overrides,
+    });
+  }
+
   it("should fetch schema and update the store", async () => {
     const vertex = createTestableVertex().with({
       types: [createVertexType("Person")],
@@ -50,13 +61,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    const result = await queryClient.fetchQuery(defaultOptions());
 
     expect(result.vertices).toHaveLength(1);
     expect(result.vertices[0].type).toBe("Person");
@@ -75,13 +80,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     const activeConfigId = store.get(activeConfigurationAtom);
     const storedSchema = store.get(schemaAtom).get(activeConfigId!);
@@ -113,13 +112,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     // Verify old schema was replaced
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
@@ -130,57 +123,36 @@ describe("schemaSyncQuery", () => {
   it("should return empty schema when no data exists", async () => {
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    const result = await queryClient.fetchQuery(defaultOptions());
 
     expect(result.vertices).toStrictEqual([]);
     expect(result.edges).toStrictEqual([]);
   });
 
   it("should be disabled when hasConnection is false", () => {
-    const options = schemaSyncQuery({
-      connectionId: store.get(activeConfigurationAtom),
-      activeSchema: undefined,
-      hasConnection: false,
-    });
+    const options = defaultOptions({ hasConnection: false });
 
     expect(options.enabled).toBe(false);
   });
 
   it("should be disabled when lastSyncFail is true", () => {
-    const options = schemaSyncQuery({
-      connectionId: store.get(activeConfigurationAtom),
+    const options = defaultOptions({
       activeSchema: { vertices: [], edges: [], lastSyncFail: true },
-      hasConnection: true,
     });
 
     expect(options.enabled).toBe(false);
   });
 
   it("should set lastSyncFail when fetch fails", async () => {
-    const fetchSchemaSpy = vi.spyOn(explorer, "fetchSchema");
-    fetchSchemaSpy.mockRejectedValue(new Error("Network error"));
+    vi.spyOn(explorer, "fetchSchema").mockRejectedValue(
+      new Error("Network error"),
+    );
 
     const queryClient = createQueryClient();
-    queryClient.setDefaultOptions({
-      ...queryClient.getDefaultOptions(),
-      queries: { ...queryClient.getDefaultOptions().queries, retry: false },
-    });
 
-    await expect(
-      queryClient.fetchQuery(
-        schemaSyncQuery({
-          connectionId: store.get(activeConfigurationAtom),
-          activeSchema: undefined,
-          hasConnection: true,
-        }),
-      ),
-    ).rejects.toThrow("Network error");
+    await expect(queryClient.fetchQuery(defaultOptions())).rejects.toThrow(
+      "Network error",
+    );
 
     const activeConfigId = store.get(activeConfigurationAtom);
     const storedSchema = store.get(schemaAtom).get(activeConfigId!);
@@ -201,13 +173,7 @@ describe("schemaSyncQuery", () => {
     });
 
     const queryClient = createQueryClient();
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
     expect(storedSchema?.edgeConnections).toBeUndefined();
@@ -227,13 +193,7 @@ describe("schemaSyncQuery", () => {
     });
 
     const queryClient = createQueryClient();
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
     expect(storedSchema?.lastSyncFail).toBe(false);
@@ -252,24 +212,15 @@ describe("schemaSyncQuery", () => {
       return updated;
     });
 
-    const fetchSchemaSpy = vi.spyOn(explorer, "fetchSchema");
-    fetchSchemaSpy.mockRejectedValue(new Error("Network error"));
+    vi.spyOn(explorer, "fetchSchema").mockRejectedValue(
+      new Error("Network error"),
+    );
 
     const queryClient = createQueryClient();
-    queryClient.setDefaultOptions({
-      ...queryClient.getDefaultOptions(),
-      queries: { ...queryClient.getDefaultOptions().queries, retry: false },
-    });
 
-    await expect(
-      queryClient.fetchQuery(
-        schemaSyncQuery({
-          connectionId: store.get(activeConfigurationAtom),
-          activeSchema: undefined,
-          hasConnection: true,
-        }),
-      ),
-    ).rejects.toThrow("Network error");
+    await expect(queryClient.fetchQuery(defaultOptions())).rejects.toThrow(
+      "Network error",
+    );
 
     // Verify existing data was preserved
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
@@ -294,13 +245,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     const activeConfigId = store.get(activeConfigurationAtom);
     const storedSchema = store.get(schemaAtom).get(activeConfigId!);
@@ -315,13 +260,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    await queryClient.fetchQuery(defaultOptions());
 
     expect(fetchSchemaSpy).toHaveBeenCalledWith(
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -346,18 +285,8 @@ describe("schemaSyncQuery", () => {
     );
 
     const queryClient = createQueryClient();
-    queryClient.setDefaultOptions({
-      ...queryClient.getDefaultOptions(),
-      queries: { ...queryClient.getDefaultOptions().queries, retry: false },
-    });
 
-    const queryPromise = queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    const queryPromise = queryClient.fetchQuery(defaultOptions());
 
     // Cancel the query
     await queryClient.cancelQueries({ queryKey: ["schema"] });
@@ -373,13 +302,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    const result = await queryClient.fetchQuery(defaultOptions());
 
     expect(result.vertices.length).toBeGreaterThanOrEqual(2);
     expect(result.totalVertices).toBe(2);
@@ -399,13 +322,7 @@ describe("schemaSyncQuery", () => {
 
     const queryClient = createQueryClient();
 
-    const result = await queryClient.fetchQuery(
-      schemaSyncQuery({
-        connectionId: store.get(activeConfigurationAtom),
-        activeSchema: undefined,
-        hasConnection: true,
-      }),
-    );
+    const result = await queryClient.fetchQuery(defaultOptions());
 
     expect(result.totalVertices).toBe(100);
     expect(result.totalEdges).toBe(50);
@@ -424,24 +341,15 @@ describe("schemaSyncQuery", () => {
       return updated;
     });
 
-    const fetchSchemaSpy = vi.spyOn(explorer, "fetchSchema");
-    fetchSchemaSpy.mockRejectedValue(new Error("Network error"));
+    vi.spyOn(explorer, "fetchSchema").mockRejectedValue(
+      new Error("Network error"),
+    );
 
     const queryClient = createQueryClient();
-    queryClient.setDefaultOptions({
-      ...queryClient.getDefaultOptions(),
-      queries: { ...queryClient.getDefaultOptions().queries, retry: false },
-    });
 
-    await expect(
-      queryClient.fetchQuery(
-        schemaSyncQuery({
-          connectionId: store.get(activeConfigurationAtom),
-          activeSchema: undefined,
-          hasConnection: true,
-        }),
-      ),
-    ).rejects.toThrow("Network error");
+    await expect(queryClient.fetchQuery(defaultOptions())).rejects.toThrow(
+      "Network error",
+    );
 
     const storedSchema = store.get(schemaAtom).get(activeConfigId);
     expect(storedSchema?.lastSyncFail).toBe(true);

--- a/packages/graph-explorer/src/connector/queries/schemaSyncQuery.ts
+++ b/packages/graph-explorer/src/connector/queries/schemaSyncQuery.ts
@@ -3,6 +3,7 @@ import { atom } from "jotai";
 
 import {
   activeConfigurationAtom,
+  type ConfigurationId,
   type PrefixTypeConfig,
   schemaAtom,
 } from "@/core";
@@ -18,7 +19,10 @@ import type { SchemaResponse } from "../useGEFetchTypes";
 
 import { getExplorer, getStore } from "./helpers";
 
-export const schemaSyncQueryKey = ["schema", "discovery"] as const;
+/** Returns the query key for the schema sync query for the given connection. */
+export function schemaSyncQueryKey(connectionId: ConfigurationId | null) {
+  return ["schema", "discovery", connectionId] as const;
+}
 
 /**
  * Fetches the schema from the given explorer and persists it to the local cache on success.
@@ -30,15 +34,18 @@ export const schemaSyncQueryKey = ["schema", "discovery"] as const;
  * a browser refresh and automatic retry is suppressed.
  */
 export function schemaSyncQuery({
+  connectionId,
   activeSchema,
   hasConnection,
 }: {
+  connectionId: ConfigurationId | null;
   activeSchema: SchemaStorageModel | undefined;
   hasConnection: boolean;
 }) {
   return queryOptions({
-    queryKey: schemaSyncQueryKey,
+    queryKey: schemaSyncQueryKey(connectionId),
     staleTime: Infinity,
+    retryOnMount: false,
     initialData: activeSchema,
     enabled: hasConnection && !activeSchema?.lastSyncFail,
     queryFn: async ({ signal, meta }) => {

--- a/packages/graph-explorer/src/hooks/useSchemaSync.test.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.test.ts
@@ -13,6 +13,7 @@ import {
 import { getAppStore } from "@/core/StateProvider/appStore";
 import {
   createRandomEdgeTypeConfig,
+  createRandomRawConfiguration,
   createRandomVertexTypeConfig,
   DbState,
   FakeExplorer,
@@ -20,7 +21,11 @@ import {
   renderHookWithState,
 } from "@/utils/testing";
 
-import { useSchemaSync } from "./useSchemaSync";
+import {
+  useCancelSchemaSync,
+  useIsSyncing,
+  useSchemaSync,
+} from "./useSchemaSync";
 
 describe("useSchemaSync", () => {
   let explorer: FakeExplorer;
@@ -402,6 +407,157 @@ describe("useSchemaSync", () => {
       });
 
       expect(fetchSchemaSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("remount behavior", () => {
+    it("should not auto-fetch when lastSyncFail is true after remount", () => {
+      // Simulate: sync failed, user navigated away, then came back.
+      // Start with lastSyncFail already set (as if a previous sync failed).
+      const state = new DbState(explorer);
+      state.activeSchema.lastSyncFail = true;
+
+      const fetchSchemaSpy = vi
+        .spyOn(explorer, "fetchSchema")
+        .mockRejectedValue(new Error("Network error"));
+
+      // First mount — sync should not fire due to lastSyncFail
+      const { unmount } = renderHookWithState(() => useSchemaSync(), state);
+      expect(fetchSchemaSpy).not.toHaveBeenCalled();
+
+      // User navigates away
+      unmount();
+
+      // User navigates back — re-render with same state
+      renderHookWithState(() => useSchemaSync(), state);
+
+      // Should still not auto-fetch because lastSyncFail is true
+      expect(fetchSchemaSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("connection switching", () => {
+    it("should fetch schema when switching to a connection with no schema", async () => {
+      const state = new DbState(explorer);
+      state.activeSchema.vertices = [createRandomVertexTypeConfig()];
+
+      const fetchSchemaSpy = vi.spyOn(explorer, "fetchSchema");
+
+      const { result, rerender } = renderHookWithState(
+        () => useSchemaSync(),
+        state,
+      );
+
+      // Should not fetch because initialData exists
+      expect(fetchSchemaSpy).not.toHaveBeenCalled();
+      expect(result.current.schemaDiscoveryQuery.data).toBeDefined();
+
+      // Switch to a new connection with no schema
+      const store = getAppStore();
+      const newConfig = createRandomRawConfiguration();
+      store.set(configurationAtom, prev => {
+        const updated = new Map(prev);
+        updated.set(newConfig.id, newConfig);
+        return updated;
+      });
+      store.set(activeConfigurationAtom, newConfig.id);
+
+      rerender();
+
+      await waitFor(() => {
+        expect(fetchSchemaSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("lastEdgeConnectionSyncFail", () => {
+    it("should not auto-fetch edge connections when lastEdgeConnectionSyncFail is true", () => {
+      const edgeType = createEdgeType("knows");
+      const state = createStateWithSchema([], [edgeType]);
+      state.activeSchema.lastEdgeConnectionSyncFail = true;
+      state.activeSchema.edgeConnections = undefined;
+
+      const fetchEdgeConnectionsSpy = vi.spyOn(
+        explorer,
+        "fetchEdgeConnections",
+      );
+
+      const { result } = renderHookWithState(() => useSchemaSync(), state);
+
+      expect(result.current.edgeDiscoveryQuery.fetchStatus).toBe("idle");
+      expect(fetchEdgeConnectionsSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useIsSyncing", () => {
+  let explorer: FakeExplorer;
+
+  beforeEach(() => {
+    explorer = new FakeExplorer();
+  });
+
+  it("should return false when no schema queries are running", () => {
+    const state = new DbState(explorer);
+
+    const { result } = renderHookWithState(() => useIsSyncing(), state);
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should return true when a schema query is fetching", () => {
+    const state = new DbState(explorer).withNoActiveSchema();
+
+    vi.spyOn(explorer, "fetchSchema").mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    // Both hooks must share the same query client to observe fetching state
+    const { result } = renderHookWithState(
+      () => ({ syncing: useIsSyncing(), schema: useSchemaSync() }),
+      state,
+    );
+
+    expect(result.current.syncing).toBe(true);
+  });
+});
+
+describe("useCancelSchemaSync", () => {
+  let explorer: FakeExplorer;
+
+  beforeEach(() => {
+    explorer = new FakeExplorer();
+  });
+
+  it("should return a function", () => {
+    const state = new DbState(explorer);
+
+    const { result } = renderHookWithState(() => useCancelSchemaSync(), state);
+
+    expect(typeof result.current).toBe("function");
+  });
+
+  it("should cancel in-flight schema queries", async () => {
+    const state = new DbState(explorer).withNoActiveSchema();
+
+    const fetchSchemaSpy = vi
+      .spyOn(explorer, "fetchSchema")
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHookWithState(
+      () => ({
+        cancel: useCancelSchemaSync(),
+        schema: useSchemaSync(),
+      }),
+      state,
+    );
+
+    // Schema fetch should have been triggered
+    expect(fetchSchemaSpy).toHaveBeenCalled();
+
+    // Cancel should not throw
+    await act(async () => {
+      await result.current.cancel();
     });
   });
 });

--- a/packages/graph-explorer/src/hooks/useSchemaSync.ts
+++ b/packages/graph-explorer/src/hooks/useSchemaSync.ts
@@ -1,7 +1,12 @@
 import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 
 import { edgeConnectionsQuery, schemaSyncQuery } from "@/connector";
-import { useConfiguration, useMaybeActiveSchema } from "@/core";
+import {
+  activeConfigurationAtom,
+  maybeActiveSchemaAtom,
+  useConfiguration,
+} from "@/core";
 import { logger } from "@/utils";
 
 /** Returns true if any schema sync query is running. Will not trigger the query to run. */
@@ -31,10 +36,19 @@ export function useCancelSchemaSync() {
  */
 export function useSchemaSync() {
   const config = useConfiguration();
-  const activeSchema = useMaybeActiveSchema();
+  // Read the atom directly instead of useMaybeActiveSchema() because that hook
+  // wraps the value in useDeferredValue, which delays the update by one render.
+  // The schema and connectionId must update in the same render so the query
+  // options stay consistent when switching connections.
+  const activeSchema = useAtomValue(maybeActiveSchemaAtom);
+  const connectionId = useAtomValue(activeConfigurationAtom);
 
   const schemaDiscoveryQuery = useQuery(
-    schemaSyncQuery({ activeSchema, hasConnection: config != null }),
+    schemaSyncQuery({
+      connectionId,
+      activeSchema,
+      hasConnection: config != null,
+    }),
   );
   const edgeDiscoveryQuery = useQuery(
     edgeConnectionsQuery(schemaDiscoveryQuery.data),


### PR DESCRIPTION
## Description

When switching to a connection with no cached schema, the schema sync did not automatically trigger. The `schemaSyncQuery` used a static query key (`["schema", "discovery"]`) that did not include the connection ID. Combined with `staleTime: Infinity`, TanStack Query did not recognize the connection switch as requiring a new fetch.

Additionally, failed schema syncs would retry automatically when the user navigated away and back, because TanStack Query's default `retryOnMount: true` retries errored queries when a new observer subscribes.

- Change `schemaSyncQueryKey` from a constant to a function that includes the active connection ID so each connection gets its own query cache entry
- Read `maybeActiveSchemaAtom` directly instead of `useMaybeActiveSchema()` to avoid `useDeferredValue` causing a one-render lag where the old schema poisons the new connection's query key
- Add `retryOnMount: false` to both schema and edge connection queries to prevent TanStack Query from retrying failed queries on component remount
- Add tests for connection switching and remount-after-failure scenarios

## Validation

- `pnpm run checks` passes
- `pnpm test` passes (1618/1618)
- New tests verify: switching to a connection with no schema triggers a fetch; remounting after a sync failure does not auto-retry

## Related Issues

- Fixes #1563

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.