### PR TITLE
Clean up tsconfig structure across monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "pnpm": {
     "overrides": {
+      "semver@<7.0.0": ">=7.7.3",
       "brace-expansion@>=5.0.0 <5.0.5": ">=5.0.5",
       "dompurify@<=3.3.3": ">=3.4.0",
       "fast-xml-parser@<5.5.7": ">=5.5.7",

--- a/packages/graph-explorer-proxy-server/tsconfig.build.json
+++ b/packages/graph-explorer-proxy-server/tsconfig.build.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "types": ["node"],
     "outDir": "./dist",
-    "noEmit": false
+    "noEmit": false,
+    "sourceMap": true
   }
 }

--- a/packages/graph-explorer-proxy-server/tsconfig.json
+++ b/packages/graph-explorer-proxy-server/tsconfig.json
@@ -2,23 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    /* Modules */
-    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator"],
-    "module": "nodenext",
-    "target": "es2022",
-    "moduleResolution": "node16",
-    "esModuleInterop": true,
-
-    /* Type Resolution */
-    "types": ["node", "vitest/globals"],
-    "skipLibCheck": true,
-
-    /* Paths */
-    "baseUrl": "./src",
-    "rootDir": "./src",
-    "paths": {
-      "@/*": ["./*"],
-      "@shared/*": ["../../shared/src/*"]
-    }
+    "types": ["node", "vitest/globals"]
   }
 }

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -114,18 +114,6 @@
       "prettier --write"
     ]
   },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "msw": {
     "workerDirectory": "public"
   }

--- a/packages/graph-explorer/tsconfig.json
+++ b/packages/graph-explorer/tsconfig.json
@@ -2,15 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src", "vite.config.ts"],
   "compilerOptions": {
-    "noEmit": true,
-
     /* Modules */
     "module": "ESNext",
-    "target": "ESNext",
     "moduleResolution": "Bundler",
     "moduleDetection": "force",
     "isolatedModules": true,
     "allowImportingTsExtensions": true,
+
+    /* JSX */
+    "jsx": "react-jsx",
 
     /* Type Resolution */
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
@@ -20,11 +20,10 @@
       "@testing-library/jest-dom",
       "@types/wicg-file-system-access"
     ],
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"],
-      "@/types/*": ["./@types/*"],
-      "@shared/*": ["../../shared/src/*"]
+      "@/*": ["./src/*"],
+      "@/types/*": ["./src/@types/*"],
+      "@shared/*": ["../shared/src/*"]
     }
   }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "types": ["vitest/globals"],
-    "baseUrl": "./src"
+    "types": ["vitest/globals"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  semver@<7.0.0: '>=7.7.3'
   brace-expansion@>=5.0.0 <5.0.5: '>=5.0.5'
   dompurify@<=3.3.3: '>=3.4.0'
   fast-xml-parser@<5.5.7: '>=5.5.7'
@@ -4846,10 +4847,6 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
@@ -5821,7 +5818,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5843,7 +5840,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.3
 
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -5854,7 +5851,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5863,7 +5860,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
-      semver: 6.3.1
+      semver: 7.7.3
 
   '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0)':
     dependencies:
@@ -6465,7 +6462,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
       core-js-compat: 3.48.0
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8589,7 +8586,7 @@ snapshots:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
-      semver: 6.3.1
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9148,7 +9145,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.5
-      semver: 6.3.1
+      semver: 7.7.3
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -10486,8 +10483,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   secure-json-parse@4.1.0: {}
-
-  semver@6.3.1: {}
 
   semver@7.7.3: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,23 +7,17 @@
     "verbatimModuleSyntax": true,
 
     /* Emit */
-    "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
+    "noEmit": true,
     "skipLibCheck": true,
 
     /* Linting */
     "strict": true,
-    "strictNullChecks": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "noImplicitOverride": true,
-    "noImplicitAny": true,
-    "forceConsistentCasingInFileNames": true,
-    "checkJs": true,
-    "jsx": "react-jsx"
+    "forceConsistentCasingInFileNames": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true,
-    "checkJs": false
+    "allowJs": true
   },
   "files": ["vitest.config.ts", "eslint.config.mjs"]
 }


### PR DESCRIPTION
## Description

Simplifies and consolidates TypeScript configuration across the monorepo. The base config now provides sensible defaults so package-level configs only override what differs.

- Move `module`, `target`, and `noEmit` to the base config so packages inherit common defaults
- Remove redundant strict flags (`strictNullChecks`, `noImplicitAny`) already covered by `strict: true`
- Scope `jsx: react-jsx` to graph-explorer, the only package that uses JSX
- Remove unused `baseUrl`, `rootDir`, path aliases, `esModuleInterop`, `moduleResolution`, `skipLibCheck`, and `checkJs` from package configs
- Make path aliases explicit by removing `baseUrl` and using paths relative to the tsconfig
- Add `sourceMap: true` to the proxy server build config for production stack traces
- Remove unused `browserslist` from graph-explorer package.json (Vite does not use it)
- Add semver override to update transitive semver dependencies to latest version

## Validation

- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes (1618 tests)
- Proxy server build produces JS + source maps correctly

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.