### PR TITLE
Set border-opacity on per-type node styles to fix invisible borders

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -140,6 +140,7 @@ describe("useGraphStyles", () => {
     const { result } = renderHookWithState(() => useGraphStyles(), dbState);
 
     const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+    expect(vertexStyle["border-width"]).toBe(0);
     expect(vertexStyle["border-opacity"]).toBe(0);
   });
 

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -63,6 +63,7 @@ describe("useGraphStyles", () => {
         "background-opacity": 0.8,
         "border-color": "#000000",
         "border-width": 2,
+        "border-opacity": 1,
         "border-style": "solid",
         shape: "ellipse",
         width: 24,
@@ -112,7 +113,22 @@ describe("useGraphStyles", () => {
     });
   });
 
-  it("should handle vertex config without border width", () => {
+  it("should set border-opacity to 1 when border width is non-zero", () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      type: createVertexType("Person"),
+      borderWidth: 3,
+    };
+    dbState.activeSchema.vertices = [vertexConfig];
+    dbState.addVertexStyle(vertexConfig.type, vertexConfig);
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+    expect(vertexStyle["border-opacity"]).toBe(1);
+  });
+
+  it("should set border-opacity to 0 when border width is zero", () => {
     const vertexConfig = {
       ...createRandomVertexTypeConfig(),
       type: createVertexType("Person"),
@@ -124,7 +140,7 @@ describe("useGraphStyles", () => {
     const { result } = renderHookWithState(() => useGraphStyles(), dbState);
 
     const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
-    expect(vertexStyle["border-width"]).toBe(0);
+    expect(vertexStyle["border-opacity"]).toBe(0);
   });
 
   it("should handle edge config with dotted line style", () => {

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -53,6 +53,7 @@ function createGraphStyles(
       "background-opacity": vtConfig.backgroundOpacity,
       "border-color": vtConfig.borderColor,
       "border-width": vtConfig.borderWidth,
+      "border-opacity": vtConfig.borderWidth > 0 ? 1 : 0,
       "border-style": vtConfig.borderStyle,
       shape: vtConfig.shape,
       width: 24,


### PR DESCRIPTION
## Summary

The base node cytoscape style sets `border-opacity: 0`, but `useGraphStyles` never overrides it in per-type selectors. Cytoscape cascades the base value, keeping borders invisible regardless of what the user sets in the Node Style Dialog.

The fix derives `border-opacity` from `borderWidth` — 1 when non-zero, 0 when zero — so borders become visible as soon as the user sets a width.

## How to read

1. `useGraphStyles.ts` — the one-line fix
2. `useGraphStyles.test.tsx` — two new tests for border-opacity behavior, plus updated assertion on the existing exhaustive test

- Closes #1812
- Related to #1726