### PR TITLE
Add tooltips and refine clickable schema type affordances

### DIFF
--- a/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
@@ -77,19 +77,7 @@ export default function SchemaGraph({ className, ...props }: SchemaGraphProps) {
 
   const handleSidebarSelectionChange = (item: SchemaGraphSelectionItem) => {
     setSelection(item);
-    setGraphSelection(
-      item.type === "vertex-type"
-        ? {
-            nodeIds: new Set([item.id]),
-            edgeIds: new Set(),
-            groupIds: new Set(),
-          }
-        : {
-            nodeIds: new Set(),
-            edgeIds: new Set([item.id]),
-            groupIds: new Set(),
-          },
-    );
+    setGraphSelection(toSelectedElements(item));
   };
 
   const hasSchemaData = nodes.length > 0;
@@ -128,6 +116,17 @@ export default function SchemaGraph({ className, ...props }: SchemaGraphProps) {
       />
     </div>
   );
+}
+
+/** Maps a single schema graph selection item to the graph view's selected elements. */
+export function toSelectedElements(
+  item: SchemaGraphSelectionItem,
+): SelectedElements {
+  return {
+    nodeIds: new Set(item.type === "vertex-type" ? [item.id] : []),
+    edgeIds: new Set(item.type === "edge-connection" ? [item.id] : []),
+    groupIds: new Set(),
+  };
 }
 
 /** Maps raw graph selection elements to a SchemaGraphSelection. */

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.test.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 // @vitest-environment happy-dom
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -5,6 +7,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import type * as Core from "@/core";
 
