### PR TITLE
Add diagnostic logging user setting

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -58,6 +58,7 @@ const [
   allowLoggingDbQueryAtom,
   defaultNeighborExpansionLimitEnabledAtom,
   defaultNeighborExpansionLimitAtom,
+  diagnosticLoggingAtom,
 ] = await Promise.all([
   atomWithLocalForage<ConfigurationId | null>("active-configuration", null),
   atomWithLocalForage<Map<ConfigurationId, RawConfiguration>>(
@@ -78,12 +79,14 @@ const [
    */
   /** Shows debug actions in various places around the app. */
   atomWithLocalForage<boolean>("showDebugActions", false),
-  /** Shows debug actions in various places around the app. */
+  /** Enables logging of generated database queries on the proxy server. */
   atomWithLocalForage<boolean>("allowLoggingDbQuery", false),
   /** Setting that enables/disables the default limit for neighbor expansion. */
   atomWithLocalForage<boolean>("defaultNeighborExpansionLimitEnabled", true),
   /** Setting that defines the default limit for neighbor expansion. */
   atomWithLocalForage<number>("defaultNeighborExpansionLimit", 10),
+  /** Enables verbose diagnostic logging to the browser console. */
+  atomWithLocalForage<boolean>("diagnosticLogging", false),
 ]);
 
 export {
@@ -97,4 +100,5 @@ export {
   allowLoggingDbQueryAtom,
   defaultNeighborExpansionLimitEnabledAtom,
   defaultNeighborExpansionLimitAtom,
+  diagnosticLoggingAtom,
 };

--- a/packages/graph-explorer/src/routes/DefaultLayout.tsx
+++ b/packages/graph-explorer/src/routes/DefaultLayout.tsx
@@ -1,21 +1,36 @@
 import { QueryClientProvider } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router";
 
 import { TooltipProvider } from "@/components";
 import { Toaster } from "@/components/Toaster";
+import { diagnosticLoggingAtom } from "@/core";
 import AppErrorPage from "@/core/AppErrorPage";
 import AppStatusLoader from "@/core/AppStatusLoader";
+import { setDiagnosticLogging } from "@/utils/logger";
 
 import { createQueryClient } from "../core/queryClient";
 
 const queryClient = createQueryClient();
+
+/** Bridges the diagnosticLogging Jotai atom to the logger's module-level flag. */
+function useSyncDiagnosticLogging() {
+  const enabled = useAtomValue(diagnosticLoggingAtom);
+  useEffect(() => {
+    setDiagnosticLogging(enabled);
+    return () => setDiagnosticLogging(false);
+  }, [enabled]);
+}
 
 /**
  * The default layout for the app, which sets up the query client, a global
  * error boundary, and other app wide services.
  */
 export default function DefaultLayout() {
+  useSyncDiagnosticLogging();
+
   return (
     <ErrorBoundary FallbackComponent={AppErrorPage}>
       <QueryClientProvider client={queryClient}>

--- a/packages/graph-explorer/src/routes/Settings/SettingsGeneral.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SettingsGeneral.tsx
@@ -21,6 +21,7 @@ import {
   allowLoggingDbQueryAtom,
   defaultNeighborExpansionLimitAtom,
   defaultNeighborExpansionLimitEnabledAtom,
+  diagnosticLoggingAtom,
   showDebugActionsAtom,
 } from "@/core";
 import { saveLocalForageToFile } from "@/core/StateProvider/localDb";
@@ -33,6 +34,10 @@ export default function SettingsGeneral() {
 
   const [allowLoggingDbQuery, setAllowLoggingDbQuery] = useAtom(
     allowLoggingDbQueryAtom,
+  );
+
+  const [diagnosticLogging, setDiagnosticLogging] = useAtom(
+    diagnosticLoggingAtom,
   );
 
   const [defaultNeighborExpansionLimit, setDefaultNeighborExpansionLimit] =
@@ -105,6 +110,17 @@ export default function SettingsGeneral() {
             with the data within the configuration file.
           </p>
         </ImportantBlock>
+
+        <ToggleSetting
+          id="isDiagnosticLoggingEnabled"
+          value="isDiagnosticLoggingEnabled"
+          checked={diagnosticLogging}
+          onCheckedChange={isSelected => {
+            setDiagnosticLogging(Boolean(isSelected));
+          }}
+          label="Diagnostic logging"
+          description="Enables verbose logging to the browser console for troubleshooting."
+        />
 
         <ToggleSetting
           id="isLoggingDbQueryEnabled"

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -103,6 +103,7 @@ vi.mock("@/utils/logger", () => ({
     info: vi.fn(),
     warn: vi.fn(),
   },
+  setDiagnosticLogging: vi.fn(),
 }));
 
 // Mock Monaco editor to prevent script injection errors in tests

--- a/packages/graph-explorer/src/utils/logger.test.ts
+++ b/packages/graph-explorer/src/utils/logger.test.ts
@@ -1,0 +1,114 @@
+/* eslint-disable no-console */
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Unmock logger so we test the real implementation
+vi.unmock("@/utils/logger");
+
+describe("logger", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("in production mode", () => {
+    beforeEach(() => {
+      vi.doMock("./env", () => ({
+        env: { DEV: false, PROD: true },
+      }));
+    });
+
+    test("should suppress debug and log calls", async () => {
+      const { default: logger } = await import("./logger");
+
+      logger.debug("test debug");
+      logger.log("test log");
+
+      expect(console.debug).not.toHaveBeenCalled();
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    test("should allow warn and error calls", async () => {
+      const { default: logger } = await import("./logger");
+
+      logger.warn("test warn");
+      logger.error("test error");
+
+      expect(console.warn).toHaveBeenCalledWith("test warn");
+      expect(console.error).toHaveBeenCalledWith("test error");
+    });
+
+    test("should enable debug and log when diagnostic logging is on", async () => {
+      const { default: logger, setDiagnosticLogging } =
+        await import("./logger");
+
+      setDiagnosticLogging(true);
+
+      logger.debug("test debug");
+      logger.log("test log");
+
+      expect(console.debug).toHaveBeenCalledWith("test debug");
+      expect(console.log).toHaveBeenCalledWith("test log");
+    });
+
+    test("should suppress debug and log again when diagnostic logging is turned off", async () => {
+      const { default: logger, setDiagnosticLogging } =
+        await import("./logger");
+
+      setDiagnosticLogging(true);
+      setDiagnosticLogging(false);
+
+      logger.debug("test debug");
+      logger.log("test log");
+
+      expect(console.debug).not.toHaveBeenCalled();
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    test("should forward multiple arguments", async () => {
+      const { default: logger, setDiagnosticLogging } =
+        await import("./logger");
+
+      setDiagnosticLogging(true);
+
+      logger.debug("msg", 1, { key: "value" });
+      logger.log("msg", 2, [3]);
+
+      expect(console.debug).toHaveBeenCalledWith("msg", 1, { key: "value" });
+      expect(console.log).toHaveBeenCalledWith("msg", 2, [3]);
+    });
+
+    test("should not affect warn and error when diagnostic logging is toggled", async () => {
+      const { default: logger, setDiagnosticLogging } =
+        await import("./logger");
+
+      setDiagnosticLogging(true);
+      setDiagnosticLogging(false);
+
+      logger.warn("still warns");
+      logger.error("still errors");
+
+      expect(console.warn).toHaveBeenCalledWith("still warns");
+      expect(console.error).toHaveBeenCalledWith("still errors");
+    });
+  });
+
+  describe("in dev mode", () => {
+    beforeEach(() => {
+      vi.doMock("./env", () => ({
+        env: { DEV: true, PROD: false },
+      }));
+    });
+
+    test("should allow debug and log calls", async () => {
+      const { default: logger } = await import("./logger");
+
+      logger.debug("test debug");
+      logger.log("test log");
+
+      expect(console.debug).toHaveBeenCalledWith("test debug");
+      expect(console.log).toHaveBeenCalledWith("test log");
+    });
+  });
+});

--- a/packages/graph-explorer/src/utils/logger.ts
+++ b/packages/graph-explorer/src/utils/logger.ts
@@ -2,46 +2,38 @@
 
 import { env } from "./env";
 
-/*
-# DEV NOTE
+let diagnosticLogging = false;
 
-This is a simple logging utility that will allow `console.log` calls any time
-`env.DEV === true`. This will be useful for local development and debugging.
+/** Enables or disables diagnostic logging at runtime. */
+export function setDiagnosticLogging(enabled: boolean) {
+  diagnosticLogging = enabled;
+}
 
-I can imagine a future where this logger has some additional functionality where
-it can send errors to the server and maybe allow the use to enable debug logging
-at runtime.
-*/
+/** Returns true when debug and log calls should be written to the console. */
+function isLoggingEnabled() {
+  return env.DEV || diagnosticLogging;
+}
 
+/** A thin wrapper around console that suppresses debug/log in production unless diagnostic logging is enabled. */
 export default {
-  /** Calls `console.log` if the app is running in DEV mode. */
-  debug(message?: any, ...optionalParams: any[]) {
-    if (env.PROD) {
-      return;
+  /** Calls `console.debug` if the app is running in DEV mode or diagnostic logging is enabled. */
+  debug(...args: unknown[]) {
+    if (isLoggingEnabled()) {
+      console.debug(...args);
     }
-    optionalParams.length > 0
-      ? console.debug(message, ...optionalParams)
-      : console.debug(message);
   },
-  /** Calls `console.log` if the app is running in DEV mode. */
-  log(message?: any, ...optionalParams: any[]) {
-    if (env.PROD) {
-      return;
+  /** Calls `console.log` if the app is running in DEV mode or diagnostic logging is enabled. */
+  log(...args: unknown[]) {
+    if (isLoggingEnabled()) {
+      console.log(...args);
     }
-    optionalParams.length > 0
-      ? console.log(message, ...optionalParams)
-      : console.log(message);
   },
   /** Calls `console.warn`. */
-  warn(message?: any, ...optionalParams: any[]) {
-    optionalParams.length > 0
-      ? console.warn(message, ...optionalParams)
-      : console.warn(message);
+  warn(...args: unknown[]) {
+    console.warn(...args);
   },
   /** Calls `console.error`. */
-  error(message?: any, ...optionalParams: any[]) {
-    optionalParams.length > 0
-      ? console.error(message, ...optionalParams)
-      : console.error(message);
+  error(...args: unknown[]) {
+    console.error(...args);
   },
 };


### PR DESCRIPTION
## Description

Add a new **Diagnostic Logging** toggle to the General Settings page that enables verbose console logging at runtime, even in production builds.

- Add `diagnosticLoggingAtom` persisted to IndexedDB with default `false`
- Update `logger.ts` to check a runtime flag alongside `env.DEV`, tighten method signatures from `any` to `unknown`, and simplify method bodies
- Add `useSyncDiagnosticLogging` hook in `DefaultLayout` to bridge the Jotai atom to the logger's module-level flag
- Add toggle in General Settings above the DB query logging toggle
- Fix pre-existing copy-paste JSDoc on `allowLoggingDbQueryAtom`

## Validation

- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes (1625 tests)
- 7 new logger tests covering: production suppression, warn/error passthrough, diagnostic toggle on/off, multi-argument forwarding, and warn/error independence from the toggle

## Related Issues

- Resolves #1705

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.