### PR TITLE
Make active connection per-tab with a persisted breadcrumb

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,14 @@ _Avoid_: Relationship, link
 A saved database profile — the URL, query engine, authentication settings, and proxy routing needed to reach a graph database. Users create and manage these in the UI.
 _Avoid_: Configuration (legacy term being phased out — previously bundled connection + schema + user preferences into one object)
 
+**Active Connection**:
+The one Connection a single browser tab is currently exploring — what the entire app reads to decide which Schema, Session, and queries are in play. Held per-tab (sessionStorage): it survives that tab's reload but dies with the tab, and one tab activating a Connection never changes another tab's Active Connection.
+_Avoid_: Active configuration (legacy code term `activeConfigurationAtom`)
+
+**Last Active Connection**:
+A persisted, shared breadcrumb recording the most recently activated Connection across all tabs. Last-writer-wins; used only as the cold-start seed for a fresh tab's Active Connection, never read live by the app.
+_Avoid_: Default connection (that is a separate new-user/notebook injection path)
+
 **Query Language**:
 The graph query protocol a Connection uses — one of Gremlin, openCypher, or SPARQL. Determines which Explorer is instantiated and implies the graph type (Gremlin/openCypher → property graph, SPARQL → RDF).
 _Avoid_: Query engine (internal code name `queryEngine`, but UI says "Query Language")
