### PR TITLE
Add issue audience conventions for internal vs community issues

### DIFF
--- a/docs/agents/issue-audience.md
+++ b/docs/agents/issue-audience.md
@@ -1,0 +1,19 @@
+# Issue Audience
+
+How issues in this repo are marked for internal team use vs. open community contribution.
+
+## Internal
+
+- **Label:** `internal`
+- **Footer:**
+
+  > [!IMPORTANT] Internal only — this issue is maintained by the core team and is not accepting external contributions.
+
+## Community
+
+- **Signal labels:** `help wanted`
+- **Footer:**
+
+  > [!IMPORTANT] If you are interested in working on this issue, please leave a comment.
+  >
+  > [!TIP] Please use a 👍 reaction to provide a +1/vote. This helps the community and maintainers prioritize this request.


### PR DESCRIPTION
## Description

Adds `docs/agents/issue-audience.md` documenting how we signal issue audience — the `internal` label + footer for team-only issues, and `help wanted` label + footer for community contributions.

## Validation

- Labels `internal` and `help wanted` verified to exist in the repo
- Format matches sibling docs (`triage-labels.md`, `issue-tracker.md`)

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.