### PR TITLE
Rewrite schema merge for efficiency and referential equality

### DIFF
--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -98,6 +98,19 @@ export type PrefixTypeConfig = {
   __inferred?: boolean;
 };
 
+/** Creates a PrefixTypeConfig from plain strings. */
+export function createPrefixTypeConfig(options: {
+  prefix: string;
+  uri: string;
+  inferred?: boolean;
+}): PrefixTypeConfig {
+  return {
+    prefix: options.prefix as RdfPrefix,
+    uri: options.uri as IriNamespace,
+    __inferred: options.inferred,
+  };
+}
+
 /**
  * Represents a connection between node labels via an edge type.
  * Used by Schema Explorer to visualize relationships between node types.

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { createArray, createRandomName } from "@shared/utils/testing";
+import { act } from "@testing-library/react";
 import { useAtomValue } from "jotai";
 
 import type { IriNamespace, RdfPrefix } from "@/utils/rdf";
@@ -14,7 +15,6 @@ import { LABELS } from "@/utils";
 import {
   createRandomEdge,
   createRandomEdgeConnection,
-  createRandomEntities,
   createRandomRawConfiguration,
   createRandomSchema,
   createRandomVertex,
@@ -24,12 +24,12 @@ import {
   renderHookWithState,
 } from "@/utils/testing";
 
-import type {
-  EdgeTypeConfig,
-  PrefixTypeConfig,
-  VertexTypeConfig,
+import {
+  createPrefixTypeConfig,
+  type EdgeTypeConfig,
+  type PrefixTypeConfig,
+  type VertexTypeConfig,
 } from "../ConfigurationProvider";
-
 import {
   createEdge,
   createEdgeType,
@@ -43,12 +43,12 @@ import {
   mapVertexToTypeConfigs,
   maybeActiveSchemaAtom,
   type SchemaStorageModel,
-  shouldUpdateSchemaFromEntities,
   updateSchemaFromEntities,
   useActiveSchema,
   useGraphSchema,
   useHasActiveSchema,
   useMaybeActiveSchema,
+  useUpdateSchemaFromEntities,
 } from "./schema";
 
 describe("schema", () => {
@@ -264,6 +264,136 @@ describe("schema", () => {
       const prefixes = result.prefixes?.map(p => p.prefix);
       expect(prefixes).toContain("country");
     });
+
+    it("should add all types from a multi-label vertex", () => {
+      const schema: SchemaStorageModel = {
+        vertices: [],
+        edges: [],
+      };
+
+      const vertex = createVertex({
+        id: "1",
+        types: ["Person", "Employee"],
+        attributes: { name: "Alice" },
+      });
+
+      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+      expect(result.vertices).toHaveLength(2);
+      expect(result.vertices.map(v => v.type)).toStrictEqual([
+        createVertexType("Person"),
+        createVertexType("Employee"),
+      ]);
+      expect(result.vertices[0].attributes).toStrictEqual([
+        { name: "name", dataType: "String" },
+      ]);
+      expect(result.vertices[1].attributes).toStrictEqual([
+        { name: "name", dataType: "String" },
+      ]);
+    });
+
+    it("should not regenerate prefixes for existing schema types", () => {
+      const schema: SchemaStorageModel = {
+        vertices: [
+          {
+            type: createVertexType("http://example.com/ontology#Person"),
+            attributes: [
+              { name: "http://example.com/ontology#name", dataType: "String" },
+            ],
+          },
+        ],
+        edges: [],
+        prefixes: [
+          createPrefixTypeConfig({
+            prefix: "ontology",
+            uri: "http://example.com/ontology#",
+            inferred: true,
+          }),
+        ],
+      };
+
+      const vertex = createVertex({
+        id: "1",
+        types: ["http://example.com/ontology#Person"],
+        attributes: {
+          "http://example.com/ontology#name": "Alice",
+        },
+      });
+
+      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+      expect(result.prefixes).toBe(schema.prefixes);
+    });
+
+    it("should generate prefixes for new attribute namespaces on existing types", () => {
+      const schema: SchemaStorageModel = {
+        vertices: [
+          {
+            type: createVertexType("http://example.com/ontology#Person"),
+            attributes: [
+              { name: "http://example.com/ontology#name", dataType: "String" },
+            ],
+          },
+        ],
+        edges: [],
+        prefixes: [
+          createPrefixTypeConfig({
+            prefix: "ontology",
+            uri: "http://example.com/ontology#",
+            inferred: true,
+          }),
+        ],
+      };
+
+      const vertex = createVertex({
+        id: "1",
+        types: ["http://example.com/ontology#Person"],
+        attributes: {
+          "http://new.example.com/props#age": 30,
+        },
+      });
+
+      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+      const newPrefixes = result.prefixes!.filter(
+        p => !schema.prefixes!.includes(p),
+      );
+      expect(newPrefixes).toHaveLength(1);
+      expect(newPrefixes[0].prefix).toBe("props");
+    });
+
+    it("should generate prefixes for new types but not existing ones", () => {
+      const schema: SchemaStorageModel = {
+        vertices: [
+          {
+            type: createVertexType("http://example.com/ontology#Person"),
+            attributes: [],
+          },
+        ],
+        edges: [],
+        prefixes: [
+          createPrefixTypeConfig({
+            prefix: "ontology",
+            uri: "http://example.com/ontology#",
+            inferred: true,
+          }),
+        ],
+      };
+
+      const vertex = createVertex({
+        id: "http://example.com/resource/1",
+        types: ["http://example.com/classes#Employee"],
+        attributes: {},
+      });
+
+      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+      const newPrefixes = result.prefixes!.filter(
+        p => !schema.prefixes!.includes(p),
+      );
+      expect(newPrefixes.length).toBeGreaterThan(0);
+      expect(newPrefixes.every(p => p.__inferred)).toBe(true);
+    });
   });
 
   describe("generateSchemaPrefixes", () => {
@@ -282,24 +412,24 @@ describe("schema", () => {
       const result = generateSchemaPrefixes(iris, []);
 
       expect(result).toEqual([
-        {
-          prefix: "vertex" as RdfPrefix,
-          uri: "http://abcdefg.com/vertex#" as IriNamespace,
-          __inferred: true,
-        },
-        {
-          prefix: "edge" as RdfPrefix,
-          uri: "http://abcdefg.com/edge#" as IriNamespace,
-          __inferred: true,
-        },
+        createPrefixTypeConfig({
+          prefix: "vertex",
+          uri: "http://abcdefg.com/vertex#",
+          inferred: true,
+        }),
+        createPrefixTypeConfig({
+          prefix: "edge",
+          uri: "http://abcdefg.com/edge#",
+          inferred: true,
+        }),
       ] satisfies PrefixTypeConfig[]);
     });
 
     it("should not regenerate prefixes already covered by existing ones", () => {
-      const existingPrefix: PrefixTypeConfig = {
-        prefix: "custom" as RdfPrefix,
-        uri: "http://custom.example.com/" as IriNamespace,
-      };
+      const existingPrefix = createPrefixTypeConfig({
+        prefix: "custom",
+        uri: "http://custom.example.com/",
+      });
 
       const result = generateSchemaPrefixes(
         new Set(["http://custom.example.com/Thing"]),
@@ -308,73 +438,33 @@ describe("schema", () => {
 
       expect(result).toStrictEqual([]);
     });
-  });
 
-  describe("shouldUpdateSchemaFromEntities", () => {
-    it("should return false when no entities are provided", () => {
-      const result = shouldUpdateSchemaFromEntities(
-        { vertices: [], edges: [] },
-        createRandomSchema(),
+    it("should append next numeral when prefix name collides with existing deduplicated prefixes", () => {
+      const existingPrefixes = [
+        createPrefixTypeConfig({
+          prefix: "country",
+          uri: "http://data.example.org/country/",
+          inferred: true,
+        }),
+        createPrefixTypeConfig({
+          prefix: "country2",
+          uri: "http://stats.example.org/country/",
+          inferred: true,
+        }),
+      ];
+
+      const result = generateSchemaPrefixes(
+        new Set(["http://geo.example.org/country/France"]),
+        existingPrefixes,
       );
-      expect(result).toBeFalsy();
-    });
 
-    it("should return true when entities are provided", () => {
-      const entities = createRandomEntities();
-      const result = shouldUpdateSchemaFromEntities(
-        entities,
-        createRandomSchema(),
-      );
-      expect(result).toBeTruthy();
-    });
-
-    it("should return false when the vertex has an existing type", () => {
-      const schema = createRandomSchema();
-      const vertex = createRandomVertex();
-      vertex.type = schema.vertices[0].type;
-      vertex.attributes = schema.vertices[0].attributes.reduce((acc, attr) => {
-        acc[attr.name] = createRandomName("value");
-        return acc;
-      }, {} as EntityProperties);
-      const result = shouldUpdateSchemaFromEntities(
-        {
-          vertices: [vertex],
-          edges: [],
-        },
-        schema,
-      );
-      expect(result).toBeFalsy();
-    });
-
-    it("should return false when the edge is an existing type", () => {
-      const schema = createRandomSchema();
-      const source = createRandomVertex();
-      const target = createRandomVertex();
-      source.type = schema.vertices[0].type;
-      source.attributes = schema.vertices[0].attributes.reduce((acc, attr) => {
-        acc[attr.name] = createRandomName("value");
-        return acc;
-      }, {} as EntityProperties);
-      target.type = schema.vertices[1].type;
-      target.attributes = schema.vertices[1].attributes.reduce((acc, attr) => {
-        acc[attr.name] = createRandomName("value");
-        return acc;
-      }, {} as EntityProperties);
-      const edge = createRandomEdge(source, target);
-      edge.type = schema.edges[0].type;
-      edge.attributes = schema.edges[0].attributes.reduce((acc, attr) => {
-        acc[attr.name] = createRandomName("value");
-        return acc;
-      }, {} as EntityProperties);
-
-      const result = shouldUpdateSchemaFromEntities(
-        {
-          vertices: [source, target],
-          edges: [edge],
-        },
-        schema,
-      );
-      expect(result).toBeFalsy();
+      expect(result).toStrictEqual([
+        createPrefixTypeConfig({
+          prefix: "country3",
+          uri: "http://geo.example.org/country/",
+          inferred: true,
+        }),
+      ]);
     });
   });
 });
@@ -462,6 +552,33 @@ describe("referential integrity", () => {
 
     expect(result.edges[0]).not.toBe(schema.edges[0]);
     expect(result.edges[0].attributes).not.toBe(schema.edges[0].attributes);
+  });
+
+  it("should preserve vertices array reference when only edges change", () => {
+    const schema = createRandomSchema();
+    const edge = createRandomEdge();
+
+    const result = updateSchemaFromEntities({ edges: [edge] }, schema);
+
+    expect(result.vertices).toBe(schema.vertices);
+  });
+
+  it("should preserve edges array reference when only vertices change", () => {
+    const schema = createRandomSchema();
+    const vertex = createRandomVertex();
+
+    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+    expect(result.edges).toBe(schema.edges);
+  });
+
+  it("should preserve prefixes reference when no new prefixes needed", () => {
+    const schema = createRandomSchema();
+    const vertex = createRandomVertex();
+
+    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+
+    expect(result.prefixes).toBe(schema.prefixes);
   });
 });
 
@@ -557,6 +674,30 @@ describe("useGraphSchema edgeConnections", () => {
     expect(
       result.current.edgeConnections.byEdgeConnectionId.get(id),
     ).toStrictEqual(conn);
+  });
+});
+
+describe("useUpdateSchemaFromEntities", () => {
+  it("should not churn schemaAtom when active config has no schema entry", () => {
+    const state = new DbState().withNoActiveSchema();
+
+    const { result } = renderHookWithState(
+      () => ({
+        updateSchema: useUpdateSchemaFromEntities(),
+        schemaMap: useAtomValue(schemaAtom),
+      }),
+      state,
+    );
+
+    const schemaMapBefore = result.current.schemaMap;
+
+    act(() => {
+      result.current.updateSchema({
+        vertices: [createRandomVertex()],
+      });
+    });
+
+    expect(result.current.schemaMap).toBe(schemaMapBefore);
   });
 });
 
@@ -738,11 +879,11 @@ describe("backward compatibility: legacy __matches on prefixes", () => {
 
     // New prefix should be generated
     expect(result).toStrictEqual([
-      {
-        prefix: "vertex" as RdfPrefix,
-        uri: "http://newdomain.com/vertex#" as IriNamespace,
-        __inferred: true,
-      },
+      createPrefixTypeConfig({
+        prefix: "vertex",
+        uri: "http://newdomain.com/vertex#",
+        inferred: true,
+      }),
     ]);
   });
 
@@ -791,10 +932,12 @@ describe("backward compatibility: legacy __matches on prefixes", () => {
     expect(result.prefixes?.[0]).toBe(legacyPrefix);
     // New prefix should be appended for the new namespace
     expect(result.prefixes).toHaveLength(2);
-    expect(result.prefixes?.[1]).toStrictEqual({
-      prefix: "vertex" as RdfPrefix,
-      uri: "http://new.example.com/vertex#" as IriNamespace,
-      __inferred: true,
-    });
+    expect(result.prefixes?.[1]).toStrictEqual(
+      createPrefixTypeConfig({
+        prefix: "vertex",
+        uri: "http://new.example.com/vertex#",
+        inferred: true,
+      }),
+    );
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -699,6 +699,36 @@ describe("useUpdateSchemaFromEntities", () => {
 
     expect(result.current.schemaMap).toBe(schemaMapBefore);
   });
+
+  it("should not churn schemaAtom when entities already match schema", () => {
+    const state = new DbState();
+    const existingVertex = createRandomVertex();
+    existingVertex.type = state.activeSchema.vertices[0].type;
+    existingVertex.types = [state.activeSchema.vertices[0].type];
+    existingVertex.attributes =
+      state.activeSchema.vertices[0].attributes.reduce((acc, attr) => {
+        acc[attr.name] = createRandomName("value");
+        return acc;
+      }, {} as EntityProperties);
+
+    const { result } = renderHookWithState(
+      () => ({
+        updateSchema: useUpdateSchemaFromEntities(),
+        schemaMap: useAtomValue(schemaAtom),
+      }),
+      state,
+    );
+
+    const schemaMapBefore = result.current.schemaMap;
+
+    act(() => {
+      result.current.updateSchema({
+        vertices: [existingVertex],
+      });
+    });
+
+    expect(result.current.schemaMap).toBe(schemaMapBefore);
+  });
 });
 
 describe("useHasActiveSchema", () => {

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -288,17 +288,21 @@ export function updateSchemaFromEntities(
     return schema;
   }
 
-  const mergedVertices = mergeVertices(schema.vertices, vertices);
-  const mergedEdges = mergeEdges(schema.edges, edges);
+  const { configs: mergedVertices, newIris: vertexIris } = mergeVertices(
+    schema.vertices,
+    vertices,
+  );
+  const { configs: mergedEdges, newIris: edgeIris } = mergeEdges(
+    schema.edges,
+    edges,
+  );
 
   const existingPrefixes = schema.prefixes ?? [];
   const mergedPrefixes = mergePrefixes(
     existingPrefixes,
     entities,
-    mergedVertices,
-    mergedEdges,
-    schema.vertices,
-    schema.edges,
+    vertexIris,
+    edgeIris,
   );
 
   if (
@@ -322,16 +326,22 @@ export function updateSchemaFromEntities(
   return result;
 }
 
+type MergeResult<T> = {
+  configs: T[];
+  newIris: Set<string>;
+};
+
 /** Merges new vertex entities into existing vertex type configs. */
 function mergeVertices(
   existing: VertexTypeConfig[],
   vertices: Vertex[],
-): VertexTypeConfig[] {
+): MergeResult<VertexTypeConfig> {
   if (!vertices.length) {
-    return existing;
+    return { configs: existing, newIris: new Set() };
   }
 
   const byType = new Map(existing.map(v => [v.type, v]));
+  const newIris = new Set<string>();
   let hasChanges = false;
 
   for (const vertex of vertices) {
@@ -343,6 +353,10 @@ function mergeVertices(
           type,
           attributes: attributesFromProperties(vertex.attributes),
         });
+        newIris.add(type);
+        for (const attr of attributesFromProperties(vertex.attributes)) {
+          newIris.add(attr.name);
+        }
         hasChanges = true;
       } else {
         const mergedAttrs = mergeAttributesFromProperties(
@@ -352,25 +366,32 @@ function mergeVertices(
         if (mergedAttrs !== existingConfig.attributes) {
           logger.debug("Discovered new attributes for vertex type:", type);
           byType.set(type, { ...existingConfig, attributes: mergedAttrs });
+          for (const attr of mergedAttrs) {
+            newIris.add(attr.name);
+          }
           hasChanges = true;
         }
       }
     }
   }
 
