### PR TITLE
Update CLAUDE.md to use file reference and add missing git skill pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - For React related patterns and conventions, refer to `.kiro/skills/react/SKILL.md`
 - For schema storage and discovery, refer to `.kiro/skills/schema/SKILL.md`
 - For GitHub issue and PR management, refer to `.kiro/skills/github/SKILL.md`
+- For git workflow conventions, refer to `.kiro/skills/git/SKILL.md`
 - For product overview and architecture, refer to `.kiro/skills/product/SKILL.md`
 
 ## Monorepo Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-Follow the rules and conventions defined in [AGENTS.md](./AGENTS.md).
+@AGENTS.md


### PR DESCRIPTION
## Description

- `CLAUDE.md` now uses the `@AGENTS.md` file reference syntax so Claude Code auto-loads the contents into context each session (previously it was a markdown link that rendered as inert text)
- `AGENTS.md` adds the missing pointer to `.kiro/skills/git/SKILL.md` for git workflow conventions

## Validation

- Claude Code sessions should show AGENTS.md contents in the loaded project instructions
- Kiro reads AGENTS.md natively and is unaffected by the CLAUDE.md change

## Related Issues

_None_

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.