### PR TITLE
Switch schema sync summary API from detailed to basic mode

### DIFF
--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -530,7 +530,7 @@ describe("createApp", () => {
   // ── Summary routes ────────────────────────────────────────────────
 
   describe("GET /summary", () => {
-    it("proxies to the graph database summary endpoint without injecting query params", async () => {
+    it("proxies to the graph database summary endpoint with mode=basic", async () => {
       mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
         "content-type": "application/json",
       });
@@ -540,42 +540,14 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/summary`,
-        expect.objectContaining({ method: "GET" }),
-      );
-    });
-
-    it("forwards query params to the graph database", async () => {
-      mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
-        "content-type": "application/json",
-      });
-
-      const app = createTestApp();
-      await request(app).get("/summary?mode=basic").set(dbHeaders());
-
-      expect(mockFetch).toHaveBeenCalledWith(
         `${graphDbUrl}/summary?mode=basic`,
-        expect.objectContaining({ method: "GET" }),
-      );
-    });
-
-    it("forwards multiple query params to the graph database", async () => {
-      mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
-        "content-type": "application/json",
-      });
-
-      const app = createTestApp();
-      await request(app).get("/summary?mode=basic&foo=bar").set(dbHeaders());
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/summary?mode=basic&foo=bar`,
         expect.objectContaining({ method: "GET" }),
       );
     });
   });
 
   describe("GET /pg/statistics/summary", () => {
-    it("proxies to the PG statistics summary endpoint without injecting query params", async () => {
+    it("proxies to the PG statistics summary endpoint with mode=basic", async () => {
       mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
         "content-type": "application/json",
       });
@@ -587,22 +559,6 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/pg/statistics/summary`,
-        expect.objectContaining({ method: "GET" }),
-      );
-    });
-
-    it("forwards query params to the graph database", async () => {
-      mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
-        "content-type": "application/json",
-      });
-
-      const app = createTestApp();
-      await request(app)
-        .get("/pg/statistics/summary?mode=basic")
-        .set(dbHeaders());
-
-      expect(mockFetch).toHaveBeenCalledWith(
         `${graphDbUrl}/pg/statistics/summary?mode=basic`,
         expect.objectContaining({ method: "GET" }),
       );
@@ -610,7 +566,7 @@ describe("createApp", () => {
   });
 
   describe("GET /rdf/statistics/summary", () => {
-    it("proxies to the RDF statistics summary endpoint without injecting query params", async () => {
+    it("proxies to the RDF statistics summary endpoint with mode=basic", async () => {
       mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
         "content-type": "application/json",
       });
@@ -621,22 +577,6 @@ describe("createApp", () => {
         .set(dbHeaders());
 
       expect(response.status).toBe(200);
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/rdf/statistics/summary`,
-        expect.objectContaining({ method: "GET" }),
-      );
-    });
-
-    it("forwards query params to the graph database", async () => {
-      mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
-        "content-type": "application/json",
-      });
-
-      const app = createTestApp();
-      await request(app)
-        .get("/rdf/statistics/summary?mode=basic")
-        .set(dbHeaders());
-
       expect(mockFetch).toHaveBeenCalledWith(
         `${graphDbUrl}/rdf/statistics/summary?mode=basic`,
         expect.objectContaining({ method: "GET" }),
@@ -946,7 +886,7 @@ describe("createApp", () => {
       await request(app).get("/summary").set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/summary`,
+        `${blazegraphUrl}/summary?mode=basic`,
         expect.anything(),
       );
     });
@@ -958,7 +898,7 @@ describe("createApp", () => {
       await request(app).get("/pg/statistics/summary").set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/pg/statistics/summary`,
+        `${blazegraphUrl}/pg/statistics/summary?mode=basic`,
         expect.anything(),
       );
     });
@@ -972,7 +912,7 @@ describe("createApp", () => {
         .set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/rdf/statistics/summary`,
+        `${blazegraphUrl}/rdf/statistics/summary?mode=basic`,
         expect.anything(),
       );
     });
@@ -1078,14 +1018,6 @@ describe("resolveEndpointUrl", () => {
     expect(url.href).toBe("https://neptune:8182/blazegraph/sparql");
   });
 
-  it("strips a leading slash from the endpoint", () => {
-    const url = resolveEndpointUrl(
-      "https://neptune:8182",
-      "/summary?mode=basic",
-    );
-    expect(url.href).toBe("https://neptune:8182/summary?mode=basic");
-  });
-
   it("preserves query params from the endpoint", () => {
     const url = resolveEndpointUrl(
       "https://neptune:8182",
@@ -1103,10 +1035,9 @@ describe("resolveEndpointUrl", () => {
   });
 
   it("does not allow protocol-relative URLs to escape the origin", () => {
-    const url = resolveEndpointUrl(
-      "https://neptune:8182",
-      "//other-host.com/data",
-    );
-    expect(url.origin).toBe("https://neptune:8182");
+    expect(() =>
+      // @ts-expect-error Testing runtime SSRF guard with input rejected by type
+      resolveEndpointUrl("https://neptune:8182", "//other-host.com/data"),
+    ).toThrow(/does not match base/);
   });
 });

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { Readable } from "stream";
 import request from "supertest";
 
-import { createApp } from "./app.ts";
+import { createApp, resolveEndpointUrl } from "./app.ts";
 import { createLogger } from "./logging.ts";
 
 // node-fetch is globally mocked in test-setup.ts
@@ -530,7 +530,7 @@ describe("createApp", () => {
   // ── Summary routes ────────────────────────────────────────────────
 
   describe("GET /summary", () => {
-    it("proxies to the graph database summary endpoint", async () => {
+    it("proxies to the graph database summary endpoint without injecting query params", async () => {
       mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
         "content-type": "application/json",
       });
@@ -540,14 +540,42 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/summary?mode=detailed`,
+        `${graphDbUrl}/summary`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("forwards query params to the graph database", async () => {
+      mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
+        "content-type": "application/json",
+      });
+
+      const app = createTestApp();
+      await request(app).get("/summary?mode=basic").set(dbHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${graphDbUrl}/summary?mode=basic`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("forwards multiple query params to the graph database", async () => {
+      mockFetchOnce(JSON.stringify({ graphSummary: {} }), 200, {
+        "content-type": "application/json",
+      });
+
+      const app = createTestApp();
+      await request(app).get("/summary?mode=basic&foo=bar").set(dbHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${graphDbUrl}/summary?mode=basic&foo=bar`,
         expect.objectContaining({ method: "GET" }),
       );
     });
   });
 
   describe("GET /pg/statistics/summary", () => {
-    it("proxies to the PG statistics summary endpoint", async () => {
+    it("proxies to the PG statistics summary endpoint without injecting query params", async () => {
       mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
         "content-type": "application/json",
       });
@@ -559,14 +587,30 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/pg/statistics/summary?mode=detailed`,
+        `${graphDbUrl}/pg/statistics/summary`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("forwards query params to the graph database", async () => {
+      mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
+        "content-type": "application/json",
+      });
+
+      const app = createTestApp();
+      await request(app)
+        .get("/pg/statistics/summary?mode=basic")
+        .set(dbHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${graphDbUrl}/pg/statistics/summary?mode=basic`,
         expect.objectContaining({ method: "GET" }),
       );
     });
   });
 
   describe("GET /rdf/statistics/summary", () => {
-    it("proxies to the RDF statistics summary endpoint", async () => {
+    it("proxies to the RDF statistics summary endpoint without injecting query params", async () => {
       mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
         "content-type": "application/json",
       });
@@ -578,7 +622,23 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${graphDbUrl}/rdf/statistics/summary?mode=detailed`,
+        `${graphDbUrl}/rdf/statistics/summary`,
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("forwards query params to the graph database", async () => {
+      mockFetchOnce(JSON.stringify({ stats: {} }), 200, {
+        "content-type": "application/json",
+      });
+
+      const app = createTestApp();
+      await request(app)
+        .get("/rdf/statistics/summary?mode=basic")
+        .set(dbHeaders());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${graphDbUrl}/rdf/statistics/summary?mode=basic`,
         expect.objectContaining({ method: "GET" }),
       );
     });
@@ -886,7 +946,7 @@ describe("createApp", () => {
       await request(app).get("/summary").set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/summary?mode=detailed`,
+        `${blazegraphUrl}/summary`,
         expect.anything(),
       );
     });
@@ -898,7 +958,7 @@ describe("createApp", () => {
       await request(app).get("/pg/statistics/summary").set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/pg/statistics/summary?mode=detailed`,
+        `${blazegraphUrl}/pg/statistics/summary`,
         expect.anything(),
       );
     });