-  return hasChanges ? Array.from(byType.values()) : existing;
+  return {
+    configs: hasChanges ? Array.from(byType.values()) : existing,
+    newIris,
+  };
 }
 
 /** Merges new edge entities into existing edge type configs. */
 function mergeEdges(
   existing: EdgeTypeConfig[],
   edges: Edge[],
-): EdgeTypeConfig[] {
+): MergeResult<EdgeTypeConfig> {
   if (!edges.length) {
-    return existing;
+    return { configs: existing, newIris: new Set() };
   }
 
   const byType = new Map(existing.map(e => [e.type, e]));
+  const newIris = new Set<string>();
   let hasChanges = false;
 
   for (const edge of edges) {
@@ -381,6 +402,7 @@ function mergeEdges(
         type: edge.type,
         attributes: attributesFromProperties(edge.attributes),
       });
+      newIris.add(edge.type);
       hasChanges = true;
     } else {
       const mergedAttrs = mergeAttributesFromProperties(
@@ -395,48 +417,29 @@ function mergeEdges(
     }
   }
 
-  return hasChanges ? Array.from(byType.values()) : existing;
+  return {
+    configs: hasChanges ? Array.from(byType.values()) : existing,
+    newIris,
+  };
 }
 
-/** Generates and merges new RDF prefixes from entity IRIs and newly-added schema types/attributes. */
+/** Generates and merges new RDF prefixes from entity IRIs and newly-discovered schema IRIs. */
 function mergePrefixes(
   existing: PrefixTypeConfig[],
   entities: Partial<Entities>,
-  mergedVertices: VertexTypeConfig[],
-  mergedEdges: EdgeTypeConfig[],
-  previousVertices: VertexTypeConfig[],
-  previousEdges: EdgeTypeConfig[],
+  vertexIris: Set<string>,
+  edgeIris: Set<string>,
 ): PrefixTypeConfig[] {
-  const iris = new Set<string>();
+  const iris = new Set<string>(vertexIris);
 
+  for (const iri of edgeIris) {
+    iris.add(iri);
+  }
   for (const v of entities.vertices ?? []) {
     iris.add(String(v.id));
   }
   for (const e of entities.edges ?? []) {
     iris.add(String(e.id));
-  }
-
-  // Only scan types/attributes that were actually added or changed
-  const previousVertexByType = new Map(previousVertices.map(v => [v.type, v]));
-  for (const v of mergedVertices) {
-    const prev = previousVertexByType.get(v.type);
-    if (!prev) {
-      iris.add(v.type);
-      for (const attr of v.attributes) {
-        iris.add(attr.name);
-      }
-    } else if (v.attributes !== prev.attributes) {
-      for (const attr of v.attributes) {
-        iris.add(attr.name);
-      }
-    }
-  }
-  const previousEdgeByType = new Map(previousEdges.map(e => [e.type, e]));
-  for (const e of mergedEdges) {
-    const prev = previousEdgeByType.get(e.type);
-    if (!prev) {
-      iris.add(e.type);
-    }
   }
 
   const newPrefixes = generateSchemaPrefixes(iris, existing);

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -345,16 +345,14 @@ function mergeVertices(
   let hasChanges = false;
 
   for (const vertex of vertices) {
+    const attrs = attributesFromProperties(vertex.attributes);
     for (const type of vertex.types) {
       const existingConfig = byType.get(type);
       if (!existingConfig) {
         logger.debug("Discovered new vertex type:", type);
-        byType.set(type, {
-          type,
-          attributes: attributesFromProperties(vertex.attributes),
-        });
+        byType.set(type, { type, attributes: attrs });
         newIris.add(type);
-        for (const attr of attributesFromProperties(vertex.attributes)) {
+        for (const attr of attrs) {
           newIris.add(attr.name);
         }
         hasChanges = true;
@@ -366,8 +364,13 @@ function mergeVertices(
         if (mergedAttrs !== existingConfig.attributes) {
           logger.debug("Discovered new attributes for vertex type:", type);
           byType.set(type, { ...existingConfig, attributes: mergedAttrs });
-          for (const attr of mergedAttrs) {
-            newIris.add(attr.name);
+          // Only the newly added attributes need IRI scanning
+          for (
+            let i = existingConfig.attributes.length;
+            i < mergedAttrs.length;
+            i++
+          ) {
+            newIris.add(mergedAttrs[i].name);
           }
           hasChanges = true;
         }
@@ -462,7 +465,7 @@ function mergeAttributesFromProperties(
   const existingNames = new Set(existing.map(a => a.name));
   const newAttrs: AttributeConfig[] = [];
 
-  for (const name in properties) {
+  for (const name of Object.keys(properties)) {
     if (!existingNames.has(name)) {
       newAttrs.push({ name, dataType: detectDataType(properties[name]) });
     }

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -29,7 +29,7 @@ import {
   type VertexType,
 } from "@/core";
 import { logger } from "@/utils";
-import { generatePrefixes, PrefixLookup, splitIri } from "@/utils/rdf";
+import { generatePrefixes, PrefixLookup } from "@/utils/rdf";
 
 /**
  * Persisted schema state for a database connection.
@@ -252,21 +252,23 @@ export const activeSchemaSelector = atom(
       return;
     }
     set(schemaAtom, prevSchemaMap => {
-      const updatedSchemaMap = new Map(prevSchemaMap);
-      const prev = updatedSchemaMap.get(schemaId);
+      const prev = prevSchemaMap.get(schemaId);
       const newValue = typeof update === "function" ? update(prev) : update;
-
-      // Handle reset value or undefined
-      if (newValue === RESET || !newValue) {
-        updatedSchemaMap.delete(schemaId);
-        return updatedSchemaMap;
-      }
 
       if (newValue === prev) {
         return prevSchemaMap;
       }
 
-      // Update the map
+      const updatedSchemaMap = new Map(prevSchemaMap);
+
+      if (newValue === RESET || !newValue) {
+        if (!prev) {
+          return prevSchemaMap;
+        }
+        updatedSchemaMap.delete(schemaId);
+        return updatedSchemaMap;
+      }
+
       updatedSchemaMap.set(schemaId, newValue);
 
       return updatedSchemaMap;
@@ -274,7 +276,7 @@ export const activeSchemaSelector = atom(
   },
 );
 
-/** Updates the schema based on the given nodes and edges. */
+/** Updates the schema based on the given nodes and edges. Preserves referential equality at every level when nothing changes. */
 export function updateSchemaFromEntities(
   entities: Partial<Entities>,
   schema: SchemaStorageModel,
@@ -286,131 +288,211 @@ export function updateSchemaFromEntities(
     return schema;
   }
 
-  const newVertexConfigs = vertices.flatMap(mapVertexToTypeConfigs);
-  const newEdgeConfigs = edges.map(mapEdgeToTypeConfig);
+  const mergedVertices = mergeVertices(schema.vertices, vertices);
+  const mergedEdges = mergeEdges(schema.edges, edges);
 
-  const mergedVertices = merge(schema.vertices, newVertexConfigs);
-  const mergedEdges = merge(schema.edges, newEdgeConfigs);
-
-  // Generate new prefixes for the schema changes and resource IRIs
   const existingPrefixes = schema.prefixes ?? [];
-  const entityUris = getEntityUris(entities);
-  const schemaUris = getSchemaUris({
-    vertices: mergedVertices,
-    edges: mergedEdges,
-  });
-  const newPrefixes = generateSchemaPrefixes(
-    entityUris.union(schemaUris),
+  const mergedPrefixes = mergePrefixes(
     existingPrefixes,
+    entities,
+    mergedVertices,
+    mergedEdges,
+    schema.vertices,
+    schema.edges,
   );
 
   if (
     mergedVertices === schema.vertices &&
     mergedEdges === schema.edges &&
-    newPrefixes.length === 0
+    mergedPrefixes === existingPrefixes
   ) {
+    logger.debug("Schema already up to date with given entities");
     return schema;
   }
 
-  const newSchema = {
+  const result = {
     ...schema,
     vertices: mergedVertices,
     edges: mergedEdges,
     prefixes:
-      newPrefixes.length > 0
-        ? [...existingPrefixes, ...newPrefixes]
-        : schema.prefixes,
+      mergedPrefixes !== existingPrefixes ? mergedPrefixes : schema.prefixes,
   };
 
-  logger.debug("Updated schema:", { newSchema, prevSchema: schema });
-  return newSchema;
+  logger.debug("Updated schema from entities", result);
+  return result;
 }
 
-/** Merges new node or edge configs in to a set of existing node or edge configs. */
-function merge<T extends VertexTypeConfig | EdgeTypeConfig>(
-  existing: T[],
-  newConfigs: T[],
-): T[] {
-  const configMap = new Map(existing.map(vt => [vt.type, vt]));
+/** Merges new vertex entities into existing vertex type configs. */
+function mergeVertices(
+  existing: VertexTypeConfig[],
+  vertices: Vertex[],
+): VertexTypeConfig[] {
+  if (!vertices.length) {
+    return existing;
+  }
+
+  const byType = new Map(existing.map(v => [v.type, v]));
   let hasChanges = false;
 
-  for (const newConfig of newConfigs) {
-    const existingConfig = configMap.get(newConfig.type);
-    if (!existingConfig) {
-      configMap.set(newConfig.type, newConfig);
-      hasChanges = true;
-    } else {
-      const mergedAttributes = mergeAttributes(
-        existingConfig.attributes,
-        newConfig.attributes,
-      );
-      if (mergedAttributes === existingConfig.attributes) {
-        continue;
+  for (const vertex of vertices) {
+    for (const type of vertex.types) {
+      const existingConfig = byType.get(type);
+      if (!existingConfig) {
+        logger.debug("Discovered new vertex type:", type);
+        byType.set(type, {
+          type,
+          attributes: attributesFromProperties(vertex.attributes),
+        });
+        hasChanges = true;
+      } else {
+        const mergedAttrs = mergeAttributesFromProperties(
+          existingConfig.attributes,
+          vertex.attributes,
+        );
+        if (mergedAttrs !== existingConfig.attributes) {
+          logger.debug("Discovered new attributes for vertex type:", type);
+          byType.set(type, { ...existingConfig, attributes: mergedAttrs });
+          hasChanges = true;
+        }
       }
-      configMap.set(newConfig.type, {
-        ...existingConfig,
-        attributes: mergedAttributes,
+    }
+  }
+
+  return hasChanges ? Array.from(byType.values()) : existing;
+}
+
+/** Merges new edge entities into existing edge type configs. */
+function mergeEdges(
+  existing: EdgeTypeConfig[],
+  edges: Edge[],
+): EdgeTypeConfig[] {
+  if (!edges.length) {
+    return existing;
+  }
+
+  const byType = new Map(existing.map(e => [e.type, e]));
+  let hasChanges = false;
+
+  for (const edge of edges) {
+    const existingConfig = byType.get(edge.type);
+    if (!existingConfig) {
+      logger.debug("Discovered new edge type:", edge.type);
+      byType.set(edge.type, {
+        type: edge.type,
+        attributes: attributesFromProperties(edge.attributes),
       });
       hasChanges = true;
+    } else {
+      const mergedAttrs = mergeAttributesFromProperties(
+        existingConfig.attributes,
+        edge.attributes,
+      );
+      if (mergedAttrs !== existingConfig.attributes) {
+        logger.debug("Discovered new attributes for edge type:", edge.type);
+        byType.set(edge.type, { ...existingConfig, attributes: mergedAttrs });
+        hasChanges = true;
+      }
     }
   }
 
-  // Return original array if nothing changed
-  return hasChanges ? Array.from(configMap.values()) : existing;
+  return hasChanges ? Array.from(byType.values()) : existing;
 }
 
-export function mergeAttributes(
-  existing: AttributeConfig[],
-  newAttributes: AttributeConfig[],
-): AttributeConfig[] {
-  const attrMap = new Map(existing.map(attr => [attr.name, attr]));
-  let hasChanges = false;
+/** Generates and merges new RDF prefixes from entity IRIs and newly-added schema types/attributes. */
+function mergePrefixes(
+  existing: PrefixTypeConfig[],
+  entities: Partial<Entities>,
+  mergedVertices: VertexTypeConfig[],
+  mergedEdges: EdgeTypeConfig[],
+  previousVertices: VertexTypeConfig[],
+  previousEdges: EdgeTypeConfig[],
+): PrefixTypeConfig[] {
+  const iris = new Set<string>();
 
-  for (const newAttr of newAttributes) {
-    const existingAttr = attrMap.get(newAttr.name);
-    if (!existingAttr) {
-      attrMap.set(newAttr.name, newAttr);
-      hasChanges = true;
-    } else if (
-      existingAttr.name === newAttr.name &&
-      existingAttr.dataType !== newAttr.dataType
-    ) {
-      continue;
-    } else {
-      // Check if merge would actually change anything
-      const merged = { ...existingAttr, ...newAttr };
-      if (
-        merged.name === existingAttr.name &&
-        merged.dataType === existingAttr.dataType
-      ) {
-        continue;
+  for (const v of entities.vertices ?? []) {
+    iris.add(String(v.id));
+  }
+  for (const e of entities.edges ?? []) {
+    iris.add(String(e.id));
+  }
+
+  // Only scan types/attributes that were actually added or changed
+  const previousVertexByType = new Map(previousVertices.map(v => [v.type, v]));
+  for (const v of mergedVertices) {
+    const prev = previousVertexByType.get(v.type);
+    if (!prev) {
+      iris.add(v.type);
+      for (const attr of v.attributes) {
+        iris.add(attr.name);
       }
-      attrMap.set(newAttr.name, merged);
-      hasChanges = true;
+    } else if (v.attributes !== prev.attributes) {
+      for (const attr of v.attributes) {
+        iris.add(attr.name);
+      }
+    }
+  }
+  const previousEdgeByType = new Map(previousEdges.map(e => [e.type, e]));
+  for (const e of mergedEdges) {
+    const prev = previousEdgeByType.get(e.type);
+    if (!prev) {
+      iris.add(e.type);
     }
   }
 
-  // Return original array if nothing changed
-  return hasChanges ? Array.from(attrMap.values()) : existing;
+  const newPrefixes = generateSchemaPrefixes(iris, existing);
+  if (newPrefixes.length === 0) {
+    return existing;
+  }
+
+  logger.debug(
+    "Discovered new prefixes:",
+    newPrefixes.map(p => p.prefix),
+  );
+  return [...existing, ...newPrefixes];
+}
+
+/** Merges entity properties into an existing attribute list. Preserves existing dataType on conflicts. */
+function mergeAttributesFromProperties(
+  existing: AttributeConfig[],
+  properties: EntityProperties,
+): AttributeConfig[] {
+  const existingNames = new Set(existing.map(a => a.name));
+  const newAttrs: AttributeConfig[] = [];
+
+  for (const name in properties) {
+    if (!existingNames.has(name)) {
+      newAttrs.push({ name, dataType: detectDataType(properties[name]) });
+    }
+  }
+
+  if (newAttrs.length === 0) {
+    return existing;
+  }
+
+  return [...existing, ...newAttrs];
+}
+
+/** Converts entity properties to an attribute config array. */
+function attributesFromProperties(
+  properties: EntityProperties,
+): AttributeConfig[] {
+  return Object.entries(properties).map(([name, value]) => ({
+    name,
+    dataType: detectDataType(value),
+  }));
 }
 
 export function mapVertexToTypeConfigs(vertex: Vertex): VertexTypeConfig[] {
   return vertex.types.map(type => ({
     type,
-    attributes: Object.entries(vertex.attributes).map(([name, value]) => ({
-      name,
-      dataType: detectDataType(value),
-    })),
+    attributes: attributesFromProperties(vertex.attributes),
   }));
 }
 
 export function mapEdgeToTypeConfig(edge: Edge): EdgeTypeConfig {
   return {
     type: edge.type,
-    attributes: Object.entries(edge.attributes).map(([name, value]) => ({
-      name,
-      dataType: detectDataType(value),
-    })),
+    attributes: attributesFromProperties(edge.attributes),
   };
 }
 
@@ -450,8 +532,6 @@ export function generateSchemaPrefixes(
     return [];
   }
 
-  logger.debug("Generated new prefixes:", newPrefixes);
-
   return newPrefixes;
 }
 
@@ -462,28 +542,14 @@ export function getSchemaUris(schema: {
 }) {
   const result = new Set<string>();
 
-  schema.vertices.forEach(v => {
+  for (const v of schema.vertices) {
     result.add(v.type);
-    v.attributes.forEach(attr => {
+    for (const attr of v.attributes) {
       result.add(attr.name);
-    });
-  });
-  schema.edges.forEach(e => {
-    result.add(e.type);
-  });
-
-  return result;
-}
-
-/** Collects IDs from entities. */
-function getEntityUris(entities: Partial<Entities>) {
-  const result = new Set<string>();
-
-  for (const v of entities.vertices ?? []) {
-    result.add(String(v.id));
+    }
   }
-  for (const e of entities.edges ?? []) {
-    result.add(String(e.id));
+  for (const e of schema.edges) {
+    result.add(e.type);
   }
 
   return result;
@@ -492,24 +558,13 @@ function getEntityUris(entities: Partial<Entities>) {
 /** Updates the schema with any new vertex or edge types, any new attributes, and updates the generated prefixes for sparql connections. */
 export function useUpdateSchemaFromEntities() {
   return useAtomCallback(
-    useCallback((get, set, entities: Partial<Entities>) => {
+    useCallback((_get, set, entities: Partial<Entities>) => {
       const vertices = entities.vertices ?? [];
       const edges = entities.edges ?? [];
-      const activeSchema = get(activeSchemaSelector);
       if (vertices.length === 0 && edges.length === 0) {
         return;
       }
-      if (!activeSchema) {
-        return;
-      }
-      if (
-        !shouldUpdateSchemaFromEntities(entities, activeSchema) &&
-        !hasNewPrefixNamespaces(entities, get(prefixesAtom))
-      ) {
-        logger.debug("Schema is already up to date with the given entities");
-        return;
-      }
-      logger.debug("Updating schema from entities");
+
       set(activeSchemaSelector, prev => {
         if (!prev) {
           return prev;
@@ -523,85 +578,3 @@ export function useUpdateSchemaFromEntities() {
 export type UpdateSchemaHandler = ReturnType<
   typeof useUpdateSchemaFromEntities
 >;
-
-/** Attempts to efficiently detect if the schema should be updated. */
-export function shouldUpdateSchemaFromEntities(
-  entities: Partial<Entities>,
-  schema: SchemaStorageModel,
-) {
-  const vertices = entities.vertices ?? [];
-  const edges = entities.edges ?? [];
-  if (vertices.length > 0) {
-    // Check if the vertex types and attributes are the same
-    const fromEntities = getUniqueTypesAndAttributes(vertices);
-    const fromSchema = getUniqueTypesAndAttributes(schema.vertices);
-
-    if (!fromSchema.isSupersetOf(fromEntities)) {
-      logger.debug(
-        "Found new vertex types or attributes:",
-        fromEntities.difference(fromSchema),
-      );
-      return true;
-    }
-  }
-
-  if (edges.length > 0) {
-    // Check if the edge types and attributes are the same
-    const fromEntities = getUniqueTypesAndAttributes(edges);
-    const fromSchema = getUniqueTypesAndAttributes(schema.edges);
-
-    if (!fromSchema.isSupersetOf(fromEntities)) {
-      logger.debug(
-        "Found new edge types or attributes:",
-        fromEntities.difference(fromSchema),
-      );
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/** Checks if any entity IDs have namespaces not yet covered by existing prefixes. */
-function hasNewPrefixNamespaces(
-  entities: Partial<Entities>,
-  prefixes: PrefixLookup,
-) {
-  for (const v of entities.vertices ?? []) {
-    const parts = splitIri(String(v.id));
-    if (parts && !prefixes.findPrefix(parts.namespace)) {
-      return true;
-    }
-  }
-  for (const e of entities.edges ?? []) {
-    const parts = splitIri(String(e.id));
-    if (parts && !prefixes.findPrefix(parts.namespace)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Creates a set of unique types and attribute names as a set of strings in order to be used for comparisons.
- *
- * The entries in the set will be in the format of `vertexType.attributeName` or `edgeType.attributeName`.
- */
-function getUniqueTypesAndAttributes(
-  entities: (Vertex | Edge | VertexTypeConfig | EdgeTypeConfig)[],
-) {
-  return new Set(
-    entities.flatMap(e => {
-      return [
-        e.type,
-        ...getAttributeNames(e.attributes).map(a => `${e.type}.${a}`),
-      ];
-    }),
-  );
-}
-
-function getAttributeNames(attributes: EntityProperties | AttributeConfig[]) {
-  return Array.isArray(attributes)
-    ? attributes.map(a => a.name)
-    : Object.keys(attributes);
-}


### PR DESCRIPTION
## Description

Rewrites `updateSchemaFromEntities` and its supporting functions to be more efficient and preserve referential equality at every level of the schema when nothing changes. This reduces unnecessary React re-renders when entities are merged into an already-up-to-date schema.

### Changes

- **Single-pass merge instead of pre-check + merge** — The old code ran `shouldUpdateSchemaFromEntities` + `hasNewPrefixNamespaces` to decide *if* an update was needed, then `updateSchemaFromEntities` repeated the same work to do the merge. The new code does one merge pass that preserves referential equality when nothing changes, making the pre-check redundant and removing it entirely.

- **Merge directly from entities** — `mergeVertices` and `mergeEdges` work directly from `Vertex[]`/`Edge[]` instead of first converting to intermediate `VertexTypeConfig[]`/`EdgeTypeConfig[]` via `mapVertexToTypeConfigs`/`mapEdgeToTypeConfig`, avoiding throwaway allocations.

- **Merge functions return discovered IRIs** — `mergeVertices` and `mergeEdges` return `{ configs, newIris }` where `newIris` contains only the type/attribute IRIs that were actually new. This keeps prefix scanning focused on what changed.

- **Optimized prefix scanning** — `mergePrefixes` only scans newly-discovered IRIs and entity IDs, rather than re-scanning all existing schema types on every call.

- **Fixed `activeSchemaSelector` setter churn** — The setter allocated a new `Map` unconditionally, even when the update was a no-op (e.g., returning the same value, or deleting a key that was not present). Now it checks `newValue === prev` before cloning and guards the RESET/undefined path against no-op deletes.

- **Added `createPrefixTypeConfig` factory** — Accepts plain strings `{ prefix, uri, inferred? }` and produces the branded `RdfPrefix`/`IriNamespace` types, reducing manual `as` casts.

- **Added debug logging** — Logs when the schema is updated, when it is already up to date, and when new vertex types, edge types, attributes, or prefixes are discovered.

### Benchmarks (70k vertex types, 3 attributes each)

The old code called `getSchemaUris` on every merge, which iterated all 70k types and 210k attributes to build a `Set<string>` — even when nothing changed.

| Scenario | Old | New | Speedup |
|----------|-----|-----|---------|
| No-op (50 entities already in schema) | 935ms | 6.5ms | **144x** |
| 10 new types added | 1,306ms | 6.4ms | **203x** |
| Mixed (40 existing + 10 new) | 1,293ms | 6.9ms | **188x** |
| Empty schema, 100 new entities | 0.99ms | 1.18ms | ~1x |

The empty schema case is roughly equivalent since there is no existing schema to skip.

### New tests

- Multi-label vertex adds all types to schema
- Prefix deduplication stability across incremental updates (`country`, `country2` → `country3`)
- New attribute namespace on existing type generates a prefix
- New types get prefixes but existing types do not
- `schemaAtom` not churned when active config has no schema entry
- `schemaAtom` not churned when entities already match schema
- Vertices/edges/prefixes array references preserved when only the other changes

## Validation

- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes (1646 tests across 152 files)
- Manually tested by emptying the schema via debug action and verifying incremental rediscovery through search

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.