+import { TooltipProvider } from "@/components";
 import {
   createEdgeType,
   createVertexType,
@@ -13,6 +16,10 @@ import {
 } from "@/core";
 
 import { EdgeConnectionRow, PropertiesDetails } from "./Details";
+
+function renderWithTooltips(ui: ReactNode) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
 
 vi.mock("@/hooks", async () => {
   const actual = await vi.importActual("@/hooks");
@@ -110,21 +117,38 @@ describe("EdgeConnectionRow", () => {
     expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 
-  test("renders three buttons (source, edge, target) when onSelectionChange is provided", () => {
-    render(
+  test("renders the unselected vertex types as buttons", () => {
+    renderWithTooltips(
       <EdgeConnectionRow
         edgeConnection={createEdgeConnection()}
         onSelectionChange={() => {}}
       />,
     );
 
-    expect(screen.getAllByRole("button")).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "Person" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Company" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+  });
+
+  test("does not make the selected vertex type clickable", () => {
+    renderWithTooltips(
+      <EdgeConnectionRow
+        edgeConnection={createEdgeConnection()}
+        selectedVertexType={createVertexType("Person")}
+        onSelectionChange={() => {}}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Person" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Company" })).toBeInTheDocument();
   });
 
   test("calls onSelectionChange with the source vertex when source button is clicked", async () => {
     const user = userEvent.setup();
     const onSelectionChange = vi.fn();
-    render(
+    renderWithTooltips(
       <EdgeConnectionRow
         edgeConnection={createEdgeConnection()}
         onSelectionChange={onSelectionChange}
@@ -142,7 +166,7 @@ describe("EdgeConnectionRow", () => {
   test("calls onSelectionChange with the target vertex when target button is clicked", async () => {
     const user = userEvent.setup();
     const onSelectionChange = vi.fn();
-    render(
+    renderWithTooltips(
       <EdgeConnectionRow
         edgeConnection={createEdgeConnection()}
         onSelectionChange={onSelectionChange}
@@ -160,18 +184,48 @@ describe("EdgeConnectionRow", () => {
   test("calls onSelectionChange with the edge connection id when edge button is clicked", async () => {
     const user = userEvent.setup();
     const onSelectionChange = vi.fn();
-    render(
+    renderWithTooltips(
       <EdgeConnectionRow
         edgeConnection={createEdgeConnection()}
+        selectedVertexType={createVertexType("Person")}
         onSelectionChange={onSelectionChange}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /knows/ }));
+    await user.click(screen.getByRole("button", { name: "knows" }));
 
     expect(onSelectionChange).toHaveBeenCalledWith({
       type: "edge-connection",
       id: "Person-[knows]->Company",
     });
+  });
+
+  test("names the edge button by its label without the decorative arrows", () => {
+    renderWithTooltips(
+      <EdgeConnectionRow
+        edgeConnection={createEdgeConnection()}
+        selectedVertexType={createVertexType("Person")}
+        onSelectionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "knows" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /→/ })).not.toBeInTheDocument();
+  });
+
+  test("explains via tooltip that activating a type changes the selection", async () => {
+    const user = userEvent.setup();
+    renderWithTooltips(
+      <EdgeConnectionRow
+        edgeConnection={createEdgeConnection()}
+        onSelectionChange={() => {}}
+      />,
+    );
+
+    await user.tab();
+
+    expect(
+      await screen.findAllByText("Change selection to Person"),
+    ).not.toHaveLength(0);
   });
 });

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef } from "react";
+import type { ComponentPropsWithRef, CSSProperties, ReactNode } from "react";
 
 import { ListIcon } from "lucide-react";
 
@@ -10,6 +10,9 @@ import {
   EmptyStateIcon,
   EmptyStateTitle,
   toHumanString,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@/components";
 import {
   createEdgeConnectionId,
@@ -126,6 +129,14 @@ export function PropertiesDetails({
 }
 
 /**
+ * Decorative arrow between the parts of an edge connection. Hidden from assistive
+ * technology so the type buttons keep clean accessible names.
+ */
+function EdgeConnectionSeparator() {
+  return <span aria-hidden>{`${ASCII.NBSP}${ASCII.RARR} `}</span>;
+}
+
+/**
  * Renders an edge connection as "SourceType → EdgeType → TargetType" with the
  * selected vertex type highlighted.
  *
@@ -144,29 +155,9 @@ export function EdgeConnectionRow({
   edgeConnection: EdgeConnection;
   onSelectionChange?: (item: SchemaGraphSelectionItem) => void;
 }) {
-  const handleSourceClick = onSelectionChange
-    ? () =>
-        onSelectionChange({
-          type: "vertex-type",
-          id: edgeConnection.sourceVertexType,
-        })
-    : undefined;
-
-  const handleTargetClick = onSelectionChange
-    ? () =>
-        onSelectionChange({
-          type: "vertex-type",
-          id: edgeConnection.targetVertexType,
-        })
-    : undefined;
-
-  const handleEdgeClick = onSelectionChange
-    ? () =>
-        onSelectionChange({
-          type: "edge-connection",
-          id: createEdgeConnectionId(edgeConnection),
-        })
-    : undefined;
+  function selectionHandlerFor(item: SchemaGraphSelectionItem) {
+    return onSelectionChange ? () => onSelectionChange(item) : undefined;
+  }
 
   return (
     <p
@@ -176,24 +167,88 @@ export function EdgeConnectionRow({
       <VertexTypeText
         vertexType={edgeConnection.sourceVertexType}
         selected={selectedVertexType === edgeConnection.sourceVertexType}
-        onClick={handleSourceClick}
+        onClick={selectionHandlerFor({
+          type: "vertex-type",
+          id: edgeConnection.sourceVertexType,
+        })}
       />
+      <EdgeConnectionSeparator />
       <EdgeTypeText
         edgeType={edgeConnection.edgeType}
         selected={selectedVertexType == null}
-        onClick={handleEdgeClick}
+        onClick={selectionHandlerFor({
+          type: "edge-connection",
+          id: createEdgeConnectionId(edgeConnection),
+        })}
       />
+      <EdgeConnectionSeparator />
       <VertexTypeText
         vertexType={edgeConnection.targetVertexType}
         selected={selectedVertexType === edgeConnection.targetVertexType}
-        onClick={handleTargetClick}
+        onClick={selectionHandlerFor({
+          type: "vertex-type",
+          id: edgeConnection.targetVertexType,
+        })}
       />
     </p>
   );
 }
 
-const interactiveTextStyles =
-  "cursor-pointer bg-transparent p-0 font-[inherit] hover:text-text-primary focus-visible:ring-ring focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none";
+/**
+ * Renders a type label. It becomes a tooltip-wrapped button when an `onClick` is
+ * provided and the type is not already selected; the currently selected type is
+ * never clickable and renders as a plain span. Decorative separators are rendered
+ * by the parent as `aria-hidden` siblings, so the button text is the accessible name.
+ *
+ * The `data-selected` styling lives only on the span branch: a button is rendered
+ * only when the type is not selected, so it never needs the selected variants.
+ */
+function ClickableTypeText({
+  label,
+  selected,
+  onClick,
+  className,
+  style,
+  children,
+}: {
+  label: string;
+  selected: boolean;
+  onClick?: () => void;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}) {
+  if (selected || !onClick) {
+    return (
+      <span
+        className={className}
+        data-selected={selected ? true : undefined}
+        style={style}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "hover:text-text-primary hover:bg-brand-300/25 focus-visible:ring-ring-3 cursor-pointer bg-transparent p-0 font-[inherit] focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+            className,
+          )}
+          style={style}
+          onClick={onClick}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Change selection to {label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 function EdgeTypeText({
   selected,
@@ -205,28 +260,16 @@ function EdgeTypeText({
   onClick?: () => void;
 }) {
   const { displayLabel } = useDisplayEdgeTypeConfig(edgeType);
-  const labelText = `${ASCII.NBSP}${ASCII.RARR} ${displayLabel}${ASCII.NBSP}${ASCII.RARR} `;
-  const baseClass =
-    "data-selected:text-text-primary italic data-selected:font-bold";
-  const dataSelected = selected ? true : undefined;
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className={cn(baseClass, interactiveTextStyles)}
-        data-selected={dataSelected}
-        onClick={onClick}
-      >
-        {labelText}
-      </button>
-    );
-  }
 
   return (
-    <span className={baseClass} data-selected={dataSelected}>
-      {labelText}
-    </span>
+    <ClickableTypeText
+      label={displayLabel}
+      selected={selected}
+      onClick={onClick}
+      className="data-selected:text-text-primary italic data-selected:font-bold"
+    >
+      {displayLabel}
+    </ClickableTypeText>
   );
 }
 
@@ -241,32 +284,16 @@ function VertexTypeText({
 }) {
   const style = useVertexPreferences(vertexType);
   const { displayLabel } = useDisplayVertexTypeConfig(vertexType);
-  const baseClass =
-    "data-selected:text-text-primary underline decoration-2 underline-offset-4 data-selected:font-bold";
-  const dataSelected = selected ? true : undefined;
-  const inlineStyle = { textDecorationColor: style.color };
-
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className={cn(baseClass, interactiveTextStyles)}
-        data-selected={dataSelected}
-        style={inlineStyle}
-        onClick={onClick}
-      >
-        {displayLabel}
-      </button>
-    );
-  }
 
   return (
-    <span
-      className={baseClass}
-      data-selected={dataSelected}
-      style={inlineStyle}
+    <ClickableTypeText
+      label={displayLabel}
+      selected={selected}
+      onClick={onClick}
+      className="data-selected:text-text-primary underline decoration-2 underline-offset-4 data-selected:font-bold"
+      style={{ textDecorationColor: style.color }}
     >
       {displayLabel}
-    </span>
+    </ClickableTypeText>
   );
 }

--- a/packages/graph-explorer/src/modules/SchemaGraph/toSchemaGraphSelection.test.ts
+++ b/packages/graph-explorer/src/modules/SchemaGraph/toSchemaGraphSelection.test.ts
@@ -1,7 +1,7 @@
 import { createEdgeType, createVertexType } from "@/core";
 import { createEdgeConnectionId } from "@/core/StateProvider/edgeConnectionId";
 
-import { toSchemaGraphSelection } from "./SchemaGraph";
+import { toSchemaGraphSelection, toSelectedElements } from "./SchemaGraph";
 
 function createSelectedElements(
   nodeIds: string[] = [],
@@ -72,5 +72,28 @@ describe("toSchemaGraphSelection", () => {
         { type: "edge-connection", id: edgeId },
       ],
     });
+  });
+});
+
+describe("toSelectedElements", () => {
+  test("maps a vertex-type item to a single selected node", () => {
+    const result = toSelectedElements({
+      type: "vertex-type",
+      id: createVertexType("Person"),
+    });
+
+    expect(result).toStrictEqual(createSelectedElements(["Person"]));
+  });
+
+  test("maps an edge-connection item to a single selected edge", () => {
+    const edgeId = createEdgeConnectionId({
+      sourceVertexType: createVertexType("Person"),
+      edgeType: createEdgeType("knows"),
+      targetVertexType: createVertexType("Company"),
+    });
+
+    const result = toSelectedElements({ type: "edge-connection", id: edgeId });
+
+    expect(result).toStrictEqual(createSelectedElements([], [edgeId]));
   });
 });


### PR DESCRIPTION
## Description

Follow-up polish on the clickable node/edge types in the Schema Explorer details panel (shipped in #1731). Makes the click affordance discoverable and explains what it does:

- **Tooltip on hover or keyboard focus** — each clickable type shows "Change selection to {label}" so users know activating it re-selects that type (and highlights it in the graph).
- **Clearer at-rest affordance** — clickable types get a hover background tint and color shift; the focus ring now matches the rest of the codebase (`ring-ring-3` / `outline-hidden`).
- **The currently-selected type is intentionally not clickable** — it renders as a plain label with no tooltip, since re-selecting it would be a no-op.
- **Accessibility** — the decorative `→` arrow separators are now `aria-hidden` siblings, so each type button's accessible name is just its label (e.g. "knows", not "→ knows →").

Supporting refactor (no behavior change): extracted a shared `ClickableTypeText` primitive to remove the duplicated button-vs-span branches, and a `toSelectedElements` helper alongside the existing `toSchemaGraphSelection` so both selection-mapping directions live together.

## How to read

1. [Details.tsx](https://github.com/aws/graph-explorer/pull/1860/files#diff-2209aea05ba1c2f1e92357f3effc4b1e87493906aee3f25b7352f3ceec863885) — start here; the `ClickableTypeText` primitive, tooltip, hover/focus styling, selected-type span, and `aria-hidden` separators
2. [SchemaGraph.tsx](https://github.com/aws/graph-explorer/pull/1860/files#diff-6571c855e584947af6c560c186a63f0464f5deb4375bd85aabd12d57fc252304) — the extracted `toSelectedElements` helper next to `toSchemaGraphSelection`
3. [Details.test.tsx](https://github.com/aws/graph-explorer/pull/1860/files#diff-eb0e0e2c3c66993d2185b447618f04bc88bff60286ff65e28efb2a1d84cbd1df) — behavior coverage for the clickable/selected/tooltip/accessible-name cases
4. [toSchemaGraphSelection.test.ts](https://github.com/aws/graph-explorer/pull/1860/files#diff-6e8e9933b8abf9134115162d5542eb56b8c640a2c52a2bc0ebd2577982d46416) — mapping tests for `toSelectedElements`

## Validation

- `node_modules/.bin/vitest run packages/graph-explorer/src/modules/SchemaGraph` — 22 tests pass, including new coverage for the selected-type-not-clickable behavior, the clean accessible name, the focus tooltip, and the `toSelectedElements` mapping.
- `tsc --noEmit`, `oxlint`, and `oxfmt --check` clean on the changed files.

## Related Issues

- Related to #1731
- Related to #1542

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