@@ -912,7 +972,7 @@ describe("createApp", () => {
         .set(blazegraphHeaders());
 
       expect(mockFetch).toHaveBeenCalledWith(
-        `${blazegraphUrl}/rdf/statistics/summary?mode=detailed`,
+        `${blazegraphUrl}/rdf/statistics/summary`,
         expect.anything(),
       );
     });
@@ -1001,5 +1061,52 @@ describe("createApp", () => {
         expect(mockFetch).not.toHaveBeenCalled();
       },
     );
+  });
+});
+
+describe("resolveEndpointUrl", () => {
+  it("appends a relative endpoint to the base path", () => {
+    const url = resolveEndpointUrl(
+      "https://neptune:8182",
+      "pg/statistics/summary",
+    );
+    expect(url.href).toBe("https://neptune:8182/pg/statistics/summary");
+  });
+
+  it("preserves the base path when appending", () => {
+    const url = resolveEndpointUrl("https://neptune:8182/blazegraph", "sparql");
+    expect(url.href).toBe("https://neptune:8182/blazegraph/sparql");
+  });
+
+  it("strips a leading slash from the endpoint", () => {
+    const url = resolveEndpointUrl(
+      "https://neptune:8182",
+      "/summary?mode=basic",
+    );
+    expect(url.href).toBe("https://neptune:8182/summary?mode=basic");
+  });
+
+  it("preserves query params from the endpoint", () => {
+    const url = resolveEndpointUrl(
+      "https://neptune:8182",
+      "pg/statistics/summary?mode=basic&foo=bar",
+    );
+    expect(url.href).toBe(
+      "https://neptune:8182/pg/statistics/summary?mode=basic&foo=bar",
+    );
+  });
+
+  it("throws if the resolved URL escapes the base origin", () => {
+    expect(() =>
+      resolveEndpointUrl("https://neptune:8182", "https://other-host.com/data"),
+    ).toThrow(/does not match base/);
+  });
+
+  it("does not allow protocol-relative URLs to escape the origin", () => {
+    const url = resolveEndpointUrl(
+      "https://neptune:8182",
+      "//other-host.com/data",
+    );
+    expect(url.origin).toBe("https://neptune:8182");
   });
 });

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -38,6 +38,25 @@ export function resolveEndpointUrl(base: string, endpoint: string): URL {
   return resolved;
 }
 
