### PR TITLE
Add feature highlights to the features page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Graph Explorer Documentation
 
 - [Getting Started](./getting-started) — Install and run Graph Explorer with Docker.
-- [Features](./features) — Explore the UI: graph view, connections, data table, schema, and settings.
+- [Features](./features) — Key capabilities and detailed guides for each part of the application.
 - [Guides](./guides) — Connect to databases, deploy to AWS, and troubleshoot common issues.
 - [References](./references) — Security, logging, health checks, and configuration details.
 - [Development](./development.md) — Build from source and contribute to Graph Explorer.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,7 +22,7 @@ Execute raw Gremlin, openCypher, or SPARQL queries directly from the Search pane
 
 ### Customizable Styles
 
-Personalize how each node and edge type appears on the canvas. Change colors, shapes, borders, icons, and which property is displayed as the label. You can also rename how type names are displayed throughout the application — for example, show the `airport` label as "Airport" or a `route` edge as "Flies To" — without modifying the underlying data. Styling is saved per connection and persists across sessions.
+Personalize how each node and edge type appears on the canvas. Change colors, shapes, borders, icons, and which property is displayed as the label. You can also rename how type names are displayed throughout the application — for example, show the `airport` label as "Airport" or a `route` edge as "Flies To" — without modifying the underlying data.
 
 ### Save & Load Graph
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,7 +10,7 @@ Graph Explorer supports property graphs via [Gremlin](https://tinkerpop.apache.o
 
 ### No Centralized Database
 
-All user data — connections, preferences, layout settings, and query history — is stored client-side in the browser using IndexedDB. The proxy server handles authentication and request routing but does not store any user data. There is no external database to set up or manage.
+All user data — connections, preferences, layout settings, and query history — is stored client-side in the browser using IndexedDB. The proxy server handles SigV4 request signing and request routing but does not store any user data. There is no external database to set up or manage.
 
 ### Interactive Graph Exploration
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -14,7 +14,7 @@ All user data — connections, preferences, layout settings, and query history �
 
 ### Interactive Graph Exploration
 
-Double-click any node to expand its first-order neighbors directly on the canvas. Use the Expand sidebar panel for more control: filter by neighbor type, narrow by attribute value, or limit the number of results returned.
+Double-click any node to expand its first-order neighbors directly on the canvas. Use the Expand sidebar panel for more control: filter by neighbor type, narrow by attribute value, or limit the number of results returned. As the graph grows, use the Entities Filter to show or hide specific node and edge types without removing them from the graph.
 
 ### Query Editor
 
@@ -22,15 +22,11 @@ Execute raw Gremlin, openCypher, or SPARQL queries directly from the Search pane
 
 ### Customizable Styles
 
-Personalize how each node and edge type appears on the canvas. Change colors, shapes, borders, icons, and which property is displayed as the label. Styling is saved per connection and persists across sessions.
+Personalize how each node and edge type appears on the canvas. Change colors, shapes, borders, icons, and which property is displayed as the label. You can also rename how type names are displayed throughout the application — for example, show the `airport` label as "Airport" or a `route` edge as "Flies To" — without modifying the underlying data. Styling is saved per connection and persists across sessions.
 
-### Rename Labels
+### Save & Load Graph
 
-Override how node and edge type names are displayed throughout the application. For example, rename the `airport` label to "Airport" or a `route` edge to "Flies To" without modifying the underlying data.
-
-### Entities Filter
-
-Control which node and edge types are visible on the canvas. Unchecking a type hides those entities from view without removing them from the graph, letting you focus on the subset of data that matters.
+Export the current graph as a JSON file to save your work, share it with a colleague, or reload it later. Anyone with the same database connection can import the file and pick up exactly where you left off.
 
 ## Feature Details
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,9 +1,45 @@
 # Features
 
-Graph Explorer provides a visual interface for exploring and analyzing graph data. If you are interested in where Graph Explorer is headed in the future then check out our [roadmap](../../ROADMAP.md) and [participate in the discussions](https://github.com/aws/graph-explorer/discussions).
+Graph Explorer provides a visual interface for exploring and analyzing graph data without writing queries.
+
+## Feature Highlights
+
+### Multiple Query Languages
+
+Graph Explorer supports property graphs via [Gremlin](https://tinkerpop.apache.org/gremlin.html) and [openCypher](https://opencypher.org), as well as RDF graphs via [SPARQL](https://www.w3.org/TR/sparql11-overview/). Connect to [Amazon Neptune](https://aws.amazon.com/neptune/), [Apache TinkerPop Gremlin Server](https://tinkerpop.apache.org/), [JanusGraph](https://janusgraph.org/), or any database that supports these protocols over HTTP.
+
+### No Centralized Database
+
+All user data — connections, preferences, layout settings, and query history — is stored client-side in the browser using IndexedDB. The proxy server handles authentication and request routing but does not store any user data. There is no external database to set up or manage.
+
+### Interactive Graph Exploration
+
+Double-click any node to expand its first-order neighbors directly on the canvas. Use the Expand sidebar panel for more control: filter by neighbor type, narrow by attribute value, or limit the number of results returned.
+
+### Query Editor
+
+Execute raw Gremlin, openCypher, or SPARQL queries directly from the Search panel's Query tab. Results are displayed inline and can be added to the graph individually or all at once.
+
+### Customizable Styles
+
+Personalize how each node and edge type appears on the canvas. Change colors, shapes, borders, icons, and which property is displayed as the label. Styling is saved per connection and persists across sessions.
+
+### Rename Labels
+
+Override how node and edge type names are displayed throughout the application. For example, rename the `airport` label to "Airport" or a `route` edge to "Flies To" without modifying the underlying data.
+
+### Entities Filter
+
+Control which node and edge types are visible on the canvas. Unchecking a type hides those entities from view without removing them from the graph, letting you focus on the subset of data that matters.
+
+## Feature Details
+
+For detailed documentation on each part of the application:
 
 - [Connections](./connections.md) — Create and manage connections to graph databases.
 - [Graph View](./graph-view.md) — Search, browse, expand, and customize views of your graph data.
 - [Data Table](./data-table.md) — View tabular data for specific node types.
 - [Schema View](./schema-view.md) — Visualize the schema of your graph database.
 - [Settings](./settings.md) — Configure application-wide preferences.
+
+If you are interested in where Graph Explorer is headed in the future, check out our [roadmap](../../ROADMAP.md) and [participate in the discussions](https://github.com/aws/graph-explorer/discussions).


### PR DESCRIPTION
## Description

Adds a "Feature Highlights" section to `docs/features/README.md` that introduces the key behavioral features of Graph Explorer before linking to the per-page detail docs.

Features highlighted:
- **Multiple Query Languages** — Gremlin, openCypher, SPARQL with supported databases
- **No Centralized Database** — client-side storage, no server-side user data
- **Interactive Graph Exploration** — double-click expansion and filtered expansion
- **Query Editor** — raw query execution from the Search panel
- **Customizable Styles** — colors, shapes, borders, icons per type
- **Rename Labels** — override display names without modifying data
- **Entities Filter** — show/hide types on the canvas

Also updated the docs index description to reflect the broader scope of the features page.

## Validation

Documentation-only change. Verify the page renders correctly and all links resolve.

## Related Issues

- Fixes #1304
- Part of #1097

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.