### PR TITLE
Harden Docker image

### DIFF
--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -38,15 +38,21 @@ jobs:
           docker run --rm --entrypoint="" test-image openssl --version
           docker run --rm --entrypoint="" test-image-neptune openssl --version
 
-      - name: Verify package managers are removed
+      - name: Verify unnecessary packages are removed
         run: |
           docker run --rm --entrypoint="" test-image sh -c '
             (command -v npm && echo "FAIL: npm found" && exit 1) || echo "✓ npm removed"
             (command -v pnpm && echo "FAIL: pnpm found" && exit 1) || echo "✓ pnpm removed"
             (command -v corepack && echo "FAIL: corepack found" && exit 1) || echo "✓ corepack removed"
+            (command -v python3 && echo "FAIL: python3 found" && exit 1) || echo "✓ python3 removed"
+            (command -v yum && echo "FAIL: yum found" && exit 1) || echo "✓ yum removed"
+            (command -v dnf && echo "FAIL: dnf found" && exit 1) || echo "✓ dnf removed"
           '
           docker run --rm --entrypoint="" test-image-neptune sh -c '
             (command -v npm && echo "FAIL: npm found" && exit 1) || echo "✓ npm removed"
             (command -v pnpm && echo "FAIL: pnpm found" && exit 1) || echo "✓ pnpm removed"
             (command -v corepack && echo "FAIL: corepack found" && exit 1) || echo "✓ corepack removed"
+            (command -v python3 && echo "FAIL: python3 found" && exit 1) || echo "✓ python3 removed"
+            (command -v yum && echo "FAIL: yum found" && exit 1) || echo "✓ yum removed"
+            (command -v dnf && echo "FAIL: dnf found" && exit 1) || echo "✓ dnf removed"
           '

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 FROM amazonlinux:2023 AS base
 ENV NODE_VERSION=24.13.0
 
-RUN yum update -y && \
+# Install Node.js and openssl, then remove everything not needed at runtime
+# (package managers, python3, build tools) to minimize potential issues.
+RUN yum update -y --releasever 2023.11.20260413 && \
     yum install -y tar xz openssl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \
@@ -13,7 +15,9 @@ RUN yum update -y && \
     corepack enable && \
     yum remove -y tar xz && \
     yum clean all && \
-    rm -rf /var/cache/yum
+    rpm -qa 'python3*' | while read pkg; do rpm -e --nodeps "$pkg"; done && \
+    rpm -qa 'dnf*' 'yum*' 'libdnf*' | while read pkg; do rpm -e --nodeps "$pkg"; done && \
+    rm -rf /var/cache/yum /var/cache/dnf
 
 FROM base
 ARG NEPTUNE_NOTEBOOK


### PR DESCRIPTION
## Description

- Pin AL2023 releasever to pick up latest package patches
- Remove python3, dnf, and yum from the final image since they are not needed at runtime
- Add CI verification that python3, yum, and dnf are absent from the image

## Validation

- Built both default and Neptune variants locally
- Trivy scan passes with zero HIGH/CRITICAL findings
- All existing CI checks (openSSL, package manager removal) continue to pass

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.