### PR TITLE
Block cross-origin requests by default

### DIFF
--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -62,12 +62,12 @@ Uses the self-signed certificate to serve the proxy-server over https if true.
 
 ### `PROXY_SERVER_CORS_ORIGIN`
 
-Restricts which origins are allowed to make cross-origin requests to the proxy server. When set, only requests from these exact origins will receive CORS headers. When not set, all origins are allowed. Each origin must include the scheme and must not have a trailing slash or path.
+Restricts which origins are allowed to make cross-origin requests to the proxy server. When set, only requests from these exact origins will receive CORS headers. When not set, cross-origin requests are blocked. Each origin must include the scheme and must not have a trailing slash or path.
 
 Example: `https://my-app.example.com` or `https://app-a.example.com,https://app-b.example.com`
 
 - Optional
-- Default: all origins allowed
+- Default: cross-origin requests blocked
 - Type: `string` (comma-separated for multiple origins)
 
 ### `LOG_STYLE`

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -73,7 +73,9 @@ For browsers like Safari and Firefox, trusting the certificate from the browser 
 
 ## CORS
 
-To restrict cross-origin requests, set the `PROXY_SERVER_CORS_ORIGIN` environment variable to the origin you want to allow. The default option allows cross-origin requests from all origins.
+By default, the proxy server does not allow cross-origin requests. Since the proxy server serves both the API and the UI from the same origin, CORS is not needed in standard deployments. In development mode, the Vite dev server proxies API requests to the Express server to maintain same-origin behavior.
+
+If you serve the UI from a different origin than the proxy server, set the `PROXY_SERVER_CORS_ORIGIN` environment variable to the origin you want to allow.
 
 ```bash
 PROXY_SERVER_CORS_ORIGIN=https://my-app.example.com

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -70,15 +70,23 @@ describe("createApp", () => {
   // ── CORS ────────────────────────────────────────────────────────────
 
   describe("CORS", () => {
-    it("reflects the request origin by default", async () => {
+    it("does not allow cross-origin requests by default", async () => {
       const app = createTestApp();
       const response = await request(app)
         .get("/status")
         .set("Origin", "http://example.com");
 
-      expect(response.headers["access-control-allow-origin"]).toBe(
-        "http://example.com",
-      );
+      expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+    });
+
+    it("does not set CORS headers on preflight by default", async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .options("/status")
+        .set("Origin", "http://example.com")
+        .set("Access-Control-Request-Method", "POST");
+
+      expect(response.headers["access-control-allow-origin"]).toBeUndefined();
     });
 
     it("does not set origin header when request has no Origin", async () => {
@@ -99,7 +107,7 @@ describe("createApp", () => {
       );
     });
 
-    it("returns the configured origin regardless of the requesting origin", async () => {
+    it("sets the configured origin as a fixed header for single-origin config", async () => {
       const app = createTestApp(".", ["https://my-app.example.com"]);
       const response = await request(app)
         .get("/status")
@@ -151,8 +159,8 @@ describe("createApp", () => {
       expect(response.headers["access-control-allow-origin"]).toBeUndefined();
     });
 
-    it("only allows GET and POST methods", async () => {
-      const app = createTestApp();
+    it("only allows GET and POST methods when corsOrigin is configured", async () => {
+      const app = createTestApp(".", ["http://example.com"]);
       const response = await request(app)
         .options("/status")
         .set("Origin", "http://example.com")
@@ -161,8 +169,8 @@ describe("createApp", () => {
       expect(response.headers["access-control-allow-methods"]).toBe("GET,POST");
     });
 
-    it("sets preflight max-age cache header", async () => {
-      const app = createTestApp();
+    it("sets preflight max-age cache header when corsOrigin is configured", async () => {
+      const app = createTestApp(".", ["http://example.com"]);
       const response = await request(app)
         .options("/status")
         .set("Origin", "http://example.com")

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -81,17 +81,15 @@ export function createApp({
 
   app.use(requestLoggingMiddleware());
   app.use(compression());
-  app.use(
-    cors({
-      origin: corsOrigin
-        ? corsOrigin.length === 1
-          ? corsOrigin[0]
-          : corsOrigin
-        : true,
-      methods: ["GET", "POST"],
-      maxAge: 86400,
-    }),
-  );
+  if (corsOrigin) {
+    app.use(
+      cors({
+        origin: corsOrigin.length === 1 ? corsOrigin[0] : corsOrigin,
+        methods: ["GET", "POST"],
+        maxAge: 86400,
+      }),
+    );
+  }
   app.use(bodyParser.json({ limit: "50mb" }));
   app.use(bodyParser.urlencoded({ extended: true, limit: "50mb" }));
   app.use(

--- a/packages/graph-explorer/vite.config.ts
+++ b/packages/graph-explorer/vite.config.ts
@@ -38,15 +38,13 @@ export default defineConfig(({ mode }) => {
         ignored: ["**/*.test.ts", "**/*.test.tsx"],
       },
       proxy: {
-        // Forward these requests to the express server when in dev mode
-        "/defaultConnection": {
-          target: expressServerUrl,
-          changeOrigin: true,
-        },
-        "/status": {
-          target: expressServerUrl,
-          changeOrigin: true,
-        },
+        // Forward API requests to the Express proxy server in dev mode so
+        // the browser stays on the same origin and CORS is not needed.
+        "^/(defaultConnection|gremlin|logger|openCypher|pg|rdf|sparql|status|summary)(/|$)":
+          {
+            target: expressServerUrl,
+            changeOrigin: true,
+          },
       },
     },
     base: env.GRAPH_EXP_ENV_ROOT_FOLDER,


### PR DESCRIPTION
## Description

The proxy server now blocks cross-origin requests by default instead of allowing all origins. The CORS middleware is only added when `PROXY_SERVER_CORS_ORIGIN` is explicitly configured.

Since the proxy server serves both the API and the UI from the same origin in all standard deployments (Docker, SageMaker, ECS Fargate), CORS is unnecessary.

- **Remove always-on CORS middleware** — the `cors` middleware is now conditionally mounted only when `PROXY_SERVER_CORS_ORIGIN` is set, eliminating any dependency on the cors package's internal behavior for the default-deny case
- **Expand Vite dev proxy** — forward all API routes (`gremlin`, `sparql`, `openCypher`, `summary`, `pg`, `rdf`, `logger`, `status`, `defaultConnection`) through the Vite dev server so dev mode stays same-origin and works without CORS
- **Update tests** — add negative tests for default-deny on both simple and preflight requests, rename tests for clarity
- **Update docs** — security.md and configuration.md reflect the new default

> [!IMPORTANT]
> This is a breaking change for anyone serving the UI from a different origin than the proxy server. They will need to set `PROXY_SERVER_CORS_ORIGIN` to the UI origin.

## Validation

- All 66 proxy server tests pass, including new default-deny tests for simple requests and preflight
- `pnpm checks` passes (lint, format, types)
- `pnpm coverage` passes across the full monorepo
- Manually verified dev server proxy works as expected

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.