### PR TITLE
Add PROXY_SERVER_ALLOWED_DB_ORIGINS to restrict proxy forwarding targets

### DIFF
--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -74,7 +74,7 @@ Example: `https://my-app.example.com` or `https://app-a.example.com,https://app-
 
 Restricts which database origins the proxy server will forward requests to. When set, requests targeting an origin not in the list receive a 403 response. When not set, the proxy forwards to any database URL specified by the client (current default behavior).
 
-Each entry must be an origin only (scheme + host + port) — paths are not supported and will cause a startup error. The proxy also disables HTTP redirects on outbound requests, preventing an allowed origin from redirecting to an unrelated internal service.
+Values must be origins (scheme + host + optional port). Including a path will cause a startup error.
 
 Examples:
 
@@ -84,6 +84,9 @@ PROXY_SERVER_ALLOWED_DB_ORIGINS=https://my-neptune-cluster:8182
 
 # Multiple origins
 PROXY_SERVER_ALLOWED_DB_ORIGINS=https://cluster-a:8182,https://cluster-b:8182
+
+# INVALID — paths are not allowed
+PROXY_SERVER_ALLOWED_DB_ORIGINS=https://my-neptune-cluster:8182/sparql
 ```
 
 - Optional

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -90,6 +90,10 @@ PROXY_SERVER_ALLOWED_DB_ORIGINS=https://cluster-a:8182,https://cluster-b:8182
 - Default: all origins allowed
 - Type: `string` (comma-separated for multiple origins)
 
