### PR TITLE
Add domain glossary and agent skill configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # Local planning docs
 plans/
+
+# Claude Code local files
+.claude/

--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -2,7 +2,7 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 80,
   "arrowParens": "avoid",
-  "ignorePatterns": ["pnpm-lock.yaml"],
+  "ignorePatterns": ["pnpm-lock.yaml", ".claude/"],
   "sortImports": {
     "groups": [
       "type-import",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,7 +18,11 @@
   "env": {
     "builtin": true
   },
-  "ignorePatterns": ["**/*.config.{js,ts,mjs}", "**/vitest.workspace.ts"],
+  "ignorePatterns": [
+    "**/*.config.{js,ts,mjs}",
+    "**/vitest.workspace.ts",
+    ".claude/"
+  ],
   "rules": {
     "vitest/require-mock-type-parameters": "off",
     "jest/require-to-throw-message": "off",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,17 @@ pnpm lint -- 'packages/graph-explorer/src/**/*.ts'
   - Visualization settings
   - Layout preferences
 - **External Data**: Graph data is queried directly from the connected graph databases and is not owned or persisted by Graph Explorer
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues on aws/graph-explorer. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary (needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,97 @@
+# Graph Explorer
+
+A React-based web application that lets users visually explore graph databases without writing queries. Connects to property graph and RDF databases over HTTP.
+
+## Language
+
+**Vertex**:
+A node in the graph — an entity with an ID, one or more types, and attributes. Called "node" in the UI to match user expectations; called "vertex" in code to avoid collision with Node.js global types.
+_Avoid_: Node (in code)
+
+**Edge**:
+A directed relationship between two vertices (source → target), with a type and optional attributes. Always directed in the data model regardless of graph type.
+_Avoid_: Relationship, link
+
+**Connection**:
+A saved database profile — the URL, query engine, authentication settings, and proxy routing needed to reach a graph database. Users create and manage these in the UI.
+_Avoid_: Configuration (legacy term being phased out — previously bundled connection + schema + user preferences into one object)
+
+**Query Language**:
+The graph query protocol a Connection uses — one of Gremlin, openCypher, or SPARQL. Determines which Explorer is instantiated and implies the graph type (Gremlin/openCypher → property graph, SPARQL → RDF).
+_Avoid_: Query engine (internal code name `queryEngine`, but UI says "Query Language")
+
+**Vertex Type**:
+A classification of vertices. The schema, styling, filtering, and exploration all operate at the type level. UI label varies by query language: "Node Label" (Gremlin/openCypher), "Class" (SPARQL).
+
+**Edge Type**:
+A classification of edges. UI label varies by query language: "Edge Label" (Gremlin), "Relationship Type" (openCypher), "Predicate" (SPARQL).
+
+**Neighbors**:
+Vertices directly connected to a given vertex (one hop away). Users "expand neighbors" to progressively discover the graph. Neighbor counts track total vs. unfetched to indicate how much remains unexplored.
+_Avoid_: Connections (ambiguous with Connection)
+
+**Session**:
+The set of vertices and edges a user has loaded through exploration for a given Connection. Persisted to IndexedDB so users can close the browser and restore where they left off.
+_Avoid_: State, workspace
+
+**Graph View**:
+The interactive canvas where vertices and edges are visualized using Cytoscape.js. Users explore the graph here by expanding neighbors and applying layouts. Nav label: "Graph".
+_Avoid_: Graph Explorer (ambiguous with the product name)
+
+**Data Table View**:
+Tabular view of all vertices and edges currently in the Session, filterable by type. Complements the Graph View for structured browsing.
+_Avoid_: Data Explorer (legacy route name)
+
+**Schema View**:
+Visual representation of the Schema — shows vertex types and their edge connections as a graph.
+_Avoid_: Schema Explorer (legacy route name)
+
+**Edge Connection**:
+A schema-level pattern describing how two vertex types can be related via an edge type: sourceVertexType --[edgeType]--> targetVertexType. What the Schema View visualizes. Not an actual edge instance.
+_Avoid_: Relationship (Gremlin UI term), Object Property (SPARQL UI term)
+
+**Property**:
+A key-value pair on a Vertex or Edge. UI label varies by query language: "Property" (Gremlin/openCypher), "Datatype Property" (SPARQL).
+_Avoid_: Attribute (legacy code term being phased out)
+
+**User Preferences**:
+Display customizations per Vertex Type and Edge Type — shape, color, icon, line style, and display labels. Persisted and merged with Schema-discovered metadata to produce the final rendering.
+_Avoid_: User styling, user settings
+
+**Schema Sync**:
+The process that queries the database to discover vertex types, edge types, and their attributes. Required before a user can explore a new Connection.
+_Avoid_: Fetch, load
+
+**Schema**:
+The discovered structure of a connected graph database — vertex types, edge types, their attributes, and how they connect. Populated by Schema Sync when a Connection is first used; not user-defined.
+_Avoid_: Model, structure
+
+## Relationships
+
+- A **Connection** has exactly one **Query Language**
+- A **Connection** has one **Schema**, populated by **Schema Sync**
+- A **Schema** contains **Vertex Types**, **Edge Types**, and **Edge Connections**
+- A **Vertex** has one or more **Vertex Types** and zero or more **Properties**
+- An **Edge** connects exactly two **Vertices** (source → target), has one **Edge Type**, and zero or more **Properties**
+- An **Edge Connection** links a source **Vertex Type** to a target **Vertex Type** via an **Edge Type**
+- A **Session** belongs to a **Connection** and contains **Vertices** and **Edges**
+- **Neighbors** are **Vertices** one hop away from a given **Vertex**
+- **User Preferences** are scoped per **Vertex Type** and **Edge Type**
+- The **Graph View**, **Data Table View**, and **Schema View** all render from the same **Session** and **Schema**
+
+## Example dialogue
+
+> **Dev:** "When a user creates a new **Connection** and opens the **Graph View**, can they start exploring immediately?"
+> **Domain expert:** "No — a **Schema Sync** has to complete first. Until the **Schema** is populated, we don't know what **Vertex Types** or **Edge Types** exist, so there's nothing to search or filter by."
+
+> **Dev:** "If a user expands **Neighbors** on a vertex, do we fetch all connected vertices at once?"
+> **Domain expert:** "No, it's progressive. We fetch one page at a time and track unfetched **Neighbor** counts so the user knows how much is left to explore."
+
+> **Dev:** "Are **User Preferences** shared across **Connections**?"
+> **Domain expert:** "No — well, actually right now they're per **Vertex Type** and **Edge Type** globally, not scoped to a specific **Connection**. So if two databases happen to have the same type name, they'd share styling."
+
+## Flagged ambiguities
+
+- "Configuration" was used to mean both **Connection** and the bundled object (connection + schema + user preferences) — resolved: **Connection** is canonical, "Configuration" is legacy.
+- "Node" means **Vertex** in code but is the preferred UI term for property graphs — resolved: use **Vertex** in code, "node" in UI copy.
+- "Attribute" vs "Property" — resolved: **Property** is canonical, "attribute" is legacy code term being phased out.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Description

Bootstraps the project's domain vocabulary in `CONTEXT.md` and adds agent skill configuration under `docs/agents/`.

**CONTEXT.md** defines the canonical terms for the project's domain model (Vertex, Edge, Connection, Schema, etc.), documents UI translation conventions across query languages, flags legacy terms being phased out (Configuration, Attribute), and captures relationships between concepts.

**docs/agents/** configures engineering skills (triage, to-issues, diagnose, etc.) with:
- Issue tracker pointing at GitHub Issues
- Default triage label vocabulary
- Single-context domain doc layout

**Ignore lists** — adds `.claude/` to `.gitignore`, `.oxlintrc.json`, and `.oxfmtrc.jsonc` so that Claude Code's local workspace files don't get committed or trip up linting/formatting tools.

**How to read**: Start with `CONTEXT.md` for the domain glossary, then glance at `AGENTS.md` (bottom) for the skill pointers and `docs/agents/` for the skill-specific configs. The ignore-list changes are independent housekeeping.

## Validation

- Documentation and config only — no application code changes
- `pnpm checks` passes with no errors

## Related Issues

- None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.