### PR TITLE
Move EC2 setup to deployment guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Run Graph Explorer wherever it fits your workflow: as a Docker container, on an 
 There are many ways to deploy and run Graph Explorer. If you are new to graph databases and Graph Explorer, we recommend that you check out the [Getting Started](./docs/getting-started/README.md) guide.
 
 - [Local Docker Setup](./docs/getting-started/README.md#local-docker-setup) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
-- [Amazon EC2 Setup](./docs/getting-started/README.md#amazon-ec2-setup) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
+- [Amazon EC2 Setup](./docs/guides/deploy-to-ec2.md) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
 - [Local Development](./docs/getting-started/README.md#local-development-setup) - A quick start guide building the Docker image from source code.
 - [Troubleshooting](./docs/guides/troubleshooting.md) - A collection of helpful tips if you run in to issues while setting up Graph Explorer.
 - [Samples](./samples) - A collection of Docker Compose files that show various ways to configure and use Graph Explorer.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -77,60 +77,6 @@ Gremlin Server is an easy way to get started with graph databases. This example 
    - Using Proxy Server: `true`
    - Graph Connection URL: `http://localhost:8182`
 
-## Amazon EC2 Setup
-
-The following instructions detail how to deploy graph-explorer onto an Amazon EC2 instance and use it as a proxy server with SSH tunneling to connect to Amazon Neptune.
-
-<!-- prettier-ignore -->
-> [!NOTE]
-> 
-> This documentation is not an official recommendation on
-network setups as there are many ways to connect to Amazon Neptune from outside
-of the VPC, such as setting up a load balancer or VPC peering.
-
-### Prerequisites
-
-- Provision an Amazon EC2 instance that will be used to host the application and connect to Neptune as a proxy server. For more details, see instructions [here](https://github.com/aws/graph-notebook/tree/main/additional-databases/neptune).
-- Ensure the Amazon EC2 instance can send and receive on ports `22` (SSH), `8182` (Neptune), and `443` or `80` depending on protocol used (graph-explorer).
-
-### Steps
-
-These steps describe how to install Graph Explorer on your Amazon EC2 instance.
-
-1. Open an SSH client and connect to the EC2 instance.
-2. Download and install the necessary command line tools such as [Git](https://git-scm.com/downloads) and [Docker](https://docs.docker.com/get-docker/).
-3. Clone the repository
-   ```
-   git clone https://github.com/aws/graph-explorer.git
-   ```
-4. Navigate to the repository
-   ```
-   cd graph-explorer
-   ```
-5. Build the image
-   ```
-   docker build -t graph-explorer .
-   ```
-
-<!-- prettier-ignore -->
-> [!TIP]
->
-> If you receive an error relating to the docker service not running, run
-> `service docker start`.
-
-4. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance.
-   ```
-   docker run -p 80:80 -p 443:443 \
-    --env HOST={hostname-or-ip-address} \
-    graph-explorer
-   ```
-5. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
-   ```
-   https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
-   ```
-6. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](../guides/troubleshooting.md#https-connections) section.
-7. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.
-
 ## Local Development Setup
 
 You can build the Docker image locally by following the steps below.
@@ -167,6 +113,10 @@ You can build the Docker image locally by following the steps below.
    http://localhost/explorer
    ```
 
-## Troubleshooting
+## Next Steps
 
-If the instructions above do not work for you, please see the [Troubleshooting](../guides/troubleshooting.md) page for more information. It contains workarounds for common issues and information on how to diagnose other issues.
+- [Connecting to databases](../guides#connecting-to-databases) — Neptune, Gremlin Server, BlazeGraph
+- [Deployment guides](../guides#deployment) — EC2, ECS Fargate, SageMaker
+- [References](../references) — Security, logging, health checks, and configuration
+- [Development](../development.md) — Build from source for local development
+- [Troubleshooting](../guides/troubleshooting.md) — Common issues and workarounds

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ Guides for connecting to graph databases, deploying Graph Explorer, and troubles
 
 ## Deployment
 
+- [Deploy to Amazon EC2](./deploy-to-ec2.md)
 - [Deploy to ECS Fargate](./deploy-to-ecs-fargate.md)
 - [Deploy to SageMaker](./deploy-to-sagemaker.md)
 

--- a/docs/guides/deploy-to-ec2.md
+++ b/docs/guides/deploy-to-ec2.md
@@ -1,0 +1,51 @@
+# Deploy to Amazon EC2
+
+Deploy Graph Explorer onto an Amazon EC2 instance and use it as a proxy server with SSH tunneling to connect to Amazon Neptune.
+
+<!-- prettier-ignore -->
+> [!NOTE]
+>
+> This documentation is not an official recommendation on
+network setups as there are many ways to connect to Amazon Neptune from outside
+of the VPC, such as setting up a load balancer or VPC peering.
+
+## Prerequisites
+
+- Provision an Amazon EC2 instance that will be used to host the application and connect to Neptune as a proxy server. For more details, see instructions [here](https://github.com/aws/graph-notebook/tree/main/additional-databases/neptune).
+- Ensure the Amazon EC2 instance can send and receive on ports `22` (SSH), `8182` (Neptune), and `443` or `80` depending on protocol used (graph-explorer).
+
+## Steps
+
+1. Open an SSH client and connect to the EC2 instance.
+2. Download and install the necessary command line tools such as [Git](https://git-scm.com/downloads) and [Docker](https://docs.docker.com/get-docker/).
+3. Clone the repository
+   ```
+   git clone https://github.com/aws/graph-explorer.git
+   ```
+4. Navigate to the repository
+   ```
+   cd graph-explorer
+   ```
+5. Build the image
+   ```
+   docker build -t graph-explorer .
+   ```
+
+<!-- prettier-ignore -->
+> [!TIP]
+>
+> If you receive an error relating to the docker service not running, run
+> `service docker start`.
+
+6. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance.
+   ```
+   docker run -p 80:80 -p 443:443 \
+    --env HOST={hostname-or-ip-address} \
+    graph-explorer
+   ```
+7. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
+   ```
+   https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
+   ```
+8. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](./troubleshooting.md#https-connections) section.
+9. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.


### PR DESCRIPTION
## Description

Move the Amazon EC2 setup instructions from the getting started page to a new `docs/guides/deploy-to-ec2.md` file, alongside the existing ECS Fargate and SageMaker deployment guides.

- Create `docs/guides/deploy-to-ec2.md` with the EC2 content
- Remove the EC2 section from `docs/getting-started/README.md`
- Add EC2 link to `docs/guides/README.md`
- Update root README link to point to the new location
- Replace the standalone Troubleshooting section with a Next Steps section linking to guides, references, development, and troubleshooting
- Fix step numbering that restarted at 4 after the tip callout
- Tighten intro prose

## Validation

Documentation-only change. Verified all links resolve correctly.

## Related Issues

- Part of #1580
- Part of #1577

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.