### PR TITLE
Fix outdated instructions and align terminology with UI

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -25,6 +25,8 @@ Otherwise, use whatever method you use to install [Node v24.13.0](https://nodejs
 corepack enable
 ```
 
+If `corepack` is not found, install it first with `npm install -g corepack@latest`.
+
 ### Supported Graph Data Models and Query Languages
 
 - Labelled Property Graph (PG) using Gremlin or openCypher
@@ -155,7 +157,7 @@ Example: `/explorer`
 
 #### `HOST`
 
-The public hostname of the server. This is used to generate the SSL certificate during the Docker build.
+The public hostname of the server. This is used to generate the self-signed SSL certificate at container startup.
 
 Example: `localhost`
 
@@ -204,6 +206,16 @@ Example: `https://my-app.example.com` or `https://app-a.example.com,https://app-
 - Optional
 - Default: all origins allowed
 - Type: `string` (comma-separated for multiple origins)
+
+#### `LOG_STYLE`
+
+Controls the log output format.
+
+- Optional
+- Default: `default`
+- Type: `"cloudwatch" | "default"`
+- `cloudwatch` omits timestamps and hostname/pid (these are provided by CloudWatch)
+- `default` uses the standard log format
 
 #### `CONFIGURATION_FOLDER_PATH`
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -40,11 +40,11 @@ The quickest way to get started with Graph Explorer is to use the official Docke
 #### Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed on your machine
-- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed on your machine
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed on your machine
 
 #### Steps
 
-1. Authenticate with the Amazon ECR Public Registry. [More information](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
+1. Authenticate with the [Amazon ECR Public Registry](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
 
    ```
    aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws

--- a/docs/guides/deploy-to-ec2.md
+++ b/docs/guides/deploy-to-ec2.md
@@ -15,22 +15,19 @@ of the VPC, such as setting up a load balancer or VPC peering.
 
 - Provision an Amazon EC2 instance that will be used to host the application and connect to Neptune as a proxy server. For more details, see instructions [here](https://github.com/aws/graph-notebook/tree/main/additional-databases/neptune).
 - Ensure the Amazon EC2 instance can send and receive on ports `22` (SSH), `8182` (Neptune), and `443` or `80` depending on protocol used (graph-explorer).
+- [Docker](https://docs.docker.com/get-docker/) installed on the EC2 instance
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed on the EC2 instance
 
 ## Steps
 
-1. Open an SSH client and connect to the EC2 instance.
-2. Download and install the necessary command line tools such as [Git](https://git-scm.com/downloads) and [Docker](https://docs.docker.com/get-docker/).
-3. Clone the repository
+1. Open an SSH client and connect to the EC2 instance
+2. Authenticate with the [Amazon ECR Public Registry](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
    ```
-   git clone https://github.com/aws/graph-explorer.git
+   aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
    ```
-4. Navigate to the repository
+3. Pull the Docker image
    ```
-   cd graph-explorer
-   ```
-5. Build the image
-   ```
-   docker build -t graph-explorer .
+   docker pull public.ecr.aws/neptune/graph-explorer
    ```
 
 <!-- prettier-ignore -->
@@ -39,15 +36,15 @@ of the VPC, such as setting up a load balancer or VPC peering.
 > If you receive an error relating to the docker service not running, run
 > `service docker start`.
 
-6. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance.
+4. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance
    ```
    docker run -p 80:80 -p 443:443 \
     --env HOST={hostname-or-ip-address} \
-    graph-explorer
+    public.ecr.aws/neptune/graph-explorer
    ```
-7. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
+5. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
    ```
    https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
    ```
-8. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](./troubleshooting.md#https-connections) section.
-9. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.
+6. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](./troubleshooting.md#https-connections) section.
+7. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -6,7 +6,7 @@ This page contains workarounds for common issues and information on how to diagn
 
 - [Docker Container Issues](#docker-container-issues)
 - [Schema Sync Fails](#schema-sync-fails)
-- [Backup Graph Explorer Data](#backup-graph-explorer-data)
+- [Save & Load Configuration](#save--load-configuration)
 - [Gathering SageMaker Logs](#gathering-sagemaker-logs)
 
 ## Docker Container Issues
@@ -116,20 +116,20 @@ This can manifest as different types of errors depending on the root cause. You 
 > [!IMPORTANT]  
 > The paths listed here could always change in the future. If they do change, we will note that in the release notes.
 
-## Backup Graph Explorer Data
+## Save & Load Configuration
 
-Inside of Graph Explorer there is an option to export all the configuration data that Graph Explorer uses. This data is local to the user's browser and does not exist on the server.
+Inside of Graph Explorer there is an option to save all the configuration data that Graph Explorer uses. This data is local to the user's browser and does not exist on the server.
 
-To gather the config data:
+To save the configuration data:
 
 1. Launch Graph Explorer
 2. Navigate to the connections screen
 3. Press the "Settings" button in the navigation bar
 4. Select the "General" page within settings
 5. Press the "Save Configuration" button
-6. Choose where to save the exported file
+6. Choose where to save the configuration file
 
-This backup can be restored using the "Load Configuration" button in the same settings page.
+This configuration can be restored using the "Load Configuration" button in the same settings page.
 
 ## Gathering SageMaker Logs
 


### PR DESCRIPTION
## Description

- **EC2 deploy guide**: Replace build-from-source instructions with pre-built ECR image. Users deploying to EC2 shouldn't need to clone the repo and build — the ECR image is the recommended approach and matches the getting-started guide.
- **HOST env var**: Fix description from "during the Docker build" to "at container startup" — the SSL cert is generated at runtime by the entrypoint script, not during `docker build`.
- **Add LOG_STYLE env var**: Document the undocumented `LOG_STYLE` environment variable (`"cloudwatch" | "default"`) used by the proxy server.
- **Corepack**: Add fallback note for environments where corepack isn't bundled with Node.
- **Save & Load terminology**: Rename "Backup Graph Explorer Data" section in troubleshooting to "Save & Load Configuration" to match the UI button labels.

## Validation

- Verified HOST behavior against `docker-entrypoint.sh` and `setup-ssl.sh`
- Verified LOG_STYLE values against `packages/graph-explorer-proxy-server/src/env.ts`
- Verified Save/Load button labels against `docs/features/settings.md`

## Related Issues

- Part of #1166

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.