### PR TITLE
Consolidate certificate trust instructions into security reference

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -236,17 +236,7 @@ Example: `5174`
 
 ### Using Self-signed certificates on Chrome
 
-For browsers like Safari and Firefox, [trusting the certificate from the browser](./references/security.md#https-connections) is enough to bypass the "Not Secure" warning. However, Chrome treats self-signed certificates differently. If you want to use a self-signed certificate on Chrome **without** the "Not Secure" warning and you do not have your own certificate, or one provided by Let's Encrypt, you can use the following instructions to add the root certificate and remove the warning. These instructions assume you're using an EC2 instance to run the Docker container for Graph Explorer.
-
-1. After the Docker container is built and running, open a terminal prompt and SSH into your proxy server instance (e.g., EC2).
-2. Get the container ID by running `sudo docker ps`
-3. Copy the root certificate file (rootCA.crt) from the container to EC2: `sudo docker cp {container_id}:~/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt ~/rootCA.crt`
-4. Exit SSH session
-5. Copy the root certificate file from EC2 to your local machine (where you would run Graph Explorer on Chrome): `scp -i {path_to_pem_file} {EC2_login}:~/rootCA.crt {path_on_local_to_place_file}` For example, `scp -i /Users/user1/EC2.pem ec2-user@XXX.XXX.XXX.XXX:~/rootCA.crt /Users/user1/downloads`
-6. After copying the certificate from the container to your local machine's file system, you can delete the rootCA.crt file from the EC2 file store with `rm -rf ~/rootCA.crt`
-7. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
-8. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
-9. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain "Not Secure" due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
+See [Removing the "Not Secure" warning on Chrome](./references/security.md#removing-the-not-secure-warning-on-chrome) in the security reference.
 
 ### Troubleshooting
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -53,21 +53,9 @@ docker run -p 80:80 \
 
 ### HTTPS Connections
 
-If either of the Graph Explorer or the proxy-server are served over an HTTPS connection (which it is by default), you will have to bypass the warning message from the browser due to the included certificate being a self-signed certificate.
+If either Graph Explorer or the proxy server are served over an HTTPS connection (which is the default), your browser will show a security warning due to the self-signed certificate.
 
-You can bypass by manually ignoring them from the browser or downloading the correct certificate and configuring them to be trusted. Alternatively, you can provide your own certificate.
-
-The following instructions can be used as an example to bypass the warnings for Chrome, but note that different browsers and operating systems will have slightly different steps.
-
-1. Download the certificate directly from the browser. For example, if using Google Chrome, click the "Not Secure" section on the left of the URL bar and select "Certificate is not valid" to show the certificate. Then click Details tab and click Export at the bottom.
-2. Once you have the certificate, you will need to trust it on your machine. For MacOS, you can open the Keychain Access app. Select System under System Keychains. Then go to File > Import Items... and import the certificate you downloaded in the previous step.
-3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
-4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain "Not Secure" due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
-
-<!-- prettier-ignore -->
-> [!TIP]
-> To get rid of the "Not Secure" warning, see
-[Using self-signed certificates on Chrome](../development.md#using-self-signed-certificates-on-chrome).
+See [Trusting the self-signed certificate](../references/security.md#trusting-the-self-signed-certificate) for step-by-step instructions, or [Removing the "Not Secure" warning on Chrome](../references/security.md#removing-the-not-secure-warning-on-chrome) for Chrome-specific instructions.
 
 ## Schema Sync Fails
 

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -58,10 +58,18 @@ When using the default self-signed certificate, your browser will show a securit
 3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
 4. You should now refresh the browser and see that you can proceed to open the application. For Chrome, the application will remain "Not Secure" due to the fact that this is a self-signed certificate. If you have trouble accessing Graph Explorer after completing the previous step and reloading the browser, consider running a docker restart command and refreshing the browser again.
 
-<!-- prettier-ignore -->
-> [!TIP] 
-> 
-> To get rid of the "Not Secure" warning, see [Using self-signed certificates on Chrome](../development.md#using-self-signed-certificates-on-chrome).
+### Removing the "Not Secure" warning on Chrome
+
+For browsers like Safari and Firefox, trusting the certificate from the browser (steps above) is enough to bypass the "Not Secure" warning. However, Chrome treats self-signed certificates differently. To remove the warning on Chrome, you need to trust the **root CA certificate** rather than the server certificate. See the [Chrome Root Store FAQ](https://chromium.googlesource.com/chromium/src/+/main/net/data/ssl/chrome_root_store/faq.md#how-does-the-chrome-certificate-verifier-integrate-with-platform-trust-stores-for-local-trust-decisions) for details on how Chrome integrates with platform trust stores.
+
+1. Copy the root certificate from the running container to your local machine:
+   ```
+   docker cp graph-explorer:/graph-explorer/packages/graph-explorer-proxy-server/cert-info/rootCA.crt ./rootCA.crt
+   ```
+   If Graph Explorer is running on a remote host (e.g., EC2), copy the file to the remote host first, then use `scp` to transfer it to your local machine.
+2. Trust the root certificate on your machine. For macOS, open the Keychain Access app, select System under System Keychains, then go to File > Import Items... and import `rootCA.crt`.
+3. Once imported, select the certificate and right-click to select "Get Info". Expand the Trust section, and change the value of "When using this certificate" to "Always Trust".
+4. Refresh the browser. The "Not Secure" warning should be gone.
 
 ## CORS
 


### PR DESCRIPTION
## Description

Certificate trust instructions were duplicated in three places with risk of drift. This consolidates them:

- **`references/security.md`** is now the canonical location with the full trust steps plus a new Chrome-specific section for trusting the root CA certificate
- **`guides/troubleshooting.md`** now links to security.md instead of duplicating the 4-step instructions
- **`development.md`** now links to security.md instead of duplicating the 9-step Chrome instructions

The Chrome rootCA extraction steps from development.md were simplified (using `docker cp` directly instead of SSH/SCP through EC2) and merged into security.md.

## Validation

All internal links verified. No functional changes.

## Related Issues

- Fixes #1695

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.