+> [!NOTE]
+>
+> This check only applies to requests routed through the proxy server. Connections configured to contact the database directly (bypassing the proxy) are not subject to the allowlist.
+
 ### `LOG_STYLE`
 
 Controls the log output format.

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -70,6 +70,26 @@ Example: `https://my-app.example.com` or `https://app-a.example.com,https://app-
 - Default: cross-origin requests blocked
 - Type: `string` (comma-separated for multiple origins)
 
+### `PROXY_SERVER_ALLOWED_DB_ORIGINS`
+
+Restricts which database origins the proxy server will forward requests to. When set, requests targeting an origin not in the list receive a 403 response. When not set, the proxy forwards to any database URL specified by the client (current default behavior).
+
+Each entry must be an origin only (scheme + host + port) — paths are not supported and will cause a startup error. The proxy also disables HTTP redirects on outbound requests, preventing an allowed origin from redirecting to an unrelated internal service.
+
+Examples:
+
+```bash
+# Single origin
+PROXY_SERVER_ALLOWED_DB_ORIGINS=https://my-neptune-cluster:8182
+
+# Multiple origins
+PROXY_SERVER_ALLOWED_DB_ORIGINS=https://cluster-a:8182,https://cluster-b:8182
+```
+
+- Optional
+- Default: all origins allowed
+- Type: `string` (comma-separated for multiple origins)
+
 ### `LOG_STYLE`
 
 Controls the log output format.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -93,6 +93,10 @@ When set, browsers will block cross-origin requests from any other origin. This 
 >
 > CORS headers only affect browser-initiated requests — direct API calls from scripts or other servers are not restricted by CORS. CORS is a defense-in-depth layer, not a substitute for authentication or network-level access controls. Ensure the proxy server is not exposed to untrusted networks.
 
+## Database Origin Allowlist
+
+By default, the proxy server forwards requests to any database URL specified by the client. You can restrict which database origins the proxy will contact by setting [`PROXY_SERVER_ALLOWED_DB_ORIGINS`](./configuration.md#proxy_server_allowed_db_origins). Requests targeting an unlisted origin receive a 403 response.
+
 ## Permissions
 
 Graph Explorer does not provide any mechanisms for controlling user permissions. If you are using Graph Explorer with AWS, Neptune permissions can be controlled through IAM roles.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -101,6 +101,10 @@ By default, the proxy server forwards requests to any database URL specified by 
 >
 > This check only applies to requests routed through the proxy server. Connections configured to contact the database directly (bypassing the proxy) are not subject to the allowlist.
 
+## HTTP Redirects
+
+The proxy server does not follow HTTP redirects from the database. If the database responds with a redirect (3xx status), the proxy returns an error to the client instead of following it. This prevents a compromised or misconfigured database endpoint from redirecting the proxy to an unrelated internal service.
+
 ## Permissions
 
 Graph Explorer does not provide any mechanisms for controlling user permissions. If you are using Graph Explorer with AWS, Neptune permissions can be controlled through IAM roles.

--- a/docs/references/security.md
+++ b/docs/references/security.md
@@ -97,6 +97,10 @@ When set, browsers will block cross-origin requests from any other origin. This 
 
 By default, the proxy server forwards requests to any database URL specified by the client. You can restrict which database origins the proxy will contact by setting [`PROXY_SERVER_ALLOWED_DB_ORIGINS`](./configuration.md#proxy_server_allowed_db_origins). Requests targeting an unlisted origin receive a 403 response.
 
+> [!NOTE]
+>
+> This check only applies to requests routed through the proxy server. Connections configured to contact the database directly (bypassing the proxy) are not subject to the allowlist.
+
 ## Permissions
 
 Graph Explorer does not provide any mechanisms for controlling user permissions. If you are using Graph Explorer with AWS, Neptune permissions can be controlled through IAM roles.

--- a/packages/graph-explorer-proxy-server/src/allowed-db-origins.test.ts
+++ b/packages/graph-explorer-proxy-server/src/allowed-db-origins.test.ts
@@ -1,0 +1,79 @@
+import { assertAllowedDbOrigin } from "./allowed-db-origins.ts";
+import { HttpError } from "./errors.ts";
+
+describe("assertAllowedDbOrigin", () => {
+  it("does nothing when allowlist is undefined (permissive)", () => {
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:8182", undefined),
+    ).not.toThrow();
+  });
+
+  it("does nothing when the origin is in the allowlist", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:8182/sparql", allowed),
+    ).not.toThrow();
+  });
+
+  it("throws HttpError 403 when the origin is not in the allowlist", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() => assertAllowedDbOrigin("https://evil:9999", allowed)).toThrow(
+      expect.objectContaining({
+        status: 403,
+        message: expect.stringContaining("https://evil:9999"),
+      }),
+    );
+    expect(() => assertAllowedDbOrigin("https://evil:9999", allowed)).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining("administrator"),
+      }),
+    );
+  });
+
+  it("is case insensitive (URL constructor normalizes)", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() =>
+      assertAllowedDbOrigin("HTTPS://NEPTUNE:8182/gremlin", allowed),
+    ).not.toThrow();
+  });
+
+  it("ignores trailing slashes (origin strips path)", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:8182/", allowed),
+    ).not.toThrow();
+  });
+
+  it("treats different ports as different origins", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:8183", allowed),
+    ).toThrow(HttpError);
+  });
+
+  it("treats different schemes as different origins", () => {
+    const allowed = new Set(["https://neptune:8182"]);
+    expect(() => assertAllowedDbOrigin("http://neptune:8182", allowed)).toThrow(
+      HttpError,
+    );
+  });
+
+  it("rejects all requests when allowlist is an empty set", () => {
+    const allowed = new Set<string>();
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:8182", allowed),
+    ).toThrow(HttpError);
+  });
+
+  it("normalizes default ports (443 for https, 80 for http)", () => {
+    const allowedHttps = new Set(["https://neptune"]);
+    expect(() =>
+      assertAllowedDbOrigin("https://neptune:443/sparql", allowedHttps),
+    ).not.toThrow();
+
+    const allowedHttp = new Set(["http://neptune"]);
+    expect(() =>
+      assertAllowedDbOrigin("http://neptune:80/sparql", allowedHttp),
+    ).not.toThrow();
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/allowed-db-origins.ts
+++ b/packages/graph-explorer-proxy-server/src/allowed-db-origins.ts
@@ -1,0 +1,17 @@
+import { HttpError } from "./errors.ts";
+
+export function assertAllowedDbOrigin(
+  url: string,
+  allowedOrigins: Set<string> | undefined,
+) {
+  if (!allowedOrigins) {
+    return;
+  }
+  const origin = new URL(url).origin;
+  if (!allowedOrigins.has(origin)) {
+    throw new HttpError(
+      403,
+      `Database origin "${origin}" is not in the allowed origins list. Contact your administrator.`,
+    );
+  }
+}

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -13,13 +13,18 @@ const mockFetch = vi.mocked(fetch);
 
 const testVersion = "1.2.3";
 
-function createTestApp(configPath = ".", corsOrigin?: string[]) {
+function createTestApp(
+  configPath = ".",
+  corsOrigin?: string[],
+  allowedDbOrigins?: Set<string>,
+) {
   const app = createApp({
     configPath,
     staticFilesVirtualPath: "/explorer",
     staticFilesPath: ".",
     version: testVersion,
     corsOrigin,
+    allowedDbOrigins,
   });
   app.locals.logger = createLogger({
     HOST: "localhost",
@@ -927,5 +932,74 @@ describe("createApp", () => {
 
       expect(response.status).toBe(500);
     });
+
+    it("disables HTTP redirects on outbound requests", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      await request(app)
+        .post("/sparql")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      const fetchOptions = mockFetch.mock.calls[0][1] as any;
+      expect(fetchOptions.redirect).toBe("error");
+    });
+  });
+
+  // ── Allowed DB origins ─────────────────────────────────────────────
+
+  describe("PROXY_SERVER_ALLOWED_DB_ORIGINS", () => {
+    const allowedOrigins = new Set(["https://my-graph-db.example.com:8182"]);
+
+    it("allows requests when the origin is in the allowlist", async () => {
+      mockFetchOnce(JSON.stringify({ results: [] }), 200, {
+        "content-type": "application/json",
+      });
+
+      const app = createTestApp(".", undefined, allowedOrigins);
+      const response = await request(app)
+        .post("/sparql")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("allows all requests when allowlist is not configured", async () => {
+      mockFetchOnce();
+
+      const app = createTestApp();
+      const response = await request(app)
+        .post("/sparql")
+        .set(dbHeaders())
+        .send({ query: "SELECT 1" });
+
+      expect(response.status).toBe(200);
+    });
+
+    it.each([
+      { method: "post", route: "/sparql", body: { query: "test" } },
+      { method: "post", route: "/gremlin", body: { query: "test" } },
+      { method: "post", route: "/openCypher", body: { query: "test" } },
+      { method: "get", route: "/summary", body: undefined },
+      { method: "get", route: "/pg/statistics/summary", body: undefined },
+      { method: "get", route: "/rdf/statistics/summary", body: undefined },
+    ] as const)(
+      "$method $route returns 403 for disallowed origin without calling fetch",
+      async ({ method, route, body }) => {
+        const app = createTestApp(".", undefined, allowedOrigins);
+        const req = request(app)
+          [method](route)
+          .set(
+            dbHeaders({ "graph-db-connection-url": "https://blocked:8182" }),
+          );
+        const response = body ? await req.send(body) : await req;
+
+        expect(response.status).toBe(403);
+        expect(response.body.error.message).toContain("allowed origins list");
+        expect(mockFetch).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -11,6 +11,7 @@ import path from "path";
 import { pipeline } from "stream";
 import { z } from "zod";
 
+import { assertAllowedDbOrigin } from "./allowed-db-origins.ts";
 import { errorHandlingMiddleware } from "./error-handler.ts";
 import { RequestValidationError } from "./errors.ts";
 import { type AppLogger, requestLoggingMiddleware } from "./logging.ts";
@@ -80,6 +81,7 @@ interface CreateAppOptions {
   staticFilesPath: string;
   version?: string;
   corsOrigin?: string[];
+  allowedDbOrigins?: Set<string>;
 }
 
 export function createApp({
@@ -88,6 +90,7 @@ export function createApp({
   staticFilesPath,
   version,
   corsOrigin,
+  allowedDbOrigins,
 }: CreateAppOptions): express.Express {
   const app = express();
 
@@ -180,7 +183,8 @@ export function createApp({
         method: options.method,
         body: options.body ?? undefined,
         headers: options.headers,
-        compress: false, // prevent automatic decompression
+        compress: false,
+        redirect: "error",
       };
 
       try {
@@ -272,6 +276,7 @@ export function createApp({
       region,
       serviceType,
     } = parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
 
     /// Function to cancel long running queries if the client disappears before completion
     async function cancelQuery() {
@@ -366,6 +371,7 @@ export function createApp({
       region,
       serviceType,
     } = parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
 
     // Validate the input before making any external calls.
     const queryString = req.body.query;
@@ -450,6 +456,7 @@ export function createApp({
       region,
       serviceType,
     } = parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
 
     const queryString = req.body.query;
     // Validate the input before making any external calls.
@@ -490,6 +497,7 @@ export function createApp({
   app.get("/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
     const rawUrl = resolveEndpointUrl(
       graphDbConnectionUrl,
       "summary?mode=detailed",
@@ -510,6 +518,7 @@ export function createApp({
   app.get("/pg/statistics/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
     const rawUrl = resolveEndpointUrl(
       graphDbConnectionUrl,
       "pg/statistics/summary?mode=detailed",
@@ -530,6 +539,7 @@ export function createApp({
   app.get("/rdf/statistics/summary", async (req, res, next) => {
     const { graphDbConnectionUrl, isIamEnabled, region, serviceType } =
       parseDbQueryHeaders(req.headers);
+    assertAllowedDbOrigin(graphDbConnectionUrl, allowedDbOrigins);
     const rawUrl = resolveEndpointUrl(
       graphDbConnectionUrl,
       "rdf/statistics/summary?mode=detailed",

--- a/packages/graph-explorer-proxy-server/src/env.test.ts
+++ b/packages/graph-explorer-proxy-server/src/env.test.ts
@@ -190,4 +190,107 @@ describe("parseEnvironmentValues", () => {
       "https://my-app.example.com",
     ]);
   });
+
+  describe("PROXY_SERVER_ALLOWED_DB_ORIGINS", () => {
+    it("defaults to undefined when not provided", () => {
+      const result = parseEnvironmentValues({});
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toBeUndefined();
+    });
+
+    it("treats empty string as unset", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toBeUndefined();
+    });
+
+    it("parses a single origin into a Set", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "https://neptune:8182",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182"]),
+      );
+    });
+
+    it("parses comma-separated origins into a Set", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS:
+          "https://neptune:8182,https://other-db:8182",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182", "https://other-db:8182"]),
+      );
+    });
+
+    it("trims whitespace around values", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS:
+          " https://neptune:8182 , https://other:8182 ",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182", "https://other:8182"]),
+      );
+    });
+
+    it("accepts a trailing slash (treated as no path)", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "https://neptune:8182/",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182"]),
+      );
+    });
+
+    it("normalizes case to lowercase", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "HTTPS://Neptune:8182",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182"]),
+      );
+    });
+
+    it("deduplicates entries", () => {
+      const result = parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS:
+          "https://neptune:8182,https://neptune:8182",
+      });
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS).toEqual(
+        new Set(["https://neptune:8182"]),
+      );
+      expect(result.PROXY_SERVER_ALLOWED_DB_ORIGINS!.size).toBe(1);
+    });
+  });
+
+  describe("PROXY_SERVER_ALLOWED_DB_ORIGINS validation failures", () => {
+    beforeEach(() => {
+      vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+
+    it("exits process when value is not a valid URL", () => {
+      parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "not-a-url",
+      });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits process when value has a trailing comma", () => {
+      parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "https://neptune:8182,",
+      });
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("exits process when value contains a path", () => {
+      parseEnvironmentValues({
+        PROXY_SERVER_ALLOWED_DB_ORIGINS: "https://neptune:8182/some/path",
+      });
+      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("origin only"),
+      );
+    });
+  });
 });

--- a/packages/graph-explorer-proxy-server/src/env.ts
+++ b/packages/graph-explorer-proxy-server/src/env.ts
@@ -33,6 +33,39 @@ export const EnvironmentValuesSchema = z.object({
         )
         .optional(),
     ),
+  PROXY_SERVER_ALLOWED_DB_ORIGINS: z
+    .string()
+    .optional()
+    .transform(value => value || undefined)
+    .transform(value => value?.split(",").map(v => v.trim()))
+    .pipe(
+      z
+        .array(
+          z
+            .url({
+              protocol: /^https?$/,
+              message:
+                "Must be an HTTP or HTTPS URL (e.g. https://neptune:8182)",
+            })
+            .refine(
+              value => {
+                try {
+                  const pathname = new URL(value).pathname;
+                  return pathname === "/" || pathname === "";
+                } catch {
+                  return true;
+                }
+              },
+              {
+                message:
+                  "Must be an origin only (scheme://host:port), paths are not supported",
+              },
+            )
+            .transform(value => new URL(value).origin),
+        )
+        .transform(origins => new Set(origins))
+        .optional(),
+    ),
 });
 
 export type EnvironmentValues = z.infer<typeof EnvironmentValuesSchema>;

--- a/packages/graph-explorer-proxy-server/src/error-handler.ts
+++ b/packages/graph-explorer-proxy-server/src/error-handler.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from "express";
 
-import { RequestValidationError } from "./errors.ts";
+import { HttpError } from "./errors.ts";
 import { type AppLogger, getRequestLoggerPrefix } from "./logging.ts";
 
 /**
@@ -57,18 +57,17 @@ export function errorHandlingMiddleware() {
 function extractErrorInfo(error: unknown) {
   const defaultErrorMessage = "Internal Server Error";
 
-  if (error instanceof RequestValidationError) {
+  if (error instanceof HttpError) {
     return {
-      status: 400,
+      ...error.details,
+      status: error.status,
       message: error.message,
     };
   }
 
   if (error instanceof Error) {
     return {
-      // oxlint-disable-next-line typescript/no-misused-spread -- Intentionally extracting Error properties for serialization
-      ...error,
-      status: getStatusFromError(error),
+      status: 500,
       message: error.message || defaultErrorMessage,
     };
   }
@@ -78,15 +77,4 @@ function extractErrorInfo(error: unknown) {
     message: defaultErrorMessage,
     name: "Error",
   };
-}
-
-function getStatusFromError(error: unknown) {
-  if (
-    error instanceof Error &&
-    "status" in error &&
-    typeof error.status === "number"
-  ) {
-    return error.status;
-  }
-  return 500;
 }

--- a/packages/graph-explorer-proxy-server/src/errors.test.ts
+++ b/packages/graph-explorer-proxy-server/src/errors.test.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+import { HttpError, RequestValidationError } from "./errors.ts";
+
+describe("HttpError", () => {
+  it("carries status and message", () => {
+    const error = new HttpError(403, "Forbidden");
+    expect(error.status).toBe(403);
+    expect(error.message).toBe("Forbidden");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("is an instance of Error", () => {
+    const error = new HttpError(500, "Internal");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("carries optional details", () => {
+    const error = new HttpError(422, "Validation failed", {
+      field: "name",
+      reason: "too short",
+    });
+    expect(error.details).toEqual({ field: "name", reason: "too short" });
+  });
+
+  it("has undefined details when none provided", () => {
+    const error = new HttpError(500, "Internal");
+    expect(error.details).toBeUndefined();
+  });
+});
+
+describe("RequestValidationError", () => {
+  it("extends HttpError with status 400", () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({});
+    assert(!result.success);
+
+    const error = new RequestValidationError(result.error);
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error.status).toBe(400);
+    expect(error.zodError).toBe(result.error);
+  });
+
+  it("formats the Zod error as the message", () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({});
+    assert(!result.success);
+
+    const error = new RequestValidationError(result.error);
+    expect(error.message).toBe(z.prettifyError(result.error));
+  });
+
+  it("includes zodError in details for serialization", () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({});
+    assert(!result.success);
+
+    const error = new RequestValidationError(result.error);
+    expect(error.details).toEqual({ zodError: result.error });
+  });
+});

--- a/packages/graph-explorer-proxy-server/src/errors.ts
+++ b/packages/graph-explorer-proxy-server/src/errors.ts
@@ -1,11 +1,27 @@
 import { z } from "zod";
 
+export class HttpError extends Error {
+  readonly status: number;
+  readonly details: Record<string, unknown> | undefined;
+
+  constructor(
+    status: number,
+    message: string,
+    details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+    this.details = details;
+  }
+}
+
 /** Thrown when request validation via Zod fails. Carries the original ZodError. */
-export class RequestValidationError extends Error {
+export class RequestValidationError extends HttpError {
   readonly zodError: z.core.$ZodError;
 
   constructor(zodError: z.core.$ZodError) {
-    super(z.prettifyError(zodError));
+    super(400, z.prettifyError(zodError), { zodError });
     this.name = "RequestValidationError";
     this.zodError = zodError;
   }

--- a/packages/graph-explorer-proxy-server/src/node-server.ts
+++ b/packages/graph-explorer-proxy-server/src/node-server.ts
@@ -55,6 +55,7 @@ const app = createApp({
   staticFilesPath,
   version: packageJson.version,
   corsOrigin: env.PROXY_SERVER_CORS_ORIGIN,
+  allowedDbOrigins: env.PROXY_SERVER_ALLOWED_DB_ORIGINS,
 });
 
 // Store logger on app.locals for access in middleware and routes


### PR DESCRIPTION
## Description

Adds an optional `PROXY_SERVER_ALLOWED_DB_ORIGINS` env var that restricts which database origins the proxy server will forward requests to. When set (comma-separated origins like `https://neptune:8182`), the proxy rejects requests targeting unlisted origins with a 403. When unset, behavior is unchanged (fully permissive).

