### PR TITLE
Preserve URL path when proxy constructs database endpoint URLs

### DIFF
--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -791,6 +791,126 @@ describe("createApp", () => {
         `graph-explorer/${testVersion}`,
       );
     });
+
+    it("preserves request-specific headers after IAM signing", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/sparql")
+        .set(
+          dbHeaders({
+            "aws-neptune-region": "us-east-1",
+            "service-type": "neptune-db",
+          }),
+        )
+        .send({ query: "SELECT 1" });
+
+      const fetchOptions = mockFetch.mock.calls[0][1] as any;
+      expect(fetchOptions.headers["content-type"]).toBe(
+        "application/x-www-form-urlencoded",
+      );
+      expect(fetchOptions.headers["accept"]).toBe(
+        "application/sparql-results+json",
+      );
+      expect(fetchOptions.headers["Authorization"]).toBeDefined();
+    });
+  });
+
+  // ── URL path preservation ────────────────────────────────────────
+
+  describe("preserves base URL path for non-root endpoints", () => {
+    const blazegraphUrl = "http://blazegraph:9999/blazegraph/namespace/kb";
+
+    function blazegraphHeaders(overrides: Record<string, string> = {}) {
+      return {
+        "graph-db-connection-url": blazegraphUrl,
+        ...overrides,
+      };
+    }
+
+    it("POST /sparql appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/sparql")
+        .set(blazegraphHeaders())
+        .send({ query: "SELECT 1" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/sparql`,
+        expect.anything(),
+      );
+    });
+
+    it("POST /gremlin appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/gremlin")
+        .set(blazegraphHeaders())
+        .send({ query: "g.V()" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/gremlin`,
+        expect.anything(),
+      );
+    });
+
+    it("POST /openCypher appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/openCypher")
+        .set(blazegraphHeaders())
+        .send({ query: "MATCH (n) RETURN n" });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/openCypher`,
+        expect.anything(),
+      );
+    });
+
+    it("GET /summary appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app).get("/summary").set(blazegraphHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/summary?mode=detailed`,
+        expect.anything(),
+      );
+    });
+
+    it("GET /pg/statistics/summary appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app).get("/pg/statistics/summary").set(blazegraphHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/pg/statistics/summary?mode=detailed`,
+        expect.anything(),
+      );
+    });
+
+    it("GET /rdf/statistics/summary appends to the base URL path", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .get("/rdf/statistics/summary")
+        .set(blazegraphHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${blazegraphUrl}/rdf/statistics/summary?mode=detailed`,
+        expect.anything(),
+      );
+    });
   });
 
   // ── Fetch error handling ──────────────────────────────────────────

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -17,6 +17,18 @@ import { type AppLogger, requestLoggingMiddleware } from "./logging.ts";
 
 const DEFAULT_SERVICE_TYPE = "neptune-db";
 
+/**
+ * Resolves a relative endpoint path against a base URL, preserving the base
+ * path. Forces a trailing slash on the base so that `new URL` appends rather
+ * than replaces the path.
+ */
+function resolveEndpointUrl<T extends string>(
+  base: string,
+  endpoint: T extends `/${string}` ? never : T,
+): URL {
+  return new URL(endpoint, base.replace(/\/?$/, "/"));
+}
+
 /** Zod schema for the custom headers expected on database query requests. */
 const DbQueryHeadersSchema = z.object({
   queryid: z.string().optional(),
@@ -268,7 +280,10 @@ export function createApp({
       }
       logger.debug(`Cancelling request ${queryId}...`);
       try {
-        const statusUrl = new URL("/sparql/status", graphDbConnectionUrl);
+        const statusUrl = resolveEndpointUrl(
+          graphDbConnectionUrl,
+          "sparql/status",
+        );
         await retryFetch(
           statusUrl,
           {
@@ -315,7 +330,7 @@ export function createApp({
       logger.debug("[SPARQL] Received database query:\n%s", queryString);
     }
 
-    const rawUrl = new URL("/sparql", graphDbConnectionUrl).href;
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, "sparql").href;
     let body = `query=${encodeURIComponent(queryString)}`;
     if (queryId) {
       body += `&queryId=${encodeURIComponent(queryId)}`;
@@ -370,7 +385,10 @@ export function createApp({
       }
       logger.debug(`Cancelling request ${queryId}...`);
       try {
-        const cancelUrl = new URL("/gremlin/status", graphDbConnectionUrl);
+        const cancelUrl = resolveEndpointUrl(
+          graphDbConnectionUrl,
+          "gremlin/status",
+        );
         cancelUrl.searchParams.set("cancelQuery", "");
         cancelUrl.searchParams.set("queryId", queryId);
         await retryFetch(
@@ -401,7 +419,7 @@ export function createApp({
     });
 
     const body = { gremlin: queryString, queryId };
-    const rawUrl = new URL("/gremlin", graphDbConnectionUrl).href;
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, "gremlin").href;
     const requestOptions = {
       method: "POST",
       headers: {
@@ -444,7 +462,10 @@ export function createApp({
       logger.debug("[openCypher] Received database query:\n%s", queryString);
     }
 
-    const openCypherUrl = new URL("/openCypher", graphDbConnectionUrl).href;
+    const openCypherUrl = resolveEndpointUrl(
+      graphDbConnectionUrl,
+      "openCypher",
+    ).href;
     const requestOptions = {
       method: "POST",
       headers: {
@@ -469,7 +490,10 @@ export function createApp({
   app.get("/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
-    const rawUrl = new URL("/summary?mode=detailed", graphDbConnectionUrl).href;
+    const rawUrl = resolveEndpointUrl(
+      graphDbConnectionUrl,
+      "summary?mode=detailed",
+    ).href;
 
     await fetchData(
       res,
@@ -486,9 +510,9 @@ export function createApp({
   app.get("/pg/statistics/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
-    const rawUrl = new URL(
-      "/pg/statistics/summary?mode=detailed",
+    const rawUrl = resolveEndpointUrl(
       graphDbConnectionUrl,
+      "pg/statistics/summary?mode=detailed",
     ).href;
 
     await fetchData(
@@ -506,9 +530,9 @@ export function createApp({
   app.get("/rdf/statistics/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
-    const rawUrl = new URL(
-      "/rdf/statistics/summary?mode=detailed",
+    const rawUrl = resolveEndpointUrl(
       graphDbConnectionUrl,
+      "rdf/statistics/summary?mode=detailed",
     ).href;
 
     await fetchData(

--- a/packages/graph-explorer-proxy-server/src/process-environment.test.ts
+++ b/packages/graph-explorer-proxy-server/src/process-environment.test.ts
@@ -295,6 +295,28 @@ describe("process-environment.sh", () => {
       expect(defaultConnection).toHaveProperty("GRAPH_EXP_CONNECTION_URL", "");
     });
 
+    it("preserves path in GRAPH_CONNECTION_URL", () => {
+      const { defaultConnection } = runScript(workDir, {
+        PUBLIC_OR_PROXY_ENDPOINT: "http://localhost:8080",
+        GRAPH_CONNECTION_URL: "http://blazegraph:9999/blazegraph/namespace/kb",
+      });
+      expect(defaultConnection).toHaveProperty(
+        "GRAPH_EXP_CONNECTION_URL",
+        "http://blazegraph:9999/blazegraph/namespace/kb",
+      );
+    });
+
+    it("preserves trailing slash in GRAPH_CONNECTION_URL", () => {
+      const { defaultConnection } = runScript(workDir, {
+        PUBLIC_OR_PROXY_ENDPOINT: "http://localhost:8080",
+        GRAPH_CONNECTION_URL: "http://blazegraph:9999/blazegraph/namespace/kb/",
+      });
+      expect(defaultConnection).toHaveProperty(
+        "GRAPH_EXP_CONNECTION_URL",
+        "http://blazegraph:9999/blazegraph/namespace/kb/",
+      );
+    });
+
     it("defaults AWS_REGION to empty string", () => {
       const { defaultConnection } = runScript(workDir, {
         PUBLIC_OR_PROXY_ENDPOINT: "https://endpoint:8182",

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -356,6 +356,40 @@ describe("normalizeConnection", () => {
     const result = normalizeConnection({ url: "https://example.com" });
     expect(result.awsAuthEnabled).toBe(false);
   });
+
+  test("should preserve path in url", () => {
+    const result = normalizeConnection({
+      url: "http://localhost:9999/blazegraph/namespace/kb",
+    });
+    expect(result.url).toBe("http://localhost:9999/blazegraph/namespace/kb");
+  });
+
+  test("should remove only trailing slash from url with path", () => {
+    const result = normalizeConnection({
+      url: "http://localhost:9999/blazegraph/namespace/kb/",
+    });
+    expect(result.url).toBe("http://localhost:9999/blazegraph/namespace/kb");
+  });
+
+  test("should preserve path in graphDbUrl", () => {
+    const result = normalizeConnection({
+      url: "http://proxy:8080",
+      graphDbUrl: "http://blazegraph:9999/blazegraph/namespace/kb",
+    });
+    expect(result.graphDbUrl).toBe(
+      "http://blazegraph:9999/blazegraph/namespace/kb",
+    );
+  });
+
+  test("should remove only trailing slash from graphDbUrl with path", () => {
+    const result = normalizeConnection({
+      url: "http://proxy:8080",
+      graphDbUrl: "http://blazegraph:9999/blazegraph/namespace/kb/",
+    });
+    expect(result.graphDbUrl).toBe(
+      "http://blazegraph:9999/blazegraph/namespace/kb",
+    );
+  });
 });
 
 describe("getDefaultVertexTypeConfig", () => {

--- a/packages/graph-explorer/src/core/defaultConnection.test.ts
+++ b/packages/graph-explorer/src/core/defaultConnection.test.ts
@@ -82,6 +82,30 @@ describe("DefaultConnectionDataSchema", () => {
       GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT: "",
     });
   });
+
+  test("should preserve path in GRAPH_EXP_CONNECTION_URL", () => {
+    const data = {
+      ...createRandomDefaultConnectionData(),
+      GRAPH_EXP_CONNECTION_URL:
+        "http://blazegraph:9999/blazegraph/namespace/kb",
+    };
+    const actual = DefaultConnectionDataSchema.parse(data);
+    expect(actual.GRAPH_EXP_CONNECTION_URL).toBe(
+      "http://blazegraph:9999/blazegraph/namespace/kb",
+    );
+  });
+
+  test("should preserve path in GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT", () => {
+    const data = {
+      ...createRandomDefaultConnectionData(),
+      GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT:
+        "http://localhost:8080/proxy/explorer",
+    };
+    const actual = DefaultConnectionDataSchema.parse(data);
+    expect(actual.GRAPH_EXP_PUBLIC_OR_PROXY_ENDPOINT).toBe(
+      "http://localhost:8080/proxy/explorer",
+    );
+  });
 });
 
 function createRandomDefaultConnectionData() {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,9 +7,9 @@ export default defineConfig({
       thresholds: {
         autoUpdate: (newThreshold: number) => Math.floor(newThreshold),
         statements: 64,
-        branches: 43,
-        functions: 57,
-        lines: 71,
+        branches: 44,
+        functions: 58,
+        lines: 72,
       },
     },
   },


### PR DESCRIPTION
## Description

The proxy server used absolute paths in `new URL()` calls (e.g., `new URL("/sparql", baseUrl)`) which replaced the entire base URL path. This broke databases with non-root endpoints like BlazeGraph (`/blazegraph/namespace/kb/sparql`).

- Extract `resolveEndpointUrl` helper that ensures a trailing slash on the base URL before resolving relative endpoint paths
- Use a TypeScript template literal type constraint to prevent passing leading-slash paths at compile time
- Add tests for path preservation across proxy endpoints, connection normalization, environment variable parsing, and IAM header preservation

## Validation

- All 1695 tests pass, all checks (lint, format, types) pass
- End-to-end verified with finch compose: Graph Explorer proxy → BlazeGraph at `/blazegraph/namespace/kb/sparql` returns real SPARQL results
- TypeScript enforces that `resolveEndpointUrl` rejects absolute paths (`"/sparql"` → compile error)

## Related Issues

- Fixes #1752

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.