@@ -72,6 +80,8 @@ _Avoid_: Configuration file (the wire format is not the in-memory or persisted s
 
 ## Relationships
 
+- Each browser tab has at most one **Active Connection**; different tabs may have different ones
+- The **Last Active Connection** seeds a fresh tab's **Active Connection** on cold start only
 - A **Connection** has exactly one **Query Language**
 - A **Connection** has one **Schema**, populated by **Schema Sync**
 - A **Schema** contains **Vertex Types**, **Edge Types**, and **Edge Connections**
@@ -100,3 +110,4 @@ _Avoid_: Configuration file (the wire format is not the in-memory or persisted s
 - A Connection's data now has three distinct shapes that look similar but must not be conflated: the **Exported Connection File** (on-disk wire format), the in-memory configuration, and the IndexedDB storage shape. They are being separated into explicit types so each can evolve independently.
 - "Node" means **Vertex** in code but is the preferred UI term for property graphs — resolved: use **Vertex** in code, "node" in UI copy.
 - "Attribute" vs "Property" — resolved: **Property** is canonical, "attribute" is legacy code term being phased out.
+- "Active connection" meant a single shared per-origin value, but the app consumed it as if it were per-tab — resolved: **Active Connection** is per-tab (sessionStorage), **Last Active Connection** is the shared persisted breadcrumb. The legacy `activeConfigurationAtom` / `active-configuration` key is reused as the breadcrumb.

--- a/docs/adr/20260618-per-tab-active-connection.md
+++ b/docs/adr/20260618-per-tab-active-connection.md
@@ -1,0 +1,36 @@
+# Per-tab Active Connection with a persisted breadcrumb
+
+## Status
+
+accepted
+
+## Context
+
+"Active connection" was a single value persisted to shared IndexedDB (the `active-configuration` localForage key, read once at startup with no cross-tab sync), yet the entire app consumed it as if it were per-tab state. Two same-origin tabs therefore could not hold different active connections: whoever wrote last silently changed what the other tab was exploring, and a reload adopted whatever was persisted last. The URL-connect feature (open a connection from a link, in a new tab) made this latent flaw trivially triggerable, but it exists independently on `main`.
+
+We need both: a tab keeps its own active connection regardless of what other tabs do, **and** a returning user's cold start lands on their last connection rather than the connection screen.
+
+## Decision
+
+Split the concept into two roles:
+
+- **Active Connection** — per-tab, held in `sessionStorage`. The value the whole app reads. Survives that tab's reload, dies with the tab. Different tabs are independent.
+- **Last Active Connection** — the existing persisted `active-configuration` localForage key, reused unchanged and redefined as a shared, last-writer-wins breadcrumb. Read only as the cold-start seed; never read live.
+
+A fresh tab's Active Connection is seeded with `sessionStorage value ?? persisted breadcrumb value`, resolved before the atom is created (the breadcrumb read is async, in the factory; the atom itself is then created with an already-resolved seed, so there is no post-mount flash or ordering race). On a cold start — no sessionStorage value — the tab does not merely read the breadcrumb, it **claims** it, writing the seeded value into its own sessionStorage. This is the load-bearing property for per-tab stability: a later reload of that tab reads its own value back rather than re-seeding from a breadcrumb another tab may have since overwritten. (Without the claim, two tabs that both cold-started would each re-seed from the shared breadcrumb on every reload, so one tab switching connections would silently change the other on its next reload.)
+
+Writing the per-tab value and the breadcrumb is funneled through the `activeConfigurationAtom` setter (in `activeConnectionStorage.ts`), so every existing `set(activeConfigurationAtom, …)` call site updates both backings with no change. Session-state reset is not part of this atom; each activation call site still pairs the set with `useResetState()` — a known duplication that a single `useActivateConnection` hook could centralize as a clean additive follow-up.
+
+## Considered Options
+
+- **Pure shared global (status quo)** — satisfies restart-persistence, fails multi-tab. The current hazard.
+- **Pure per-tab, no breadcrumb** — satisfies multi-tab, fails restart-persistence. Rejected; restart-persistence is a product requirement.
+- **Per-tab + breadcrumb (chosen)** — satisfies both. Persistence demoted to a cold-start hint; liveness is per-tab.
+- **Primary-tab election for breadcrumb writes (BroadcastChannel / Web Locks)** — would make cold start resume a chosen tab rather than the most-recent activation. Rejected: reintroduces the cross-tab coordination this design avoids, to refine a hint rather than fix a correctness property. Last-writer-wins is accepted instead; election remains a clean additive follow-up if it ever bites.
+
+## Consequences
+
+- **No migration.** Returning users' existing `active-configuration` value is the breadcrumb already; a fresh tab with empty sessionStorage seeds from it and lands on the last connection.
+- **Deleted-connection degrades safely with no new guard.** `activeConfigSelector` was hardened here to coalesce a map miss to `null` (it previously returned `undefined`), so a tab holding a now-deleted id resolves to the connection screen on its next reload. Covered by a regression test, not runtime logic.
+- **Cold start can resume a connection activated in a _different_ tab** (last-writer-wins breadcrumb). Accepted as honest "resume the most recent activation" semantics; only observable after all tabs close.
+- The sessionStorage backing is injectable so two-tab isolation can be tested directly with two Jotai stores over one shared mock localForage and separate sessionStorage mocks.

--- a/docs/features/connections.md
+++ b/docs/features/connections.md
@@ -24,6 +24,8 @@ For guides on connecting to specific databases, see [Connecting to databases](..
 
 Once a connection is created, this section will appear as a left-hand pane. When you create more than one connection to a graph database, you can only connect to and visualize from one graph database endpoint at a time. To select the active database, toggle the "Active" switch.
 
+The active connection is per browser tab: switching connections in one tab does not change what another open tab is viewing, so you can explore different connections side by side. When you reopen Graph Explorer after closing all tabs, it resumes the connection you most recently used.
+
 ## Connection Details
 
 Once a connection is created, this section will appear as a right-hand information pane for a selected connection. It shows details such as the connection name, query language, endpoint and a summary of the graph data, such as the count of nodes, edges, and a list of node types.

--- a/packages/graph-explorer/src/core/StateProvider/activeConnectionStorage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/activeConnectionStorage.test.ts
@@ -1,0 +1,197 @@
+import { createStore } from "jotai";
+import localForage from "localforage";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { createNewConfigurationId } from "@/core";
+import { readPersistedValue } from "@/utils/testing";
+
+import {
+  ACTIVE_CONNECTION_STORAGE_KEY,
+  createActiveConfigurationAtom,
+} from "./activeConnectionStorage";
+import { createInMemorySessionStorage } from "./safeSessionStorage";
+
+/**
+ * Simulates one browser tab exploring the active connection. Each tab has its
+ * own Jotai store and its own sessionStorage (per-tab state), while all tabs
+ * share the one fake-indexeddb the test provisions — exactly how same-origin
+ * tabs relate. Opening a tab preloads the breadcrumb, like app startup does.
+ */
+async function openTab() {
+  // sessionStorage is per-tab and survives a reload, so it persists across the
+  // store/atom rebuild that reload() models.
+  const sessionStorage = createInMemorySessionStorage();
+  let store = createStore();
+  let atom = await createActiveConfigurationAtom({ sessionStorage });
+  return {
+    read: () => store.get(atom),
+    /** Activates a connection; resolves once the breadcrumb has landed. */
+    activate: (id: ReturnType<typeof createNewConfigurationId> | null) =>
+      store.set(atom, id),
+    /** Reloads this tab: a fresh store and atom over the same sessionStorage. */
+    reload: async () => {
+      store = createStore();
+      atom = await createActiveConfigurationAtom({ sessionStorage });
+    },
+  };
+}
+
+describe("activeConnectionStorage", () => {
+  beforeEach(async () => {
+    await localForage.clear();
+  });
+
+  test("cold start seeds the active connection from the persisted breadcrumb", async () => {
+    const breadcrumb = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, breadcrumb);
+    const sessionStorage = createInMemorySessionStorage();
+
+    const atom = await createActiveConfigurationAtom({ sessionStorage });
+
+    const store = createStore();
+    expect(store.get(atom)).toBe(breadcrumb);
+  });
+
+  test("treats an empty sessionStorage value as a miss and falls back to the breadcrumb", async () => {
+    const breadcrumb = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, breadcrumb);
+    const sessionStorage = createInMemorySessionStorage();
+    sessionStorage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, "");
+
+    const atom = await createActiveConfigurationAtom({ sessionStorage });
+
+    const store = createStore();
+    expect(store.get(atom)).toBe(breadcrumb);
+  });
+
+  test("warm reload keeps this tab's sessionStorage value over the breadcrumb", async () => {
+    const breadcrumb = createNewConfigurationId();
+    const tabValue = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, breadcrumb);
+    const sessionStorage = createInMemorySessionStorage();
+    sessionStorage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, tabValue);
+
+    const atom = await createActiveConfigurationAtom({ sessionStorage });
+
+    const store = createStore();
+    expect(store.get(atom)).toBe(tabValue);
+  });
+
+  test("activating a connection writes both this tab and the breadcrumb", async () => {
+    const sessionStorage = createInMemorySessionStorage();
+    const atom = await createActiveConfigurationAtom({ sessionStorage });
+    const store = createStore();
+
+    const activated = createNewConfigurationId();
+    // The in-memory value and sessionStorage update synchronously; the write
+    // returns the breadcrumb persistence promise to await without timeouts.
+    const persisted = store.set(atom, activated);
+
+    expect(store.get(atom)).toBe(activated);
+    expect(sessionStorage.getItem(ACTIVE_CONNECTION_STORAGE_KEY)).toBe(
+      activated,
+    );
+    await persisted;
+    expect(await localForage.getItem(ACTIVE_CONNECTION_STORAGE_KEY)).toBe(
+      activated,
+    );
+  });
+
+  test("clearing the active connection clears this tab but is reflected in the breadcrumb", async () => {
+    const previous = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, previous);
+    const sessionStorage = createInMemorySessionStorage();
+    sessionStorage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, previous);
+
+    const atom = await createActiveConfigurationAtom({ sessionStorage });
+    const store = createStore();
+    const persisted = store.set(atom, null);
+
+    expect(store.get(atom)).toBeNull();
+    expect(sessionStorage.getItem(ACTIVE_CONNECTION_STORAGE_KEY)).toBeNull();
+    await persisted;
+    expect(await localForage.getItem(ACTIVE_CONNECTION_STORAGE_KEY)).toBeNull();
+  });
+
+  // No sessionStorage argument exercises the built-in fallback used when no DOM
+  // storage is available (non-DOM contexts, or storage blocked/throwing). It
+  // must still seed from the breadcrumb and round-trip writes in memory.
+  test("falls back to in-memory storage when no sessionStorage is available", async () => {
+    const breadcrumb = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, breadcrumb);
+
+    const atom = await createActiveConfigurationAtom();
+    const store = createStore();
+    expect(store.get(atom)).toBe(breadcrumb);
+
+    const activated = createNewConfigurationId();
+    store.set(atom, activated);
+    expect(store.get(atom)).toBe(activated);
+  });
+});
+
+// These exercise the cross-tab behavior end-to-end over one shared
+// fake-indexeddb backend: each tab has its own store and sessionStorage, so the
+// only thing they share is the persisted breadcrumb — exactly like same-origin
+// browser tabs.
+describe("activeConnectionStorage across tabs", () => {
+  beforeEach(async () => {
+    await localForage.clear();
+  });
+
+  test("activating a connection in one tab does not change an already-open tab", async () => {
+    const tabB = await openTab();
+    const tabBConnection = createNewConfigurationId();
+    await tabB.activate(tabBConnection);
+
+    const tabA = await openTab();
+    await tabA.activate(createNewConfigurationId());
+
+    expect(tabB.read()).toBe(tabBConnection);
+  });
+
+  test("a tab opened later cold-starts to the connection an earlier tab activated", async () => {
+    const earlierTab = await openTab();
+    const connection = createNewConfigurationId();
+    await earlierTab.activate(connection);
+
+    const freshTab = await openTab();
+
+    expect(freshTab.read()).toBe(connection);
+  });
+
+  test("a cold-started tab keeps its connection across reload when another tab changes the breadcrumb", async () => {
+    // Tab A cold-starts on X (seeded from the breadcrumb), without ever
+    // explicitly activating it.
+    const connectionX = createNewConfigurationId();
+    await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, connectionX);
+    const tabA = await openTab();
+    expect(tabA.read()).toBe(connectionX);
+
+    // Another tab switches to Y, moving the shared breadcrumb.
+    const tabB = await openTab();
+    const connectionY = createNewConfigurationId();
+    await tabB.activate(connectionY);
+
+    // Tab A reloads. Its connection must remain X, not adopt the breadcrumb's Y.
+    await tabA.reload();
+    expect(tabA.read()).toBe(connectionX);
+  });
+
+  test("the breadcrumb is last-writer-wins across tabs", async () => {
+    const tabA = await openTab();
+    const tabB = await openTab();
+
+    const connectionA = createNewConfigurationId();
+    const connectionB = createNewConfigurationId();
+    await tabA.activate(connectionA);
+    await tabB.activate(connectionB);
+
+    expect(await readPersistedValue(ACTIVE_CONNECTION_STORAGE_KEY)).toBe(
+      connectionB,
+    );
+
+    const freshTab = await openTab();
+    expect(freshTab.read()).toBe(connectionB);
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/activeConnectionStorage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/activeConnectionStorage.ts
@@ -1,0 +1,69 @@
+import localForage from "localforage";
+
+import type { ConfigurationId } from "../ConfigurationProvider";
+
+import { resolveSessionStorage } from "./safeSessionStorage";
+import { createWriteThroughAtom } from "./writeThroughAtom";
+
+/**
+ * Storage key for the active connection. Used for both the per-tab
+ * sessionStorage value and the persisted localForage breadcrumb, so existing
+ * users' stored value is reused with no migration.
+ */
+export const ACTIVE_CONNECTION_STORAGE_KEY = "active-configuration";
+
+function readSessionValue(sessionStorage: Storage): ConfigurationId | null {
+  // Treat an empty/corrupted value as a miss so it falls through to the
+  // breadcrumb rather than seeding an invalid connection id.
+  const value = sessionStorage.getItem(ACTIVE_CONNECTION_STORAGE_KEY);
+  return value ? (value as ConfigurationId) : null;
+}
+
+/**
+ * Creates the atom holding this tab's active connection.
+ *
+ * The active connection is per-tab: it lives in sessionStorage so it survives
+ * a reload of this tab but never leaks to other tabs. Each write also updates a
+ * shared, persisted breadcrumb in localForage; that breadcrumb is read only
+ * once, here, to seed a fresh tab on cold start.
+ *
+ * Seeding order: this tab's sessionStorage value (warm reload) wins; otherwise
+ * the persisted breadcrumb (cold start) seeds it. A cold-start seed is claimed
+ * into this tab's sessionStorage so the tab owns that connection: a later
+ * reload reads its own value back instead of re-seeding from a breadcrumb that
+ * another tab may have since moved.
+ *
+ * @param sessionStorage The per-tab storage backing. Injectable so multi-tab
+ * isolation can be tested with separate storages.
+ */
+export async function createActiveConfigurationAtom({
+  sessionStorage = resolveSessionStorage(),
+}: { sessionStorage?: Storage } = {}) {
+  let seedValue = readSessionValue(sessionStorage);
+  if (seedValue === null) {
+    // Cold start: seed from the shared breadcrumb and claim it into this tab's
+    // sessionStorage, so a later reload reads this value back rather than
+    // re-seeding from a breadcrumb another tab may have since moved.
+    seedValue = await localForage.getItem<ConfigurationId | null>(
+      ACTIVE_CONNECTION_STORAGE_KEY,
+    );
+    if (seedValue !== null) {
+      sessionStorage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, seedValue);
+    }
+  }
+
+  return createWriteThroughAtom<ConfigurationId | null>(
+    seedValue,
+    // sessionStorage updates synchronously; the returned promise tracks the
+    // breadcrumb landing in localForage.
+    async nextValue => {
+      if (nextValue === null) {
+        sessionStorage.removeItem(ACTIVE_CONNECTION_STORAGE_KEY);
+      } else {
+        sessionStorage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, nextValue);
+      }
+      await localForage.setItem(ACTIVE_CONNECTION_STORAGE_KEY, nextValue);
+    },
+    "activeConfigurationAtom",
+  );
+}

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -1,5 +1,6 @@
-import { atom } from "jotai";
 import localForage from "localforage";
+
+import { createWriteThroughAtom } from "./writeThroughAtom";
 
 localForage.config({
   name: "ge",
@@ -23,8 +24,6 @@ function createLocalForageStorage<T>(key: string, initialValue: T) {
   };
 }
 
-type SetStateAction<Value> = Value | ((prev: Value) => Value);
-
 /**
  * Creates an atom that persists its value in localForage.
  *
@@ -40,36 +39,12 @@ type SetStateAction<Value> = Value | ((prev: Value) => Value);
  * @returns An atom that persists to localForage
  */
 export async function atomWithLocalForage<T>(key: string, initialValue: T) {
-  // Interactions with local forage
   const storage = createLocalForageStorage<T>(key, initialValue);
   const preloadValue = await storage.getItem();
 
-  // Cached value
-  const baseAtom = atom<T>(preloadValue);
-
-  // Persist data to local forage on change. The in-memory value updates
-  // synchronously; the write returns the background persistence promise so
-  // callers can await the value landing in storage when they need to (the app
-  // does not, but tests do). It is never awaited in production.
-  const derivedAtom = atom(
-    get => get(baseAtom),
-    (get, set, update: SetStateAction<T>): Promise<void> => {
-      const prevValue = get(baseAtom);
-      const nextValue =
-        typeof update === "function"
-          ? (update as (prev: T) => T)(prevValue)
-          : update;
-
-      if (prevValue === nextValue) {
-        return Promise.resolve();
-      }
-
-      set(baseAtom, nextValue);
-      return storage.setItem(nextValue);
-    },
+  return createWriteThroughAtom<T>(
+    preloadValue,
+    nextValue => storage.setItem(nextValue),
+    `atomWithLocalForage(${key})`,
   );
-
-  derivedAtom.debugLabel = `atomWithLocalForage(${key})`;
-
-  return derivedAtom;
 }

--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -1,5 +1,7 @@
 import { createRandomName } from "@shared/utils/testing";
+import { createStore } from "jotai";
 
+import { activeConfigurationAtom, configurationAtom } from "@/core";
 import { createEdgeType, createVertexType } from "@/core/entities";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
 import {
@@ -19,6 +21,7 @@ import type { SchemaStorageModel } from "./schema";
 import type { UserStyling } from "./userPreferences";
 
 import {
+  activeConfigSelector,
   defaultEdgeTypeConfig,
   defaultVertexTypeConfig,
   getDefaultEdgeTypeConfig,
@@ -409,5 +412,30 @@ describe("getDefaultEdgeTypeConfig", () => {
       ...defaultEdgeTypeConfig,
       type: createEdgeType("knows"),
     });
+  });
+});
+
+describe("activeConfigSelector", () => {
+  test("resolves the active connection's config", () => {
+    const config = createRandomRawConfiguration();
+    const store = createStore();
+    store.set(configurationAtom, new Map([[config.id, config]]));
+    store.set(activeConfigurationAtom, config.id);
+
+    expect(store.get(activeConfigSelector)).toBe(config);
+  });
+
+  // A tab's active connection lives in per-tab sessionStorage, but the
+  // connections map is shared and only refreshed on reload. A connection
+  // deleted in another tab leaves this tab pointing at a missing id. The
+  // selector must degrade to null (the connection screen) rather than expose a
+  // dangling pointer.
+  test("resolves to null when the active connection was deleted in another tab", () => {
+    const deletedConfig = createRandomRawConfiguration();
+    const store = createStore();
+    store.set(configurationAtom, new Map());
+    store.set(activeConfigurationAtom, deletedConfig.id);
+
+    expect(store.get(activeConfigSelector)).toBeNull();
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -27,11 +27,12 @@ import {
 } from "./userPreferences";
 
 /** Gets the currently active config. */
-const activeConfigSelector = atom(get => {
+export const activeConfigSelector = atom(get => {
   const configMap = get(configurationAtom);
   const id = get(activeConfigurationAtom);
-  const activeConfig = id ? configMap.get(id) : null;
-  return activeConfig;
+  // The id may point at a connection deleted in another tab, so a map miss
+  // resolves to null (no active connection) rather than a dangling pointer.
+  return (id && configMap.get(id)) ?? null;
 });
 
 export const activeConnectionAtom = atom(get => {

--- a/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { logger } from "@/utils";
+
+import {
+  createInMemorySessionStorage,
+  resolveSessionStorage,
+} from "./safeSessionStorage";
+
+describe("createInMemorySessionStorage", () => {
+  test("round-trips values and removes them", () => {
+    const storage = createInMemorySessionStorage();
+
+    storage.setItem("key", "value");
+    expect(storage.getItem("key")).toBe("value");
+
+    storage.removeItem("key");
+    expect(storage.getItem("key")).toBeNull();
+  });
+});
+
+describe("resolveSessionStorage", () => {
+  // The default test environment is non-DOM, so globalThis.sessionStorage is
+  // undefined and resolveSessionStorage exercises the in-memory fallback.
+  test("warns and falls back to in-memory storage when sessionStorage is unavailable", () => {
+    const storage = resolveSessionStorage();
+
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledOnce();
+    storage.setItem("key", "value");
+    expect(storage.getItem("key")).toBe("value");
+  });
+
+  test("includes the thrown error in the warning when sessionStorage access throws", () => {
+    const accessError = new Error("storage disabled");
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    );
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      get() {
+        throw accessError;
+      },
+    });
+
+    try {
+      const storage = resolveSessionStorage();
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.any(String),
+        accessError,
+      );
+      storage.setItem("key", "value");
+      expect(storage.getItem("key")).toBe("value");
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "sessionStorage", original);
+      } else {
+        delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+      }
+    }
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.ts
@@ -1,0 +1,47 @@
+import { logger } from "@/utils";
+
+/**
+ * In-memory Storage used when sessionStorage is unavailable — either absent
+ * (non-DOM contexts such as SSR or node-based tests) or blocked (accessing it
+ * throws a SecurityError in sandboxed iframes or with storage disabled).
+ */
+export function createInMemorySessionStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    getItem: key => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: key => void map.delete(key),
+    clear: () => map.clear(),
+    key: index => Array.from(map.keys())[index] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+}
+
+/**
+ * Returns a usable sessionStorage, degrading to an in-memory store when none is
+ * available. Accessing `globalThis.sessionStorage` can throw a SecurityError
+ * (not return undefined) when DOM storage is disabled, so the access is guarded
+ * to avoid crashing app startup.
+ */
+export function resolveSessionStorage(): Storage {
+  try {
+    if (globalThis.sessionStorage) {
+      logger.debug("Using browser sessionStorage for per-tab state");
+      return globalThis.sessionStorage;
+    }
+    logger.warn(
+      "sessionStorage is unavailable; falling back to in-memory storage. " +
+        "Per-tab state will not survive a reload.",
+    );
+    return createInMemorySessionStorage();
+  } catch (error) {
+    logger.warn(
+      "sessionStorage access threw; falling back to in-memory storage. " +
+        "Per-tab state will not survive a reload.",
+      error,
+    );
+    return createInMemorySessionStorage();
+  }
+}

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -6,6 +6,7 @@ import type { GraphSessionStorageModel } from "./graphSession/storage";
 import type { SchemaStorageModel } from "./schema";
 import type { UserStyling } from "./userPreferences";
 
+import { createActiveConfigurationAtom } from "./activeConnectionStorage";
 import { atomWithLocalForage } from "./atomWithLocalForage";
 import { defaultUserLayout } from "./userLayoutDefaults";
 
@@ -58,7 +59,7 @@ const [
   defaultNeighborExpansionLimitAtom,
   diagnosticLoggingAtom,
 ] = await Promise.all([
-  atomWithLocalForage<ConfigurationId | null>("active-configuration", null),
+  createActiveConfigurationAtom(),
   atomWithLocalForage<Map<ConfigurationId, RawConfiguration>>(
     "configuration",
     new Map(),

--- a/packages/graph-explorer/src/core/StateProvider/writeThroughAtom.ts
+++ b/packages/graph-explorer/src/core/StateProvider/writeThroughAtom.ts
@@ -1,0 +1,52 @@
+import { atom } from "jotai";
+
+export type SetStateAction<Value> = Value | ((prev: Value) => Value);
+
+/**
+ * Creates an atom that caches its value in memory and writes every change
+ * through to an external store via the `persist` callback.
+ *
+ * The atom is seeded synchronously, reads come from the in-memory cache, and
+ * writes resolve a function update, short-circuit when the value is unchanged,
+ * update the cache, then persist. Callers supply how seeding and persistence
+ * map to their backing store (localForage, sessionStorage, etc.).
+ *
+ * The in-memory value updates synchronously; the write returns the background
+ * persistence promise so callers can await the value landing in storage when
+ * they need to (the app does not, but tests do). It is never awaited in
+ * production.
+ *
+ * @param seed The initial value, already loaded from the backing store.
+ * @param persist Writes a changed value to the backing store, returning a
+ * promise that resolves once it has landed.
+ * @param debugLabel Label surfaced in Jotai devtools.
+ */
+export function createWriteThroughAtom<Value>(
+  seed: Value,
+  persist: (value: Value) => Promise<void>,
+  debugLabel: string,
+) {
+  const baseAtom = atom<Value>(seed);
+
+  const derivedAtom = atom(
+    get => get(baseAtom),
+    (get, set, update: SetStateAction<Value>): Promise<void> => {
+      const prevValue = get(baseAtom);
+      const nextValue =
+        typeof update === "function"
+          ? (update as (prev: Value) => Value)(prevValue)
+          : update;
+
+      if (prevValue === nextValue) {
+        return Promise.resolve();
+      }
+
+      set(baseAtom, nextValue);
+      return persist(nextValue);
+    },
+  );
+
+  derivedAtom.debugLabel = debugLabel;
+
+  return derivedAtom;
+}


### PR DESCRIPTION
## Description

The active database connection was a per-origin singleton in IndexedDB that the app consumed as if it were per-tab state, with no cross-tab awareness. Switching or opening a connection in one browser tab silently changed the active connection of every other open tab, and on reload a tab adopted whatever the last writer persisted.

This makes the **Active Connection** per-tab. It now lives in `sessionStorage` (survives that tab's reload, dies with the tab, never leaks to other tabs). The existing persisted `active-configuration` value is reused unchanged as a **Last Active Connection** breadcrumb that only seeds a fresh tab on cold start — so returning users still land on their last connection with **no migration**.

### How to read the changes

- **Core:** `core/StateProvider/activeConnectionStorage.ts` (new) holds the per-tab atom and the dual sessionStorage + breadcrumb write; `storageAtoms.ts` swaps one line to use it. The ~12 readers and existing writers of `activeConfigurationAtom` are untouched — the export name and contract are preserved.
- **Hardening:** `configuration.ts` — `activeConfigSelector` now coalesces a map miss to `null`, so a tab whose connection was deleted in another tab degrades to the connection screen instead of holding a dangling pointer.
- **Supporting cleanup:**
  - The shared in-memory-cache + write-through persistence pattern is extracted into `writeThroughAtom.ts`, which both `atomWithLocalForage` and the new atom compose over (removes a near-duplicate). Its write returns the persistence promise so tests can await a value landing in storage instead of using timeouts.
  - `safeSessionStorage.ts` (new) provides the in-memory `Storage` fallback and `resolveSessionStorage`, which guards `globalThis.sessionStorage` against a `SecurityError` (storage disabled / sandboxed iframe) so it can't crash startup, logging which backing was chosen (debug when real, warn — with the thrown error — when falling back).
- **Docs:** ADR `docs/adr/0001` records the decision and rejected alternatives; `CONTEXT.md` adds the glossary terms; `docs/features/connections.md` notes the per-tab behavior.

The design and its rejected alternatives (pure-global, pure-per-tab, BroadcastChannel tab election) are documented in the ADR.

## Validation

- `pnpm checks` passes with no errors.
- `pnpm test` passes (1822 tests).
- Unit tests cover cold-start seeding, warm reload, write-through to both backings, clear-on-delete, the in-memory fallback, and the deleted-connection selector degrade.
- Multi-tab tests run end-to-end over one shared `fake-indexeddb` backend (each tab with its own store + sessionStorage): activating in one tab does not change an already-open tab, a tab opened later cold-starts to the connection an earlier tab activated, and the breadcrumb is last-writer-wins across tabs.
- `safeSessionStorage` tests cover the in-memory round-trip and that a thrown access is surfaced in the warning.

To verify manually: open two tabs on different connections; switching one does not change the other. Close all tabs and reopen — the most recently used connection is restored.

## Related Issues

- Fixes #1825

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
