### PR TITLE
Fix Zed formatter config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,15 +1,15 @@
 {
   "format_on_save": "on",
   "prettier": { "allowed": false },
-  "formatter": [{ "language_server": { "name": "oxfmt" } }],
-  "lsp": {
-    "oxfmt": {
-      "initialization_options": {
-        "settings": {
-          "fmt.configPath": null
-        }
+  "formatter": [
+    {
+      "external": {
+        "command": "pnpm",
+        "arguments": ["exec", "oxfmt", "--stdin-filepath", "{buffer_path}"]
       }
-    },
+    }
+  ],
+  "lsp": {
     "tailwindcss-language-server": {
       "settings": {
         "rootFontSize": 14,


### PR DESCRIPTION
## Description

The oxfmt formatter was configured as a `language_server` in `.zed/settings.json`, but no such Zed LSP adapter exists — oxfmt is a standalone CLI tool. This caused a warning in Zed. Replaced with an `external` formatter that pipes through `pnpm exec oxfmt --stdin-filepath`.

Also removed the dead `lsp.oxfmt` initialization options block.

## Validation

- Format-on-save works in Zed with the new external formatter config

## Related Issues

- None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.