### PR TITLE
Break circular dependency in storageAtoms

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/index.ts
+++ b/packages/graph-explorer/src/core/StateProvider/index.ts
@@ -15,3 +15,4 @@ export * from "./schema";
 export * from "./storageAtoms";
 export * from "./graphSession";
 export * from "./userLayout";
+export * from "./userLayoutDefaults";

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.test.ts
@@ -1,0 +1,64 @@
+import { createStore } from "jotai";
+
+import {
+  activeConfigurationAtom,
+  allGraphSessionsAtom,
+  allowLoggingDbQueryAtom,
+  configurationAtom,
+  defaultNeighborExpansionLimitAtom,
+  defaultNeighborExpansionLimitEnabledAtom,
+  diagnosticLoggingAtom,
+  schemaAtom,
+  showDebugActionsAtom,
+  userLayoutAtom,
+  userStylingAtom,
+} from "./storageAtoms";
+import { defaultUserLayout } from "./userLayoutDefaults";
+
+/**
+ * storageAtoms.ts uses top-level await to preload IndexedDB data into Jotai
+ * atoms. These tests verify that all atoms are properly initialized and
+ * readable from a fresh store, which guards against circular dependency
+ * regressions that would leave atoms as `undefined`.
+ */
+describe("storageAtoms", () => {
+  it("should initialize all atoms as defined values", () => {
+    expect(activeConfigurationAtom).toBeDefined();
+    expect(configurationAtom).toBeDefined();
+    expect(schemaAtom).toBeDefined();
+    expect(userStylingAtom).toBeDefined();
+    expect(userLayoutAtom).toBeDefined();
+    expect(allGraphSessionsAtom).toBeDefined();
+    expect(showDebugActionsAtom).toBeDefined();
+    expect(allowLoggingDbQueryAtom).toBeDefined();
+    expect(defaultNeighborExpansionLimitEnabledAtom).toBeDefined();
+    expect(defaultNeighborExpansionLimitAtom).toBeDefined();
+    expect(diagnosticLoggingAtom).toBeDefined();
+  });
+
+  it("should provide correct default values from a fresh store", () => {
+    const store = createStore();
+
+    expect(store.get(activeConfigurationAtom)).toBeNull();
+    expect(store.get(configurationAtom)).toStrictEqual(new Map());
+    expect(store.get(schemaAtom)).toStrictEqual(new Map());
+    expect(store.get(userStylingAtom)).toStrictEqual({});
+    expect(store.get(userLayoutAtom)).toStrictEqual(defaultUserLayout);
+    expect(store.get(allGraphSessionsAtom)).toStrictEqual(new Map());
+    expect(store.get(showDebugActionsAtom)).toBe(false);
+    expect(store.get(allowLoggingDbQueryAtom)).toBe(false);
+    expect(store.get(defaultNeighborExpansionLimitEnabledAtom)).toBe(true);
+    expect(store.get(defaultNeighborExpansionLimitAtom)).toBe(10);
+    expect(store.get(diagnosticLoggingAtom)).toBe(false);
+  });
+
+  it("should persist a written value on subsequent reads", () => {
+    const store = createStore();
+
+    store.set(showDebugActionsAtom, true);
+    expect(store.get(showDebugActionsAtom)).toBe(true);
+
+    store.set(showDebugActionsAtom, false);
+    expect(store.get(showDebugActionsAtom)).toBe(false);
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -7,7 +7,7 @@ import type { SchemaStorageModel } from "./schema";
 import type { UserStyling } from "./userPreferences";
 
 import { atomWithLocalForage } from "./atomWithLocalForage";
-import { defaultUserLayout } from "./userLayout";
+import { defaultUserLayout } from "./userLayoutDefaults";
 
 /**
  DEV NOTE

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -2,14 +2,12 @@ import type {
   ConfigurationId,
   RawConfiguration,
 } from "../ConfigurationProvider";
+import type { GraphSessionStorageModel } from "./graphSession/storage";
+import type { SchemaStorageModel } from "./schema";
+import type { UserStyling } from "./userPreferences";
 
 import { atomWithLocalForage } from "./atomWithLocalForage";
-import {
-  defaultUserLayout,
-  type GraphSessionStorageModel,
-  type SchemaStorageModel,
-  type UserStyling,
-} from "./index";
+import { defaultUserLayout } from "./userLayout";
 
 /**
  DEV NOTE

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
@@ -1,6 +1,4 @@
 // @vitest-environment happy-dom
-import type { ExtractAtomValue } from "jotai";
-
 import { act } from "react";
 
 import {
@@ -9,17 +7,22 @@ import {
   renderHookWithState,
 } from "@/utils/testing";
 
-import { userLayoutAtom } from "./storageAtoms";
-import { useSidebar, useViewToggles } from "./userLayout";
+import type { UserLayout } from "./userLayoutDefaults";
 
-type UserLayout = ExtractAtomValue<typeof userLayoutAtom>;
+import { userLayoutAtom } from "./storageAtoms";
+import {
+  useSidebar,
+  useSidebarSize,
+  useTableViewSize,
+  useViewToggles,
+} from "./userLayout";
 
 describe("useViewToggles", () => {
   it("should default to both views open", () => {
     const { result } = renderHookWithState(() => useViewToggles());
 
-    expect(result.current.isGraphVisible).toBeTruthy();
-    expect(result.current.isTableVisible).toBeTruthy();
+    expect(result.current.isGraphVisible).toBe(true);
+    expect(result.current.isTableVisible).toBe(true);
   });
 
   it("should toggle graph view", () => {
@@ -27,13 +30,13 @@ describe("useViewToggles", () => {
 
     act(() => result.current.toggleGraphVisibility());
 
-    expect(result.current.isGraphVisible).toBeFalsy();
-    expect(result.current.isTableVisible).toBeTruthy();
+    expect(result.current.isGraphVisible).toBe(false);
+    expect(result.current.isTableVisible).toBe(true);
 
     act(() => result.current.toggleGraphVisibility());
 
-    expect(result.current.isGraphVisible).toBeTruthy();
-    expect(result.current.isTableVisible).toBeTruthy();
+    expect(result.current.isGraphVisible).toBe(true);
+    expect(result.current.isTableVisible).toBe(true);
   });
 
   it("should toggle table view", () => {
@@ -41,13 +44,13 @@ describe("useViewToggles", () => {
 
     act(() => result.current.toggleTableVisibility());
 
-    expect(result.current.isGraphVisible).toBeTruthy();
-    expect(result.current.isTableVisible).toBeFalsy();
+    expect(result.current.isGraphVisible).toBe(true);
+    expect(result.current.isTableVisible).toBe(false);
 
     act(() => result.current.toggleTableVisibility());
 
-    expect(result.current.isGraphVisible).toBeTruthy();
-    expect(result.current.isTableVisible).toBeTruthy();
+    expect(result.current.isGraphVisible).toBe(true);
+    expect(result.current.isTableVisible).toBe(true);
   });
 });
 
@@ -58,7 +61,7 @@ describe("useSidebar", () => {
     expect(result.current.isSidebarOpen).toBe(true);
   });
 
-  it("should change to the give sidebar item", () => {
+  it("should change to the given sidebar item", () => {
     const { result } = renderHookWithJotai(() => useSidebar());
 
     act(() => result.current.toggleSidebar("details"));
@@ -132,5 +135,56 @@ describe("useSidebar", () => {
     expect(result.current.isSidebarOpen).toBe(false);
     expect(result.current.activeSidebarItem).toBeNull();
     expect(result.current.shouldShowNamespaces).toBe(false);
+  });
+});
+
+describe("useTableViewSize", () => {
+  it("should default to DEFAULT_TABLE_VIEW_HEIGHT", () => {
+    const { result } = renderHookWithState(() => useTableViewSize());
+
+    expect(result.current[0]).toBe(300);
+  });
+
+  it("should return 100% when graph viewer is hidden", () => {
+    const { result } = renderHookWithState(() => ({
+      tableView: useTableViewSize(),
+      toggles: useViewToggles(),
+    }));
+
+    act(() => result.current.toggles.toggleGraphVisibility());
+
+    expect(result.current.tableView[0]).toBe("100%");
+  });
+
+  it("should adjust height by delta", () => {
+    const { result } = renderHookWithState(() => useTableViewSize());
+
+    act(() => result.current[1](50));
+
+    expect(result.current[0]).toBe(350);
+
+    act(() => result.current[1](-100));
+
+    expect(result.current[0]).toBe(250);
+  });
+});
+
+describe("useSidebarSize", () => {
+  it("should default to 400", () => {
+    const { result } = renderHookWithState(() => useSidebarSize());
+
+    expect(result.current[0]).toBe(400);
+  });
+
+  it("should adjust width by delta", () => {
+    const { result } = renderHookWithState(() => useSidebarSize());
+
+    act(() => result.current[1](100));
+
+    expect(result.current[0]).toBe(500);
+
+    act(() => result.current[1](-200));
+
+    expect(result.current[0]).toBe(300);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.ts
@@ -2,41 +2,12 @@ import { useAtom } from "jotai";
 
 import { useQueryEngine } from "../connector";
 import { userLayoutAtom } from "./storageAtoms";
-
-export type ToggleableView = "graph-viewer" | "table-view";
-
-type UserLayout = {
-  activeToggles: Set<ToggleableView>;
-  activeSidebarItem:
-    | "search"
-    | "details"
-    | "filters"
-    | "expand"
-    | "nodes-styling"
-    | "edges-styling"
-    | "namespaces"
-    | null;
-  tableView?: {
-    height: number;
-  };
-  sidebar?: {
-    width: number;
-  };
-  detailsAutoOpenOnSelection?: boolean;
-};
-
-export type SidebarItems = UserLayout["activeSidebarItem"];
-
-export const DEFAULT_TABLE_VIEW_HEIGHT = 300;
-
-export const defaultUserLayout: UserLayout = {
-  activeToggles: new Set(["graph-viewer", "table-view"]),
-  activeSidebarItem: "search",
-  detailsAutoOpenOnSelection: true,
-  tableView: {
-    height: DEFAULT_TABLE_VIEW_HEIGHT,
-  },
-};
+import {
+  DEFAULT_SIDEBAR_WIDTH,
+  DEFAULT_TABLE_VIEW_HEIGHT,
+  type SidebarItems,
+  type ToggleableView,
+} from "./userLayoutDefaults";
 
 export function useViewToggles() {
   const [userLayout, setUserLayout] = useAtom(userLayoutAtom);
@@ -75,7 +46,7 @@ export function useTableViewSize() {
 
   const tableViewHeight = !userLayout.activeToggles.has("graph-viewer")
     ? "100%"
-    : userLayout.tableView?.height || DEFAULT_TABLE_VIEW_HEIGHT;
+    : (userLayout.tableView?.height ?? DEFAULT_TABLE_VIEW_HEIGHT);
 
   /** Sets the table view height to the current height + the given delta */
   const setTableViewHeight = (deltaHeight: number) =>
@@ -84,7 +55,7 @@ export function useTableViewSize() {
       return {
         ...prev,
         tableView: {
-          ...(prev.tableView || {}),
+          ...prev.tableView,
           height: prevHeight + deltaHeight,
         },
       };
@@ -138,15 +109,12 @@ export function useSidebar() {
   };
 }
 
-export const DEFAULT_SIDEBAR_WIDTH = 400;
-export const CLOSED_SIDEBAR_WIDTH = 50;
-
 export function useSidebarSize() {
   const [userLayout, setUserLayout] = useAtom(userLayoutAtom);
 
   const sidebarWidth = userLayout.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;
 
-  /** Sets the sidebar width to the current with + the given delta */
+  /** Sets the sidebar width to the current width + the given delta */
   const setSidebarWidth = (deltaWidth: number) => {
     setUserLayout(prev => {
       const prevWidth = prev.sidebar?.width ?? DEFAULT_SIDEBAR_WIDTH;

--- a/packages/graph-explorer/src/core/StateProvider/userLayoutDefaults.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayoutDefaults.ts
@@ -1,0 +1,45 @@
+/** The two main content views that can be toggled on or off. */
+export type ToggleableView = "graph-viewer" | "table-view";
+
+/** Identifiers for the sidebar panels, or null when the sidebar is closed. */
+export type SidebarItems =
+  | "search"
+  | "details"
+  | "filters"
+  | "expand"
+  | "nodes-styling"
+  | "edges-styling"
+  | "namespaces"
+  | null;
+
+/** Persisted layout preferences for the main application shell. */
+export type UserLayout = {
+  activeToggles: Set<ToggleableView>;
+  activeSidebarItem: SidebarItems;
+  tableView?: {
+    height: number;
+  };
+  sidebar?: {
+    width: number;
+  };
+  detailsAutoOpenOnSelection?: boolean;
+};
+
+/** Default height for the table view panel in pixels. */
+export const DEFAULT_TABLE_VIEW_HEIGHT = 300;
+
+/** Default width for the sidebar panel in pixels. */
+export const DEFAULT_SIDEBAR_WIDTH = 400;
+
+/** Width of the sidebar when collapsed. */
+export const CLOSED_SIDEBAR_WIDTH = 50;
+
+/** Initial layout state used when no persisted layout exists. */
+export const defaultUserLayout: UserLayout = {
+  activeToggles: new Set(["graph-viewer", "table-view"]),
+  activeSidebarItem: "search",
+  detailsAutoOpenOnSelection: true,
+  tableView: {
+    height: DEFAULT_TABLE_VIEW_HEIGHT,
+  },
+};


### PR DESCRIPTION
## Description

`storageAtoms.ts` imported `defaultUserLayout` from `./index` (the barrel), which triggered loading all barrel re-exports. Several of those modules import storage atoms back through `@/core`, creating a circular dependency. Because `storageAtoms` uses top-level `await`, the atoms were `undefined` when the circular modules evaluated, causing 6 flaky test failures in `userLayout.test.ts` that depended on module loading order.

- Replace the barrel import in `storageAtoms.ts` with direct imports from source modules
- Extract types and layout constants into `userLayoutDefaults.ts` as a pure leaf module with no imports, fully decoupling `storageAtoms` from `userLayout`
- Add regression tests for `storageAtoms` (atoms defined, correct defaults, write/read roundtrip)
- Add tests for `useTableViewSize` and `useSidebarSize` hooks
- Fix pre-existing `||` vs `??` bug in `useTableViewSize` where a height of 0 silently fell back to the default
- Fix pre-existing dead code (`|| {}` guard), typos, and loose test assertions

## Validation

- All 153 test files pass (1654 tests), including the 6 previously flaky tests in `userLayout.test.ts`
- `pnpm checks` passes (lint, format, types)
- The `storageAtoms.test.ts` regression tests verify all atoms are defined and return correct defaults from a fresh store, which would catch a circular dependency regression

## Related Issues

- Part of general codebase health

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.