### PR TITLE
Fix .claude gitignore pattern to match symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 plans/
 
 # Claude Code local files
-.claude/
+.claude


### PR DESCRIPTION
## Description

The `.gitignore` pattern `.claude/` (with trailing slash) only matches directories. In worktree setups where `.claude` is a symlink, git doesn't ignore it. Removing the trailing slash makes the pattern match both directories and symlinks.

## Validation

```
$ git check-ignore -v .claude
.gitignore:16:.claude	.claude
```

## Related Issues

- None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.