### PR TITLE
Update AL2023 releasever to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_VERSION=24.16.0
 
 # Install Node.js and openssl, then remove everything not needed at runtime
 # (package managers, python3, build tools) to minimize potential issues.
-RUN yum update -y --releasever 2023.11.20260526 && \
+RUN yum update -y --releasever 2023.12.20260608 && \
     yum install -y tar xz openssl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \


### PR DESCRIPTION
## Description

Bumps the Amazon Linux 2023 releasever pin to the latest available release to pick up the newest OS package versions.

## Validation

- Docker image builds successfully

## Related Issues

- None

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.