### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "private": true,
   "description": "Graph Explorer",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Graph Explorer",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "private": true,
   "description": "Shared types and functions across client and server.",
   "keywords": [],


### PR DESCRIPTION
## Description

Bump all package versions from 3.0.3 to 3.1.0 in preparation for the next minor release.

## Validation

- `pnpm checks` passes (lint, format, types all clean)
- All 4 package.json files updated consistently

## Related Issues

## Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.