### PR TITLE
Use fake-indexeddb as the persistence test backend

### DIFF
--- a/.kiro/skills/testing/SKILL.md
+++ b/.kiro/skills/testing/SKILL.md
@@ -133,7 +133,8 @@ test("should filter vertices by type", () => {
 All tests automatically inherit the configuration from `setupTests.ts`, which provides:
 
 - **Consistent Environment**: UTC timezone, en-US locale
-- **Mocked Dependencies**: localforage, logger, query client with no retries
+- **Mocked Dependencies**: logger, query client with no retries
+- **Real persistence backend**: localForage runs unmocked against `fake-indexeddb`, so tests exercise the real serialization and IndexedDB read/write paths. A fresh `IDBFactory` is provisioned per test (in an async `beforeEach`) so persisted state never bleeds between tests.
 - **Cleanup**: Automatic cleanup after each test
 - **Global Mocks**: Intl, environment variables
 
@@ -493,6 +494,33 @@ test("should handle errors gracefully", async () => {
 
   // Test error handling behavior
   await expect(functionUnderTest(mockFetch)).rejects.toThrow("Test error");
+});
+```
+
+## Persistence Testing
+
+Because localForage runs against a real (fake-indexeddb) backend, tests can exercise the actual persistence path. `@/utils/testing` provides helpers for this, especially for cross-tab scenarios (two same-origin tabs share one IndexedDB but each holds its own in-memory cache — see the per-key diff-merge reconciliation ADR):
+
+- `openPersistenceTab(key, initialValue)` — simulates one browser tab: its own Jotai store and its own `atomWithLocalForage` instance, sharing the per-test IndexedDB. Open two tabs on the same key to express "Tab A persisted X; Tab B holds stale memory" situations.
+- `tab.read()` — the tab's in-memory value.
+- `tab.write(value)` — writes through the tab; returns a promise that resolves once the value has landed in storage (`atomWithLocalForage`'s write returns its background persistence promise, which is what makes this awaitable).
+- `tab.flush()` — awaits the tab's most recent background write, so assertions don't need arbitrary timeouts.
+- `readPersistedValue(key)` — reads what actually landed in storage, bypassing any tab's in-memory cache. Use this to assert against durable state.
+
+```typescript
+import { openPersistenceTab, readPersistedValue } from "@/utils/testing";
+
+test("a later tab preloads what an earlier tab persisted", async () => {
+  const tabA = await openPersistenceTab("user-styling", {});
+  await tabA.write({ vertices: [{ type: "Person", color: "#ff0000" }] });
+
+  const tabB = await openPersistenceTab("user-styling", {});
+  expect(tabB.read()).toEqual({
+    vertices: [{ type: "Person", color: "#ff0000" }],
+  });
+  expect(await readPersistedValue("user-styling")).toEqual({
+    vertices: [{ type: "Person", color: "#ff0000" }],
+  });
 });
 ```
 

--- a/docs/adr/20260616-indexeddb-not-localstorage-for-persistence.md
+++ b/docs/adr/20260616-indexeddb-not-localstorage-for-persistence.md
@@ -31,7 +31,7 @@ Rationale, recorded so it is not re-litigated:
 
 - The persistence layer is inherently **asynchronous**. `atomWithLocalForage` preloads each value before returning the atom so reads are synchronous thereafter, but writes flush to IndexedDB in the background. The cross-tab fix in ADR `per-key-diff-merge-cross-tab-reconciliation` has to live inside that async write path.
 - IndexedDB is **shared across all same-origin tabs** but has **no built-in cross-tab synchronization**. That sharing is precisely what makes the concurrent-write clobber in #1820 possible, and what ADR `per-key-diff-merge-cross-tab-reconciliation` reconciles.
-- Tests mock localForage globally (see `setupTests.ts`), so this constraint does not impose IndexedDB on the test environment.
+- Tests run localForage unmocked against `fake-indexeddb` (a fresh `IDBFactory` per test, see `setupTests.ts`), so the persistence layer is exercised against real IndexedDB semantics rather than a stub. This is what lets the #1820 cross-tab clobber be reproduced in a test.
 
 ## Out of scope
 

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -95,6 +95,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "4.1.9",
     "core-js": "^3.49.0",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.10.5",
     "jsdom": "^29.1.1",
     "rimraf": "^6.1.3",

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
@@ -32,6 +32,30 @@ describe("atomWithLocalForage", () => {
     expect(stored).toBe("new-value");
   });
 
+  test("should return the persistence promise from a write", async () => {
+    const key = "test-awaitable-write";
+    const atom = await atomWithLocalForage(key, "initial");
+
+    // The in-memory value updates synchronously; the write returns the
+    // background persistence promise so callers can wait for the value to land
+    // in storage without relying on arbitrary timeouts.
+    const persisted = store.set(atom, "new-value");
+    expect(persisted).toBeInstanceOf(Promise);
+    await persisted;
+
+    const stored = await localforage.getItem(key);
+    expect(stored).toBe("new-value");
+  });
+
+  test("should return a resolved promise when a write is a no-op", async () => {
+    const atom = await atomWithLocalForage("test-no-op", "initial");
+
+    // Writing the same value short-circuits, but callers can still await the
+    // result uniformly.
+    const persisted = store.set(atom, "initial");
+    await expect(persisted).resolves.toBeUndefined();
+  });
+
   test("should handle function updates", async () => {
     const atom = await atomWithLocalForage("test-fn", 10);
 

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -47,10 +47,13 @@ export async function atomWithLocalForage<T>(key: string, initialValue: T) {
   // Cached value
   const baseAtom = atom<T>(preloadValue);
 
-  // Persist data to local forage on change
+  // Persist data to local forage on change. The in-memory value updates
+  // synchronously; the write returns the background persistence promise so
+  // callers can await the value landing in storage when they need to (the app
+  // does not, but tests do). It is never awaited in production.
   const derivedAtom = atom(
     get => get(baseAtom),
-    (get, set, update: SetStateAction<T>) => {
+    (get, set, update: SetStateAction<T>): Promise<void> => {
       const prevValue = get(baseAtom);
       const nextValue =
         typeof update === "function"
@@ -58,11 +61,11 @@ export async function atomWithLocalForage<T>(key: string, initialValue: T) {
           : update;
 
       if (prevValue === nextValue) {
-        return;
+        return Promise.resolve();
       }
 
       set(baseAtom, nextValue);
-      storage.setItem(nextValue);
+      return storage.setItem(nextValue);
     },
   );
 

--- a/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userLayout.test.ts
@@ -25,29 +25,29 @@ describe("useViewToggles", () => {
     expect(result.current.isTableVisible).toBe(true);
   });
 
-  it("should toggle graph view", () => {
+  it("should toggle graph view", async () => {
     const { result } = renderHookWithState(() => useViewToggles());
 
-    act(() => result.current.toggleGraphVisibility());
+    await act(async () => result.current.toggleGraphVisibility());
 
     expect(result.current.isGraphVisible).toBe(false);
     expect(result.current.isTableVisible).toBe(true);
 
-    act(() => result.current.toggleGraphVisibility());
+    await act(async () => result.current.toggleGraphVisibility());
 
     expect(result.current.isGraphVisible).toBe(true);
     expect(result.current.isTableVisible).toBe(true);
   });
 
-  it("should toggle table view", () => {
+  it("should toggle table view", async () => {
     const { result } = renderHookWithState(() => useViewToggles());
 
-    act(() => result.current.toggleTableVisibility());
+    await act(async () => result.current.toggleTableVisibility());
 
     expect(result.current.isGraphVisible).toBe(true);
     expect(result.current.isTableVisible).toBe(false);
 
-    act(() => result.current.toggleTableVisibility());
+    await act(async () => result.current.toggleTableVisibility());
 
     expect(result.current.isGraphVisible).toBe(true);
     expect(result.current.isTableVisible).toBe(true);
@@ -61,19 +61,19 @@ describe("useSidebar", () => {
     expect(result.current.isSidebarOpen).toBe(true);
   });
 
-  it("should change to the given sidebar item", () => {
+  it("should change to the given sidebar item", async () => {
     const { result } = renderHookWithJotai(() => useSidebar());
 
-    act(() => result.current.toggleSidebar("details"));
+    await act(async () => result.current.toggleSidebar("details"));
     expect(result.current.isSidebarOpen).toBe(true);
     expect(result.current.activeSidebarItem).toBe("details");
 
-    act(() => result.current.toggleSidebar("search"));
+    await act(async () => result.current.toggleSidebar("search"));
     expect(result.current.isSidebarOpen).toBe(true);
     expect(result.current.activeSidebarItem).toBe("search");
   });
 
-  it("should close the sidebar if toggling to the same item", () => {
+  it("should close the sidebar if toggling to the same item", async () => {
     const { result } = renderHookWithJotai(
       () => useSidebar(),
       store =>
@@ -83,16 +83,16 @@ describe("useSidebar", () => {
         } satisfies UserLayout),
     );
 
-    act(() => result.current.toggleSidebar("details"));
+    await act(async () => result.current.toggleSidebar("details"));
 
     expect(result.current.isSidebarOpen).toBe(false);
     expect(result.current.activeSidebarItem).toBeNull();
   });
 
-  it("should close the sidebar", () => {
+  it("should close the sidebar", async () => {
     const { result } = renderHookWithJotai(() => useSidebar());
 
-    act(() => result.current.closeSidebar());
+    await act(async () => result.current.closeSidebar());
 
     expect(result.current.isSidebarOpen).toBe(false);
   });
@@ -145,25 +145,25 @@ describe("useTableViewSize", () => {
     expect(result.current[0]).toBe(300);
   });
 
-  it("should return 100% when graph viewer is hidden", () => {
+  it("should return 100% when graph viewer is hidden", async () => {
     const { result } = renderHookWithState(() => ({
       tableView: useTableViewSize(),
       toggles: useViewToggles(),
     }));
 
-    act(() => result.current.toggles.toggleGraphVisibility());
+    await act(async () => result.current.toggles.toggleGraphVisibility());
 
     expect(result.current.tableView[0]).toBe("100%");
   });
 
-  it("should adjust height by delta", () => {
+  it("should adjust height by delta", async () => {
     const { result } = renderHookWithState(() => useTableViewSize());
 
-    act(() => result.current[1](50));
+    await act(async () => result.current[1](50));
 
     expect(result.current[0]).toBe(350);
 
-    act(() => result.current[1](-100));
+    await act(async () => result.current[1](-100));
 
     expect(result.current[0]).toBe(250);
   });

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -57,31 +57,33 @@ describe("useVertexStyling", () => {
     expect(result.current.vertexStyle).toStrictEqual(expected);
   });
 
-  it("should insert the vertex style when none exist", () => {
+  it("should insert the vertex style when none exist", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useVertexStyling(createVertexType("test")),
       dbState,
     );
 
-    act(() => result.current.setVertexStyle({ color: "red" }));
+    await act(async () => result.current.setVertexStyle({ color: "red" }));
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({ type: createVertexType("test"), color: "red" }),
     );
   });
 
-  it("should update the existing style, merging new styles", () => {
+  it("should update the existing style, merging new styles", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useVertexStyling(createVertexType("test")),
       dbState,
     );
 
-    act(() =>
+    await act(async () =>
       result.current.setVertexStyle({ color: "red", borderColor: "green" }),
     );
-    act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+    await act(async () =>
+      result.current.setVertexStyle({ borderColor: "blue" }),
+    );
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({
@@ -92,7 +94,7 @@ describe("useVertexStyling", () => {
     );
   });
 
-  it("should reset the vertex style", () => {
+  it("should reset the vertex style", async () => {
     const dbState = new DbState();
     dbState.addVertexStyle(createVertexType("test"), { borderColor: "blue" });
 
@@ -101,14 +103,14 @@ describe("useVertexStyling", () => {
       dbState,
     );
 
-    act(() => result.current.resetVertexStyle());
+    await act(async () => result.current.resetVertexStyle());
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({ type: createVertexType("test") }),
     );
   });
 
-  it("should not affect other vertex styles when updating", () => {
+  it("should not affect other vertex styles when updating", async () => {
     const dbState = new DbState();
     dbState.addVertexStyle(createVertexType("type1"), { color: "red" });
     dbState.addVertexStyle(createVertexType("type2"), { color: "blue" });
@@ -118,7 +120,9 @@ describe("useVertexStyling", () => {
       dbState,
     );
 
-    act(() => result.current.setVertexStyle({ borderColor: "green" }));
+    await act(async () =>
+      result.current.setVertexStyle({ borderColor: "green" }),
+    );
 
     // Check that type1 was updated
     expect(result.current.vertexStyle).toStrictEqual(
@@ -142,7 +146,7 @@ describe("useVertexStyling", () => {
     );
   });
 
-  it("should not affect other vertex styles when resetting", () => {
+  it("should not affect other vertex styles when resetting", async () => {
     const dbState = new DbState();
     dbState.addVertexStyle(createVertexType("type1"), { color: "red" });
     dbState.addVertexStyle(createVertexType("type2"), { color: "blue" });
@@ -152,7 +156,7 @@ describe("useVertexStyling", () => {
       dbState,
     );
 
-    act(() => result.current.resetVertexStyle());
+    await act(async () => result.current.resetVertexStyle());
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({ type: createVertexType("type1") }),
@@ -171,14 +175,14 @@ describe("useVertexStyling", () => {
     );
   });
 
-  it("should handle empty style updates", () => {
+  it("should handle empty style updates", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useVertexStyling(createVertexType("test")),
       dbState,
     );
 
-    act(() => result.current.setVertexStyle({}));
+    await act(async () => result.current.setVertexStyle({}));
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({ type: createVertexType("test") }),
@@ -212,14 +216,14 @@ describe("useEdgeStyling", () => {
     expect(result.current.edgeStyle).toStrictEqual(createExpectedEdge(style));
   });
 
-  it("should insert the edge style when none exist", () => {
+  it("should insert the edge style when none exist", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useEdgeStyling(createEdgeType("test")),
       dbState,
     );
 
-    act(() => result.current.setEdgeStyle({ lineColor: "red" }));
+    await act(async () => result.current.setEdgeStyle({ lineColor: "red" }));
 
     expect(result.current.edgeStyle).toStrictEqual(
       createExpectedEdge({
@@ -229,17 +233,17 @@ describe("useEdgeStyling", () => {
     );
   });
 
-  it("should update the existing style, merging new styles", () => {
+  it("should update the existing style, merging new styles", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useEdgeStyling(createEdgeType("test")),
       dbState,
     );
 
-    act(() =>
+    await act(async () =>
       result.current.setEdgeStyle({ lineColor: "red", labelColor: "green" }),
     );
-    act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
+    await act(async () => result.current.setEdgeStyle({ labelColor: "blue" }));
 
     expect(result.current.edgeStyle).toStrictEqual(
       createExpectedEdge({
@@ -250,22 +254,22 @@ describe("useEdgeStyling", () => {
     );
   });
 
-  it("should reset the edge style", () => {
+  it("should reset the edge style", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useEdgeStyling(createEdgeType("test")),
       dbState,
     );
 
-    act(() => result.current.setEdgeStyle({ labelColor: "blue" }));
-    act(() => result.current.resetEdgeStyle());
+    await act(async () => result.current.setEdgeStyle({ labelColor: "blue" }));
+    await act(async () => result.current.resetEdgeStyle());
 
     expect(result.current.edgeStyle).toStrictEqual(
       createExpectedEdge({ type: createEdgeType("test") }),
     );
   });
 
-  it("should not affect other edge styles when updating", () => {
+  it("should not affect other edge styles when updating", async () => {
     const dbState = new DbState();
     dbState.addEdgeStyle(createEdgeType("type1"), { lineColor: "red" });
     dbState.addEdgeStyle(createEdgeType("type2"), { lineColor: "blue" });
@@ -275,7 +279,7 @@ describe("useEdgeStyling", () => {
       dbState,
     );
 
-    act(() => result.current.setEdgeStyle({ labelColor: "green" }));
+    await act(async () => result.current.setEdgeStyle({ labelColor: "green" }));
 
     // Check that type1 was updated
     expect(result.current.edgeStyle).toStrictEqual(
@@ -299,7 +303,7 @@ describe("useEdgeStyling", () => {
     );
   });
 
-  it("should not affect other edge styles when resetting", () => {
+  it("should not affect other edge styles when resetting", async () => {
     const dbState = new DbState();
     dbState.addEdgeStyle(createEdgeType("type1"), { lineColor: "red" });
     dbState.addEdgeStyle(createEdgeType("type2"), { lineColor: "blue" });
@@ -309,7 +313,7 @@ describe("useEdgeStyling", () => {
       dbState,
     );
 
-    act(() => result.current.resetEdgeStyle());
+    await act(async () => result.current.resetEdgeStyle());
 
     expect(result.current.edgeStyle).toStrictEqual(
       createExpectedEdge({ type: createEdgeType("type1") }),
@@ -328,14 +332,14 @@ describe("useEdgeStyling", () => {
     );
   });
 
-  it("should handle empty style updates", () => {
+  it("should handle empty style updates", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useEdgeStyling(createEdgeType("test")),
       dbState,
     );
 
-    act(() => result.current.setEdgeStyle({}));
+    await act(async () => result.current.setEdgeStyle({}));
 
     expect(result.current.edgeStyle).toStrictEqual(
       createExpectedEdge({ type: createEdgeType("test") }),
@@ -344,7 +348,7 @@ describe("useEdgeStyling", () => {
 });
 
 describe("useDeferredAtom integration", () => {
-  it("should handle multiple rapid updates correctly", () => {
+  it("should handle multiple rapid updates correctly", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useVertexStyling(createVertexType("test")),
@@ -352,10 +356,10 @@ describe("useDeferredAtom integration", () => {
     );
 
     // Simulate rapid updates that might happen in real usage
-    act(() => {
-      result.current.setVertexStyle({ color: "red" });
-      result.current.setVertexStyle({ borderColor: "blue" });
-      result.current.setVertexStyle({ shape: "ellipse" });
+    await act(async () => {
+      await result.current.setVertexStyle({ color: "red" });
+      await result.current.setVertexStyle({ borderColor: "blue" });
+      await result.current.setVertexStyle({ shape: "ellipse" });
     });
 
     expect(result.current.vertexStyle).toStrictEqual(
@@ -368,7 +372,7 @@ describe("useDeferredAtom integration", () => {
     );
   });
 
-  it("should handle deferred atom updates correctly", () => {
+  it("should handle deferred atom updates correctly", async () => {
     const dbState = new DbState();
     const { result } = renderHookWithState(
       () => useVertexStyling(createVertexType("test")),
@@ -376,7 +380,7 @@ describe("useDeferredAtom integration", () => {
     );
 
     // Test that the deferred atom pattern works with the hook
-    act(() => result.current.setVertexStyle({ color: "red" }));
+    await act(async () => result.current.setVertexStyle({ color: "red" }));
 
     // The hook should immediately reflect the change in its local state
     expect(result.current.vertexStyle).toStrictEqual(
@@ -387,7 +391,9 @@ describe("useDeferredAtom integration", () => {
     );
 
     // Test that subsequent updates work correctly
-    act(() => result.current.setVertexStyle({ borderColor: "blue" }));
+    await act(async () =>
+      result.current.setVertexStyle({ borderColor: "blue" }),
+    );
 
     expect(result.current.vertexStyle).toStrictEqual(
       createExpectedVertex({

--- a/packages/graph-explorer/src/setupTests.ts
+++ b/packages/graph-explorer/src/setupTests.ts
@@ -2,9 +2,12 @@
  * Global test setup for all tests
  */
 
+import "fake-indexeddb/auto";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
+import { IDBFactory } from "fake-indexeddb";
 import { createStore } from "jotai";
+import localforage from "localforage";
 import { afterEach, expect, vi } from "vitest";
 
 expect.extend(matchers);
@@ -21,10 +24,23 @@ afterEach(() => {
   cleanup();
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   store = createStore();
   vi.stubEnv("DEV", true);
   vi.stubEnv("PROD", false);
+
+  // Give each test a fresh IndexedDB so persisted state never bleeds between
+  // tests. The vitest thread pool reuses workers, so the database must be
+  // swapped out rather than relying on process isolation.
+  //
+  // The reset has to happen in this exact order: localForage caches its open
+  // database handle keyed by name, so simply swapping `indexedDB` would leave
+  // that stale handle pointing at the previous test's data. `dropInstance()`
+  // deletes the database and clears the cached handle, the new `IDBFactory`
+  // gives a clean backing store, and `ready()` re-opens against it.
+  await localforage.dropInstance();
+  globalThis.indexedDB = new IDBFactory();
+  await localforage.ready();
 });
 
 // Mock sonner toast notifications to prevent requestAnimationFrame errors
@@ -87,48 +103,3 @@ vi.mock("@monaco-editor/react", () => ({
     config: vi.fn(),
   },
 }));
-
-// Stub out localforage using map
-vi.mock(import("localforage"), () => {
-  const localForageStore: Map<string, any> = new Map();
-  return {
-    default: {
-      config: vi.fn(),
-      async getItem(key: string) {
-        await Promise.resolve();
-        return localForageStore.has(key) ? localForageStore.get(key) : null;
-      },
-      async setItem(key: string, value: any) {
-        await Promise.resolve();
-        localForageStore.set(key, value);
-        return value;
-      },
-      async removeItem(key: string) {
-        await Promise.resolve();
-        localForageStore.delete(key);
-      },
-      async clear() {
-        await Promise.resolve();
-        localForageStore.clear();
-      },
-
-      // Other functions that we don't use
-      LOCALSTORAGE: "",
-      WEBSQL: "",
-      INDEXEDDB: "",
-      createInstance: vi.fn(),
-      driver: vi.fn(),
-      setDriver: vi.fn(),
-      defineDriver: vi.fn(),
-      getDriver: vi.fn(),
-      getSerializer: vi.fn(),
-      supports: vi.fn(),
-      ready: vi.fn(),
-      length: vi.fn(),
-      key: vi.fn(),
-      keys: vi.fn(),
-      iterate: vi.fn(),
-      dropInstance: vi.fn(),
-    } satisfies LocalForage,
-  };
-});

--- a/packages/graph-explorer/src/utils/testing/index.ts
+++ b/packages/graph-explorer/src/utils/testing/index.ts
@@ -5,6 +5,7 @@ export * from "./graphsonHelpers";
 export * from "./legacyExportedConnectionFile";
 export * from "./normalize";
 export * from "./ocHelpers";
+export * from "./persistence";
 export * from "./randomData";
 export * from "./randomSchemaResponse";
 export * from "./renderHookWithJotai";

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -1,0 +1,166 @@
+import { createRandomName } from "@shared/utils/testing";
+
+import type { VertexType } from "@/core/entities/vertex";
+import type {
+  UserStyling,
+  VertexPreferencesStorageModel,
+} from "@/core/StateProvider/userPreferences";
+
+import { openPersistenceTab, readPersistedValue } from "./persistence";
+import { createRandomVertexType } from "./randomData";
+
+describe("persistence test helpers", () => {
+  test("a tab reads back the value it persisted", async () => {
+    const key = createRandomName("key");
+    const tab = await openPersistenceTab(key, "initial");
+
+    await tab.write("updated");
+
+    expect(tab.read()).toBe("updated");
+  });
+
+  test("flush waits for the value to land in storage", async () => {
+    const key = createRandomName("key");
+    const tab = await openPersistenceTab(key, "initial");
+
+    tab.write("updated");
+    await tab.flush();
+
+    expect(await readPersistedValue(key)).toBe("updated");
+  });
+
+  test("flush waits for every write, not just the most recent", async () => {
+    const key = createRandomName("key");
+    const tab = await openPersistenceTab(key, "initial");
+
+    // Fire several writes without awaiting each, then flush once. flush() must
+    // wait for all of them; tracking only the latest would let earlier writes
+    // be unobserved.
+    tab.write("first");
+    tab.write("second");
+    tab.write("third");
+    await tab.flush();
+
+    expect(await readPersistedValue(key)).toBe("third");
+  });
+
+  test("a tab opened later preloads what an earlier tab persisted", async () => {
+    const key = createRandomName("key");
+    const firstTab = await openPersistenceTab(key, "initial");
+    await firstTab.write("from-first-tab");
+
+    const secondTab = await openPersistenceTab(key, "initial");
+
+    expect(secondTab.read()).toBe("from-first-tab");
+  });
+
+  test("two tabs over the same key share one storage backend", async () => {
+    const key = createRandomName("key");
+    const tabA = await openPersistenceTab(key, "initial");
+    const tabB = await openPersistenceTab(key, "initial");
+
+    await tabA.write("written-by-a");
+
+    // Tab B holds its own stale in-memory copy until it reloads, but the shared
+    // storage already reflects Tab A's write.
+    expect(tabB.read()).toBe("initial");
+    expect(await readPersistedValue(key)).toBe("written-by-a");
+  });
+
+  test("readPersistedValue returns null when nothing was persisted", async () => {
+    const key = createRandomName("key");
+
+    expect(await readPersistedValue(key)).toBeNull();
+  });
+});
+
+/**
+ * Guards the per-test IndexedDB reset in `setupTests.ts`. These two tests share
+ * a FIXED key on purpose: random keys would pass even if isolation were broken,
+ * because each test would read a key the previous one never wrote. The fixed
+ * key forces the second test to observe whether the first test's persisted
+ * write actually bled through.
+ */
+describe("per-test storage isolation", () => {
+  const sharedKey = "shared-isolation-key";
+
+  test("first test persists a value under the shared key", async () => {
+    const tab = await openPersistenceTab(sharedKey, "initial");
+    await tab.write("written-by-first-test");
+
+    expect(await readPersistedValue(sharedKey)).toBe("written-by-first-test");
+  });
+
+  test("second test does not see the first test's persisted value", async () => {
+    expect(await readPersistedValue(sharedKey)).toBeNull();
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab styling clobber
+ *
+ * Two tabs share one IndexedDB but each keeps its own in-memory copy of the
+ * user styling collection. `atomWithLocalForage` writes the whole collection
+ * back on every change, so a tab with a stale in-memory copy silently drops
+ * entries another tab added.
+ *
+ * Scenario from the issue: Tab A styles vertex type X and persists it. Tab B —
+ * opened before that write and never having seen X — styles type Y and persists
+ * its stale collection, clobbering X.
+ *
+ * Two assertions encode this:
+ *
+ * 1. A normal, currently-passing test that pins the CLOBBER as it behaves today
+ *    — type X is dropped, only type Y survives. This is the deterministic guard:
+ *    if the scenario ever stops reproducing (setup breaks, the bug changes
+ *    shape), this test fails loudly instead of silently passing.
+ * 2. A `test.fails` describing the DESIRED behaviour — both types survive. It
+ *    turns green when reconciliation (#1831) lands, signalling that the fix
+ *    works and this whole block should be collapsed into a single passing test.
+ *
+ * The fixture runs in `beforeAll`, OUTSIDE both tests. `test.fails` passes on
+ * any throw, so building the fixture inside it would let a setup failure keep
+ * the test green for the wrong reason. Keeping setup out means only the final
+ * assertion can satisfy (or break) the expectation.
+ *
+ * TODO #1820 / #1831: collapse into one passing test once reconciliation lands.
+ */
+describe("cross-tab user styling reconciliation", () => {
+  let persistedTypes: Set<string>;
+  let typeX: VertexType;
+  let typeY: VertexType;
+
+  beforeAll(async () => {
+    const key = createRandomName("user-styling");
+    typeX = createRandomVertexType();
+    typeY = createRandomVertexType();
+
+    const styleForType = (type: VertexType): VertexPreferencesStorageModel => ({
+      type,
+      color: "#ff0000",
+    });
+
+    // Both tabs open against empty styling.
+    const tabA = await openPersistenceTab<UserStyling>(key, {});
+    const tabB = await openPersistenceTab<UserStyling>(key, {});
+
+    // Tab A styles type X and persists.
+    await tabA.write({ vertices: [styleForType(typeX)] });
+
+    // Tab B, still holding its stale empty copy, styles type Y and persists.
+    await tabB.write(prev => ({
+      vertices: [...(prev.vertices ?? []), styleForType(typeY)],
+    }));
+
+    const persisted = await readPersistedValue<UserStyling>(key);
+    persistedTypes = new Set(persisted?.vertices?.map(vertex => vertex.type));
+  });
+
+  test("clobbers type X today — only the stale tab's type Y survives", () => {
+    expect(persistedTypes).toEqual(new Set([typeY]));
+  });
+
+  test.fails("should preserve styling from both tabs (fixed by #1831)", () => {
+    expect(persistedTypes).toEqual(new Set([typeX, typeY]));
+  });
+});

--- a/packages/graph-explorer/src/utils/testing/persistence.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.ts
@@ -1,0 +1,85 @@
+import { createStore } from "jotai";
+import localforage from "localforage";
+
+import type { AppStore } from "@/core";
+
+import { atomWithLocalForage } from "@/core/StateProvider/atomWithLocalForage";
+
+type SetStateAction<Value> = Value | ((prev: Value) => Value);
+
+/**
+ * Simulates a single browser tab persisting one localForage-backed value.
+ *
+ * Each tab has its own Jotai store and its own `atomWithLocalForage` instance,
+ * so its in-memory cache is independent of every other tab. All tabs created
+ * for the same key share the one fake-indexeddb database that `setupTests.ts`
+ * provisions per test, which is exactly how same-origin browser tabs relate:
+ * separate memory, shared IndexedDB.
+ *
+ * Use {@link openPersistenceTab} to create a tab; it preloads the persisted
+ * value just like the real app does at startup.
+ */
+export class PersistenceTab<T> {
+  #store: AppStore;
+  #atom: Awaited<ReturnType<typeof atomWithLocalForage<T>>>;
+  #pendingWrite: Promise<void> = Promise.resolve();
+
+  constructor(
+    store: AppStore,
+    atom: Awaited<ReturnType<typeof atomWithLocalForage<T>>>,
+  ) {
+    this.#store = store;
+    this.#atom = atom;
+  }
+
+  /** Reads this tab's in-memory value. */
+  read(): T {
+    return this.#store.get(this.#atom);
+  }
+
+  /**
+   * Writes a new value to this tab. The in-memory value updates synchronously;
+   * the returned promise resolves once this write has been persisted to storage.
+   */
+  write(update: SetStateAction<T>): Promise<void> {
+    // store.set updates the in-memory value synchronously and returns the
+    // background persistence promise for THIS write.
+    const persisted = this.#store.set(this.#atom, update);
+    // Accumulate every write so flush() waits for all of them, not just the
+    // latest. Replacing #pendingWrite here would drop earlier writes that have
+    // not yet landed, leaving flush() to await an incomplete set.
+    this.#pendingWrite = this.#pendingWrite.then(() => persisted);
+    return persisted;
+  }
+
+  /**
+   * Waits for all of this tab's background writes to land in storage, letting
+   * tests assert against persisted state without arbitrary timeouts.
+   */
+  flush(): Promise<void> {
+    return this.#pendingWrite;
+  }
+}
+
+/**
+ * Opens a new {@link PersistenceTab} for the given key, preloading whatever is
+ * currently persisted (or the initial value when storage is empty), mirroring
+ * how the app loads a localForage atom at startup.
+ */
+export async function openPersistenceTab<T>(
+  key: string,
+  initialValue: T,
+): Promise<PersistenceTab<T>> {
+  const store = createStore();
+  const atom = await atomWithLocalForage<T>(key, initialValue);
+  return new PersistenceTab(store, atom);
+}
+
+/**
+ * Reads what actually landed in persisted storage for the given key, bypassing
+ * any tab's in-memory cache. Use this to assert against the durable state
+ * rather than what a tab happens to hold in memory.
+ */
+export function readPersistedValue<T>(key: string): Promise<T | null> {
+  return localforage.getItem<T>(key);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,6 +504,9 @@ importers:
       core-js:
         specifier: ^3.49.0
         version: 3.49.0
+      fake-indexeddb:
+        specifier: ^6.2.5
+        version: 6.2.5
       happy-dom:
         specifier: ^20.10.5
         version: 20.10.5
@@ -3904,6 +3907,10 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
+
+  fake-indexeddb@6.2.5:
+    resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
+    engines: {node: '>=18'}
 
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
@@ -8908,6 +8915,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  fake-indexeddb@6.2.5: {}
 
   fast-copy@4.0.2: {}
 


### PR DESCRIPTION
## Description

The test suite stubbed localForage with an in-memory `Map`, so the real persistence path (serialization, the IndexedDB driver, read/write round-trips) was never exercised — which is why the #1820 cross-tab clobber shipped undetected.

This replaces the mock with the real localForage driver running against [`fake-indexeddb`](https://www.npmjs.com/package/fake-indexeddb) (Apache-2.0, zero runtime deps, dev-only), registered globally. The ~140 tests that seed state via `DbState` keep working unchanged; they just run on a realistic backend now.

**Suggested reading order:**

1. `setupTests.ts` — the core swap. The `Map` mock is gone; each test gets a fresh IndexedDB. The reset order is load-bearing: localForage caches its open DB handle by name, so `dropInstance()` must clear it before swapping `IDBFactory`, then `ready()` re-opens against the clean store. Without `dropInstance()` the stale handle leaks persisted state across tests.
2. `atomWithLocalForage.ts` — the only production change: the write now returns its background persistence promise so tests can await a value landing in storage. Production never awaits it (in-memory value still updates synchronously); behaviour is unchanged.
3. `utils/testing/persistence.ts` — new cross-tab test helpers: `openPersistenceTab` (a tab = its own Jotai store + atom instance over the shared IndexedDB), `PersistenceTab.read/write/flush`, and `readPersistedValue` (asserts durable state, bypassing in-memory caches).
4. `utils/testing/persistence.test.ts` — pins #1820: one test asserts the clobber as it behaves today (only the stale tab's type survives), and an expected-fail (`test.fails`) asserts the desired both-survive behaviour that #1831 will deliver. Also a fixed-key isolation guard for the per-test reset.

**Supporting changes:** `userPreferences.test.ts` / `userLayout.test.ts` swept to `async` / `await act(...)` (the returned promise makes React Testing Library's `act()` switch to async mode). Agent docs updated — testing SKILL no longer claims localForage is mocked and documents the new helpers; the IndexedDB ADR's now-false "tests mock localForage" consequence is corrected.

## Validation

- `pnpm checks` passes (lint, format, types).
- `pnpm test` for graph-explorer: 1570 passed, 1 expected-fail (the #1831 pin).
- Verified empirically that the per-test reset was leaking fixed-key state before the `dropInstance()` fix, and that the fix closes it — encoded as a regression guard.

## Related Issues

- Closes #1830
- Related to #1820
- Related to #1831

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.