### PR TITLE
Restructure root README with clear user paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,42 +26,24 @@ Understand your data model at a glance. See node types, their relationships, and
 
 ![Schema Explorer showing the relationships between airport, country, continent, and version node types](./images/schema-explorer.png)
 
-### Flexible Deployment
+## Get Started
 
-Run Graph Explorer wherever it fits your workflow: as a Docker container, on an Amazon EC2 instance, through Amazon SageMaker, or locally from source during development. Configure multiple connections to different databases and switch between them seamlessly. See [Getting Started](#getting-started) for setup guides.
+- [Hands-on tutorial](./docs/getting-started/README.md) — Try Graph Explorer with sample data using Docker Compose
+- [Deployment & connection guides](./docs/guides) — Run with Docker, EC2, ECS Fargate, or SageMaker and connect to your database
+- [Development](./docs/development.md) — Build from source for local development
 
-## Learn More
+## Documentation
 
-- [Documentation](./docs) - Full documentation index
-- [Getting Started](./docs/getting-started/README.md) - A hands-on tutorial using the air routes sample dataset
-- [Features Overview](./docs/features/README.md) - Detailed guide to all features and functionality
-- [Guides](./docs/guides) - Database connections, deployment, and troubleshooting
-- [Roadmap](./ROADMAP.md) - See what's planned for future releases
-- [Discussions](https://github.com/aws/graph-explorer/discussions) - Ask questions, share ideas, and connect with the community
-- [Submit an Issue](https://github.com/aws/graph-explorer/issues/new/choose) - Report bugs or request new features
-- [Contributing](./CONTRIBUTING.md) - Learn how to contribute to Graph Explorer
-- [Changelog](./Changelog.md) - See what's changed in recent releases
+See the [full documentation](./docs) for features, guides, references, and more.
 
-## Getting Started
+## Community
 
-There are many ways to deploy and run Graph Explorer. If you are new to graph databases and Graph Explorer, we recommend that you check out the [Getting Started](./docs/getting-started/README.md) guide.
+- [Roadmap](./ROADMAP.md) — See what's planned
+- [Changelog](./Changelog.md) — Recent releases
+- [Discussions](https://github.com/aws/graph-explorer/discussions) — Ask questions and share ideas
+- [Submit an Issue](https://github.com/aws/graph-explorer/issues/new/choose) — Report bugs or request features
 
-- [Try It Out](./docs/getting-started/README.md#launch-graph-explorer) - Launch Graph Explorer with sample data using Docker Compose.
-- [Local Docker Setup](./docs/guides/deploy-with-docker.md) - A quick start guide to deploying Graph Explorer locally using the official Docker image.
-- [Amazon EC2 Setup](./docs/guides/deploy-to-ec2.md) - A quick start guide to setting up Graph Explorer on Amazon EC2 with Neptune.
-- [Local Development](./docs/development.md) - Build from source for local development.
-- [Troubleshooting](./docs/guides/troubleshooting.md) - A collection of helpful tips if you run in to issues while setting up Graph Explorer.
-- [Samples](./samples) - A collection of Docker Compose files that show various ways to configure and use Graph Explorer.
-
-## Connections
-
-Graph Explorer supports visualizing both **property graphs** and **RDF graphs**. You can connect to Amazon Neptune or you can also connect to open graph databases that implement an Apache TinkerPop Gremlin endpoint or the SPARQL 1.1 protocol, such as Blazegraph. For additional details on connecting to different graph databases, see [Guides](./docs/guides).
-
-## Development
-
-For development guidance, see [Development](./docs/development.md).
-
-## Contributing Guidelines
+## Contributing
 
 See [CONTRIBUTING](./CONTRIBUTING.md) for more information.
 


### PR DESCRIPTION
## Description

Replace the overlapping "Learn More", "Getting Started", and "Connections" sections in the root README with a focused structure:

- **Get Started** — Three clear paths: hands-on tutorial, deployment/connection guides, and build from source
- **Documentation** — Single link to the full docs index, avoiding duplication
- **Community** — Roadmap, changelog, discussions, and issue submission links that were previously buried in the "Learn More" list
- Removed the "Connections" section (redundant with the intro paragraph and guides)
- Removed the standalone "Development" section (now covered by Get Started)
- Kept the product intro, screenshots, Contributing, and License sections as-is

## Validation

- All internal links verified against the repo file structure
- Prettier formatting confirmed clean
- `pnpm audit` clean

## Related Issues

- Fixes #1718

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.