### PR TITLE
Bump AL2023 releasever to pick up latest glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_VERSION=24.13.0
 
 # Install Node.js and openssl, then remove everything not needed at runtime
 # (package managers, python3, build tools) to minimize potential issues.
-RUN yum update -y --releasever 2023.11.20260413 && \
+RUN yum update -y --releasever 2023.11.20260427 && \
     yum install -y tar xz openssl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \


### PR DESCRIPTION
## Description

Bump the Amazon Linux 2023 releasever from `2023.11.20260413` to `2023.11.20260427` in the Dockerfile to pick up `glibc-2.34-231.amzn2023.0.4`, which includes a fix for an iconv assertion crash when converting from IBM1390/IBM1399 character sets.

## Validation

- Built the Docker image and confirmed `glibc-2.34-231.amzn2023.0.4` is installed
- Ran Trivy scan against the built image with 0 HIGH/CRITICAL vulnerabilities

## Related Issues

None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.