### PR TITLE
Add CSS transition and shadow tokens for docs site

### DIFF
--- a/packages/docs/src/components/FeatureCard.astro
+++ b/packages/docs/src/components/FeatureCard.astro
@@ -6,7 +6,7 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<article class="card sl-flex not-content">
+<article class="feature-card sl-flex not-content">
   <span class="icon-wrapper">
     <slot name="icon" />
   </span>
@@ -18,19 +18,20 @@ const { title } = Astro.props;
 
 <style>
   @layer starlight.components {
-    .card {
+    .feature-card {
       position: relative;
       border: 1px solid var(--sl-color-gray-5);
       background-color: var(--sl-color-black);
       padding: clamp(1rem, calc(0.125rem + 3vw), 2.5rem);
       flex-direction: column;
       gap: clamp(0.5rem, calc(0.125rem + 1vw), 1rem);
-      transition: border-color var(--sl-transition-speed);
+      cursor: pointer;
+      transition: border-color var(--sl-transition);
     }
-    .card:hover {
+    .feature-card:hover {
       border-color: var(--sl-color-accent);
     }
-    .card .body :global(a)::after {
+    .feature-card .body :global(a)::after {
       content: "";
       position: absolute;
       inset: 0;
@@ -56,12 +57,12 @@ const { title } = Astro.props;
       width: 1.333em;
       height: 1.333em;
     }
-    .card .content-wrapper {
+    .feature-card .content-wrapper {
       display: flex;
       flex-direction: column;
       gap: 0.5rem;
     }
-    .card .body {
+    .feature-card .body {
       margin: 0;
       font-size: clamp(var(--sl-text-sm), calc(0.5rem + 1vw), var(--sl-text-body));
     }

--- a/packages/docs/src/components/FeatureCard.astro
+++ b/packages/docs/src/components/FeatureCard.astro
@@ -19,11 +19,21 @@ const { title } = Astro.props;
 <style>
   @layer starlight.components {
     .card {
+      position: relative;
       border: 1px solid var(--sl-color-gray-5);
       background-color: var(--sl-color-black);
       padding: clamp(1rem, calc(0.125rem + 3vw), 2.5rem);
       flex-direction: column;
       gap: clamp(0.5rem, calc(0.125rem + 1vw), 1rem);
+      transition: border-color var(--sl-transition-speed);
+    }
+    .card:hover {
+      border-color: var(--sl-color-accent);
+    }
+    .card .body :global(a)::after {
+      content: "";
+      position: absolute;
+      inset: 0;
     }
     .title {
       font-weight: 700;

--- a/packages/docs/src/components/ScreenshotCarousel.astro
+++ b/packages/docs/src/components/ScreenshotCarousel.astro
@@ -104,7 +104,7 @@ const { slides } = Astro.props;
     background: var(--sl-color-gray-4);
     cursor: pointer;
     padding: 0;
-    transition: width 0.2s ease, background 0.2s ease;
+    transition: width var(--sl-transition-speed), background var(--sl-transition-speed);
   }
 
   .carousel-dot.active {
@@ -124,7 +124,7 @@ const { slides } = Astro.props;
     backdrop-filter: blur(8px);
     color: var(--sl-color-gray-2);
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all var(--sl-transition-speed);
   }
 
   .carousel-btn:hover {

--- a/packages/docs/src/components/ScreenshotCarousel.astro
+++ b/packages/docs/src/components/ScreenshotCarousel.astro
@@ -104,7 +104,7 @@ const { slides } = Astro.props;
     background: var(--sl-color-gray-4);
     cursor: pointer;
     padding: 0;
-    transition: width var(--sl-transition-speed), background var(--sl-transition-speed);
+    transition: width var(--sl-transition), background var(--sl-transition);
   }
 
   .carousel-dot.active {
@@ -124,7 +124,7 @@ const { slides } = Astro.props;
     backdrop-filter: blur(8px);
     color: var(--sl-color-gray-2);
     cursor: pointer;
-    transition: all var(--sl-transition-speed);
+    transition: all var(--sl-transition);
   }
 
   .carousel-btn:hover {

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -58,13 +58,19 @@ h6 {
 
 .sl-markdown-content a {
   font-weight: 500;
-  text-decoration: none;
+  text-decoration-style: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: -0.25rem;
   color: var(--sl-color-accent);
+  transition:
+    text-decoration-color var(--sl-transition-speed),
+    text-underline-offset var(--sl-transition-speed);
 }
 
 .sl-markdown-content a:hover,
 .sl-markdown-content a:focus {
-  text-decoration: underline;
+  text-decoration-color: var(--sl-color-accent);
+  text-underline-offset: 0.15rem;
   color: var(--sl-color-accent);
 }
 
@@ -90,8 +96,8 @@ h6 {
   background: var(--sl-color-gray-7);
   border-radius: 0.75rem;
   transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
+    border-color var(--sl-transition-speed),
+    box-shadow var(--sl-transition-speed);
 }
 
 .pagination-links a:hover {
@@ -132,8 +138,8 @@ h6 {
   outline: 2px solid transparent;
   outline-offset: -2px;
   transition:
-    outline-color 0.3s ease,
-    box-shadow 0.3s ease;
+    outline-color var(--sl-transition-speed),
+    box-shadow var(--sl-transition-speed);
 }
 
 .card:hover {
@@ -172,8 +178,8 @@ h6 {
   background: var(--sl-color-gray-7);
   border-radius: 0.75rem;
   transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease;
+    border-color var(--sl-transition-speed),
+    box-shadow var(--sl-transition-speed);
 }
 
 .sl-link-card:hover {
@@ -219,7 +225,7 @@ header.header {
 .site-title {
   font-weight: 800;
   color: var(--sl-color-white);
-  transition: color 0.2s ease;
+  transition: color var(--sl-transition-speed);
 }
 
 .site-title:hover {
@@ -263,8 +269,8 @@ header .social-icons a:hover {
   font-weight: 400;
   border-radius: 0.375rem;
   transition:
-    color 0.15s,
-    background-color 0.15s;
+    color var(--sl-transition-speed),
+    background-color var(--sl-transition-speed);
   padding: 0.35rem 0.75rem;
 }
 
@@ -305,8 +311,8 @@ header .social-icons a:hover {
   color: oklch(98.4% 0.003 247.858);
   font-weight: 500;
   transition:
-    box-shadow 0.2s ease,
-    filter 0.2s ease;
+    box-shadow var(--sl-transition-speed),
+    filter var(--sl-transition-speed);
   box-shadow: 0 2px 12px oklch(58.5% 0.233 277.117 / 0.2);
 }
 
@@ -325,8 +331,8 @@ header .social-icons a:hover {
   border-color: var(--sl-color-gray-3);
   color: var(--sl-color-gray-3);
   transition:
-    border-color 0.2s ease,
-    color 0.2s ease;
+    border-color var(--sl-transition-speed),
+    color var(--sl-transition-speed);
 }
 
 .sl-link-button.secondary:hover {
@@ -337,7 +343,7 @@ header .social-icons a:hover {
 
 /* Minimal — text only */
 .sl-link-button.minimal {
-  transition: color 0.2s ease;
+  transition: color var(--sl-transition-speed);
 }
 
 .sl-link-button.minimal:hover {

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -58,20 +58,18 @@ h6 {
 
 .sl-markdown-content a {
   font-weight: 500;
-  text-decoration-style: underline;
-  text-decoration-color: transparent;
-  text-underline-offset: -0.25rem;
+  text-decoration: underline transparent 0.075rem;
+  text-underline-offset: 0.015rem;
   color: var(--sl-color-accent);
   transition:
-    text-decoration-color var(--sl-transition-speed),
-    text-underline-offset var(--sl-transition-speed);
+    text-decoration-color var(--sl-transition),
+    text-underline-offset var(--sl-transition);
 }
 
 .sl-markdown-content a:hover,
 .sl-markdown-content a:focus {
-  text-decoration-color: var(--sl-color-accent);
-  text-underline-offset: 0.15rem;
-  color: var(--sl-color-accent);
+  text-decoration-color: currentColor;
+  text-underline-offset: 0.1rem;
 }
 
 /* ==========================================================================
@@ -95,8 +93,8 @@ h6 {
   background: var(--sl-color-gray-7);
   border-radius: 0.75rem;
   transition:
-    border-color var(--sl-transition-speed),
-    box-shadow var(--sl-transition-speed);
+    border-color var(--sl-transition),
+    box-shadow var(--sl-transition);
 }
 
 .pagination-links a:hover {
@@ -138,8 +136,8 @@ h6 {
   outline-offset: -2px;
   box-shadow: var(--sl-shadow-sm);
   transition:
-    outline-color var(--sl-transition-speed),
-    box-shadow var(--sl-transition-speed);
+    outline-color var(--sl-transition),
+    box-shadow var(--sl-transition);
 }
 
 .card .icon {
@@ -168,8 +166,8 @@ h6 {
   background: var(--sl-color-gray-7);
   border-radius: 0.75rem;
   transition:
-    border-color var(--sl-transition-speed),
-    box-shadow var(--sl-transition-speed);
+    border-color var(--sl-transition),
+    box-shadow var(--sl-transition);
 }
 
 .sl-link-card:hover {
@@ -215,7 +213,7 @@ header.header {
 .site-title {
   font-weight: 800;
   color: var(--sl-color-white);
-  transition: color var(--sl-transition-speed);
+  transition: color var(--sl-transition);
 }
 
 .site-title:hover {
@@ -237,15 +235,15 @@ header .social-icons a:hover {
 
 .sidebar-content summary {
   padding: 0;
+  margin-block-start: 1.5rem;
+  margin-block-end: 0.5rem;
 }
 
 /* Group labels */
 .sidebar-content .group-label {
   font-size: var(--sl-text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-block-start: 1.5rem;
-  margin-block-end: 0.5rem;
+  letter-spacing: 0.065em;
   padding: 0 0.75rem;
 }
 
@@ -259,8 +257,8 @@ header .social-icons a:hover {
   font-weight: 400;
   border-radius: 0.375rem;
   transition:
-    color var(--sl-transition-speed),
-    background-color var(--sl-transition-speed);
+    color var(--sl-transition),
+    background-color var(--sl-transition);
   padding: 0.35rem 0.75rem;
 }
 
@@ -301,8 +299,8 @@ header .social-icons a:hover {
   color: oklch(98.4% 0.003 247.858);
   font-weight: 500;
   transition:
-    box-shadow var(--sl-transition-speed),
-    filter var(--sl-transition-speed);
+    box-shadow var(--sl-transition),
+    filter var(--sl-transition);
   box-shadow: 0 2px 12px oklch(58.5% 0.233 277.117 / 0.2);
 }
 
@@ -321,8 +319,8 @@ header .social-icons a:hover {
   border-color: var(--sl-color-gray-3);
   color: var(--sl-color-gray-3);
   transition:
-    border-color var(--sl-transition-speed),
-    color var(--sl-transition-speed);
+    border-color var(--sl-transition),
+    color var(--sl-transition);
 }
 
 .sl-link-button.secondary:hover {
@@ -333,7 +331,7 @@ header .social-icons a:hover {
 
 /* Minimal — text only */
 .sl-link-button.minimal {
-  transition: color var(--sl-transition-speed);
+  transition: color var(--sl-transition);
 }
 
 .sl-link-button.minimal:hover {

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -91,7 +91,6 @@ h6 {
 }
 
 .pagination-links a {
-  --sl-shadow-md: var(--sl-shadow-sm);
   border: 1px solid var(--sl-color-gray-5);
   background: var(--sl-color-gray-7);
   border-radius: 0.75rem;
@@ -129,7 +128,7 @@ h6 {
 }
 
 .card {
-  border: 1px solid oklch(from var(--sl-color-gray-1) l c h / 0.05);
+  border: 1px solid oklch(from var(--sl-color-gray-1) l c h / 0.075);
   background-color: var(--sl-color-gray-7);
   border-radius: 0.75rem;
   padding: 1.5rem;
@@ -137,19 +136,10 @@ h6 {
   overflow: hidden;
   outline: 2px solid transparent;
   outline-offset: -2px;
+  box-shadow: var(--sl-shadow-sm);
   transition:
     outline-color var(--sl-transition-speed),
     box-shadow var(--sl-transition-speed);
-}
-
-.card:hover {
-  outline-color: oklch(60.6% 0.25 292.717 / 0.4);
-  box-shadow: 0 0 20px oklch(60.6% 0.25 292.717 / 0.08);
-}
-
-:root[data-theme="light"] .card:hover {
-  outline-color: oklch(54.1% 0.281 293.009 / 0.3);
-  box-shadow: 0 4px 20px oklch(54.1% 0.281 293.009 / 0.08);
 }
 
 .card .icon {

--- a/packages/docs/src/styles/tokens.css
+++ b/packages/docs/src/styles/tokens.css
@@ -125,4 +125,17 @@
     oklch(51.1% 0.262 276.966),
     oklch(54.1% 0.281 293.009)
   );
+
+  /* Shadows */
+  --shadow-color: 210deg 12% 77%;
+  --sl-shadow-sm:
+    0.3px 0.5px 0.8px hsl(var(--shadow-color) / 0.07),
+    0.4px 0.8px 1.2px -0.5px hsl(var(--shadow-color) / 0.13),
+    0.8px 1.5px 2.3px -1px hsl(var(--shadow-color) / 0.2);
+  --sl-shadow-md:
+    0.3px 0.5px 0.8px hsl(var(--shadow-color) / 0.06),
+    0.7px 1.4px 2.1px -0.2px hsl(var(--shadow-color) / 0.09),
+    1.2px 2.4px 3.6px -0.5px hsl(var(--shadow-color) / 0.12),
+    2.1px 4.2px 6.3px -0.7px hsl(var(--shadow-color) / 0.16),
+    3.8px 7.5px 11.4px -1px hsl(var(--shadow-color) / 0.19);
 }

--- a/packages/docs/src/styles/tokens.css
+++ b/packages/docs/src/styles/tokens.css
@@ -46,6 +46,9 @@
   --sl-text-h5: calc(var(--sl-text-sm) * pow(1.2, 6 - 5));
   --sl-text-h6: calc(var(--sl-text-sm) * pow(1.2, 6 - 6));
 
+  /* Transitions */
+  --sl-transition-speed: 0.2s ease-in-out;
+
   /* Brand gradient */
   --ge-gradient: linear-gradient(
     135deg,

--- a/packages/docs/src/styles/tokens.css
+++ b/packages/docs/src/styles/tokens.css
@@ -46,8 +46,12 @@
   --sl-text-h5: calc(var(--sl-text-sm) * pow(1.2, 6 - 5));
   --sl-text-h6: calc(var(--sl-text-sm) * pow(1.2, 6 - 6));
 
+  /* Shadows */
+  --sl-shadow-sm: none;
+  --sl-shadow-md: none;
+
   /* Transitions */
-  --sl-transition-speed: 0.2s ease-in-out;
+  --sl-transition: 0.2s ease-in-out;
 
   /* Brand gradient */
   --ge-gradient: linear-gradient(


### PR DESCRIPTION
## Description

Introduce design tokens for transitions and shadows across the docs site, replacing hardcoded values with CSS custom properties for consistency and maintainability.

- Add `--sl-transition` token (`0.2s ease-in-out`) used by all interactive hover transitions
- Add `--sl-shadow-sm` and `--sl-shadow-md` tokens with layered hsl-based shadows for light mode; dark mode explicitly uses no shadows
- Make FeatureCard fully clickable via stretched-link pattern with hover border accent
- Rename FeatureCard's internal class to `.feature-card` to avoid collision with global `.card` styles

## Validation

- Visual inspection of all card types, pagination links, buttons, sidebar links, and content links in both light and dark mode
- Verify FeatureCard is fully clickable and shows pointer cursor
- Verify link underline transitions animate smoothly on hover

## Related Issues

- Related to #1807

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.