### PR TITLE
Replace Prettier with oxfmt

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,0 +1,9 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 80,
+  "arrowParens": "avoid",
+  "ignorePatterns": ["pnpm-lock.yaml"],
+  "sortTailwindcss": {
+    "functions": ["cva", "cn"],
+  },
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-# Don't allow Prettier to change the PNPM lock file
-pnpm-lock.yaml
-
-**/dist/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "arrowParens": "avoid",
-  "proseWrap": "preserve",
-  "plugins": ["prettier-plugin-tailwindcss"],
-  "tailwindFunctions": ["cva", "cn"]
-}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "bradlc.vscode-tailwindcss",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
+    "oxc.oxc-vscode",
     "vitest.explorer"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,5 +1,15 @@
 {
+  "format_on_save": "on",
+  "prettier": { "allowed": false },
+  "formatter": [{ "language_server": { "name": "oxfmt" } }],
   "lsp": {
+    "oxfmt": {
+      "initialization_options": {
+        "settings": {
+          "fmt.configPath": null
+        }
+      }
+    },
     "tailwindcss-language-server": {
       "settings": {
         "rootFontSize": 14,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,21 @@ pnpm test packages/graph-explorer/src/path/to/file.test.ts
 
 # Test name pattern match
 pnpm test -- -t "pattern"
+
+# Format all files
+pnpm format
+
+# Format specific files or globs (pass paths after --)
+pnpm format -- src/foo.ts 'packages/graph-explorer/src/**/*.tsx'
+
+# Check formatting on specific files
+pnpm check:format -- src/foo.ts
+
+# Lint and auto-fix all files
+pnpm lint
+
+# Lint specific files or globs
+pnpm lint -- 'packages/graph-explorer/src/**/*.ts'
 ```
 
 # Project Organization

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,6 @@ This document describes the future roadmap for Graph Explorer.
 
 We encourage you to participate in the discussion within the individual roadmap issues linked below.
 
-<!-- prettier-ignore -->
 > [!IMPORTANT]
 > These items are subject to change.
 

--- a/docs/guides/connecting-to-gremlin-server.md
+++ b/docs/guides/connecting-to-gremlin-server.md
@@ -23,8 +23,7 @@ Then open Graph Explorer and add a new connection with the following settings:
 
 Graph Explorer only supports HTTP(S) connections. When connecting to Gremlin-Server, ensure it is configured with a channelizer that supports HTTP(S) (i.e. [Channelizer Documentation](https://tinkerpop.apache.org/javadocs/current/full/org/apache/tinkerpop/gremlin/server/Channelizer.html)).
 
-<!-- prettier-ignore -->
-> [!TIP] 
+> [!TIP]
 > The Gremlin Server configuration can be usually found at:
 >
 > ```

--- a/docs/guides/deploy-to-ec2.md
+++ b/docs/guides/deploy-to-ec2.md
@@ -4,12 +4,9 @@
 
 Deploy Graph Explorer onto an Amazon EC2 instance and use it as a proxy server with SSH tunneling to connect to Amazon Neptune.
 
-<!-- prettier-ignore -->
 > [!NOTE]
 >
-> This documentation is not an official recommendation on
-network setups as there are many ways to connect to Amazon Neptune from outside
-of the VPC, such as setting up a load balancer or VPC peering.
+> This documentation is not an official recommendation on network setups as there are many ways to connect to Amazon Neptune from outside of the VPC, such as setting up a load balancer or VPC peering.
 
 ## Prerequisites
 
@@ -30,7 +27,6 @@ of the VPC, such as setting up a load balancer or VPC peering.
    docker pull public.ecr.aws/neptune/graph-explorer
    ```
 
-<!-- prettier-ignore -->
 > [!TIP]
 >
 > If you receive an error relating to the docker service not running, run
@@ -44,13 +40,10 @@ of the VPC, such as setting up a load balancer or VPC peering.
     public.ecr.aws/neptune/graph-explorer
    ```
 
-<!-- prettier-ignore -->
 > [!TIP]
 >
-> The `--restart unless-stopped` flag ensures the container automatically
-restarts after a host reboot or if the container crashes. See Docker's
-[restart policy documentation](https://docs.docker.com/engine/containers/start-containers-automatically/)
-for other options.
+> The `--restart unless-stopped` flag ensures the container automatically restarts after a host reboot or if the container crashes. See Docker's [restart policy documentation](https://docs.docker.com/engine/containers/start-containers-automatically/) for other options.
+
 5. Navigate to the public URL of your EC2 instance accessing the `/explorer` endpoint. You will receive a warning as the SSL certificate used is self-signed. The URL will look like this:
 
 ```

--- a/docs/guides/deploy-to-sagemaker.md
+++ b/docs/guides/deploy-to-sagemaker.md
@@ -24,9 +24,8 @@ To restrict Graph Explorer access for its most basic functionality you can use t
 - Get the graph summary information (used for schema sync)
 - Cancel query
 
-<!-- prettier-ignore -->
 > [!CAUTION]
-> 
+>
 > If you are using the standard notebook setup, these policies will apply to both the Jupyter graph notebooks as well as Graph Explorer.
 
 If a user attempts to execute a mutation query inside of Graph Explorer, they will be presented with an error that informs them they are not authorized for that request.

--- a/docs/guides/deploy-with-docker.md
+++ b/docs/guides/deploy-with-docker.md
@@ -7,7 +7,6 @@ Deploy Graph Explorer locally using the official Docker image from Amazon's ECR 
 You can find the latest version of the image on
 [Amazon's ECR Public Registry](https://gallery.ecr.aws/neptune/graph-explorer).
 
-<!-- prettier-ignore -->
 > [!NOTE]
 >
 > Make sure to use the version of the image that does not include `sagemaker` in the tag.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -99,7 +99,6 @@ Graph Explorer does not provide any mechanisms for controlling user permissions.
 
 For information about what permissions Graph Explorer requires check out the documentation on [SageMaker configuration](../guides/deploy-to-sagemaker.md#minimum-database-permissions).
 
-<!-- prettier-ignore -->
-> [!CAUTION] 
-> 
+> [!CAUTION]
+>
 > By default, a Neptune Notebook will have full read & write access to Neptune data.

--- a/package.json
+++ b/package.json
@@ -1,34 +1,17 @@
 {
   "name": "graph-explorer",
   "version": "3.0.3",
-  "description": "Graph Explorer",
-  "author": "amazon",
-  "license": "Apache-2.0",
-  "type": "module",
-  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
-  "devEngines": {
-    "runtime": {
-      "name": "node",
-      "version": ">=24.13.0",
-      "onFail": "error"
-    },
-    "packageManager": {
-      "name": "pnpm",
-      "version": ">=10.28.1",
-      "onFail": "error"
-    }
-  },
-  "engines": {
-    "node": ">=24.13.0",
-    "pnpm": ">=10.28.1"
-  },
   "private": true,
+  "description": "Graph Explorer",
+  "license": "Apache-2.0",
+  "author": "amazon",
+  "type": "module",
   "scripts": {
     "prepare": "husky",
     "lint": "eslint --fix --concurrency=auto",
     "check:lint": "eslint --concurrency=auto",
-    "format": "prettier --write .",
-    "check:format": "prettier --check .",
+    "format": "oxfmt",
+    "check:format": "oxfmt --check",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
@@ -56,19 +39,35 @@
     "globals": "^17.5.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
-    "prettier": "^3.8.3",
-    "prettier-plugin-tailwindcss": "^0.7.2",
+    "oxfmt": "^0.47.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "4.1.5"
   },
   "lint-staged": {
-    "!(**/*.{js,ts,tsx})": "prettier --ignore-unknown --write",
+    "!(**/*.{js,ts,tsx})": "oxfmt --no-error-on-unmatched-pattern",
     "**/*.{js,ts,tsx}": [
       "eslint --fix",
-      "prettier --ignore-unknown --write"
+      "oxfmt"
     ]
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=10.28.1",
+      "onFail": "error"
+    },
+    "runtime": {
+      "name": "node",
+      "version": ">=24.13.0",
+      "onFail": "error"
+    }
+  },
+  "engines": {
+    "node": ">=24.13.0",
+    "pnpm": ">=10.28.1"
+  },
+  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "pnpm": {
     "overrides": {
       "semver@<7.0.0": ">=7.7.3",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -2,14 +2,14 @@
   "name": "graph-explorer-proxy-server",
   "version": "3.0.3",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
+  "license": "Apache-2.0",
+  "author": "amazon",
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
     "dev": "node --watch src/node-server.ts",
     "start": "NODE_ENV=production node src/node-server.ts"
   },
-  "author": "amazon",
-  "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.1034.0",
     "@graph-explorer/shared": "workspace:*",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -2,9 +2,8 @@
   "name": "graph-explorer",
   "version": "3.0.3",
   "description": "Graph Explorer",
-  "engines": {
-    "node": ">=24.13.0"
-  },
+  "license": "Apache-2.0",
+  "author": "amazon",
   "type": "module",
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -13,8 +12,6 @@
     "vite-build": "NODE_OPTIONS=--max_old_space_size=6144 vite build",
     "build": "pnpm vite-build -- --mode production"
   },
-  "author": "amazon",
-  "license": "Apache-2.0",
   "dependencies": {
     "@graph-explorer/shared": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
@@ -111,8 +108,11 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write"
+      "oxfmt"
     ]
+  },
+  "engines": {
+    "node": ">=24.13.0"
   },
   "msw": {
     "workerDirectory": "public"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@graph-explorer/shared",
   "version": "3.0.3",
-  "description": "Shared types and functions across client and server.",
-  "author": "amazon",
-  "license": "Apache-2.0",
-  "keywords": [],
   "private": true,
+  "description": "Shared types and functions across client and server.",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "author": "amazon",
   "type": "module",
   "exports": {
     "./types": "./src/types/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,12 +63,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
-      prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
-      prettier-plugin-tailwindcss:
-        specifier: ^0.7.2
-        version: 0.7.2(prettier@3.8.3)
+      oxfmt:
+        specifier: ^0.47.0
+        version: 0.47.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1520,6 +1517,128 @@ packages:
 
   '@oxc-project/types@0.126.0':
     resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
+    resolution: {integrity: sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.47.0':
+    resolution: {integrity: sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.47.0':
+    resolution: {integrity: sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.47.0':
+    resolution: {integrity: sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.47.0':
+    resolution: {integrity: sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+    resolution: {integrity: sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+    resolution: {integrity: sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+    resolution: {integrity: sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+    resolution: {integrity: sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+    resolution: {integrity: sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+    resolution: {integrity: sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+    resolution: {integrity: sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+    resolution: {integrity: sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+    resolution: {integrity: sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
+    resolution: {integrity: sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
+    resolution: {integrity: sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+    resolution: {integrity: sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+    resolution: {integrity: sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
+    resolution: {integrity: sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -4500,6 +4619,11 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.47.0:
+    resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -4590,66 +4714,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-hermes': '*'
-      '@prettier/plugin-oxc': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-multiline-arrays: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-hermes':
-        optional: true
-      '@prettier/plugin-oxc':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-multiline-arrays:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
-
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
-    engines: {node: '>=14'}
-    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -5143,6 +5207,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -6936,6 +7004,63 @@ snapshots:
   '@nodable/entities@2.1.0': {}
 
   '@oxc-project/types@0.126.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.47.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.47.0':
+    optional: true
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -10216,6 +10341,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.47.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.47.0
+      '@oxfmt/binding-android-arm64': 0.47.0
+      '@oxfmt/binding-darwin-arm64': 0.47.0
+      '@oxfmt/binding-darwin-x64': 0.47.0
+      '@oxfmt/binding-freebsd-x64': 0.47.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.47.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.47.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.47.0
+      '@oxfmt/binding-linux-arm64-musl': 0.47.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.47.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.47.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-gnu': 0.47.0
+      '@oxfmt/binding-linux-x64-musl': 0.47.0
+      '@oxfmt/binding-openharmony-arm64': 0.47.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.47.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.47.0
+      '@oxfmt/binding-win32-x64-msvc': 0.47.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -10316,12 +10465,6 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
-
-  prettier-plugin-tailwindcss@0.7.2(prettier@3.8.3):
-    dependencies:
-      prettier: 3.8.3
-
-  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -10963,6 +11106,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
 


### PR DESCRIPTION
## Description

Replace Prettier with [oxfmt](https://oxc.rs/docs/guide/usage/formatter) as the code formatter. oxfmt is a high-performance, Prettier-compatible formatter built on the Oxc compiler stack.

- Swap `prettier` and `prettier-plugin-tailwindcss` for `oxfmt`, which has built-in Tailwind class sorting
- Add `.oxfmtrc.jsonc` matching the existing Prettier config (`printWidth: 80`, `arrowParens: "avoid"`, Tailwind sorting for `cva`/`cn`)
- Delete `.prettierrc` and `.prettierignore` (ignore patterns moved to `.oxfmtrc.jsonc`)
- Update `format`/`check:format` scripts — `oxfmt` defaults to write mode and formats cwd with no args, so `pnpm format -- path/to/file` now works for scoped formatting
- Update `lint-staged` in root and `packages/graph-explorer` to use `oxfmt`
- Update VS Code default formatter and extension recommendation to `oxc.oxc-vscode`
- Update `AGENTS.md` with examples for parameterized format/lint commands
- Remove stale `<!-- prettier-ignore -->` comments from 6 markdown files and fix broken blockquote syntax in `deploy-to-ec2.md`
- Keep `eslint-config-prettier` — it disables ESLint rules that conflict with any formatter, not just Prettier

**Zero source code formatting changes.** The only formatting diffs are `package.json` key reordering from oxfmt's built-in `sortPackageJson` (enabled by default). This is a new formatter behavior that will apply to future `package.json` edits.

## Validation

Benchmarks (median of 3 runs, 806 files):

| Operation | Prettier | oxfmt | Speedup |
|-----------|----------|-------|---------|
| Check     | 5.65s    | 0.78s | ~7x     |
| Write     | 6.19s    | 0.88s | ~7x     |

## Related Issues

N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.