### PR TITLE
Fix default icon for no-type vertices

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -4,11 +4,10 @@ import { atom, useAtomValue, useSetAtom } from "jotai";
 import { atomFamily } from "jotai-family";
 import { useDeferredValue } from "react";
 
-import { RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
+import { LABELS, RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
 import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 
-import type { EdgeType, VertexType } from "../entities";
-
+import { createVertexType, type EdgeType, type VertexType } from "../entities";
 import { useActiveSchema } from "./schema";
 import { userStylingAtom } from "./storageAtoms";
 
@@ -216,7 +215,14 @@ export function createEdgePreference(
 export function useAllVertexPreferences(): VertexPreferences[] {
   const prefs = useAtomValue(vertexPreferencesAtom);
   const { vertices: allSchemas } = useActiveSchema();
-  return allSchemas.map(({ type }) => prefs.get(type));
+  const vertexTypes = allSchemas.map(({ type }) => type);
+  const missingType = createVertexType(LABELS.MISSING_TYPE);
+
+  if (!vertexTypes.includes(missingType)) {
+    vertexTypes.push(missingType);
+  }
+
+  return vertexTypes.map(type => prefs.get(type));
 }
 
 /** Returns an array of edge preferences based on the known edge types in the schema. */

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 import type { GraphProps } from "@/components/Graph";
 
 import { createEdgeType, createVertexType } from "@/core";
+import { LABELS } from "@/utils";
 import {
   createRandomEdgeTypeConfig,
   createRandomVertexTypeConfig,
@@ -64,6 +65,24 @@ describe("useGraphStyles", () => {
         "border-color": "#000000",
         "border-width": 2,
         "border-style": "solid",
+        shape: "ellipse",
+        width: 24,
+        height: 24,
+      });
+    });
+  });
+
+  it("should generate a default style for vertices without a schema type", async () => {
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    await waitFor(() => {
+      const vertexStyle = getStyles(result)[
+        `node[type="${LABELS.MISSING_TYPE}"]`
+      ] as any;
+      expect(vertexStyle).toMatchObject({
+        "background-image": "data:image/svg+xml;utf8,<svg></svg>",
+        "background-color": "#128EE5",
+        "background-opacity": 0.4,
         shape: "ellipse",
         width: 24,
         height: 24,


### PR DESCRIPTION
## Summary

Fixes #1779.

This updates the graph style preferences so the synthetic `No Type` vertex type gets the same default vertex styling as schema-backed types. That gives blank nodes without a schema type a generated Cytoscape background image, matching the default icon shown in the details panel.

I also added a regression test for the no-type node style selector.

## Verification

- Focused GraphViewer style test passed
- Formatter check passed on touched files
- Oxlint passed on touched files
- Recursive workspace typecheck passed

I also ran the full Vitest suite locally. The touched GraphViewer test passed, but the full run has unrelated Windows/environment failures: path assertions expecting POSIX separators, missing openssl, shell redirects failing because the workspace path contains spaces, and locale-specific number grouping under en-IN.