Also:
- Introduces `HttpError` base class with optional `details` for structured error responses
- Makes `RequestValidationError` extend `HttpError` (status 400, includes `zodError` in response)
- Simplifies error handler — removes duck-typed `getStatusFromError` helper and the `...error` spread
- Disables HTTP redirects on all outbound fetch calls (`redirect: "error"`)
- Documents the new env var in `docs/references/configuration.md` and `docs/references/security.md`

**Reading order**: `errors.ts` → `error-handler.ts` → `env.ts` → `allowed-db-origins.ts` → `app.ts` (wiring) → docs

## Validation

- 224 tests pass across 12 test files in the proxy-server package
- `pnpm checks` passes (lint, format, typecheck)
- New unit tests for: `HttpError` hierarchy, env var parsing (valid/invalid/edge cases), `assertAllowedDbOrigin` function (case normalization, port normalization, scheme enforcement, empty set rejection)
- New integration tests for: 403 enforcement across all 6 database routes, redirect disabled, no fetch call on rejection

### Error in UI

This is what is shown in the UI when the database URL is not in the allow list:

<img width="1246" height="716" alt="CleanShot 2026-06-02 at 10 51 50@2x" src="https://github.com/user-attachments/assets/0ea7cc9d-1060-4192-820d-eef5a27c13bc" />


## Related Issues

- Closes #1793
- Related to #1789

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.