### PR TITLE
Add Docker restart policy to deployment guides

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -60,6 +60,7 @@ The quickest way to get started with Graph Explorer is to use the official Docke
 
    ```
    docker run -p 80:80 -p 443:443 \
+    --restart unless-stopped \
     --env HOST=localhost \
     --name graph-explorer \
     public.ecr.aws/neptune/graph-explorer

--- a/docs/guides/deploy-to-ec2.md
+++ b/docs/guides/deploy-to-ec2.md
@@ -39,12 +39,23 @@ of the VPC, such as setting up a load balancer or VPC peering.
 4. Run the container substituting the `{hostname-or-ip-address}` with the hostname or IP address of the EC2 instance
    ```
    docker run -p 80:80 -p 443:443 \
+    --restart unless-stopped \
     --env HOST={hostname-or-ip-address} \
     public.ecr.aws/neptune/graph-explorer
    ```
+
+<!-- prettier-ignore -->
+> [!TIP]
+>
+> The `--restart unless-stopped` flag ensures the container automatically
+restarts after a host reboot or if the container crashes. See Docker's
+[restart policy documentation](https://docs.docker.com/engine/containers/start-containers-automatically/)
+for other options.
 5. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
-   ```
-   https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
-   ```
+
+```
+https://ec2-1-2-3-4.us-east-1.compute.amazonaws.com/explorer
+```
+
 6. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See [HTTPS Connections](./troubleshooting.md#https-connections) section.
 7. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI.


### PR DESCRIPTION
## Description

- Add `--restart unless-stopped` to the `docker run` commands in the EC2 deployment guide and the getting-started Local Docker Setup. Without a restart policy, the Graph Explorer container won't come back up after a host reboot or crash — important for EC2, EKS, and long-running local deployments.
- Add a tip in the EC2 guide linking to Docker's restart policy documentation for users who want different behavior.

## Validation

Verified `--restart unless-stopped` is the recommended Docker restart policy for containers that should survive host reboots but respect manual stops.

## Related Issues

- Fixes #1169

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.