### PR TITLE
Bump version to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Graph Explorer",
   "author": "amazon",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "type": "module",
   "scripts": {

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Graph Explorer",
   "engines": {
     "node": ">=24.13.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Shared types and functions across client and server.",
   "author": "amazon",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Bump version from 3.0.2 to 3.0.3 across all workspace packages.

- Update version in root `package.json`
- Update version in `packages/graph-explorer/package.json`
- Update version in `packages/graph-explorer-proxy-server/package.json`
- Update version in `packages/shared/package.json`

## Validation

- Verified `pnpm checks` passes (lint, format, types)

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.