### PR TITLE
Optimize Gremlin schema sync queries for large graphs

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
@@ -8,11 +8,31 @@ describe("Gremlin > edgesSchemaTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.E()
-          .project("route", "contain")
+        g.V().limit(1)
+          .project(
+            "route",
+            "contain"
+          )
           .by(V().bothE("route").limit(1))
           .by(V().bothE("contain").limit(1))
-          .limit(1)
+      `),
+    );
+  });
+
+  it("Should deduplicate labels from multi-label types", () => {
+    const template = edgesSchemaTemplate({ types: ["a::b", "b::c"] });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.V().limit(1)
+          .project(
+            "a",
+            "b",
+            "c"
+          )
+          .by(V().bothE("a").limit(1))
+          .by(V().bothE("b").limit(1))
+          .by(V().bothE("c").limit(1))
       `),
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
@@ -6,25 +6,31 @@ import { query } from "@/utils";
  * Given a set of edge types, it returns a Gremlin template that contains
  * one sample of each edge type.
  *
- * @example
- * types = ["route", "contain"]
+ * Uses g.V().limit(1) as a dummy anchor because each .by() modulator runs an
+ * independent global V() sub-traversal that doesn't depend on the anchor value.
+ * This also avoids Neptune DFE falling back to non-native execution for g.E().
  *
- * g.E()
- *  .project("route","contain")
- *  .by(V().bothE("route").limit(1))
- *  .by(V().bothE("contain").limit(1))
- *  .limit(1)
+ * @example
+ * edgesSchemaTemplate({ types: ["route", "contain"] })
+ * // Returns:
+ * // g.V().limit(1)
+ * //   .project(
+ * //     "route",
+ * //     "contain"
+ * //   )
+ * //   .by(V().bothE("route").limit(1))
+ * //   .by(V().bothE("contain").limit(1))
  */
 export default function edgesSchemaTemplate({ types }: { types: string[] }) {
-  // Labels with quotes
   const labels = uniq(types.flatMap(type => type.split("::"))).map(
     label => `"${label}"`,
   );
 
   return query`
-    g.E()
-      .project(${labels.join(", ")})
+    g.V().limit(1)
+      .project(
+        ${labels.join(",\n        ")}
+      )
       ${labels.map(label => `.by(V().bothE(${label}).limit(1))`).join("\n      ")}
-      .limit(1)
   `;
 }

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
@@ -8,14 +8,31 @@ describe("Gremlin > verticesSchemaTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V().union(
-          __.hasLabel("airport").limit(1),
-          __.hasLabel("country").limit(1)
-        )
-        .fold()
-        .project("airport", "country")
-        .by(unfold().hasLabel("airport"))
-        .by(unfold().hasLabel("country"))
+        g.V().limit(1)
+          .project(
+            "airport",
+            "country"
+          )
+          .by(V().hasLabel("airport").limit(1))
+          .by(V().hasLabel("country").limit(1))
+      `),
+    );
+  });
+
+  it("Should deduplicate labels from multi-label types", () => {
+    const template = verticesSchemaTemplate({ types: ["a::b", "b::c"] });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.V().limit(1)
+          .project(
+            "a",
+            "b",
+            "c"
+          )
+          .by(V().hasLabel("a").limit(1))
+          .by(V().hasLabel("b").limit(1))
+          .by(V().hasLabel("c").limit(1))
       `),
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
@@ -6,36 +6,31 @@ import { query } from "@/utils";
  * Given a set of nodes labels, it returns a Gremlin template that contains
  * one sample of each node label.
  *
- * @example
- * types = ["airport", "country"]
+ * Uses g.V().limit(1) as a dummy anchor because each .by() modulator runs an
+ * independent global V() sub-traversal that doesn't depend on the anchor value.
+ * This also avoids Neptune DFE falling back to non-native execution.
  *
- * g.V()
- *   .union(
- *     __.hasLabel("airport").limit(1),
- *     __.hasLabel("country").limit(1)
- *   )
- *   .fold()
- *   .project(
- *     "airport", "country"
- *   )
- *   .by(unfold().hasLabel("airport"))
- *   .by(unfold().hasLabel("country"))
+ * @example
+ * verticesSchemaTemplate({ types: ["airport", "country"] })
+ * // Returns:
+ * // g.V().limit(1)
+ * //   .project(
+ * //     "airport",
+ * //     "country"
+ * //   )
+ * //   .by(V().hasLabel("airport").limit(1))
+ * //   .by(V().hasLabel("country").limit(1))
  */
 export default function verticesSchemaTemplate({ types }: { types: string[] }) {
-  // Labels with quotes
   const labels = uniq(types.flatMap(type => type.split("::"))).map(
     label => `"${label}"`,
   );
 
   return query`
-    g.V()
-      .union(
-        ${labels.map(label => `__.hasLabel(${label}).limit(1)`).join(",\n        ")}
-      )
-      .fold()
+    g.V().limit(1)
       .project(
         ${labels.join(",\n        ")}
       )
-      ${labels.map(label => `.by(unfold().hasLabel(${label}))`).join("\n      ")}
-    `;
+      ${labels.map(label => `.by(V().hasLabel(${label}).limit(1))`).join("\n      ")}
+  `;
 }


### PR DESCRIPTION
## Description

Both vertex and edge schema templates now use `g.V().limit(1)` as a dummy anchor instead of `g.E()` (edges) and `g.V().union().fold()` (vertices). Each `.by()` modulator runs an independent global sub-traversal that doesn't depend on the anchor value, so this is semantically equivalent. The change ensures Neptune's DFE engine handles the full query natively, avoiding fallback to slower execution paths.

## Validation

- All gremlin connector tests pass (105 tests)
- `pnpm checks` passes (lint, format, types)
- Profiled on three Neptune engine versions confirming native DFE execution
- Response shape unchanged — downstream parsers unaffected

## Related Issues

- Closes #1803
- Closes #354
- Related to #498

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.