### PR TITLE
Refresh Docker base image package snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_VERSION=24.16.0
 
 # Install Node.js and openssl, then remove everything not needed at runtime
 # (package managers, python3, build tools) to minimize potential issues.
-RUN yum update -y --releasever 2023.12.20260608 && \
+RUN yum update -y --releasever 2023.12.20260622 && \
     yum install -y tar xz openssl && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then NODE_ARCH="x64"; \


### PR DESCRIPTION
## Description

Routine maintenance: refresh the Amazon Linux 2023 package snapshot used to build the Docker image so the base layer picks up current upstream package releases. Bumps the pinned `yum` releasever in the `Dockerfile` from `2023.12.20260608` to `2023.12.20260622`. No application code changes.

## Validation

- `pnpm checks` passes (lint, format, types).
- `pnpm test` passes with no failures.
- Rebuilt the image from the updated `Dockerfile` and confirmed the proxy server's SSL cert generation (`setup-ssl.sh`) runs and the HTTPS server starts as expected.

## Related Issues

- N/A

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
