### PR TITLE
Replace Codecov with Vitest built-in coverage thresholds

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -49,8 +49,3 @@ jobs:
 
       - name: Run package tests with code coverage
         run: pnpm coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          flags: unittests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@
 # All checks (lint, format, types)
 pnpm run checks
 
-# All tests
-pnpm test
+# All tests with coverage threshold enforcement
+pnpm coverage
 
 # Single test file
 pnpm test packages/graph-explorer/src/path/to/file.test.ts

--- a/packages/graph-explorer-proxy-server/vitest.config.ts
+++ b/packages/graph-explorer-proxy-server/vitest.config.ts
@@ -8,10 +8,5 @@ export default defineConfig({
     unstubEnvs: true,
     unstubGlobals: true,
     setupFiles: ["src/test-setup.ts"],
-    coverage: {
-      reportsDirectory: "coverage",
-      provider: "v8",
-      reporter: ["lcov", "text", "json", "clover"],
-    },
   },
 });

--- a/packages/graph-explorer/vite.config.ts
+++ b/packages/graph-explorer/vite.config.ts
@@ -70,9 +70,6 @@ export default defineConfig(({ mode }) => {
       globals: true,
       setupFiles: ["src/setupTests.ts"],
       coverage: {
-        reportsDirectory: "coverage",
-        provider: "v8",
-        reporter: ["lcov", "text", "json", "clover"],
         exclude: [
           "src/components/icons",
           "src/@types",

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -4,10 +4,5 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    coverage: {
-      reportsDirectory: "coverage",
-      provider: "v8",
-      reporter: ["lcov", "text", "json", "clover"],
-    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     projects: ["packages/*"],
+    coverage: {
+      thresholds: {
+        autoUpdate: (newThreshold: number) => Math.floor(newThreshold),
+        statements: 63,
+        branches: 43,
+        functions: 64,
+        lines: 72,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Description

Replace the broken Codecov integration with Vitest's native coverage thresholds. The Codecov upload has been silently failing since December 2025 when `codecov-action` was upgraded from v3 to v5 without the required `token` parameter, leaving the base report 142 commits behind.

- Add coverage thresholds to root `vitest.config.ts` based on current levels (statements 63%, branches 43%, functions 64%, lines 72%)
- Enable `autoUpdate` with `Math.floor` so thresholds ratchet up automatically as coverage improves
- Remove the broken Codecov upload step from the CI workflow
- Update `AGENTS.md` to use `pnpm coverage` instead of `pnpm test`

## Validation

- `pnpm coverage` passes with the new thresholds
- Verified thresholds fail (exit code 1) when set above current coverage
- `autoUpdate` only raises thresholds, never lowers them
- `pnpm checks` passes

## Related Issues

- Fixes #1704

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.