### PR TITLE
Move Local Docker Setup to a deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run Graph Explorer wherever it fits your workflow: as a Docker container, on an 
 There are many ways to deploy and run Graph Explorer. If you are new to graph databases and Graph Explorer, we recommend that you check out the [Getting Started](./docs/getting-started/README.md) guide.
 
 - [Try It Out](./docs/getting-started/README.md#try-it-out) - Launch Graph Explorer with sample data using Docker Compose.
-- [Local Docker Setup](./docs/getting-started/README.md#local-docker-setup) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
+- [Local Docker Setup](./docs/guides/deploy-with-docker.md) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
 - [Amazon EC2 Setup](./docs/guides/deploy-to-ec2.md) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
 - [Local Development](./docs/development.md) - Build from source for local development.
 - [Troubleshooting](./docs/guides/troubleshooting.md) - A collection of helpful tips if you run in to issues while setting up Graph Explorer.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -25,58 +25,6 @@ The fastest way to try Graph Explorer is with the [Air Routes sample](../../samp
 
 See the [samples directory](../../samples) for more examples.
 
-## Examples
-
-### Local Docker Setup
-
-The quickest way to get started with Graph Explorer is to use the official Docker image. You can find the latest version of the image on  
-[Amazon's ECR Public Registry](https://gallery.ecr.aws/neptune/graph-explorer).
-
-<!-- prettier-ignore -->
-> [!NOTE]
-> 
-> Make sure to use the version of the image that does not include `sagemaker` in the tag.
-
-#### Prerequisites
-
-- [Docker](https://docs.docker.com/get-docker/) installed on your machine
-- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed on your machine
-
-#### Steps
-
-1. Authenticate with the [Amazon ECR Public Registry](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
-
-   ```
-   aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-   ```
-
-2. Pull down the docker image
-
-   ```
-   docker pull public.ecr.aws/neptune/graph-explorer
-   ```
-
-3. Create and run a docker container using the image
-
-   ```
-   docker run -p 80:80 -p 443:443 \
-    --restart unless-stopped \
-    --env HOST=localhost \
-    --name graph-explorer \
-    public.ecr.aws/neptune/graph-explorer
-   ```
-
-   The `HOST` environment variable is used for SSL certificates generation since HTTPS is the default. If you are hosting this on a public domain, you should replace `HOST=localhost` with your domain name.
-
-4. Open a browser and type in the URL of the Graph Explorer server instance
-
-   ```
-   https://localhost/explorer
-   ```
-
-5. You will receive a warning as the SSL certificate used is self-signed. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See the [HTTPS Connections](../guides/troubleshooting.md#https-connections) section.
-6. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI. See below description on Connections UI to configure your first connection to Amazon Neptune.
-
 ## Next Steps
 
 - [Connecting to databases](../guides#connecting-to-databases) — Neptune, Gremlin Server, BlazeGraph

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -10,6 +10,7 @@ Guides for connecting to graph databases, deploying Graph Explorer, and troubles
 
 ## Deployment
 
+- [Deploy with Docker](./deploy-with-docker.md)
 - [Deploy to Amazon EC2](./deploy-to-ec2.md)
 - [Deploy to ECS Fargate](./deploy-to-ecs-fargate.md)
 - [Deploy to SageMaker](./deploy-to-sagemaker.md)

--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -1,0 +1,53 @@
+[← Guides](./)
+
+# Deploy with Docker
+
+Deploy Graph Explorer locally using the official Docker image from Amazon's ECR Public Registry.
+
+You can find the latest version of the image on
+[Amazon's ECR Public Registry](https://gallery.ecr.aws/neptune/graph-explorer).
+
+<!-- prettier-ignore -->
+> [!NOTE]
+>
+> Make sure to use the version of the image that does not include `sagemaker` in the tag.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) installed on your machine
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed on your machine
+
+## Steps
+
+1. Authenticate with the [Amazon ECR Public Registry](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html#public-registry-auth)
+
+   ```
+   aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+   ```
+
+2. Pull down the docker image
+
+   ```
+   docker pull public.ecr.aws/neptune/graph-explorer
+   ```
+
+3. Create and run a docker container using the image
+
+   ```
+   docker run -p 80:80 -p 443:443 \
+    --restart unless-stopped \
+    --env HOST=localhost \
+    --name graph-explorer \
+    public.ecr.aws/neptune/graph-explorer
+   ```
+
+   The `HOST` environment variable is used for SSL certificates generation since HTTPS is the default. If you are hosting this on a public domain, you should replace `HOST=localhost` with your domain name.
+
+4. Open a browser and type in the URL of the Graph Explorer server instance
+
+   ```
+   https://localhost/explorer
+   ```
+
+5. You will receive a warning as the SSL certificate used is self-signed. Since the application is set to use HTTPS by default and contains a self-signed certificate, you will need to add the Graph Explorer certificates to the trusted certificates directory and manually trust them. See the [HTTPS Connections](./troubleshooting.md#https-connections) section.
+6. After completing the trusted certification step and refreshing the browser, you should now see the Connections UI. See below description on Connections UI to configure your first connection to Amazon Neptune.


### PR DESCRIPTION
## Description

Move the "Local Docker Setup" section from `docs/getting-started/README.md` into a new deployment guide at `docs/guides/deploy-with-docker.md`.

- Created `docs/guides/deploy-with-docker.md` with the content from the getting-started page, structured to match the other deployment guides (back-link, top-level headings, relative links)
- Removed the Local Docker Setup section from `docs/getting-started/README.md`
- Added the new guide to the Deployment section in `docs/guides/README.md`
- Updated the root `README.md` link to point to the new location

## Validation

Documentation-only change. Verify that all links resolve correctly and the new guide renders properly.

## Related Issues

- Fixes #1714
- Part of #1097

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.