### PR TITLE
fix: Blank nodes show no icon on graph canvas but display default icon in ...

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -4,7 +4,7 @@ import { atom, useAtomValue, useSetAtom } from "jotai";
 import { atomFamily } from "jotai-family";
 import { useDeferredValue } from "react";
 
-import { RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
+import { LABELS, RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
 import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 
 import type { EdgeType, VertexType } from "../entities";
@@ -208,11 +208,21 @@ export function createEdgePreference(
   };
 }
 
-/** Returns an array of vertex preferences based on the known vertex types in the schema. */
+/** Returns an array of vertex preferences based on the known vertex types in the schema.
+ * Always includes an entry for `LABELS.MISSING_TYPE` so that blank nodes (which are
+ * assigned that synthetic type at runtime) receive icon styling on the canvas.
+ */
 export function useAllVertexPreferences(): VertexPreferences[] {
   const prefs = useAtomValue(vertexPreferencesAtom);
   const { vertices: allSchemas } = useActiveSchema();
-  return allSchemas.map(({ type }) => prefs.get(type));
+  const schemaPrefs = allSchemas.map(({ type }) => prefs.get(type));
+
+  const missingType = LABELS.MISSING_TYPE as VertexType;
+  const alreadyIncluded = schemaPrefs.some(p => p.type === missingType);
+  if (alreadyIncluded) {
+    return schemaPrefs;
+  }
+  return [...schemaPrefs, prefs.get(missingType)];
 }
 
 /** Returns an array of edge preferences based on the known edge types in the schema. */


### PR DESCRIPTION
## Description

Blank nodes are assigned the synthetic type `LABELS.MISSING_TYPE` (the "No Type" label) at runtime in `createVertex()` when no types are provided. That type is never stored in the schema, so `useAllVertexPreferences()` in `packages/graph-explorer/src/core/StateProvider/userPreferences.ts` produced no entry for it and `useGraphStyles` generated no Cytoscape style selector. As a result blank nodes rendered without an icon on the canvas, while the details panel (which uses `useVertexPreferences(type)`) still fell back to the default icon.

This change makes `useAllVertexPreferences()` always include a `LABELS.MISSING_TYPE` entry (using default preferences) unless the active schema already contains that type. `useGraphStyles` then emits a node style selector carrying the default icon for blank nodes, so the canvas matches the details panel.

## Validation

`useGraphStyles` builds one node style selector per entry returned by `useAllVertexPreferences()`. Adding the `MISSING_TYPE` entry produces the selector that carries the default icon for blank nodes, which was previously missing. A reviewer can confirm by loading a graph that contains a blank node and checking that its canvas icon now matches the icon shown in the details panel.

## Related Issues

Fixes #1779

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.

## Notes

The branch has been rebased onto the latest `main` to resolve the merge conflict. Since `main` refactored this file to type-keyed map atoms (#1867), the fix is reapplied on top of that structure with the same behavior. The earlier `package.json` and `pnpm-lock.yaml` changes were local toolchain tweaks and have been reverted, so this PR now touches a single file. The `pnpm checks` and `pnpm coverage` boxes are left for CI to verify, since the required Node version for a local run is newer than my local toolchain.

## AI Assistance Disclosure

I used GitHub Copilot to help prepare this change. I have reviewed and understand it, and I will respond to review feedback.
