### PR TITLE
Remove the dead config schema leg from the configuration merge

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -8,8 +8,6 @@ import {
   activeConfigurationAtom,
   type AttributeConfig,
   configurationAtom,
-  createEdgeType,
-  createVertexType,
   type EdgeType,
   type EdgeTypeConfig,
   type RawConfiguration,
@@ -29,7 +27,7 @@ import {
 } from "./userPreferences";
 
 /** Gets the currently active config. */
-export const activeConfigSelector = atom(get => {
+const activeConfigSelector = atom(get => {
   const configMap = get(configurationAtom);
   const id = get(activeConfigurationAtom);
   const activeConfig = id ? configMap.get(id) : null;
@@ -63,36 +61,16 @@ export function mergeConfiguration(
   currentConfig: RawConfiguration,
   userStyling: UserStyling,
 ): RawConfiguration {
-  const configVertexMap = toMapByType(currentConfig.schema?.vertices);
-  const schemaVertexMap = toMapByType(currentSchema?.vertices);
   const prefsVertexMap = toMapByType(userStyling.vertices);
-
-  const allVertexLabels = [
-    ...new Set([...configVertexMap.keys(), ...schemaVertexMap.keys()]),
-  ];
-  const mergedVertices = allVertexLabels
-    .map(vLabel =>
-      mergeVertex(
-        configVertexMap.get(vLabel),
-        schemaVertexMap.get(vLabel),
-        prefsVertexMap.get(vLabel),
-      ),
+  const mergedVertices = (currentSchema?.vertices ?? [])
+    .map(schemaVertex =>
+      mergeVertex(schemaVertex, prefsVertexMap.get(schemaVertex.type)),
     )
     .toSorted((a, b) => a.type.localeCompare(b.type));
 
-  const configEdgeMap = toMapByType(currentConfig.schema?.edges);
-  const schemaEdgeMap = toMapByType(currentSchema?.edges);
   const prefsEdgeMap = toMapByType(userStyling.edges);
-
-  const allEdgeLabels = [
-    ...new Set([...configEdgeMap.keys(), ...schemaEdgeMap.keys()]),
-  ];
-  const mergedEdges = allEdgeLabels.map(eLabel =>
-    mergeEdge(
-      configEdgeMap.get(eLabel),
-      schemaEdgeMap.get(eLabel),
-      prefsEdgeMap.get(eLabel),
-    ),
+  const mergedEdges = (currentSchema?.edges ?? []).map(schemaEdge =>
+    mergeEdge(schemaEdge, prefsEdgeMap.get(schemaEdge.type)),
   );
 
   return {
@@ -129,92 +107,37 @@ export function normalizeConnection(connection: ConnectionConfig) {
 }
 export type NormalizedConnection = ReturnType<typeof normalizeConnection>;
 
-const mergeAttributes = (
-  config: VertexTypeConfig | EdgeTypeConfig | null,
-  schema: VertexTypeConfig | EdgeTypeConfig | null,
-): AttributeConfig[] => {
-  const configAttrMap = new Map(
-    config?.attributes.map(attr => [attr.name, attr]),
-  );
-  const schemaAttrMap = new Map(
-    schema?.attributes.map(attr => [attr.name, attr]),
-  );
-  const allAttrNames = [
-    ...new Set([...configAttrMap.keys(), ...schemaAttrMap.keys()]),
-  ];
-
-  return allAttrNames.map(attrName => ({
-    name: attrName,
-    ...schemaAttrMap.get(attrName),
-    ...configAttrMap.get(attrName),
-  }));
-};
-
 const mergeVertex = (
-  configVertex?: VertexTypeConfig,
-  schemaVertex?: VertexTypeConfig,
+  schemaVertex: VertexTypeConfig,
   preferences?: VertexPreferencesStorageModel,
 ): VertexTypeConfig => {
-  // Ignore the displayLabel from schema & config
-  const patchedSchema = schemaVertex
-    ? patchToRemoveDisplayLabel(schemaVertex)
-    : null;
-  const patchedConfig = configVertex
-    ? patchToRemoveDisplayLabel(configVertex)
-    : null;
-
-  const attributes = mergeAttributes(patchedConfig, patchedSchema);
-
-  const vt =
-    preferences?.type ||
-    configVertex?.type ||
-    schemaVertex?.type ||
-    createVertexType("unknown");
+  // Ignore the displayLabel from the schema
+  const patchedSchema = patchToRemoveDisplayLabel(schemaVertex);
 
   return {
     // Defaults
-    ...getDefaultVertexTypeConfig(vt),
+    ...getDefaultVertexTypeConfig(schemaVertex.type),
     // Automatic schema override
     ...patchedSchema,
-    // File-based override
-    ...patchedConfig,
     // User preferences override
     ...preferences,
-    attributes,
   };
 };
 
 const mergeEdge = (
-  configEdge?: EdgeTypeConfig,
-  schemaEdge?: EdgeTypeConfig,
+  schemaEdge: EdgeTypeConfig,
   preferences?: EdgePreferencesStorageModel,
 ): EdgeTypeConfig => {
-  // Ignore the displayLabel from schema & config
-  const patchedSchema = schemaEdge
-    ? patchToRemoveDisplayLabel(schemaEdge)
-    : null;
-  const patchedConfig = configEdge
-    ? patchToRemoveDisplayLabel(configEdge)
-    : null;
-
-  const attributes = mergeAttributes(patchedConfig, patchedSchema);
-
-  const et =
-    preferences?.type ||
-    configEdge?.type ||
-    schemaEdge?.type ||
-    createEdgeType("unknown");
+  // Ignore the displayLabel from the schema
+  const patchedSchema = patchToRemoveDisplayLabel(schemaEdge);
 
   const config: EdgeTypeConfig = {
     // Defaults
-    ...getDefaultEdgeTypeConfig(et),
+    ...getDefaultEdgeTypeConfig(schemaEdge.type),
     // Automatic schema override
     ...patchedSchema,
-    // File-based override
-    ...patchedConfig,
     // User preferences override
     ...preferences,
-    attributes,
   };
 
   if (config.displayNameAttribute === "type") {

--- a/packages/graph-explorer/src/core/StateProvider/localDb.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/localDb.test.ts
@@ -174,6 +174,74 @@ describe("exportFromLocalForage", () => {
   });
 });
 
+/**
+ * BACKWARD COMPATIBILITY — PERSISTED DATA
+ *
+ * The full backup/restore flow snapshots every localforage key verbatim and
+ * restores it without merging or reshaping. A backup taken from an older
+ * install may contain a `configuration` entry whose `RawConfiguration` carries
+ * a stray `schema` field (the legacy in-memory schema leg that no released
+ * writer populates but that may exist in stale IndexedDB blobs).
+ *
+ * This pins that such a backup round-trips losslessly: the extra field is
+ * carried through untouched and restore succeeds. It guards against a refactor
+ * that drops `RawConfiguration.schema` introducing strict parsing that would
+ * reject or mangle a legacy backup.
+ *
+ * DO NOT delete or weaken this test without confirming that legacy backups are
+ * no longer a concern.
+ */
+describe("backward compatibility: legacy schema field on stored configuration", () => {
+  let appVersion: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(createRandomDate());
+    appVersion = `${createRandomInteger()}.${createRandomInteger()}.${createRandomInteger()}`;
+    vi.stubGlobal("__GRAPH_EXP_VERSION__", appVersion);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("round-trips a configuration entry carrying a legacy embedded schema", async () => {
+    const localDb = createFakeLocalDb();
+
+    // A stored config in the legacy shape: the schema is duplicated onto the
+    // RawConfiguration itself, which TypeScript still allows but no current
+    // writer produces.
+    const config = createRandomRawConfiguration();
+    const schema = createRandomSchema();
+    const legacyConfig = { ...config, schema } as typeof config;
+
+    const configMap = new Map([[config.id, legacyConfig]]);
+    const schemaMap = new Map([[config.id, schema]]);
+
+    localDb.setItem("schema", schemaMap);
+    localDb.setItem("configuration", configMap);
+    localDb.setItem("active-configuration", config.id);
+
+    // Backup -> serialize -> file -> parse -> restore
+    const backupBefore = await createBackupData(localDb);
+    const blob = toJsonFileData(serializeData(backupBefore));
+    const backupData = await readBackupDataFromFile(blob);
+    await restoreBackup(backupData, localDb);
+
+    // The restored configuration must still carry the stray schema field,
+    // untouched, alongside an intact connection.
+    const restoredConfigMap =
+      await localDb.getItem<typeof configMap>("configuration");
+    const restoredConfig = restoredConfigMap?.get(config.id);
+    expect(restoredConfig?.schema).toEqual(schema);
+    expect(restoredConfig?.connection).toEqual(config.connection);
+
+    // And the whole snapshot round-trips with no loss.
+    const backupAfter = await createBackupData(localDb);
+    expect(backupBefore).toEqual(backupAfter);
+  });
+});
+
 test("Rename key", async () => {
   const localDb = createFakeLocalDb();
   const oldKey = createRandomName("OldKey");

--- a/packages/graph-explorer/src/modules/AvailableConnections/useImportConnectionFile.test.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/useImportConnectionFile.test.tsx
@@ -11,7 +11,11 @@ import {
   getAppStore,
   schemaAtom,
 } from "@/core";
-import { DbState, renderHookWithState } from "@/utils/testing";
+import {
+  DbState,
+  legacyExportedConnectionFile,
+  renderHookWithState,
+} from "@/utils/testing";
 
 import { useImportConnectionFile } from "./useImportConnectionFile";
 
@@ -19,6 +23,22 @@ const mockResetState = vi.fn();
 vi.mock("@/core/StateProvider/useResetState", () => ({
   default: () => mockResetState,
 }));
+
+/**
+ * Reads the connection that import just activated. Import assigns a fresh id,
+ * makes it active, and keys both the config and schema maps by that id, so the
+ * active id is the single handle for everything that was imported.
+ */
+function getImportedConnection() {
+  const store = getAppStore();
+  const importedId = store.get(activeConfigurationAtom);
+  expect.assert(importedId);
+  const config = store.get(configurationAtom).get(importedId);
+  const schema = store.get(schemaAtom).get(importedId);
+  expect.assert(config);
+  expect.assert(schema);
+  return { importedId, config, schema };
+}
 
 describe("useImportConnectionFile", () => {
   test("should import valid configuration file", async () => {
@@ -53,29 +73,20 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const configs = getAppStore().get(configurationAtom);
-    expect(configs.size).toBe(2);
+    expect(getAppStore().get(configurationAtom).size).toBe(2);
+    expect(getAppStore().get(schemaAtom).size).toBe(2);
 
-    const schemas = getAppStore().get(schemaAtom);
-    expect(schemas.size).toBe(2);
+    const { importedId, config, schema } = getImportedConnection();
+    expect(importedId).not.toBe(state.activeConfig.id);
 
-    const activeConfigId = getAppStore().get(activeConfigurationAtom);
-    expect(activeConfigId).not.toBe(state.activeConfig.id);
+    expect(config.displayLabel).toBe(displayLabel);
+    expect(config.connection?.url).toBe(url);
+    expect(config.connection?.queryEngine).toBe("gremlin");
 
-    const importedConfig = Array.from(configs.values()).find(
-      c => c.id !== state.activeConfig.id,
-    );
-    expect(importedConfig?.displayLabel).toBe(displayLabel);
-    expect(importedConfig?.connection?.url).toBe(url);
-    expect(importedConfig?.connection?.queryEngine).toBe("gremlin");
-
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
-    expect(importedSchema?.vertices).toHaveLength(1);
-    expect(importedSchema?.vertices[0].type).toBe("Person");
-    expect(importedSchema?.edges).toHaveLength(1);
-    expect(importedSchema?.edges[0].type).toBe("knows");
+    expect(schema.vertices).toHaveLength(1);
+    expect(schema.vertices[0].type).toBe("Person");
+    expect(schema.edges).toHaveLength(1);
+    expect(schema.edges[0].type).toBe("knows");
 
     expect(mockResetState).toHaveBeenCalledOnce();
   });
@@ -138,11 +149,10 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const configs = getAppStore().get(configurationAtom);
-    expect(configs.size).toBe(2);
+    expect(getAppStore().get(configurationAtom).size).toBe(2);
 
-    const activeConfigId = getAppStore().get(activeConfigurationAtom);
-    expect(activeConfigId).not.toBe(state.activeConfig.id);
+    const { importedId } = getImportedConnection();
+    expect(importedId).not.toBe(state.activeConfig.id);
   });
 
   test("should handle schema with prefixes", async () => {
@@ -181,12 +191,9 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
-    expect(importedSchema?.prefixes).toStrictEqual([
+    expect(schema.prefixes).toStrictEqual([
       {
         prefix: "rdf",
         uri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
@@ -226,15 +233,10 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
-    expect(importedSchema?.lastUpdate).toBeInstanceOf(Date);
-    expect(importedSchema?.lastUpdate?.toISOString()).toBe(
-      lastUpdate.toISOString(),
-    );
+    expect(schema.lastUpdate).toBeInstanceOf(Date);
+    expect(schema.lastUpdate?.toISOString()).toBe(lastUpdate.toISOString());
   });
 
   test("should handle empty schema arrays", async () => {
@@ -267,13 +269,10 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
-    expect(importedSchema?.vertices).toStrictEqual([]);
-    expect(importedSchema?.edges).toStrictEqual([]);
+    expect(schema.vertices).toStrictEqual([]);
+    expect(schema.edges).toStrictEqual([]);
   });
 
   test("should handle file with complex schema", async () => {
@@ -331,19 +330,16 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
-    expect(importedSchema?.vertices).toHaveLength(2);
-    expect(importedSchema?.vertices[0].type).toBe("Person");
-    expect(importedSchema?.vertices[0].attributes).toHaveLength(2);
-    expect(importedSchema?.vertices[1].type).toBe("Company");
+    expect(schema.vertices).toHaveLength(2);
+    expect(schema.vertices[0].type).toBe("Person");
+    expect(schema.vertices[0].attributes).toHaveLength(2);
+    expect(schema.vertices[1].type).toBe("Company");
 
-    expect(importedSchema?.edges).toHaveLength(2);
-    expect(importedSchema?.edges[0].type).toBe("worksAt");
-    expect(importedSchema?.edges[1].type).toBe("knows");
+    expect(schema.edges).toHaveLength(2);
+    expect(schema.edges[0].type).toBe("worksAt");
+    expect(schema.edges[1].type).toBe("knows");
   });
 
   test("should import edgeConnections from file", async () => {
@@ -389,12 +385,9 @@ describe("useImportConnectionFile", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
-    expect(importedSchema?.edgeConnections).toStrictEqual([
+    expect(schema.edgeConnections).toStrictEqual([
       {
         edgeType: "knows",
         sourceVertexType: "Person",
@@ -471,20 +464,111 @@ describe("backward compatibility: legacy __matches in exported files", () => {
       await result.current(file);
     });
 
-    const schemas = getAppStore().get(schemaAtom);
-    const importedSchema = Array.from(schemas.values()).find(
-      (_, index) => index === 1,
-    );
+    const { schema } = getImportedConnection();
 
     // Both prefixes should be imported successfully
-    expect(importedSchema?.prefixes).toHaveLength(2);
-    expect(importedSchema?.prefixes?.[0].prefix).toBe("rdf");
-    expect(importedSchema?.prefixes?.[0].uri).toBe(
-      "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    expect(schema.prefixes).toStrictEqual([
+      {
+        prefix: "rdf",
+        uri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        __inferred: true,
+        __matches: [
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+        ],
+      },
+      {
+        prefix: "custom",
+        uri: "http://custom.example.com/",
+      },
+    ]);
+  });
+});
+
+/**
+ * BACKWARD COMPATIBILITY — PERSISTED DATA
+ *
+ * Exported connection files have, across every released version, bundled the
+ * full schema inside the top-level envelope: `{ id, displayLabel, connection,
+ * schema }`. Import must split this envelope — routing `connection` into
+ * `configurationAtom` and `schema` into `schemaAtom` — and must never write the
+ * schema into the config entry (`RawConfiguration.schema`).
+ *
+ * This pins that split for a faithful, real-world-shaped export (styled vertex
+ * and edge type configs, both `lucide:` and base64 data-URI icons, an ISO
+ * `lastUpdate`, and `edgeConnections`). It guards against a refactor that
+ * decouples the file envelope type from `RawConfiguration` accidentally
+ * dropping schema data or leaking it back into the config entry.
+ *
+ * DO NOT delete or weaken this test without confirming that exported files in
+ * the wild are no longer a concern.
+ */
+describe("backward compatibility: legacy exported connection file with embedded schema", () => {
+  test("splits the bundled schema into schemaAtom and keeps it out of the config entry", async () => {
+    const state = new DbState();
+    const { result } = renderHookWithState(
+      () => useImportConnectionFile(),
+      state,
     );
-    expect(importedSchema?.prefixes?.[1].prefix).toBe("custom");
-    expect(importedSchema?.prefixes?.[1].uri).toBe(
-      "http://custom.example.com/",
+
+    const file = new File(
+      [JSON.stringify(legacyExportedConnectionFile)],
+      "connection.json",
+      { type: "application/json" },
     );
+
+    await act(async () => {
+      await result.current(file);
+    });
+
+    const { config: importedConfig, schema: importedSchema } =
+      getImportedConnection();
+
+    // The connection lands in the config entry, fully preserved.
+    expect(importedConfig.displayLabel).toBe(
+      legacyExportedConnectionFile.displayLabel,
+    );
+    expect(importedConfig.connection).toMatchObject(
+      legacyExportedConnectionFile.connection,
+    );
+
+    // The schema must NOT be stored on the config entry — it belongs in
+    // schemaAtom. This is the invariant the dead `RawConfiguration.schema`
+    // merge leg relies on staying true.
+    expect(importedConfig.schema).toBeUndefined();
+
+    // The full schema is split out into schemaAtom, styling and all.
+    expect(importedSchema.vertices.map(v => v.type)).toStrictEqual([
+      "movie",
+      "person",
+    ]);
+    expect(importedSchema.edges.map(e => e.type)).toStrictEqual([
+      "actedIn",
+      "directed",
+    ]);
+
+    // Styling and icon data (including the base64 data-URI icon) survive intact.
+    const movie = importedSchema.vertices.find(v => v.type === "movie");
+    expect.assert(movie);
+    expect(movie.iconUrl).toBe("lucide:clapperboard");
+    expect(movie.color).toBe("#5947e6");
+    const person = importedSchema.vertices.find(v => v.type === "person");
+    expect.assert(person);
+    expect(person.iconUrl).toBe(
+      legacyExportedConnectionFile.schema.vertices[1].iconUrl,
+    );
+
+    // The ISO date string is revived into a real Date.
+    expect(importedSchema.lastUpdate).toBeInstanceOf(Date);
+    expect(importedSchema.lastUpdate?.toISOString()).toBe(
+      legacyExportedConnectionFile.schema.lastUpdate,
+    );
+
+    // Edge connections come across with their optional count preserved.
+    expect(importedSchema.edgeConnections).toStrictEqual(
+      legacyExportedConnectionFile.schema.edgeConnections,
+    );
+
+    expect(mockResetState).toHaveBeenCalledOnce();
   });
 });

--- a/packages/graph-explorer/src/utils/testing/index.ts
+++ b/packages/graph-explorer/src/utils/testing/index.ts
@@ -2,6 +2,7 @@ export * from "./createMockExplorer";
 export * from "./DbState";
 export * from "./FakeExplorer";
 export * from "./graphsonHelpers";
+export * from "./legacyExportedConnectionFile";
 export * from "./normalize";
 export * from "./ocHelpers";
 export * from "./randomData";

--- a/packages/graph-explorer/src/utils/testing/legacyExportedConnectionFile.ts
+++ b/packages/graph-explorer/src/utils/testing/legacyExportedConnectionFile.ts
@@ -1,0 +1,116 @@
+/**
+ * A realistic exported connection file, mirroring the structure produced by
+ * `saveConfigurationToFile` across many released versions of Graph Explorer.
+ *
+ * The shape intentionally matches a real-world export: a top-level
+ * `{ id, displayLabel, connection, schema }` envelope where the full schema
+ * (styled vertex/edge type configs, ISO `lastUpdate`, `edgeConnections`) is
+ * embedded alongside the connection. On import this envelope is split — the
+ * connection lands in `configurationAtom` and the schema in `schemaAtom`.
+ *
+ * The data here is synthetic (a fictional "Movies" graph against example.com
+ * endpoints) so it carries no private connection details, but the structure is
+ * faithful to genuine exports so it can pin backward-compatible import behavior.
+ */
+export const legacyExportedConnectionFile = {
+  id: "00000000-0000-4000-8000-000000000001",
+  displayLabel: "Movies - Gremlin Server",
+  connection: {
+    url: "http://localhost:5173",
+    queryEngine: "gremlin",
+    proxyConnection: true,
+    graphDbUrl:
+      "https://movies.cluster-example.us-west-2.neptune.amazonaws.com:8182",
+    awsAuthEnabled: true,
+    serviceType: "neptune-db",
+    awsRegion: "us-west-2",
+  },
+  schema: {
+    vertices: [
+      {
+        attributes: [
+          { name: "title", dataType: "String" },
+          { name: "year", dataType: "Number" },
+          { name: "runtime", dataType: "Number" },
+          { name: "genre", dataType: "String" },
+        ],
+        displayNameAttribute: "title",
+        longDisplayNameAttribute: "genre",
+        iconUrl: "lucide:clapperboard",
+        iconImageType: "image/svg+xml",
+        color: "#5947e6",
+        shape: "ellipse",
+        backgroundOpacity: 0.4,
+        borderWidth: 0,
+        borderColor: "#128EE5",
+        borderStyle: "solid",
+        type: "movie",
+      },
+      {
+        attributes: [
+          { name: "name", dataType: "String" },
+          { name: "born", dataType: "Number" },
+        ],
+        displayNameAttribute: "name",
+        longDisplayNameAttribute: "types",
+        // A base64-encoded SVG data URI, exactly as older exports stored custom icons.
+        iconUrl:
+          "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxZW0iIGhlaWdodD0iMWVtIiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxjaXJjbGUgY3g9IjEyIiBjeT0iOCIgcj0iNCIvPjwvc3ZnPg==",
+        iconImageType: "image/svg+xml",
+        color: "#128EE5",
+        shape: "ellipse",
+        backgroundOpacity: 0.4,
+        borderWidth: 0,
+        borderColor: "#128EE5",
+        borderStyle: "solid",
+        type: "person",
+      },
+    ],
+    edges: [
+      {
+        attributes: [{ name: "role", dataType: "String" }],
+        displayNameAttribute: "types",
+        labelColor: "#17457b",
+        labelBackgroundOpacity: 0.7,
+        labelBorderColor: "#17457b",
+        labelBorderStyle: "solid",
+        labelBorderWidth: 0,
+        lineColor: "#b3b3b3",
+        lineThickness: 2,
+        lineStyle: "solid",
+        sourceArrowStyle: "none",
+        targetArrowStyle: "triangle",
+        type: "actedIn",
+      },
+      {
+        attributes: [],
+        displayNameAttribute: "types",
+        labelColor: "#17457b",
+        labelBackgroundOpacity: 0.7,
+        labelBorderColor: "#17457b",
+        labelBorderStyle: "solid",
+        labelBorderWidth: 0,
+        lineColor: "#b3b3b3",
+        lineThickness: 2,
+        lineStyle: "solid",
+        sourceArrowStyle: "none",
+        targetArrowStyle: "triangle",
+        type: "directed",
+      },
+    ],
+    lastUpdate: "2026-06-10T22:14:17.810Z",
+    edgeConnections: [
+      {
+        sourceVertexType: "person",
+        edgeType: "actedIn",
+        targetVertexType: "movie",
+      },
+      {
+        sourceVertexType: "person",
+        edgeType: "directed",
+        targetVertexType: "movie",
+        count: 12,
+      },
+    ],
+  },
+} as const;


### PR DESCRIPTION
## Description

`mergeConfiguration` previously merged schema type configs from three sources: the connection config's own `schema`, the synced schema, and user styling. The first source was always empty — no released code path ever populates `RawConfiguration.schema` (import splits the bundled schema into `schemaAtom`, schema sync writes there, and create/default connections never set it). The union-of-keys logic, the `mergeAttributes` helper, and the unknown-type fallbacks all existed only to service that dead leg.

This drops the dead source, leaving a straightforward two-source merge: synced schema over defaults, with user styling applied on top. Each type now has a single schema source, so those helpers collapse away (−91/+14 in `configuration.ts`). Behavior is unchanged.

**How to read:**
- Start with the second commit (`configuration.ts`) — the actual change.
- The first commit is the safety net: regression tests pinned *before* the refactor, verifying the behavior upgrading users depend on.

**Core vs supporting:**
- Core: the `configuration.ts` simplification.
- Supporting: two backward-compatibility pins (import splits schema into `schemaAtom` and never writes it onto the config entry; a backup/restore round-trip preserves a stored config carrying a stray legacy schema field), a faithfully-shaped test fixture, and a cleanup of the surrounding import tests to share one lookup helper.

## Validation

- `pnpm checks` passes (lint, format, types).
- `pnpm test` passes (1789 tests). The pre-existing merge tests pass untouched, which is the primary evidence the refactor is behavior-preserving.
- The two new `BACKWARD COMPATIBILITY — PERSISTED DATA` tests were authored before the refactor and verified to fail loudly if the invariants break (mutation-tested).

## Related Issues

- Closes #1841

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
