### PR TITLE
Fix smart quotes and placeholder URLs in docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -216,14 +216,14 @@ Example: `5174`
 
 ### Using Self-signed certificates on Chrome
 
-For browsers like Safari and Firefox, [trusting the certificate from the browser](./references/security.md#https-connections) is enough to bypass the "Not Secure" warning. However, Chrome treats self-signed certificates differently. If you want to use a self-signed certificate on Chrome **without** the "Not Secure" warning and you do not have your own certificate, or one provided by Let’s Encrypt, you can use the following instructions to add the root certificate and remove the warning. These instructions assume you’re using an EC2 instance to run the Docker container for Graph Explorer.
+For browsers like Safari and Firefox, [trusting the certificate from the browser](./references/security.md#https-connections) is enough to bypass the "Not Secure" warning. However, Chrome treats self-signed certificates differently. If you want to use a self-signed certificate on Chrome **without** the "Not Secure" warning and you do not have your own certificate, or one provided by Let's Encrypt, you can use the following instructions to add the root certificate and remove the warning. These instructions assume you're using an EC2 instance to run the Docker container for Graph Explorer.
 
 1. After the Docker container is built and running, open a terminal prompt and SSH into your proxy server instance (e.g., EC2).
 2. Get the container ID by running `sudo docker ps`
 3. Copy the root certificate file (rootCA.crt) from the container to EC2: `sudo docker cp {container_id}:~/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt ~/rootCA.crt`
 4. Exit SSH session
 5. Copy the root certificate file from EC2 to your local machine (where you would run Graph Explorer on Chrome): `scp -i {path_to_pem_file} {EC2_login}:~/rootCA.crt {path_on_local_to_place_file}` For example, `scp -i /Users/user1/EC2.pem ec2-user@XXX.XXX.XXX.XXX:~/rootCA.crt /Users/user1/downloads`
-6. After copying the certificate from the container to your local machine’s file system, you can delete the rootCA.crt file from the EC2 file store with `rm -rf ~/rootCA.crt`
+6. After copying the certificate from the container to your local machine's file system, you can delete the rootCA.crt file from the EC2 file store with `rm -rf ~/rootCA.crt`
 7. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
 8. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
 9. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain "Not Secure" due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -57,14 +57,14 @@ You can bypass by manually ignoring them from the browser or downloading the cor
 
 The following instructions can be used as an example to bypass the warnings for Chrome, but note that different browsers and operating systems will have slightly different steps.
 
-1. Download the certificate directly from the browser. For example, if using Google Chrome, click the “Not Secure” section on the left of the URL bar and select “Certificate is not valid” to show the certificate. Then click Details tab and click Export at the bottom.
+1. Download the certificate directly from the browser. For example, if using Google Chrome, click the "Not Secure" section on the left of the URL bar and select "Certificate is not valid" to show the certificate. Then click Details tab and click Export at the bottom.
 2. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
 3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
-4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain “Not Secure” due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
+4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain "Not Secure" due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
 
 <!-- prettier-ignore -->
 > [!TIP]
-> To get rid of the “Not Secure” warning, see
+> To get rid of the "Not Secure" warning, see
 [Using self-signed certificates on Chrome](/docs/development.md#using-self-signed-certificates-on-chrome).
 
 ## Schema Sync Fails
@@ -128,18 +128,18 @@ This can manifest as different types of errors depending on the root cause. You 
 
 ## Backup Graph Explorer Data
 
-Inside of Graph Explorer there is an option to export all the configuration data that Graph Explorer uses. This data is local to the user’s browser and does not exist on the server.
+Inside of Graph Explorer there is an option to export all the configuration data that Graph Explorer uses. This data is local to the user's browser and does not exist on the server.
 
 To gather the config data:
 
 1. Launch Graph Explorer
 2. Navigate to the connections screen
-3. Press the “Settings” button in the navigation bar
-4. Select the “General” page within settings
-5. Press the “Save Configuration” button
+3. Press the "Settings" button in the navigation bar
+4. Select the "General" page within settings
+5. Press the "Save Configuration" button
 6. Choose where to save the exported file
 
-This backup can be restored using the “Load Configuration” button in the same settings page.
+This backup can be restored using the "Load Configuration" button in the same settings page.
 
 ## Gathering SageMaker Logs
 
@@ -149,19 +149,19 @@ To gather these logs:
 
 1. Open the AWS Console
 2. Navigate to the Neptune page
-3. Select “Notebook” from the sidebar
+3. Select "Notebook" from the sidebar
 4. Find the Notebook hosting Graph Explorer
 5. Open the details screen for that Notebook
-6. In the “Actions” menu, choose “View Details in SageMaker”
-7. Press the “View Logs” link in the SageMaker details screen under the field titled “Lifecycle configuration”
-8. Scroll down to the “Log Streams” panel in the CloudWatch details where you should find multiple log streams
+6. In the "Actions" menu, choose "View Details in SageMaker"
+7. Press the "View Logs" link in the SageMaker details screen under the field titled "Lifecycle configuration"
+8. Scroll down to the "Log Streams" panel in the CloudWatch details where you should find multiple log streams
 9. For each log stream related to Graph Explorer (LifecycleConfigOnStart.log, graph-explorer.log)
    1. Open the log stream
-   2. In the “Actions” menu, choose “Download search results (CSV)”
+   2. In the "Actions" menu, choose "Download search results (CSV)"
 
 ### Graph Explorer Log Stream Does Not Exist
 
-New Neptune Notebooks automatically apply the correct IAM permissions to write to CloudWatch. If your Notebook does not automatically create a graph-explorer.log in the CloudWatch Log Streams, then it is possible that the Neptune Notebook was created before those IAM permissions were added. You’ll need to add those permissions manually.
+New Neptune Notebooks automatically apply the correct IAM permissions to write to CloudWatch. If your Notebook does not automatically create a graph-explorer.log in the CloudWatch Log Streams, then it is possible that the Neptune Notebook was created before those IAM permissions were added. You'll need to add those permissions manually.
 
 Below are examples of which IAM permissions you need for Graph Explorer.
 

--- a/docs/references/default-connection.md
+++ b/docs/references/default-connection.md
@@ -30,7 +30,7 @@ First, create a `config.json` file containing values for the connection attribut
 ```js
 {
   "PUBLIC_OR_PROXY_ENDPOINT": "https://public-endpoint",
-  "GRAPH_CONNECTION_URL": "https://cluster-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182",
+  "GRAPH_CONNECTION_URL": "https://{your-cluster-id}.us-west-2.neptune.amazonaws.com:8182",
   "USING_PROXY_SERVER": true,
   "IAM": true,
   "SERVICE_TYPE": "neptune-db",
@@ -65,7 +65,7 @@ docker run -p 80:80 -p 443:443 \
  --env GRAPH_TYPE=gremlin \
  --env USING_PROXY_SERVER=true \
  --env IAM=false \
- --env GRAPH_CONNECTION_URL=https://cluster-cqmizgqgrsbf.us-west-2.neptune.amazonaws.com:8182 \
+ --env GRAPH_CONNECTION_URL=https://{your-cluster-id}.us-west-2.neptune.amazonaws.com:8182 \
  --env AWS_REGION=us-west-2 \
  --env SERVICE_TYPE=neptune-db \
  --env PROXY_SERVER_HTTPS_CONNECTION=true \


### PR DESCRIPTION
## Description

Mechanical cleanup of documentation text.

- Replace curly/smart quotes with straight quotes in `docs/guides/troubleshooting.md` and `docs/development.md`
- Replace real Neptune cluster URL (`cluster-cqmizgqgrsbf`) with placeholder `{your-cluster-id}` in `docs/references/default-connection.md`

## Validation

Documentation-only change. Verified no smart quotes remain via hexdump and no real cluster URLs remain via grep.

## Related Issues

- Part of #1581
- Part of #1577

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.