### PR TITLE
Adopt date-prefixed ADR filenames

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -18,10 +18,15 @@ Single-context repo (most repos):
 /
 ├── CONTEXT.md
 ├── docs/adr/
-│   ├── 0001-event-sourced-orders.md
-│   └── 0002-postgres-for-write-model.md
+│   ├── 20260612-event-sourced-orders.md
+│   └── 20260704-postgres-for-write-model.md
 └── src/
 ```
+
+ADR files are named `YYYYMMDD-kebab-title.md`, where the date is when the
+decision was accepted. The date prefix keeps them sortable chronologically and
+avoids the renumbering churn that sequential IDs cause when two branches add an
+ADR at once. Refer to an ADR by its slug, e.g. ADR `event-sourced-orders`.
 
 ## Use the glossary's vocabulary
 
@@ -33,4 +38,4 @@ If the concept you need isn't in the glossary yet, that's a signal — either yo
 
 If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
 
-> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+> _Contradicts ADR `event-sourced-orders` — but worth reopening because…_


### PR DESCRIPTION
## Description

Establishes the ADR file-naming convention for the repo: `YYYYMMDD-kebab-title.md`, where the date is when the decision was accepted.

The previous example in `docs/agents/domain.md` implied sequential `0001-…` numbering. Sequential IDs force a renumber whenever two branches each add an ADR from their own branch point — the second to merge collides on the same number. A date prefix stays sortable chronologically while sidestepping that churn. ADRs are referred to by their slug (e.g. `event-sourced-orders`).

Docs-only change to `docs/agents/domain.md` — updates the file-structure example and the reference style. No ADR files are added here; this just sets the naming standard so feature branches can follow it.

## Validation

- Docs-only; `pnpm checks` (format) passes.

## Related Issues

- Split out from #1828 so the convention can land independently of the connection-links feature that prompted it.

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.