### PR TITLE
Remove broken lint-staged config from graph-explorer sub-package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Follow the rules and conventions defined in [AGENTS.md](./AGENTS.md).

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -97,19 +97,12 @@
     "core-js": "^3.49.0",
     "happy-dom": "^20.9.0",
     "jsdom": "^29.0.2",
-    "lint-staged": "^16.4.0",
     "rimraf": "^6.1.3",
     "tailwindcss": "^4.2.4",
     "tw-animate-css": "^1.4.0",
     "type-fest": "^5.6.0",
     "vite": "^8.0.9",
     "vitest": "4.1.5"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "oxfmt"
-    ]
   },
   "engines": {
     "node": ">=24.13.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,9 +307,6 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
-      lint-staged:
-        specifier: ^16.4.0
-        version: 16.4.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## Description

Two fixes to the developer tooling setup:

1. **Remove broken lint-staged config from graph-explorer sub-package** — it referenced `eslint --fix` but eslint is no longer installed (migrated to oxlint). The root `package.json` lint-staged already runs `oxlint --fix` and `oxfmt` on all staged files, making the sub-package config redundant. This caused pre-commit hooks to fail with `ENOENT` when staging files under `packages/graph-explorer/`.

2. **Add `CLAUDE.md`** — points Claude Code to the existing `AGENTS.md` for project conventions.

## Validation

- Pre-commit hook passes for `.ts`/`.tsx` files in `packages/graph-explorer/`
- Pre-commit hook passes for config files (`.json`, etc.) in `packages/graph-explorer/`
- `pnpm checks` passes
- `pnpm test` passes

## Related Issues

- None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.