### PR TITLE
Add Try It Out section and update intro for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Run Graph Explorer wherever it fits your workflow: as a Docker container, on an 
 
 There are many ways to deploy and run Graph Explorer. If you are new to graph databases and Graph Explorer, we recommend that you check out the [Getting Started](./docs/getting-started/README.md) guide.
 
+- [Try It Out](./docs/getting-started/README.md#try-it-out) - Launch Graph Explorer with sample data using Docker Compose.
 - [Local Docker Setup](./docs/getting-started/README.md#local-docker-setup) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
 - [Amazon EC2 Setup](./docs/getting-started/README.md#amazon-ec2-setup) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
 - [Local Development](./docs/getting-started/README.md#local-development-setup) - A quick start guide building the Docker image from source code.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,8 +1,29 @@
 # Getting Started
 
-This project contains the code needed to create a Docker image of the Graph Explorer. The image will create the Graph Explorer application and proxy server that will be served over the standard HTTP or HTTPS ports (HTTPS by default).
+Graph Explorer is distributed as a Docker image. The image includes the Graph Explorer web application and a proxy server that handles connections to your graph database.
 
-The proxy server will be created automatically, but will only be necessary if you are connecting to Neptune. Gremlin-Server and BlazeGraph can be connected to directly. Additionally, the image will create a self-signed certificate that can be optionally used.
+## Try It Out
+
+The fastest way to try Graph Explorer is with the [Air Routes sample](../../samples/air_routes/readme.md). It launches Graph Explorer and a Gremlin Server pre-loaded with sample data using Docker Compose — no database setup or AWS account required.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed on your machine
+
+### Steps
+
+1. Clone the repository
+   ```
+   git clone https://github.com/aws/graph-explorer.git
+   ```
+2. Navigate to the sample directory and start the containers
+   ```
+   cd graph-explorer/samples/air_routes
+   docker compose up
+   ```
+3. Open the browser and navigate to: [http://localhost:8080/explorer](http://localhost:8080/explorer)
+
+See the [samples directory](../../samples) for more examples.
 
 ## Examples
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,6 @@
 # Samples
 
-These samples are intended to show possible configuration of Graph Explorer using open source databases.
+These samples show possible configurations of Graph Explorer using open source databases. They are a great way to try Graph Explorer without needing to set up your own database. See the [Getting Started](../docs/getting-started/README.md) guide for more setup options.
 
 ## Air Routes with Gremlin Server
 


### PR DESCRIPTION
## Description

Make the getting started page more welcoming for new users by leading with the simplest possible path.

- Add a "Try It Out" section at the top pointing to the air routes Docker Compose sample — no database setup or AWS account required
- Rewrite the intro to be clearer and more direct
- Add a "Try It Out" link to the root README getting started list
- Update samples README with a backlink to getting started

## Validation

Documentation-only change. Verified all links resolve correctly.

## Related Issues

- Closes #1580
- Part of #1577

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.