### PR TITLE
Add navigation back-links to all documentation leaf pages

### DIFF
--- a/docs/guides/connecting-to-blazegraph.md
+++ b/docs/guides/connecting-to-blazegraph.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Connecting to BlazeGraph
 
 - Build and run the Docker container as normal and connect Graph Explorer to BlazeGraph through the proxy server.

--- a/docs/guides/connecting-to-gremlin-server.md
+++ b/docs/guides/connecting-to-gremlin-server.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Connecting to Gremlin-Server
 
 If you are using the default Gremlin Server docker image, you can get the server running with the following commands:

--- a/docs/guides/connecting-to-neptune.md
+++ b/docs/guides/connecting-to-neptune.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Connecting to Neptune
 
 - Ensure that Graph Explorer has access to the Neptune instance by being in the same VPC or VPC peering.

--- a/docs/guides/deploy-to-ec2.md
+++ b/docs/guides/deploy-to-ec2.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Deploy to Amazon EC2
 
 Deploy Graph Explorer onto an Amazon EC2 instance and use it as a proxy server with SSH tunneling to connect to Amazon Neptune.

--- a/docs/guides/deploy-to-ecs-fargate.md
+++ b/docs/guides/deploy-to-ecs-fargate.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Running Graph Explorer on AWS Fargate + Amazon ECS
 
 The following steps will allow you set up Graph Explorer on AWS Fargate in Amazon ECS, and connect to a running Neptune database.

--- a/docs/guides/deploy-to-sagemaker.md
+++ b/docs/guides/deploy-to-sagemaker.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Launching Graph Explorer using Amazon SageMaker
 
 Graph Explorer can be hosted and launched on Amazon SageMaker Notebooks via a lifecycle configuration script. To learn more about lifecycle configurations and how to create one, see the [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-lifecycle-config.html).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,3 +1,5 @@
+[← Guides](./)
+
 # Troubleshooting
 
 This page contains workarounds for common issues and information on how to diagnose other issues.

--- a/docs/references/default-connection.md
+++ b/docs/references/default-connection.md
@@ -1,3 +1,5 @@
+[← References](./)
+
 # Providing a Default Connection
 
 To provide a default connection such that initial loads of Graph Explorer always result with the same starting connection, modify the `docker run ...` command to either take in a JSON configuration or runtime environment variables. If you provide both a JSON configuration and environmental variables, the JSON will be prioritized.

--- a/docs/references/health-check.md
+++ b/docs/references/health-check.md
@@ -1,3 +1,5 @@
+[← References](./)
+
 # Health Check Status
 
 The `graph-explorer-proxy-server` provides a `/status` endpoint for monitoring its health and readiness. This endpoint is crucial for ensuring reliable service operation and can be utilized in various deployment scenarios.

--- a/docs/references/logging.md
+++ b/docs/references/logging.md
@@ -1,3 +1,5 @@
+[← References](./)
+
 # Logging
 
 Logs are, by default, sent to the console and will be visible as output to the docker logs. If you want to access the full set of logs, you can run `docker logs {container name or id}`.

--- a/docs/references/minimum-requirements.md
+++ b/docs/references/minimum-requirements.md
@@ -1,3 +1,5 @@
+[← References](./)
+
 # Minimum Requirements
 
 Graph Explorer does not block any particular versions of graph databases, but the queries used may or may not succeed based on the version of the query engine.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -1,3 +1,5 @@
+[← References](./)
+
 # Security
 
 You can use Graph Explorer to connect to a publicly accessible graph database endpoint, or connect to a proxy endpoint that redirects to a private graph database endpoint.


### PR DESCRIPTION
## Description

Added "← Back to [Section]" links at the top of every leaf page in `docs/guides/` (7 pages) and `docs/references/` (5 pages). This helps users who land on a leaf page from a search engine discover sibling pages and navigate the docs structure.

## Validation

All links verified by inspection. No content changes.

## Related Issues

- Fixes #1696

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.