### PR TITLE
Scope Trivy scans to prevent duplicate security findings

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
+          vuln-type: library
           format: sarif
           output: trivy-fs-results.sarif
 
@@ -52,6 +53,7 @@ jobs:
         uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: public.ecr.aws/neptune/graph-explorer:latest-SNAPSHOT
+          vuln-type: os
           format: sarif
           output: trivy-image-results.sarif
 


### PR DESCRIPTION
## Description

The security-audit workflow's two Trivy scans (filesystem and Docker image) overlap on library/application vulnerabilities, causing duplicate entries in the GitHub Security tab.

This scopes each scan to a distinct surface area:
- **Filesystem scan**: `vuln-type: library` — only application/library vulnerabilities from lock files
- **Docker image scan**: `vuln-type: os` — only OS-level package vulnerabilities

Together they still cover the full vulnerability surface without overlap.

## Validation

- Verify the Security tab no longer shows duplicate findings after the next scheduled run
- Confirm both scan categories still report their respective vulnerability types

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.