### PR TITLE
feat: support ?s ?p ?o shorthand in SPARQL query results

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/parseAndMapQuads.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/parseAndMapQuads.test.ts
@@ -159,14 +159,14 @@ describe("parseAndMapQuads", () => {
     it("should parse shorthand variables (?s ?p ?o) correctly", () => {
       const vertex = createTestableVertex().withRdfValues();
       const bindings = createQuadBindingsForEntities([vertex], []);
-      
+
       // Convert standard bindings to shorthand variables
       const shorthandBindings = bindings.map(b => ({
         s: b.subject,
         p: b.predicate,
         o: b.object,
       }));
-      
+
       const data = {
         head: { vars: ["s", "p", "o"] },
         results: { bindings: shorthandBindings },

--- a/packages/graph-explorer/src/connector/sparql/parseAndMapQuads.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/parseAndMapQuads.test.ts
@@ -109,6 +109,24 @@ describe("parseAndMapQuads", () => {
       expect(() => parseAndMapQuads(invalidData)).toThrow();
       expect(logger.error).toHaveBeenCalled();
     });
+
+    it("should throw validation error for partial shorthand matches (e.g., s, predicate, object)", () => {
+      const invalidData = {
+        head: { vars: ["s", "predicate", "object"] },
+        results: {
+          bindings: [
+            {
+              s: { type: "uri", value: "http://example.com/resource" },
+              predicate: { type: "uri", value: "http://example.com/predicate" },
+              object: { type: "literal", value: "test value" },
+            },
+          ],
+        },
+      };
+
+      expect(() => parseAndMapQuads(invalidData)).toThrow();
+      expect(logger.error).toHaveBeenCalled();
+    });
   });
 
   describe("successful parsing", () => {
@@ -128,6 +146,31 @@ describe("parseAndMapQuads", () => {
       const vertex = createTestableVertex().withRdfValues();
       const bindings = createQuadBindingsForEntities([vertex], []);
       const data = createQuadSparqlResponse(bindings);
+
+      const result = parseAndMapQuads(data);
+
+      expect(result).toEqual({
+        vertices: [vertex.asResult()],
+        edges: [],
+      });
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it("should parse shorthand variables (?s ?p ?o) correctly", () => {
+      const vertex = createTestableVertex().withRdfValues();
+      const bindings = createQuadBindingsForEntities([vertex], []);
+      
+      // Convert standard bindings to shorthand variables
+      const shorthandBindings = bindings.map(b => ({
+        s: b.subject,
+        p: b.predicate,
+        o: b.object,
+      }));
+      
+      const data = {
+        head: { vars: ["s", "p", "o"] },
+        results: { bindings: shorthandBindings },
+      };
 
       const result = parseAndMapQuads(data);
 

--- a/packages/graph-explorer/src/connector/sparql/rawQuery.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/rawQuery.test.ts
@@ -224,14 +224,14 @@ describe("rawQuery", () => {
     it("should treat SELECT queries with exactly s/p/o variables as CONSTRUCT", async () => {
       const vertex1 = createTestableVertex().withRdfValues();
       const vertex2 = createTestableVertex().withRdfValues();
-      
+
       const bindings = createQuadBindingsForEntities([vertex1, vertex2], []);
       const shorthandBindings = bindings.map(b => ({
         s: b.subject,
         p: b.predicate,
         o: b.object,
       }));
-      
+
       const mockResponse = {
         head: { vars: ["s", "p", "o"] },
         results: { bindings: shorthandBindings },
@@ -307,8 +307,7 @@ describe("rawQuery", () => {
 
       const mockFetch = vi.fn().mockResolvedValue(mockResponse);
       const result = await rawQuery(mockFetch, {
-        query:
-          "SELECT ?s ?predicate ?object WHERE { ?s ?predicate ?object }",
+        query: "SELECT ?s ?predicate ?object WHERE { ?s ?predicate ?object }",
       });
 
       // Should be treated as SELECT query (bundle with 3 scalars), not CONSTRUCT

--- a/packages/graph-explorer/src/connector/sparql/rawQuery.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/rawQuery.test.ts
@@ -221,6 +221,35 @@ describe("rawQuery", () => {
       expect(result.rawResponse).toEqual(mockResponse);
     });
 
+    it("should treat SELECT queries with exactly s/p/o variables as CONSTRUCT", async () => {
+      const vertex1 = createTestableVertex().withRdfValues();
+      const vertex2 = createTestableVertex().withRdfValues();
+      
+      const bindings = createQuadBindingsForEntities([vertex1, vertex2], []);
+      const shorthandBindings = bindings.map(b => ({
+        s: b.subject,
+        p: b.predicate,
+        o: b.object,
+      }));
+      
+      const mockResponse = {
+        head: { vars: ["s", "p", "o"] },
+        results: { bindings: shorthandBindings },
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+      const result = await rawQuery(mockFetch, {
+        query: "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",
+      });
+
+      // It should map them to fragments as if it was a CONSTRUCT response
+      expect(result.results).toStrictEqual([
+        vertex1.asFragmentResult(),
+        vertex2.asFragmentResult(),
+      ]);
+      expect(result.rawResponse).toEqual(mockResponse);
+    });
+
     it("should not treat SELECT queries with subject/predicate/object variables as CONSTRUCT", async () => {
       const mockResponse = {
         head: { vars: ["subject", "predicate", "object", "extra"] },
@@ -256,6 +285,45 @@ describe("rawQuery", () => {
             }),
             createResultScalar({ name: "?object", value: "John Doe" }),
             createResultScalar({ name: "?extra", value: "additional data" }),
+          ],
+        }),
+      ]);
+      expect(result.rawResponse).toEqual(mockResponse);
+    });
+
+    it("should not treat SELECT queries with partial shorthand variables (e.g., s/predicate/object) as CONSTRUCT", async () => {
+      const mockResponse = {
+        head: { vars: ["s", "predicate", "object"] },
+        results: {
+          bindings: [
+            {
+              s: createUriValue("http://example.org/person1"),
+              predicate: createUriValue("http://example.org/name"),
+              object: createLiteralValue("John Doe"),
+            },
+          ],
+        },
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+      const result = await rawQuery(mockFetch, {
+        query:
+          "SELECT ?s ?predicate ?object WHERE { ?s ?predicate ?object }",
+      });
+
+      // Should be treated as SELECT query (bundle with 3 scalars), not CONSTRUCT
+      expect(result.results).toStrictEqual([
+        createResultBundle({
+          values: [
+            createResultScalar({
+              name: "?s",
+              value: "http://example.org/person1",
+            }),
+            createResultScalar({
+              name: "?predicate",
+              value: "http://example.org/name",
+            }),
+            createResultScalar({ name: "?object", value: "John Doe" }),
           ],
         }),
       ]);

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -206,7 +206,7 @@ export const sparqlAskResponseSchema = z.object({
   boolean: z.boolean(),
 });
 
-export const sparqlQuadBindingSchema = z
+const sparqlQuadBindingLongSchema = z
   .object({
     subject: sparqlResourceValueSchema,
     predicate: sparqlUriValueSchema,
@@ -214,4 +214,25 @@ export const sparqlQuadBindingSchema = z
     graph: sparqlValueSchema.optional(),
   })
   .strict();
+
+const sparqlQuadBindingShortSchema = z
+  .object({
+    s: sparqlResourceValueSchema,
+    p: sparqlUriValueSchema,
+    o: sparqlValueSchema,
+    g: sparqlValueSchema.optional(),
+    c: sparqlValueSchema.optional(),
+  })
+  .strict()
+  .transform(val => ({
+    subject: val.s,
+    predicate: val.p,
+    object: val.o,
+    graph: val.g ?? val.c,
+  }));
+
+export const sparqlQuadBindingSchema = z.union([
+  sparqlQuadBindingLongSchema,
+  sparqlQuadBindingShortSchema,
+]);
 export type SparqlQuadBinding = z.infer<typeof sparqlQuadBindingSchema>;


### PR DESCRIPTION
## Description

This PR supports the `?s ?p ?o` shorthand in the Query Editor so results render correctly as graph entities.

Changes include:
* Updates `sparqlQuadBindingSchema` to normalize the `{s, p, o}` short form into `{subject, predicate, object}`.
* Adds validation tests to verify shorthand parsing and strict rejection of partial matches.
* Updates query logic tests to ensure `SELECT ?s ?p ?o` executes and behaves as a `CONSTRUCT` query.

## Related Issues

Fixes #1766

### Check List

* [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
* [x] I have verified `pnpm checks` passes with no errors.
* [x] I have verified `pnpm test` passes with no failures.
* [x] I have covered new added functionality with unit tests if necessary.
* [x] I have updated documentation if necessary.
