### PR TITLE
Infer edge connections from graph exploration

### DIFF
--- a/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
+++ b/packages/graph-explorer/src/core/ConfigurationProvider/types.ts
@@ -9,8 +9,14 @@ import type {
 import type { Branded } from "@/utils";
 import type { IriNamespace, RdfPrefix } from "@/utils/rdf";
 
-import type { EdgeType, VertexType } from "../entities";
 import type { SchemaStorageModel } from "../StateProvider";
+
+import {
+  createEdgeType,
+  createVertexType,
+  type EdgeType,
+  type VertexType,
+} from "../entities";
 
 export type ConfigurationId = Branded<string, "ConfigurationId">;
 
@@ -133,6 +139,21 @@ export type EdgeConnection = {
    */
   count?: number;
 };
+
+/** Creates an EdgeConnection with branded types from plain strings. */
+export function createEdgeConnection(options: {
+  source: string;
+  edge: string;
+  target: string;
+  count?: number;
+}): EdgeConnection {
+  return {
+    sourceVertexType: createVertexType(options.source),
+    edgeType: createEdgeType(options.edge),
+    targetVertexType: createVertexType(options.target),
+    ...(options.count != null && { count: options.count }),
+  };
+}
 
 export type RawConfiguration = {
   /**

--- a/packages/graph-explorer/src/core/StateProvider/schema.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@/utils/testing";
 
 import {
+  createEdgeConnection,
   createPrefixTypeConfig,
   type EdgeTypeConfig,
   type PrefixTypeConfig,
@@ -34,10 +35,13 @@ import {
   createEdge,
   createEdgeType,
   createVertex,
+  createVertexId,
   createVertexType,
   type EntityProperties,
 } from "../entities";
 import {
+  activeSchemaSelector,
+  createVertexTypeLookup,
   generateSchemaPrefixes,
   mapEdgeToTypeConfig,
   mapVertexToTypeConfigs,
@@ -50,6 +54,8 @@ import {
   useMaybeActiveSchema,
   useUpdateSchemaFromEntities,
 } from "./schema";
+
+const EMPTY_VERTEX_TYPE_LOOKUP = createVertexTypeLookup();
 
 describe("schema", () => {
   describe("mapVertexToTypeConfigs", () => {
@@ -120,12 +126,403 @@ describe("schema", () => {
     });
   });
 
+  describe("createVertexTypeLookup", () => {
+    it("should resolve vertex types by ID", () => {
+      const v1 = createVertex({ id: "v1", types: ["Person"], attributes: {} });
+      const v2 = createVertex({
+        id: "v2",
+        types: ["Dog", "Pet"],
+        attributes: {},
+      });
+      const map = new Map([
+        [v1.id, v1],
+        [v2.id, v2],
+      ]);
+
+      const lookup = createVertexTypeLookup(map);
+
+      expect(lookup.get(v1.id)).toStrictEqual(v1.types);
+      expect(lookup.get(v2.id)).toStrictEqual(v2.types);
+    });
+
+    it("should chain multiple maps", () => {
+      const v1 = createVertex({ id: "v1", types: ["Person"], attributes: {} });
+      const v2 = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+
+      const lookup = createVertexTypeLookup(
+        new Map([[v1.id, v1]]),
+        new Map([[v2.id, v2]]),
+      );
+
+      expect(lookup.get(v1.id)).toStrictEqual(v1.types);
+      expect(lookup.get(v2.id)).toStrictEqual(v2.types);
+    });
+
+    it("should return types from the first map that contains the vertex", () => {
+      const v1 = createVertex({ id: "v1", types: ["Person"], attributes: {} });
+      const v1Duplicate = createVertex({
+        id: "v1",
+        types: ["Employee"],
+        attributes: {},
+      });
+
+      const lookup = createVertexTypeLookup(
+        new Map([[v1.id, v1]]),
+        new Map([[v1Duplicate.id, v1Duplicate]]),
+      );
+
+      expect(lookup.get(v1.id)).toStrictEqual(v1.types);
+    });
+
+    it("should return undefined for unknown vertex IDs", () => {
+      const v1 = createVertex({ id: "v1", types: ["Person"], attributes: {} });
+      const lookup = createVertexTypeLookup(new Map([[v1.id, v1]]));
+
+      expect(lookup.get(createVertexId("v99"))).toBeUndefined();
+    });
+
+    it("should report isEmpty when all maps are empty", () => {
+      const lookup = createVertexTypeLookup(new Map(), new Map());
+
+      expect(lookup.isEmpty()).toBe(true);
+    });
+
+    it("should report not empty when any map has entries", () => {
+      const v1 = createVertex({ id: "v1", types: ["Person"], attributes: {} });
+      const lookup = createVertexTypeLookup(new Map(), new Map([[v1.id, v1]]));
+
+      expect(lookup.isEmpty()).toBe(false);
+    });
+  });
+
+  describe("updateSchemaFromEntities edge connections", () => {
+    it("should not change edgeConnections when vertex lookup is empty", () => {
+      const schema = createRandomSchema();
+      const edge = createRandomEdge();
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
+
+      expect(result.edgeConnections).toBe(schema.edgeConnections);
+    });
+
+    it("should infer connections when schema has no prior edgeConnections", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const target = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+      const edge = createEdge({
+        id: "e1",
+        type: "owner",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = { vertices: [], edges: [] };
+      expect(schema.edgeConnections).toBeUndefined();
+
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toStrictEqual([
+        createEdgeConnection({
+          source: "Person",
+          edge: "owner",
+          target: "Dog",
+        }),
+      ]);
+    });
+
+    it("should not change edgeConnections when entities have no edges", () => {
+      const schema = createRandomSchema();
+      const vertex = createRandomVertex();
+
+      const vertexLookup = createVertexTypeLookup(
+        new Map([[vertex.id, vertex]]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toBe(schema.edgeConnections);
+    });
+
+    it("should infer edge connections from edges and vertex lookup", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const target = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+      const edge = createEdge({
+        id: "e1",
+        type: "owner",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = { vertices: [], edges: [] };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toStrictEqual([
+        createEdgeConnection({
+          source: "Person",
+          edge: "owner",
+          target: "Dog",
+        }),
+      ]);
+    });
+
+    it("should create connections for all type combinations of multi-label vertices", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person", "Employee"],
+        attributes: {},
+      });
+      const target = createVertex({
+        id: "v2",
+        types: ["Company"],
+        attributes: {},
+      });
+      const edge = createEdge({
+        id: "e1",
+        type: "worksAt",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = { vertices: [], edges: [] };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toStrictEqual([
+        createEdgeConnection({
+          source: "Person",
+          edge: "worksAt",
+          target: "Company",
+        }),
+        createEdgeConnection({
+          source: "Employee",
+          edge: "worksAt",
+          target: "Company",
+        }),
+      ]);
+    });
+
+    it("should skip edges where source or target vertex type cannot be resolved", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const edge = createEdge({
+        id: "e1",
+        type: "knows",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = {
+        vertices: [],
+        edges: [],
+        edgeConnections: [],
+      };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([[source.id, source]]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toBe(schema.edgeConnections);
+    });
+
+    it("should preserve existing edge connections including count", () => {
+      const existingConnection = createEdgeConnection({
+        source: "Cat",
+        edge: "chases",
+        target: "Mouse",
+        count: 7,
+      });
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const target = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+      const edge = createEdge({
+        id: "e1",
+        type: "owner",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = {
+        vertices: [],
+        edges: [],
+        edgeConnections: [existingConnection],
+      };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toStrictEqual([
+        existingConnection,
+        createEdgeConnection({
+          source: "Person",
+          edge: "owner",
+          target: "Dog",
+        }),
+      ]);
+    });
+
+    it("should not add duplicate edge connections", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const target = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+      const existingConnection = createEdgeConnection({
+        source: "Person",
+        edge: "owner",
+        target: "Dog",
+        count: 42,
+      });
+      const edge = createEdge({
+        id: "e1",
+        type: "owner",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = {
+        vertices: [],
+        edges: [],
+        edgeConnections: [existingConnection],
+      };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toBe(schema.edgeConnections);
+    });
+
+    it("should preserve edgeConnections reference when no new connections are discovered", () => {
+      const source = createVertex({
+        id: "v1",
+        types: ["Person"],
+        attributes: {},
+      });
+      const target = createVertex({ id: "v2", types: ["Dog"], attributes: {} });
+      const existingConnection = createEdgeConnection({
+        source: "Person",
+        edge: "owner",
+        target: "Dog",
+      });
+      const edge = createEdge({
+        id: "e1",
+        type: "owner",
+        sourceId: "v1",
+        targetId: "v2",
+        attributes: {},
+      });
+
+      const schema: SchemaStorageModel = {
+        vertices: [],
+        edges: [],
+        edgeConnections: [existingConnection],
+      };
+      const vertexLookup = createVertexTypeLookup(
+        new Map([
+          [source.id, source],
+          [target.id, target],
+        ]),
+      );
+
+      const result = updateSchemaFromEntities(
+        { edges: [edge], vertices: [source, target] },
+        schema,
+        vertexLookup,
+      );
+
+      expect(result.edgeConnections).toBe(schema.edgeConnections);
+    });
+  });
+
   describe("updateSchemaFromEntities", () => {
     it("should do nothing when no entities", () => {
       const originalSchema = createRandomSchema();
       const result = updateSchemaFromEntities(
         { vertices: [], edges: [] },
         originalSchema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
       );
 
       expect(result).toEqual(originalSchema);
@@ -138,6 +535,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         { vertices: newNodes, edges: newEdges },
         originalSchema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
       );
 
       expect(result).toEqual({
@@ -165,6 +563,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         { vertices: [newNode1, newNode2], edges: [newEdge1, newEdge2] },
         originalSchema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
       );
 
       const node1Configs = mapVertexToTypeConfigs(newNode1);
@@ -207,6 +606,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         { vertices: [newNode], edges: [newEdge] },
         originalSchema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
       );
 
       expect(result.vertices.flatMap(v => v.attributes)).toEqual(
@@ -236,6 +636,7 @@ describe("schema", () => {
       const result = updateSchemaFromEntities(
         { vertices: newNodes, edges: [] },
         originalSchema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
       );
 
       const emptyTypeVtConfigs = result.vertices.filter(
@@ -259,7 +660,11 @@ describe("schema", () => {
         types: ["http://data.nobelprize.org/class/Country"],
       });
 
-      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
 
       const prefixes = result.prefixes?.map(p => p.prefix);
       expect(prefixes).toContain("country");
@@ -277,7 +682,11 @@ describe("schema", () => {
         attributes: { name: "Alice" },
       });
 
-      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
 
       expect(result.vertices).toHaveLength(2);
       expect(result.vertices.map(v => v.type)).toStrictEqual([
@@ -320,7 +729,11 @@ describe("schema", () => {
         },
       });
 
-      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
 
       expect(result.prefixes).toBe(schema.prefixes);
     });
@@ -353,7 +766,11 @@ describe("schema", () => {
         },
       });
 
-      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
 
       const newPrefixes = result.prefixes!.filter(
         p => !schema.prefixes!.includes(p),
@@ -386,7 +803,11 @@ describe("schema", () => {
         attributes: {},
       });
 
-      const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+      const result = updateSchemaFromEntities(
+        { vertices: [vertex] },
+        schema,
+        EMPTY_VERTEX_TYPE_LOOKUP,
+      );
 
       const newPrefixes = result.prefixes!.filter(
         p => !schema.prefixes!.includes(p),
@@ -480,7 +901,11 @@ describe("referential integrity", () => {
       return acc;
     }, {} as EntityProperties);
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result).toBe(schema);
   });
@@ -495,7 +920,11 @@ describe("referential integrity", () => {
       return acc;
     }, {} as EntityProperties);
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.vertices[0]).toBe(schema.vertices[0]);
   });
@@ -509,7 +938,11 @@ describe("referential integrity", () => {
       return acc;
     }, {} as EntityProperties);
 
-    const result = updateSchemaFromEntities({ edges: [edge] }, schema);
+    const result = updateSchemaFromEntities(
+      { edges: [edge] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.edges[0]).toBe(schema.edges[0]);
   });
@@ -524,7 +957,11 @@ describe("referential integrity", () => {
       return acc;
     }, {} as EntityProperties);
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.vertices[0].attributes).toBe(schema.vertices[0].attributes);
   });
@@ -535,7 +972,11 @@ describe("referential integrity", () => {
     vertex.type = schema.vertices[0].type;
     vertex.types = [schema.vertices[0].type];
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.vertices[0]).not.toBe(schema.vertices[0]);
     expect(result.vertices[0].attributes).not.toBe(
@@ -548,7 +989,11 @@ describe("referential integrity", () => {
     const edge = createRandomEdge();
     edge.type = schema.edges[0].type;
 
-    const result = updateSchemaFromEntities({ edges: [edge] }, schema);
+    const result = updateSchemaFromEntities(
+      { edges: [edge] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.edges[0]).not.toBe(schema.edges[0]);
     expect(result.edges[0].attributes).not.toBe(schema.edges[0].attributes);
@@ -558,7 +1003,11 @@ describe("referential integrity", () => {
     const schema = createRandomSchema();
     const edge = createRandomEdge();
 
-    const result = updateSchemaFromEntities({ edges: [edge] }, schema);
+    const result = updateSchemaFromEntities(
+      { edges: [edge] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.vertices).toBe(schema.vertices);
   });
@@ -567,7 +1016,11 @@ describe("referential integrity", () => {
     const schema = createRandomSchema();
     const vertex = createRandomVertex();
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.edges).toBe(schema.edges);
   });
@@ -576,7 +1029,11 @@ describe("referential integrity", () => {
     const schema = createRandomSchema();
     const vertex = createRandomVertex();
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     expect(result.prefixes).toBe(schema.prefixes);
   });
@@ -728,6 +1185,103 @@ describe("useUpdateSchemaFromEntities", () => {
     });
 
     expect(result.current.schemaMap).toBe(schemaMapBefore);
+  });
+
+  it("should infer edge connections from entities and canvas vertices", () => {
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [];
+
+    // Source vertex is on the canvas
+    const source = createVertex({
+      id: "v1",
+      types: ["Person"],
+      attributes: {},
+    });
+    state.addVertexToGraph(source);
+
+    // Target vertex and edge arrive via entities
+    const target = createVertex({
+      id: "v2",
+      types: ["Dog"],
+      attributes: {},
+    });
+    const edge = createEdge({
+      id: "e1",
+      type: "owner",
+      sourceId: "v1",
+      targetId: "v2",
+      attributes: {},
+    });
+
+    const { result } = renderHookWithState(
+      () => ({
+        updateSchema: useUpdateSchemaFromEntities(),
+        schema: useAtomValue(activeSchemaSelector),
+      }),
+      state,
+    );
+
+    act(() => {
+      result.current.updateSchema({
+        vertices: [target],
+        edges: [edge],
+      });
+    });
+
+    expect(result.current.schema?.edgeConnections).toStrictEqual([
+      createEdgeConnection({ source: "Person", edge: "owner", target: "Dog" }),
+    ]);
+  });
+
+  it("should prefer entity vertices over canvas vertices for edge connections", () => {
+    const state = new DbState();
+    state.activeSchema.edgeConnections = [];
+
+    // Canvas has v1 as "Employee"
+    const canvasSource = createVertex({
+      id: "v1",
+      types: ["Employee"],
+      attributes: {},
+    });
+    state.addVertexToGraph(canvasSource);
+
+    // Entities provide v1 as "Person" (should take priority)
+    const entitySource = createVertex({
+      id: "v1",
+      types: ["Person"],
+      attributes: {},
+    });
+    const target = createVertex({
+      id: "v2",
+      types: ["Dog"],
+      attributes: {},
+    });
+    const edge = createEdge({
+      id: "e1",
+      type: "owner",
+      sourceId: "v1",
+      targetId: "v2",
+      attributes: {},
+    });
+
+    const { result } = renderHookWithState(
+      () => ({
+        updateSchema: useUpdateSchemaFromEntities(),
+        schema: useAtomValue(activeSchemaSelector),
+      }),
+      state,
+    );
+
+    act(() => {
+      result.current.updateSchema({
+        vertices: [entitySource, target],
+        edges: [edge],
+      });
+    });
+
+    expect(result.current.schema?.edgeConnections).toStrictEqual([
+      createEdgeConnection({ source: "Person", edge: "owner", target: "Dog" }),
+    ]);
   });
 });
 
@@ -956,7 +1510,11 @@ describe("backward compatibility: legacy __matches on prefixes", () => {
       attributes: {},
     });
 
-    const result = updateSchemaFromEntities({ vertices: [vertex] }, schema);
+    const result = updateSchemaFromEntities(
+      { vertices: [vertex] },
+      schema,
+      EMPTY_VERTEX_TYPE_LOOKUP,
+    );
 
     // Legacy prefix should be preserved
     expect(result.prefixes?.[0]).toBe(legacyPrefix);

--- a/packages/graph-explorer/src/core/StateProvider/schema.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schema.ts
@@ -26,10 +26,13 @@ import {
   type EntityProperties,
   schemaAtom,
   type Vertex,
+  type VertexId,
   type VertexType,
 } from "@/core";
 import { logger } from "@/utils";
 import { generatePrefixes, PrefixLookup } from "@/utils/rdf";
+
+import { nodesAtom, toNodeMap } from "./nodes";
 
 /**
  * Persisted schema state for a database connection.
@@ -280,6 +283,7 @@ export const activeSchemaSelector = atom(
 export function updateSchemaFromEntities(
   entities: Partial<Entities>,
   schema: SchemaStorageModel,
+  vertexLookup: VertexTypeLookup,
 ) {
   const vertices = entities.vertices ?? [];
   const edges = entities.edges ?? [];
@@ -305,10 +309,18 @@ export function updateSchemaFromEntities(
     edgeIris,
   );
 
+  const existingConnections = schema.edgeConnections ?? [];
+  const mergedConnections = mergeEdgeConnections(
+    existingConnections,
+    edges,
+    vertexLookup,
+  );
+
   if (
     mergedVertices === schema.vertices &&
     mergedEdges === schema.edges &&
-    mergedPrefixes === existingPrefixes
+    mergedPrefixes === existingPrefixes &&
+    mergedConnections === existingConnections
   ) {
     logger.debug("Schema already up to date with given entities");
     return schema;
@@ -320,10 +332,84 @@ export function updateSchemaFromEntities(
     edges: mergedEdges,
     prefixes:
       mergedPrefixes !== existingPrefixes ? mergedPrefixes : schema.prefixes,
+    edgeConnections:
+      mergedConnections !== existingConnections
+        ? mergedConnections
+        : schema.edgeConnections,
   };
 
   logger.debug("Updated schema from entities", result);
   return result;
+}
+
+/** Resolves a vertex ID to its type labels without copying vertex data. */
+export type VertexTypeLookup = {
+  get(id: VertexId): VertexType[] | undefined;
+  isEmpty(): boolean;
+};
+
+/** Creates a lookup that chains multiple vertex maps, checking each in order. Earlier maps take priority. */
+export function createVertexTypeLookup(
+  ...sources: ReadonlyMap<VertexId, { types: VertexType[] }>[]
+): VertexTypeLookup {
+  return {
+    get(id) {
+      for (const source of sources) {
+        const vertex = source.get(id);
+        if (vertex) {
+          return vertex.types;
+        }
+      }
+      return undefined;
+    },
+    isEmpty() {
+      return sources.every(s => s.size === 0);
+    },
+  };
+}
+
+/** Infers and merges new edge connections from edges and a vertex type lookup. Preserves existing entries including their count. */
+function mergeEdgeConnections(
+  existing: EdgeConnection[],
+  edges: Edge[],
+  vertexLookup: VertexTypeLookup,
+): EdgeConnection[] {
+  // Fast-path: skip work when there are no edges or no vertices to resolve against
+  if (edges.length === 0 || vertexLookup.isEmpty()) {
+    return existing;
+  }
+
+  const existingIds = new Set(existing.map(createEdgeConnectionId));
+  const newConnections: EdgeConnection[] = [];
+
+  for (const edge of edges) {
+    const sourceTypes = vertexLookup.get(edge.sourceId);
+    const targetTypes = vertexLookup.get(edge.targetId);
+    if (!sourceTypes || !targetTypes) {
+      continue;
+    }
+
+    for (const sourceVertexType of sourceTypes) {
+      for (const targetVertexType of targetTypes) {
+        const connection: EdgeConnection = {
+          sourceVertexType,
+          edgeType: edge.type,
+          targetVertexType,
+        };
+        const id = createEdgeConnectionId(connection);
+        if (!existingIds.has(id)) {
+          existingIds.add(id);
+          newConnections.push(connection);
+        }
+      }
+    }
+  }
+
+  if (newConnections.length === 0) {
+    return existing;
+  }
+
+  return [...existing, ...newConnections];
 }
 
 type MergeResult<T> = {
@@ -564,18 +650,24 @@ export function getSchemaUris(schema: {
 /** Updates the schema with any new vertex or edge types, any new attributes, and updates the generated prefixes for sparql connections. */
 export function useUpdateSchemaFromEntities() {
   return useAtomCallback(
-    useCallback((_get, set, entities: Partial<Entities>) => {
+    useCallback((get, set, entities: Partial<Entities>) => {
       const vertices = entities.vertices ?? [];
       const edges = entities.edges ?? [];
       if (vertices.length === 0 && edges.length === 0) {
         return;
       }
 
+      // Incoming entities take priority over canvas vertices
+      const vertexLookup = createVertexTypeLookup(
+        toNodeMap(vertices),
+        get(nodesAtom),
+      );
+
       set(activeSchemaSelector, prev => {
         if (!prev) {
           return prev;
         }
-        return updateSchemaFromEntities(entities, prev);
+        return updateSchemaFromEntities(entities, prev, vertexLookup);
       });
     }, []),
   );

--- a/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.test.ts
@@ -6,6 +6,7 @@ import { act } from "react";
 import {
   activeGraphSessionAtom,
   activeSchemaSelector,
+  createEdgeConnection,
   createVertexType,
   edgesAtom,
   type EdgeTypeConfig,
@@ -20,6 +21,8 @@ import {
   createRandomEntities,
   createRandomVertex,
   createRandomVertexForRdf,
+  createTestableEdge,
+  createTestableVertex,
   DbState,
   renderHookWithState,
 } from "@/utils/testing";
@@ -317,6 +320,102 @@ test("should update graph storage when adding an edge", async () => {
   };
 
   expect(result.current.graph).toStrictEqual(expectedGraph);
+});
+
+test("should infer edge connections when adding edges with vertices", async () => {
+  const dbState = new DbState();
+  dbState.activeSchema.edgeConnections = [];
+
+  const source = createTestableVertex().with({ types: ["Person"] });
+  const target = createTestableVertex().with({ types: ["Dog"] });
+  const edge = createTestableEdge()
+    .with({ type: "owner" })
+    .withSource(source)
+    .withTarget(target);
+
+  const { result } = renderHookWithState(() => {
+    const callback = useAddToGraph();
+    const schema = useAtomValue(activeSchemaSelector);
+    return { callback, schema };
+  }, dbState);
+
+  await act(() =>
+    result.current.callback({
+      vertices: [source.asVertex(), target.asVertex()],
+      edges: [edge.asEdge()],
+    }),
+  );
+
+  expect(result.current.schema?.edgeConnections).toStrictEqual([
+    createEdgeConnection({ source: "Person", edge: "owner", target: "Dog" }),
+  ]);
+});
+
+test("should use batch vertex types over canvas vertex types for edge connections", async () => {
+  const dbState = new DbState();
+  dbState.activeSchema.edgeConnections = [];
+
+  // Canvas has the source as "Employee"
+  const canvasSource = createTestableVertex().with({ types: ["Employee"] });
+  dbState.addVertexToGraph(canvasSource.asVertex());
+
+  // Batch provides the same vertex as "Person" (should take priority)
+  const batchSource = canvasSource.with({ types: ["Person"] });
+  const target = createTestableVertex().with({ types: ["Dog"] });
+  const edge = createTestableEdge()
+    .with({ type: "owner" })
+    .withSource(batchSource)
+    .withTarget(target);
+
+  const { result } = renderHookWithState(() => {
+    const callback = useAddToGraph();
+    const schema = useAtomValue(activeSchemaSelector);
+    return { callback, schema };
+  }, dbState);
+
+  await act(() =>
+    result.current.callback({
+      vertices: [batchSource.asVertex(), target.asVertex()],
+      edges: [edge.asEdge()],
+    }),
+  );
+
+  expect(result.current.schema?.edgeConnections).toStrictEqual([
+    createEdgeConnection({ source: "Person", edge: "owner", target: "Dog" }),
+  ]);
+});
+
+test("should resolve edge endpoints from canvas when not in batch", async () => {
+  const dbState = new DbState();
+  dbState.activeSchema.edgeConnections = [];
+
+  // Source is already on the canvas
+  const source = createTestableVertex().with({ types: ["Person"] });
+  dbState.addVertexToGraph(source.asVertex());
+
+  // Batch only has the target and the edge
+  const target = createTestableVertex().with({ types: ["Dog"] });
+  const edge = createTestableEdge()
+    .with({ type: "owner" })
+    .withSource(source)
+    .withTarget(target);
+
+  const { result } = renderHookWithState(() => {
+    const callback = useAddToGraph();
+    const schema = useAtomValue(activeSchemaSelector);
+    return { callback, schema };
+  }, dbState);
+
+  await act(() =>
+    result.current.callback({
+      vertices: [target.asVertex()],
+      edges: [edge.asEdge()],
+    }),
+  );
+
+  expect(result.current.schema?.edgeConnections).toStrictEqual([
+    createEdgeConnection({ source: "Person", edge: "owner", target: "Dog" }),
+  ]);
 });
 
 test("should ignore blank nodes when updating graph storage", async () => {

--- a/packages/graph-explorer/src/hooks/useAddToGraph.ts
+++ b/packages/graph-explorer/src/hooks/useAddToGraph.ts
@@ -1,9 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 import { useSetAtom } from "jotai";
+import { useAtomCallback } from "jotai/utils";
+import { useCallback } from "react";
 import { toast } from "sonner";
 
 import {
   activeSchemaSelector,
+  createVertexTypeLookup,
   type Edge,
   edgesAtom,
   type Entities,
@@ -24,6 +27,11 @@ export function useAddToGraph() {
   const setActiveSchema = useSetAtom(activeSchemaSelector);
   const updateGraphStorage = useUpdateGraphSession();
 
+  const getCanvasVertices = useAtomCallback(
+    useCallback(get => get(nodesAtom), []),
+  );
+
+  // async is required because useMutation expects a Promise return type
   // oxlint-disable-next-line @typescript-eslint/require-await
   return async (entities: Partial<Entities>) => {
     const newVerticesMap = toNodeMap(entities.vertices ?? []);
@@ -33,6 +41,13 @@ export function useAddToGraph() {
     if (newVerticesMap.size === 0 && newEdgesMap.size === 0) {
       return;
     }
+
+    // Build vertex lookup from batch + canvas before modifying state
+    // Batch vertices take priority over canvas vertices
+    const vertexLookup = createVertexTypeLookup(
+      newVerticesMap,
+      getCanvasVertices(),
+    );
 
     // Add new vertices to the graph
     if (newVerticesMap.size > 0) {
@@ -57,6 +72,7 @@ export function useAddToGraph() {
           edges: newEdgesMap.values().toArray(),
         },
         prev,
+        vertexLookup,
       );
     });
 
@@ -64,13 +80,13 @@ export function useAddToGraph() {
   };
 }
 
-/** Returns a callback the given vertex to the graph. */
+/** Returns a callback that adds the given vertex to the graph. */
 export function useAddVertexToGraph(vertex: Vertex) {
   const callback = useAddToGraph();
   return () => callback({ vertices: [vertex] });
 }
 
-/** Returns a callback the given edge to the graph. */
+/** Returns a callback that adds the given edge to the graph. */
 export function useAddEdgeToGraph(edge: Edge) {
   const callback = useAddToGraph();
   return () => callback({ edges: [edge] });

--- a/packages/graph-explorer/src/utils/testing/FakeExplorer.ts
+++ b/packages/graph-explorer/src/utils/testing/FakeExplorer.ts
@@ -15,6 +15,7 @@ import type {
 } from "@/connector";
 
 import {
+  createVertexTypeLookup,
   type Edge,
   type EdgeConnection,
   type Entities,
@@ -81,9 +82,11 @@ export class FakeExplorer implements Explorer {
       totalVertices: this.vertices.length,
       totalEdges: this.edges.length,
     };
+    const vertexLookup = createVertexTypeLookup(this.vertexMap);
     const schema = updateSchemaFromEntities(
       { vertices: this.vertices, edges: this.edges },
       initialSchema,
+      vertexLookup,
     );
 
     return schema;
@@ -192,7 +195,7 @@ export class FakeExplorer implements Explorer {
 
   async rawQuery(): Promise<RawQueryResponse> {
     throw new Error(
-      "rawQuery can never have a fake implmentation. Use mocking instead.",
+      "rawQuery can never have a fake implementation. Use mocking instead.",
     );
   }
 


### PR DESCRIPTION
## Description

When users explore the graph and edges are returned from queries, the edge *types* are correctly added to the schema, but the edge *connections* (source vertex type → edge type → target vertex type) are not inferred. This means the Schema Explorer diagram does not show new relationships discovered through exploration until the database summary API catches up.

- Add required `vertexLookup` parameter to `updateSchemaFromEntities` to infer `EdgeConnection` entries from edges and their endpoint vertex types
- New `VertexTypeLookup` interface with `createVertexTypeLookup` factory that chains existing `Map<VertexId, Vertex>` instances with O(1) construction (no copying)
- New `mergeEdgeConnections` function handles multi-label vertices, deduplication, and preserves existing connections (including their `count`)
- New `createEdgeConnection` helper for constructing `EdgeConnection` objects from plain strings
- Update call sites (`useAddToGraph`, `useUpdateSchemaFromEntities`, `FakeExplorer`) to build and pass the vertex lookup from the entity batch + canvas state, with batch vertices taking priority
- Schema refresh continues to overwrite edge connections entirely (current behavior preserved)

## Validation

- 7 unit tests for edge connection inference (basic, multi-label, unresolvable endpoints, dedup, count preservation, referential equality)
- 6 tests for `createVertexTypeLookup` (chaining, priority, isEmpty, unknown IDs)
- 5 integration tests through `useAddToGraph` and `useUpdateSchemaFromEntities` verifying end-to-end inference and batch-over-canvas priority
- All 153 test files pass (1678 tests)
- `pnpm checks` passes (lint, format, types)

## Related Issues

- Closes #1720
- Part of #1486

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.