+/**
+ * Builds an endpoint string from a known path and parsed query parameters.
+ * Uses URLSearchParams to safely serialize query values without passing raw
+ * user input through URL construction.
+ */
+function buildEndpointWithQuery(
+  path: string,
+  query: Record<string, unknown>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === "string") {
+      params.append(key, value);
+    }
+  }
+  const search = params.toString();
+  return search ? `${path}?${search}` : path;
+}
+
 /** Zod schema for the custom headers expected on database query requests. */
 const DbQueryHeadersSchema = z.object({
   queryid: z.string().optional(),
@@ -506,7 +525,8 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
+    const endpoint = buildEndpointWithQuery("summary", req.query);
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
 
     await fetchData(
       res,
@@ -524,7 +544,8 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
+    const endpoint = buildEndpointWithQuery("pg/statistics/summary", req.query);
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
 
     await fetchData(
       res,
@@ -542,7 +563,11 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
+    const endpoint = buildEndpointWithQuery(
+      "rdf/statistics/summary",
+      req.query,
+    );
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
 
     await fetchData(
       res,

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -19,42 +19,25 @@ import { type AppLogger, requestLoggingMiddleware } from "./logging.ts";
 const DEFAULT_SERVICE_TYPE = "neptune-db";
 
 /**
- * Resolves an endpoint path against a base URL, preserving the base path.
- * Strips any leading slash from the endpoint and forces a trailing slash on
- * the base so that `new URL` appends rather than replaces the path.
+ * Resolves a relative endpoint path against a base URL, preserving the base
+ * path. Forces a trailing slash on the base so that `new URL` appends rather
+ * than replaces the path.
  *
  * Throws if the resolved URL escapes the base origin (prevents SSRF via
  * crafted endpoint strings).
  */
-export function resolveEndpointUrl(base: string, endpoint: string): URL {
-  const relative = endpoint.startsWith("/") ? endpoint.slice(1) : endpoint;
+export function resolveEndpointUrl<T extends string>(
+  base: string,
+  endpoint: T extends `/${string}` ? never : T,
+): URL {
   const baseUrl = new URL(base.replace(/\/?$/, "/"));
-  const resolved = new URL(relative, baseUrl);
+  const resolved = new URL(endpoint, baseUrl);
   if (resolved.origin !== baseUrl.origin) {
     throw new Error(
       `Resolved URL origin "${resolved.origin}" does not match base "${baseUrl.origin}"`,
     );
   }
   return resolved;
-}
-
-/**
- * Builds an endpoint string from a known path and parsed query parameters.
- * Uses URLSearchParams to safely serialize query values without passing raw
- * user input through URL construction.
- */
-function buildEndpointWithQuery(
-  path: string,
-  query: Record<string, unknown>,
-): string {
-  const params = new URLSearchParams();
-  for (const [key, value] of Object.entries(query)) {
-    if (typeof value === "string") {
-      params.append(key, value);
-    }
-  }
-  const search = params.toString();
-  return search ? `${path}?${search}` : path;
 }
 
 /** Zod schema for the custom headers expected on database query requests. */
@@ -525,8 +508,10 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const endpoint = buildEndpointWithQuery("summary", req.query);
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
+    const rawUrl = resolveEndpointUrl(
+      graphDbConnectionUrl,
+      "summary?mode=basic",
+    ).href;
 
     await fetchData(
       res,
@@ -544,8 +529,10 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const endpoint = buildEndpointWithQuery("pg/statistics/summary", req.query);
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
+    const rawUrl = resolveEndpointUrl(
+      graphDbConnectionUrl,
+      "pg/statistics/summary?mode=basic",
+    ).href;
 
     await fetchData(
       res,
@@ -563,11 +550,10 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const endpoint = buildEndpointWithQuery(
-      "rdf/statistics/summary",
-      req.query,
-    );
-    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, endpoint).href;
+    const rawUrl = resolveEndpointUrl(
+      graphDbConnectionUrl,
+      "rdf/statistics/summary?mode=basic",
+    ).href;
 
     await fetchData(
       res,

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -196,7 +196,7 @@ export function createApp({
       };
 
       try {
-        const res = await fetch(url.href, options); // lgtm[js/request-forgery]
+        const res = await fetch(url.href, options);
         if (!res.ok) {
           logger.error("!!Request failure!!");
           return res;

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -19,15 +19,23 @@ import { type AppLogger, requestLoggingMiddleware } from "./logging.ts";
 const DEFAULT_SERVICE_TYPE = "neptune-db";
 
 /**
- * Resolves a relative endpoint path against a base URL, preserving the base
- * path. Forces a trailing slash on the base so that `new URL` appends rather
- * than replaces the path.
+ * Resolves an endpoint path against a base URL, preserving the base path.
+ * Strips any leading slash from the endpoint and forces a trailing slash on
+ * the base so that `new URL` appends rather than replaces the path.
+ *
+ * Throws if the resolved URL escapes the base origin (prevents SSRF via
+ * crafted endpoint strings).
  */
-function resolveEndpointUrl<T extends string>(
-  base: string,
-  endpoint: T extends `/${string}` ? never : T,
-): URL {
-  return new URL(endpoint, base.replace(/\/?$/, "/"));
+export function resolveEndpointUrl(base: string, endpoint: string): URL {
+  const relative = endpoint.startsWith("/") ? endpoint.slice(1) : endpoint;
+  const baseUrl = new URL(base.replace(/\/?$/, "/"));
+  const resolved = new URL(relative, baseUrl);
+  if (resolved.origin !== baseUrl.origin) {
+    throw new Error(
+      `Resolved URL origin "${resolved.origin}" does not match base "${baseUrl.origin}"`,
+    );
+  }
+  return resolved;
 }
 
 /** Zod schema for the custom headers expected on database query requests. */
@@ -188,7 +196,7 @@ export function createApp({
       };
 
       try {
-        const res = await fetch(url.href, options);
+        const res = await fetch(url.href, options); // lgtm[js/request-forgery]
         if (!res.ok) {
           logger.error("!!Request failure!!");
           return res;
@@ -498,10 +506,7 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(
-      graphDbConnectionUrl,
-      "summary?mode=detailed",
-    ).href;
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
 
     await fetchData(
       res,
@@ -519,10 +524,7 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(
-      graphDbConnectionUrl,
-      "pg/statistics/summary?mode=detailed",
-    ).href;
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
 
     await fetchData(
       res,
@@ -540,10 +542,7 @@ export function createApp({
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
     assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
-    const rawUrl = resolveEndpointUrl(
-      graphDbConnectionUrl,
-      "rdf/statistics/summary?mode=detailed",
-    ).href;
+    const rawUrl = resolveEndpointUrl(graphDbConnectionUrl, req.url).href;
 
     await fetchData(
       res,

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.test.ts
@@ -1,0 +1,103 @@
+import type { FeatureFlags, NormalizedConnection } from "@/core";
+
+import { createGremlinExplorer } from "./gremlinExplorer";
+
+function createConnection(
+  overrides?: Partial<NormalizedConnection>,
+): NormalizedConnection {
+  return {
+    url: "http://localhost:8182",
+    queryEngine: "gremlin",
+    graphDbUrl: "",
+    proxyConnection: false,
+    awsAuthEnabled: false,
+    ...overrides,
+  };
+}
+
+function createFeatureFlags(): FeatureFlags {
+  return {
+    showDebugActions: false,
+    allowLoggingDbQuery: false,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const emptyGremlinList = {
+  result: {
+    data: { "@type": "g:List", "@value": [{ "@type": "g:Map", "@value": [] }] },
+  },
+};
+
+describe("createGremlinExplorer", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchSchema", () => {
+    it("requests the summary API with mode=basic", async () => {
+      const summaryResponse = {
+        payload: {
+          graphSummary: {
+            numNodes: 10,
+            numEdges: 5,
+            nodeLabels: ["Person"],
+            edgeLabels: ["knows"],
+          },
+        },
+      };
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(summaryResponse))
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse(emptyGremlinList)),
+        );
+
+      const explorer = createGremlinExplorer(
+        createConnection(),
+        createFeatureFlags(),
+      );
+      await explorer.fetchSchema();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8182/pg/statistics/summary?mode=basic",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("falls back to query-based discovery when summary API fails", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response("Not Found", {
+            status: 404,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        )
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse(emptyGremlinList)),
+        );
+
+      const explorer = createGremlinExplorer(
+        createConnection(),
+        createFeatureFlags(),
+      );
+      const schema = await explorer.fetchSchema();
+
+      expect(schema).toBeDefined();
+      expect(schema).toHaveProperty("vertices");
+      expect(schema).toHaveProperty("edges");
+    });
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
+++ b/packages/graph-explorer/src/connector/gremlin/gremlinExplorer.ts
@@ -58,7 +58,7 @@ async function fetchSummary(
     const response = await fetchDatabaseRequest(
       connection,
       featureFlags,
-      `${connection.url}/pg/statistics/summary?mode=detailed`,
+      `${connection.url}/pg/statistics/summary?mode=basic`,
       {
         method: "GET",
         ...options,

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.test.ts
@@ -1,0 +1,124 @@
+import type { FeatureFlags, NormalizedConnection } from "@/core";
+
+import { createOpenCypherExplorer } from "./openCypherExplorer";
+
+function createConnection(
+  overrides?: Partial<NormalizedConnection>,
+): NormalizedConnection {
+  return {
+    url: "http://localhost:8182",
+    queryEngine: "openCypher",
+    graphDbUrl: "",
+    proxyConnection: false,
+    awsAuthEnabled: false,
+    ...overrides,
+  };
+}
+
+function createFeatureFlags(): FeatureFlags {
+  return {
+    showDebugActions: false,
+    allowLoggingDbQuery: false,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("createOpenCypherExplorer", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchSchema", () => {
+    it("requests the summary API with mode=basic", async () => {
+      const summaryResponse = {
+        payload: {
+          graphSummary: {
+            numNodes: 10,
+            numEdges: 5,
+            nodeLabels: ["Person"],
+            edgeLabels: ["knows"],
+          },
+        },
+      };
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(summaryResponse))
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ results: [] })),
+        );
+
+      const explorer = createOpenCypherExplorer(
+        createConnection(),
+        createFeatureFlags(),
+      );
+      await explorer.fetchSchema();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8182/pg/statistics/summary?mode=basic",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("requests the summary API from non-standard endpoint for neptune-graph service type", async () => {
+      const summaryResponse = {
+        graphSummary: {
+          numNodes: 10,
+          numEdges: 5,
+          nodeLabels: ["Person"],
+          edgeLabels: ["knows"],
+        },
+      };
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(summaryResponse))
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ results: [] })),
+        );
+
+      const explorer = createOpenCypherExplorer(
+        createConnection({ serviceType: "neptune-graph" }),
+        createFeatureFlags(),
+      );
+      await explorer.fetchSchema();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8182/summary?mode=basic",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("falls back to query-based discovery when summary API fails", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response("Not Found", {
+            status: 404,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        )
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ results: [] })),
+        );
+
+      const explorer = createOpenCypherExplorer(
+        createConnection(),
+        createFeatureFlags(),
+      );
+      const schema = await explorer.fetchSchema();
+
+      expect(schema).toBeDefined();
+      expect(schema).toHaveProperty("vertices");
+      expect(schema).toHaveProperty("edges");
+    });
+  });
+});

--- a/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
+++ b/packages/graph-explorer/src/connector/openCypher/openCypherExplorer.ts
@@ -130,8 +130,8 @@ async function fetchSummary(
   try {
     const endpoint =
       serviceType === DEFAULT_SERVICE_TYPE
-        ? `${connection.url}/pg/statistics/summary?mode=detailed`
-        : `${connection.url}/summary?mode=detailed`;
+        ? `${connection.url}/pg/statistics/summary?mode=basic`
+        : `${connection.url}/summary?mode=basic`;
     const response = await fetchDatabaseRequest(
       connection,
       featureFlags,

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.test.ts
@@ -1,0 +1,100 @@
+import type { FeatureFlags, NormalizedConnection } from "@/core";
+
+import { createSparqlExplorer } from "./sparqlExplorer";
+
+function createConnection(
+  overrides?: Partial<NormalizedConnection>,
+): NormalizedConnection {
+  return {
+    url: "http://localhost:8182",
+    queryEngine: "sparql",
+    graphDbUrl: "",
+    proxyConnection: false,
+    awsAuthEnabled: false,
+    ...overrides,
+  };
+}
+
+function createFeatureFlags(): FeatureFlags {
+  return {
+    showDebugActions: false,
+    allowLoggingDbQuery: false,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("createSparqlExplorer", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchSchema", () => {
+    it("requests the summary API with mode=basic", async () => {
+      const summaryResponse = {
+        payload: {
+          graphSummary: {
+            numDistinctSubjects: 10,
+            numQuads: 5,
+            numClasses: 1,
+            classes: ["http://example.org/Person"],
+            predicates: [{ "http://example.org/knows": 5 }],
+          },
+        },
+      };
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(summaryResponse))
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ results: { bindings: [] } })),
+        );
+
+      const explorer = createSparqlExplorer(
+        createConnection(),
+        createFeatureFlags(),
+        new Map(),
+      );
+      await explorer.fetchSchema();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:8182/rdf/statistics/summary?mode=basic",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("falls back to query-based discovery when summary API fails", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          new Response("Not Found", {
+            status: 404,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        )
+        .mockImplementation(() =>
+          Promise.resolve(jsonResponse({ results: { bindings: [] } })),
+        );
+
+      const explorer = createSparqlExplorer(
+        createConnection(),
+        createFeatureFlags(),
+        new Map(),
+      );
+      const schema = await explorer.fetchSchema();
+
+      expect(schema).toBeDefined();
+      expect(schema).toHaveProperty("vertices");
+      expect(schema).toHaveProperty("edges");
+    });
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -74,7 +74,7 @@ async function fetchSummary(
     const response = await fetchDatabaseRequest(
       connection,
       featureFlags,
-      `${connection.url}/rdf/statistics/summary?mode=detailed`,
+      `${connection.url}/rdf/statistics/summary?mode=basic`,
       {
         method: "GET",
         ...options,


### PR DESCRIPTION
## Description

Schema Sync previously requested Neptune's summary API with `mode=detailed`, which returns `nodeStructures` and `edgeStructures` that Graph Explorer never uses (they lack label association, so they can't map to GE's label-centric schema model). This switches to `mode=basic` which returns all the fields GE actually consumes: `nodeLabels`, `edgeLabels`, `numNodes`, `numEdges`.

The proxy server hardcodes `?mode=basic` on all three summary endpoints (same pattern as before, just with the correct mode value).

`resolveEndpointUrl` was hardened with a runtime origin check to prevent SSRF via crafted endpoint strings, and the template literal type constraint prevents leading-slash endpoints at compile time.

**How to read the changes:**
1. `app.ts` (proxy) — `resolveEndpointUrl` gets origin validation + template literal enforcement; summary handlers use `mode=basic` instead of `mode=detailed`
2. `gremlinExplorer.ts`, `openCypherExplorer.ts`, `sparqlExplorer.ts` — one-line URL change each (`detailed` → `basic`)
3. Test files — new explorer-level tests + updated proxy assertions + `resolveEndpointUrl` unit tests (including SSRF origin validation)

## Validation

- Manually tested against a Neptune database — schema sync works correctly with basic mode
- `pnpm checks` passes (lint, format, types)
- `pnpm test` passes (all tests including new ones)

## Related Issues

- Closes #1789
- Spike: #1786

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.