### PR TITLE
Harden CI workflows with SHA pinning and version bumps

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -32,13 +36,12 @@ jobs:
 
       - name: Get image tag
         id: get-image-tag
+        env:
+          IS_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag == 'release' }}
+          VERSION: ${{ steps.package-version.outputs.version }}
         run: |
-          if ${{ github.event_name == 'workflow_dispatch' }} ; then
-            if ${{ inputs.image_tag == 'release'}}; then
-              echo "image_tag=${{ steps.package-version.outputs.version }}" >> $GITHUB_OUTPUT
-            else
-              echo "image_tag=latest-SNAPSHOT" >> $GITHUB_OUTPUT
-            fi
+          if [ "$IS_RELEASE" = "true" ]; then
+            echo "image_tag=$VERSION" >> $GITHUB_OUTPUT
           else
             echo "image_tag=latest-SNAPSHOT" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ECR }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ECR }}
@@ -58,7 +58,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2.1.3
         with:
           registry-type: public
 

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -24,13 +24,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Get package version
-        uses: tyankatsu0105/read-package-version-actions@v1
-        with:
-          path: "./"
         id: package-version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
 
       - name: Get image tag
         id: get-image-tag
@@ -46,7 +44,7 @@ jobs:
           fi
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ECR }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ECR }}
@@ -57,7 +55,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2
         with:
           registry-type: public
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -20,10 +20,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -31,7 +31,7 @@ jobs:
           output: trivy-fs-results.sarif
 
       - name: Upload Trivy filesystem results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: trivy-fs-results.sarif
           category: dependency-scan
@@ -43,17 +43,17 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Scan Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: public.ecr.aws/neptune/graph-explorer:latest-SNAPSHOT
           format: sarif
           output: trivy-image-results.sarif
 
       - name: Upload Trivy image results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: trivy-image-results.sarif
           category: docker-image-scan

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -31,7 +31,7 @@ jobs:
           output: trivy-fs-results.sarif
 
       - name: Upload Trivy filesystem results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-fs-results.sarif
           category: dependency-scan
@@ -56,7 +56,7 @@ jobs:
           output: trivy-image-results.sarif
 
       - name: Upload Trivy image results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-image-results.sarif
           category: docker-image-scan

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Pull latest image from ECR Public
-        run: docker pull public.ecr.aws/neptune/graph-explorer:latest-SNAPSHOT
-
       - name: Scan Docker image for vulnerabilities
         uses: aquasecurity/trivy-action@v0.35.0
         with:

--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Build Docker image
         run: |
@@ -23,7 +23,7 @@ jobs:
           docker build -t test-image-neptune --build-arg NEPTUNE_NOTEBOOK=true .
 
       - name: Scan Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: test-image
           severity: HIGH,CRITICAL

--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -18,22 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Review dependencies for vulnerabilities
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
 
   install-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version-file: "package.json"
 
@@ -47,6 +47,6 @@ jobs:
         run: pnpm coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: unittests

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Description

Pin all GitHub Actions to commit SHAs to avoid supply-chain issues, bump action versions, and add CI improvements.

- Pin all 9 actions to full commit SHAs with version comments for auditability
- Replace unmaintained `tyankatsu0105/read-package-version-actions` with inline `node -p`
- Refactor image tag logic in `build_docker.yml` to use `env` block instead of inline expressions
- Add concurrency groups to `build_docker.yml`, `test_build_docker.yml`, and `unit.yml`
- Remove unnecessary `docker pull` step in `security-audit.yml`
- Bump `actions/checkout` v4 → v5.0.1
- Bump `aws-actions/configure-aws-credentials` v4 → v5.1.1
- Bump `github/codeql-action` v3 → v4.35.2
- Bump `codecov/codecov-action` v5 → v6.0.0
- Bump `pnpm/action-setup` v4 → v5.0.0

## Validation

- All SHA pins verified against upstream tags via `git ls-remote`
- YAML structure reviewed for correctness
- No application code changes; only CI workflow files modified

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.