### PR TITLE
Cross-tab reconciliation for user styling and schema (WIP)

### DIFF
--- a/.kiro/skills/testing/SKILL.md
+++ b/.kiro/skills/testing/SKILL.md
@@ -501,10 +501,10 @@ test("should handle errors gracefully", async () => {
 
 Because localForage runs against a real (fake-indexeddb) backend, tests can exercise the actual persistence path. `@/utils/testing` provides helpers for this, especially for cross-tab scenarios (two same-origin tabs share one IndexedDB but each holds its own in-memory cache — see the per-key diff-merge reconciliation ADR):
 
-- `openPersistenceTab(key, initialValue)` — simulates one browser tab: its own Jotai store and its own `atomWithLocalForage` instance, sharing the per-test IndexedDB. Open two tabs on the same key to express "Tab A persisted X; Tab B holds stale memory" situations.
+- `openPersistenceTab(key, initialValue, reconcile?)` — simulates one browser tab: its own Jotai store and its own `atomWithLocalForage` instance, sharing the per-test IndexedDB. Open two tabs on the same key to express "Tab A persisted X; Tab B holds stale memory" situations. Pass the `reconcile` the real atom is wired with (e.g. `reconcileUserStyling`) to exercise cross-tab reconciliation; omit it to model a plain whole-value-overwrite atom.
 - `tab.read()` — the tab's in-memory value.
-- `tab.write(value)` — writes through the tab; returns a promise that resolves once the value has landed in storage (`atomWithLocalForage`'s write returns its background persistence promise, which is what makes this awaitable).
-- `tab.flush()` — awaits the tab's most recent background write, so assertions don't need arbitrary timeouts.
+- `tab.write(value)` — writes through the tab; the in-memory value updates synchronously and persistence happens in the background through the shared write queue (the write returns `void`). Await `tab.flush()` to wait for it to land.
+- `tab.flush()` — resolves once the tab's outstanding background writes have settled (via `persistenceStatusStore.waitForIdle()`), so assertions don't need arbitrary timeouts.
 - `readPersistedValue(key)` — reads what actually landed in storage, bypassing any tab's in-memory cache. Use this to assert against durable state.
 
 ```typescript
@@ -512,7 +512,8 @@ import { openPersistenceTab, readPersistedValue } from "@/utils/testing";
 
 test("a later tab preloads what an earlier tab persisted", async () => {
   const tabA = await openPersistenceTab("user-styling", {});
-  await tabA.write({ vertices: [{ type: "Person", color: "#ff0000" }] });
+  tabA.write({ vertices: [{ type: "Person", color: "#ff0000" }] });
+  await tabA.flush();
 
   const tabB = await openPersistenceTab("user-styling", {});
   expect(tabB.read()).toEqual({

--- a/docs/adr/20260616-per-key-diff-merge-cross-tab-reconciliation.md
+++ b/docs/adr/20260616-per-key-diff-merge-cross-tab-reconciliation.md
@@ -19,7 +19,7 @@ Scalar atoms (e.g. active connection) are unaffected — each write is a complet
 Reconcile at the **storage layer**, inside the `atomWithLocalForage` write path, using a **per-key, diff-the-output merge**. On each persist:
 
 1. **Re-read** the current persisted value from IndexedDB (it may reflect writes by other tabs since this tab loaded).
-2. **Diff this tab's output** — compare the value this tab is about to write against this tab's _previous in-memory value_ to determine exactly which keys this tab changed.
+2. **Diff this tab's output** — compare the value this tab is about to write against _the value this tab last persisted_ (the merge baseline) to determine exactly which keys this tab changed. The baseline advances only once a write lands, so it may predate several in-memory changes when rapid writes coalesce.
 3. **Apply only those changed keys** onto the freshly-read value, and persist the result.
 
 The unit of reconciliation is the **key** (collection entry — e.g. one **Vertex Type**'s styling, one **Connection**, one **Schema** entry), so a tab editing entry Y never overwrites entry X that another tab added. The diff is computed from the _resulting_ values, not by replaying the updater function.
@@ -41,7 +41,7 @@ This decision fixes **durability** of concurrent writes to _different_ entries. 
 ## Consequences
 
 - The write path becomes **read-modify-write against live IndexedDB** rather than a blind whole-value overwrite, adding one re-read per persist. Acceptable for the mutation frequencies involved (User Preferences is the highest, still human-interaction-paced).
-- The merge needs each tab's **previous in-memory value** to compute its diff — `atomWithLocalForage` already holds this in its base atom, so no new state is introduced.
+- The merge needs each tab's **last-persisted value** as the diff baseline — the reconciling factory holds this in a closure variable that advances only after a write lands, so no new shared state is introduced.
 - Reconciliation is **per key**, so the persisted collections must be key-addressable (objects/maps keyed by entry id or type, or arrays reducible to such). Collections shaped as opaque blobs would not benefit.
 - **Same-entry conflicts and stale reads persist by design** — anyone surprised by either should read this ADR's scope boundary before "fixing" it, and the live-sync follow-up is the intended home for the freshness work.
 - This is the **inverse** of the per-tab active-connection decision (#1788): those scalars want each tab to _diverge_; these collections are genuinely shared and must _reconcile_. The two ship separately and must not be conflated.

--- a/docs/adr/20260619-storage-layer-owns-persistence-failure.md
+++ b/docs/adr/20260619-storage-layer-owns-persistence-failure.md
@@ -22,7 +22,7 @@ The **storage layer owns the write, so it owns the failure.** Concretely:
 
 ### Internal seams (deep ≠ monolithic)
 
-The depth is hidden behind composition, not crammed into one file: `classifyStorageError` (pure taxonomy) · per-key write queue (coalesce + retry, knows only a `flush` thunk) · the merge-flush (the re-read-diff-write from the cross-tab ADR) · the global status store (write-only from the queue's side). `atomWithLocalForage` composes them.
+The depth is hidden behind composition, not crammed into one file: `classifyStorageError` (pure taxonomy) · per-key write queue (coalesce + retry, knows only a `flush` thunk) · the merge-flush (the re-read-diff-write from the cross-tab ADR, realized as `atomWithReconciledLocalForage`) · the global status store (write-only from the queue's side). `atomWithLocalForage` composes the queue, taxonomy, and status store for a blind whole-value write; `atomWithReconciledLocalForage` is the variant that additionally composes the merge-flush, opted into per atom.
 
 ## Considered Options
 

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
@@ -225,4 +225,28 @@ describe("reconcileMapByKey", () => {
     expect(merged.get("sibling")).toBe("concurrent");
     expect(merged.get("own")).toBe("after");
   });
+
+  test("does not detect an entry mutated in place — write sites must replace entries, not mutate them", () => {
+    // The reference-equality diff only works because every production write
+    // site replaces a whole entry (`new Map(prev).set(id, freshEntry)`) rather
+    // than mutating one in place. This pins that contract: if a tab mutates the
+    // SAME entry object (so `previous` and `next` hold one shared reference),
+    // `Object.is` sees no change, the mutation is NOT upserted, and a concurrent
+    // value another tab wrote for that key survives instead.
+    const sharedEntry = { value: "original" };
+    const previous = new Map([["key", sharedEntry]]);
+
+    // Mutate in place and reuse the same reference as `next`.
+    sharedEntry.value = "mutated-in-place";
+    const next = new Map([["key", sharedEntry]]);
+
+    const concurrentEntry = { value: "from-another-tab" };
+    const persisted = new Map([["key", concurrentEntry]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    // The in-place mutation is invisible to the diff, so the concurrent value
+    // wins — demonstrating why write sites must construct fresh entries.
+    expect(merged.get("key")).toBe(concurrentEntry);
+  });
 });

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
@@ -2,7 +2,7 @@ import { createStore } from "jotai";
 import localforage from "localforage";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import { atomWithLocalForage } from "./atomWithLocalForage";
+import { atomWithLocalForage, reconcileMapByKey } from "./atomWithLocalForage";
 import { persistenceStatusStore } from "./persistence";
 
 describe("atomWithLocalForage", () => {
@@ -165,5 +165,64 @@ describe("atomWithLocalForage", () => {
     );
     store.set(objAtom, { b: 2 });
     expect(store.get(objAtom)).toEqual({ b: 2 });
+  });
+});
+
+describe("reconcileMapByKey", () => {
+  test("preserves a sibling key another tab added", () => {
+    // This tab loaded empty and added its own key.
+    const previous = new Map<string, string>();
+    const next = new Map([["own", "mine"]]);
+    // Another tab persisted a sibling key in the meantime.
+    const persisted = new Map([["sibling", "theirs"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect([...merged]).toStrictEqual([
+      ["sibling", "theirs"],
+      ["own", "mine"],
+    ]);
+  });
+
+  test("applies this tab's update over the persisted entry for the same key", () => {
+    const previous = new Map([["shared", "before"]]);
+    const next = new Map([["shared", "after"]]);
+    const persisted = new Map([["shared", "concurrent"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect([...merged]).toStrictEqual([["shared", "after"]]);
+  });
+
+  test("drops a key this tab removed while keeping a sibling", () => {
+    const previous = new Map([["removed", "gone"]]);
+    const next = new Map<string, string>();
+    const persisted = new Map([
+      ["removed", "gone"],
+      ["sibling", "theirs"],
+    ]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect([...merged]).toStrictEqual([["sibling", "theirs"]]);
+  });
+
+  test("leaves a key this tab never touched at the value another tab wrote", () => {
+    // This tab only ever edited "own"; "sibling" stayed identical between its
+    // previous and next, so another tab's concurrent change to it must win.
+    const previous = new Map([
+      ["own", "before"],
+      ["sibling", "stale"],
+    ]);
+    const next = new Map([
+      ["own", "after"],
+      ["sibling", "stale"],
+    ]);
+    const persisted = new Map([["sibling", "concurrent"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.get("sibling")).toBe("concurrent");
+    expect(merged.get("own")).toBe("after");
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -49,3 +49,69 @@ export async function atomWithLocalForage<T>(key: string, initialValue: T) {
     `atomWithLocalForage(${key})`,
   );
 }
+
+/**
+ * Merges this tab's change onto the value currently in storage before writing,
+ * so a tab with a stale in-memory copy cannot clobber entries another tab
+ * persisted concurrently (issue #1820).
+ *
+ * The merge diffs resulting values — `next` is this tab's value after its
+ * change, `previous` is the value this tab last persisted (the diff baseline) —
+ * never by replaying the updater, so it stays safe for non-idempotent updaters.
+ * See the per-key diff-merge reconciliation ADR.
+ */
+export type ReconcileWrite<T> = (args: {
+  persisted: T;
+  previous: T;
+  next: T;
+}) => T;
+
+/**
+ * Like {@link atomWithLocalForage}, but reconciles each persist against the
+ * value currently in storage instead of overwriting it blindly.
+ *
+ * The reconciliation lives entirely inside the flush thunk handed to the shared
+ * write queue: on each persist it re-reads the live stored value, merges this
+ * tab's change onto it via `reconcile`, then writes the result. Because the
+ * queue serializes and coalesces writes per key, concurrent persists never
+ * interleave and rapid writes collapse to the latest value.
+ *
+ * The merge baseline (`previous`) is the value this tab last persisted; it
+ * advances only once a write lands, so coalesced intermediate writes never
+ * shift it. This keeps the seam narrow — only atoms backing genuinely shared
+ * collections opt in, and the plain {@link atomWithLocalForage} stays a blind
+ * whole-value write.
+ *
+ * @param key The key to use for the stored value in localForage
+ * @param initialValue The initial value if none is found in storage
+ * @param reconcile Merges this tab's change onto the freshly-read stored value
+ * @returns An atom that reconciles then persists to localForage
+ */
+export async function atomWithReconciledLocalForage<T>(
+  key: string,
+  initialValue: T,
+  reconcile: ReconcileWrite<T>,
+) {
+  const storage = createLocalForageStorage<T>(key, initialValue);
+  const preloadValue = await storage.getItem();
+
+  // The last value this tab persisted; the baseline the reconcile diff is
+  // computed against. Advances only after a write lands.
+  let lastPersistedValue: T = preloadValue;
+
+  return createWriteThroughAtom<T>(
+    preloadValue,
+    nextValue =>
+      persistThroughQueue(key, async () => {
+        const persisted = await storage.getItem();
+        const merged = reconcile({
+          persisted,
+          previous: lastPersistedValue,
+          next: nextValue,
+        });
+        await storage.setItem(merged);
+        lastPersistedValue = nextValue;
+      }),
+    `atomWithReconciledLocalForage(${key})`,
+  );
+}

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -51,14 +51,9 @@ export async function atomWithLocalForage<T>(key: string, initialValue: T) {
 }
 
 /**
- * Merges this tab's change onto the value currently in storage before writing,
- * so a tab with a stale in-memory copy cannot clobber entries another tab
- * persisted concurrently (issue #1820).
- *
- * The merge diffs resulting values — `next` is this tab's value after its
- * change, `previous` is the value this tab last persisted (the diff baseline) —
- * never by replaying the updater, so it stays safe for non-idempotent updaters.
- * See the per-key diff-merge reconciliation ADR.
+ * Merges this tab's change (`next`, against its last-persisted `previous`
+ * baseline) onto the freshly-read stored value (`persisted`). See
+ * {@link atomWithReconciledLocalForage} for how and why this is applied.
  */
 export type ReconcileWrite<T> = (args: {
   persisted: T;

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -62,6 +62,47 @@ export type ReconcileWrite<T> = (args: {
 }) => T;
 
 /**
+ * The reconciler for any atom whose stored value is a `Map` keyed by the merge
+ * unit — one entry per connection, per id, etc. Applies this tab's net per-key
+ * changes onto the freshly-read map: keys this tab added or changed are
+ * upserted, keys it removed are dropped, and every other key another tab wrote
+ * is left untouched.
+ *
+ * Whether a key changed is decided by reference (`Object.is`), since these
+ * atoms replace a whole entry on every write (e.g. `new Map(prev).set(id, …)`)
+ * rather than mutating it in place — so an unchanged entry keeps its identity
+ * and a changed one is a fresh object. No deep compare is needed, unlike the
+ * per-`type` styling merge whose array entries are rebuilt structurally.
+ */
+export function reconcileMapByKey<K, V>({
+  persisted,
+  previous,
+  next,
+}: {
+  persisted: Map<K, V>;
+  previous: Map<K, V>;
+  next: Map<K, V>;
+}): Map<K, V> {
+  const merged = new Map(persisted);
+
+  // Upsert keys this tab added or changed.
+  for (const [key, value] of next) {
+    if (!Object.is(previous.get(key), value)) {
+      merged.set(key, value);
+    }
+  }
+
+  // Drop keys this tab removed.
+  for (const key of previous.keys()) {
+    if (!next.has(key)) {
+      merged.delete(key);
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Like {@link atomWithLocalForage}, but reconciles each persist against the
  * value currently in storage instead of overwriting it blindly.
  *

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -7,8 +7,12 @@ import type { SchemaStorageModel } from "./schema";
 import type { UserStyling } from "./userPreferences";
 
 import { createActiveConfigurationAtom } from "./activeConnectionStorage";
-import { atomWithLocalForage } from "./atomWithLocalForage";
+import {
+  atomWithLocalForage,
+  atomWithReconciledLocalForage,
+} from "./atomWithLocalForage";
 import { defaultUserLayout } from "./userLayoutDefaults";
+import { reconcileUserStyling } from "./userPreferences";
 
 /**
  DEV NOTE
@@ -66,7 +70,11 @@ const [
   ),
   /** All the stored schemas */
   atomWithLocalForage("schema", new Map<string, SchemaStorageModel>()),
-  atomWithLocalForage<UserStyling>("user-styling", {}),
+  atomWithReconciledLocalForage<UserStyling>(
+    "user-styling",
+    {},
+    reconcileUserStyling,
+  ),
   atomWithLocalForage("user-layout", defaultUserLayout),
   /** Stores the graph session data for each connection. */
   atomWithLocalForage<Map<ConfigurationId, GraphSessionStorageModel>>(

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -65,9 +65,10 @@ const [
   diagnosticLoggingAtom,
 ] = await Promise.all([
   createActiveConfigurationAtom(),
-  atomWithLocalForage<Map<ConfigurationId, RawConfiguration>>(
+  atomWithReconciledLocalForage<Map<ConfigurationId, RawConfiguration>>(
     "configuration",
     new Map(),
+    reconcileMapByKey,
   ),
   /** All the stored schemas */
   atomWithReconciledLocalForage(
@@ -82,9 +83,10 @@ const [
   ),
   atomWithLocalForage("user-layout", defaultUserLayout),
   /** Stores the graph session data for each connection. */
-  atomWithLocalForage<Map<ConfigurationId, GraphSessionStorageModel>>(
+  atomWithReconciledLocalForage<Map<ConfigurationId, GraphSessionStorageModel>>(
     "graph-sessions",
     new Map(),
+    reconcileMapByKey,
   ),
   /*
    * General App Settings

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -10,6 +10,7 @@ import { createActiveConfigurationAtom } from "./activeConnectionStorage";
 import {
   atomWithLocalForage,
   atomWithReconciledLocalForage,
+  reconcileMapByKey,
 } from "./atomWithLocalForage";
 import { defaultUserLayout } from "./userLayoutDefaults";
 import { reconcileUserStyling } from "./userPreferences";
@@ -69,7 +70,11 @@ const [
     new Map(),
   ),
   /** All the stored schemas */
-  atomWithLocalForage("schema", new Map<string, SchemaStorageModel>()),
+  atomWithReconciledLocalForage(
+    "schema",
+    new Map<string, SchemaStorageModel>(),
+    reconcileMapByKey,
+  ),
   atomWithReconciledLocalForage<UserStyling>(
     "user-styling",
     {},

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -10,8 +10,10 @@ import {
   defaultVertexPreferences,
   edgePreferencesAtom,
   type EdgePreferencesStorageModel,
+  reconcileUserStyling,
   useEdgeStyling,
   useVertexStyling,
+  type UserStyling,
   vertexPreferencesAtom,
   type VertexPreferencesStorageModel,
 } from "./userPreferences";
@@ -458,5 +460,88 @@ describe("edgePreferencesAtom", () => {
     expect(result.current.get(edgeType)).toStrictEqual(
       createExpectedEdge({ type: edgeType }),
     );
+  });
+});
+
+describe("reconcileUserStyling", () => {
+  it("preserves a sibling vertex entry another tab added", () => {
+    const ownType = createVertexType("own");
+    const siblingType = createVertexType("sibling");
+
+    // This tab loaded with empty styling and added its own type.
+    const previous: UserStyling = {};
+    const next: UserStyling = { vertices: [{ type: ownType, color: "red" }] };
+
+    // Meanwhile another tab persisted a sibling type.
+    const persisted: UserStyling = {
+      vertices: [{ type: siblingType, color: "blue" }],
+    };
+
+    const merged = reconcileUserStyling({ persisted, previous, next });
+
+    expect(merged.vertices).toStrictEqual([
+      { type: siblingType, color: "blue" },
+      { type: ownType, color: "red" },
+    ]);
+  });
+
+  it("applies this tab's update over the persisted entry for the same type", () => {
+    const sharedType = createVertexType("shared");
+
+    const previous: UserStyling = {
+      vertices: [{ type: sharedType, color: "red" }],
+    };
+    const next: UserStyling = {
+      vertices: [{ type: sharedType, color: "green" }],
+    };
+    const persisted: UserStyling = {
+      vertices: [{ type: sharedType, color: "blue" }],
+    };
+
+    const merged = reconcileUserStyling({ persisted, previous, next });
+
+    expect(merged.vertices).toStrictEqual([
+      { type: sharedType, color: "green" },
+    ]);
+  });
+
+  it("drops a type this tab removed while keeping a sibling", () => {
+    const removedType = createVertexType("removed");
+    const siblingType = createVertexType("sibling");
+
+    const previous: UserStyling = {
+      vertices: [{ type: removedType, color: "red" }],
+    };
+    const next: UserStyling = {};
+    const persisted: UserStyling = {
+      vertices: [
+        { type: removedType, color: "red" },
+        { type: siblingType, color: "blue" },
+      ],
+    };
+
+    const merged = reconcileUserStyling({ persisted, previous, next });
+
+    expect(merged.vertices).toStrictEqual([
+      { type: siblingType, color: "blue" },
+    ]);
+  });
+
+  it("merges edge entries independently of vertices", () => {
+    const ownEdge = createEdgeType("own");
+    const siblingEdge = createEdgeType("sibling");
+
+    const previous: UserStyling = {};
+    const next: UserStyling = { edges: [{ type: ownEdge, lineColor: "red" }] };
+    const persisted: UserStyling = {
+      edges: [{ type: siblingEdge, lineColor: "blue" }],
+    };
+
+    const merged = reconcileUserStyling({ persisted, previous, next });
+
+    expect(merged.edges).toStrictEqual([
+      { type: siblingEdge, lineColor: "blue" },
+      { type: ownEdge, lineColor: "red" },
+    ]);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -554,4 +554,28 @@ describe("reconcileUserStyling", () => {
 
     expect(merged).toStrictEqual({});
   });
+
+  it("keeps a collection this tab did not touch, by reference and without copying", () => {
+    // The styling setters preserve the untouched array's reference, so editing
+    // only vertices leaves `edges` reference-equal between previous and next.
+    const untouchedEdges: UserStyling["edges"] = [];
+    const previous: UserStyling = {
+      vertices: [{ type: createVertexType("a"), color: "red" }],
+      edges: untouchedEdges,
+    };
+    const next: UserStyling = {
+      vertices: [{ type: createVertexType("a"), color: "green" }],
+      edges: untouchedEdges,
+    };
+    // Another tab persisted an edge style in the meantime.
+    const persistedEdges = [
+      { type: createEdgeType("other"), lineColor: "blue" },
+    ];
+    const persisted: UserStyling = { vertices: [], edges: persistedEdges };
+
+    const merged = reconcileUserStyling({ persisted, previous, next });
+
+    // The stored edges win untouched and are returned as-is, not re-copied.
+    expect(merged.edges).toBe(persistedEdges);
+  });
 });

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.test.ts
@@ -544,4 +544,14 @@ describe("reconcileUserStyling", () => {
       { type: ownEdge, lineColor: "red" },
     ]);
   });
+
+  it("omits empty collections rather than storing undefined keys", () => {
+    const merged = reconcileUserStyling({
+      persisted: {},
+      previous: {},
+      next: {},
+    });
+
+    expect(merged).toStrictEqual({});
+  });
 });

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -2,6 +2,7 @@ import type { Simplify } from "type-fest";
 
 import { atom, useAtomValue, useSetAtom } from "jotai";
 import { atomFamily } from "jotai-family";
+import { isEqual } from "lodash";
 import { useDeferredValue } from "react";
 
 import { RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
@@ -157,6 +158,76 @@ export type UserStyling = {
   vertices?: Array<VertexPreferencesStorageModel>;
   edges?: Array<EdgePreferencesStorageModel>;
 };
+
+/**
+ * Merges this tab's changes onto the freshly-read persisted styling, keyed by
+ * the per-`type` entry, so a tab editing one type never clobbers a sibling type
+ * another tab persisted concurrently (issue #1820).
+ *
+ * The diff is computed from resulting values — `next` is this tab's styling
+ * after its change, `previous` is the styling this tab last persisted (the diff
+ * baseline) — never by replaying the updater, so it stays correct for
+ * non-idempotent updaters.
+ *
+ * @param persisted The styling currently in storage (may include other tabs' writes)
+ * @param previous The styling this tab last persisted; the diff baseline, which
+ *   may predate several in-memory changes when rapid writes coalesce
+ * @param next This tab's styling after its change
+ */
+export function reconcileUserStyling({
+  persisted,
+  previous,
+  next,
+}: {
+  persisted: UserStyling;
+  previous: UserStyling;
+  next: UserStyling;
+}): UserStyling {
+  return {
+    vertices: mergeStylingEntriesByType(
+      persisted.vertices,
+      previous.vertices,
+      next.vertices,
+    ),
+    edges: mergeStylingEntriesByType(
+      persisted.edges,
+      previous.edges,
+      next.edges,
+    ),
+  };
+}
+
+/**
+ * Applies this tab's net per-`type` changes onto the persisted entries: types
+ * this tab added or modified are upserted, types it removed are dropped, and
+ * every other type in storage is left untouched.
+ */
+function mergeStylingEntriesByType<T extends { type: string }>(
+  persisted: Array<T> = [],
+  previous: Array<T> = [],
+  next: Array<T> = [],
+): Array<T> | undefined {
+  const previousByType = new Map(previous.map(entry => [entry.type, entry]));
+  const nextByType = new Map(next.map(entry => [entry.type, entry]));
+
+  const merged = new Map(persisted.map(entry => [entry.type, entry]));
+
+  // Upsert types this tab added or changed.
+  for (const [type, entry] of nextByType) {
+    if (!isEqual(previousByType.get(type), entry)) {
+      merged.set(type, entry);
+    }
+  }
+
+  // Drop types this tab removed.
+  for (const type of previousByType.keys()) {
+    if (!nextByType.has(type)) {
+      merged.delete(type);
+    }
+  }
+
+  return merged.size > 0 ? [...merged.values()] : undefined;
+}
 
 /** Vertex preferences indexed by type for O(1) lookup with default fallback. */
 export const vertexPreferencesAtom = atom(get => {

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -183,17 +183,22 @@ export function reconcileUserStyling({
   previous: UserStyling;
   next: UserStyling;
 }): UserStyling {
+  const vertices = mergeStylingEntriesByType(
+    persisted.vertices,
+    previous.vertices,
+    next.vertices,
+  );
+  const edges = mergeStylingEntriesByType(
+    persisted.edges,
+    previous.edges,
+    next.edges,
+  );
+
+  // Omit empty collections so the reconciled value keeps the same shape as the
+  // `{}` the atom seeds with, rather than persisting explicit `undefined` keys.
   return {
-    vertices: mergeStylingEntriesByType(
-      persisted.vertices,
-      previous.vertices,
-      next.vertices,
-    ),
-    edges: mergeStylingEntriesByType(
-      persisted.edges,
-      previous.edges,
-      next.edges,
-    ),
+    ...(vertices && { vertices }),
+    ...(edges && { edges }),
   };
 }
 

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -212,6 +212,14 @@ function mergeStylingEntriesByType<T extends { type: string }>(
   previous: Array<T> = [],
   next: Array<T> = [],
 ): Array<T> | undefined {
+  // This tab did not touch this collection — the styling setters preserve the
+  // untouched array's reference, and that reference survives coalesced writes.
+  // The stored value wins as-is, so there is nothing to diff and nothing to
+  // copy.
+  if (previous === next) {
+    return persisted.length > 0 ? persisted : undefined;
+  }
+
   const previousByType = new Map(previous.map(entry => [entry.type, entry]));
   const nextByType = new Map(next.map(entry => [entry.type, entry]));
 

--- a/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
+++ b/packages/graph-explorer/src/core/StateProvider/userPreferences.ts
@@ -212,10 +212,15 @@ function mergeStylingEntriesByType<T extends { type: string }>(
   previous: Array<T> = [],
   next: Array<T> = [],
 ): Array<T> | undefined {
-  // This tab did not touch this collection — the styling setters preserve the
-  // untouched array's reference, and that reference survives coalesced writes.
-  // The stored value wins as-is, so there is nothing to diff and nothing to
-  // copy.
+  // Fast-path a collection this tab never touched: when the caller passes the
+  // SAME array reference for `previous` and `next`, there is nothing to diff
+  // and nothing to copy, so the stored value wins as-is. The styling setters
+  // guarantee this for the untouched collection — `{ ...prev, vertices: next }`
+  // keeps `prev.edges` by reference — and that reference survives coalesced
+  // writes. This keys on reference identity, not emptiness: two empty-but-
+  // distinct arrays (e.g. both defaulted from `undefined`) are not `===` and
+  // correctly fall through to the diff path below, which also returns the
+  // stored value unchanged.
   if (previous === next) {
     return persisted.length > 0 ? persisted : undefined;
   }

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -1,6 +1,9 @@
 import { createRandomName } from "@shared/utils/testing";
 
+import type { RawConfiguration } from "@/core/ConfigurationProvider";
+import type { ConfigurationId } from "@/core/ConfigurationProvider";
 import type { VertexType } from "@/core/entities/vertex";
+import type { GraphSessionStorageModel } from "@/core/StateProvider/graphSession/storage";
 import type { SchemaStorageModel } from "@/core/StateProvider/schema";
 import type {
   UserStyling,
@@ -11,7 +14,13 @@ import { reconcileMapByKey } from "@/core/StateProvider/atomWithLocalForage";
 import { reconcileUserStyling } from "@/core/StateProvider/userPreferences";
 
 import { openPersistenceTab, readPersistedValue } from "./persistence";
-import { createRandomSchema, createRandomVertexType } from "./randomData";
+import {
+  createRandomEdgeId,
+  createRandomRawConfiguration,
+  createRandomSchema,
+  createRandomVertexId,
+  createRandomVertexType,
+} from "./randomData";
 
 describe("persistence test helpers", () => {
   test("a tab reads back the value it persisted", async () => {
@@ -254,5 +263,97 @@ describe("cross-tab schema reconciliation", () => {
 
     expect(persisted?.get(connectionA)).toEqual(schemaA);
     expect(persisted?.get(connectionB)).toEqual(schemaB);
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab connection clobber
+ *
+ * The configuration atom stores `Map<ConfigurationId, RawConfiguration>` — one
+ * entry per connection. Creating a connection in one tab while another tab
+ * holds a stale copy would, on a blind whole-map write, silently drop the
+ * connection the other tab created. The same per-key map merge protects it.
+ */
+describe("cross-tab connection reconciliation", () => {
+  test("preserves connections created concurrently by two tabs", async () => {
+    const key = createRandomName("configuration");
+    const connectionX = createRandomRawConfiguration();
+    const connectionY = createRandomRawConfiguration();
+
+    type ConfigMap = Map<ConfigurationId, RawConfiguration>;
+
+    const tabA = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A creates connection X and persists.
+    tabA.write(prev => new Map(prev).set(connectionX.id, connectionX));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, creates connection Y.
+    tabB.write(prev => new Map(prev).set(connectionY.id, connectionY));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<ConfigMap>(key);
+
+    expect(persisted?.get(connectionX.id)).toEqual(connectionX);
+    expect(persisted?.get(connectionY.id)).toEqual(connectionY);
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab session clobber
+ *
+ * The graph-sessions atom stores `Map<ConfigurationId, GraphSessionStorageModel>`
+ * — one session per connection. Concurrent session changes for different
+ * connections must not clobber each other; the per-key map merge keeps each
+ * connection's session intact.
+ */
+describe("cross-tab session reconciliation", () => {
+  test("preserves sessions written concurrently for different connections", async () => {
+    const key = createRandomName("graph-sessions");
+    const connectionA = createRandomName("connection") as ConfigurationId;
+    const connectionB = createRandomName("connection") as ConfigurationId;
+    const sessionA: GraphSessionStorageModel = {
+      vertices: new Set([createRandomVertexId()]),
+      edges: new Set([createRandomEdgeId()]),
+    };
+    const sessionB: GraphSessionStorageModel = {
+      vertices: new Set([createRandomVertexId()]),
+      edges: new Set([createRandomEdgeId()]),
+    };
+
+    type SessionMap = Map<ConfigurationId, GraphSessionStorageModel>;
+
+    const tabA = await openPersistenceTab<SessionMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<SessionMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A records connection A's session and persists.
+    tabA.write(prev => new Map(prev).set(connectionA, sessionA));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, records connection B's session.
+    tabB.write(prev => new Map(prev).set(connectionB, sessionB));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<SessionMap>(key);
+
+    expect(persisted?.get(connectionA)).toEqual(sessionA);
+    expect(persisted?.get(connectionB)).toEqual(sessionB);
   });
 });

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -154,4 +154,53 @@ describe("cross-tab user styling reconciliation", () => {
 
     expect(persistedTypes).toEqual(new Set([typeX, typeY]));
   });
+
+  test("coalesces rapid writes while still merging onto a concurrent sibling", async () => {
+    const key = createRandomName("user-styling");
+    const siblingType = createRandomVertexType();
+    const typeX = createRandomVertexType();
+    const typeY = createRandomVertexType();
+    const typeZ = createRandomVertexType();
+
+    const styleForType = (type: VertexType): VertexPreferencesStorageModel => ({
+      type,
+      color: "#ff0000",
+    });
+
+    // A sibling tab persists its type first, so it is already in storage when
+    // this tab — which opened stale against empty styling — writes.
+    const siblingTab = await openPersistenceTab<UserStyling>(
+      key,
+      {},
+      reconcileUserStyling,
+    );
+    const editingTab = await openPersistenceTab<UserStyling>(
+      key,
+      {},
+      reconcileUserStyling,
+    );
+
+    siblingTab.write({ vertices: [styleForType(siblingType)] });
+    await siblingTab.flush();
+
+    // Three rapid writes without awaiting between them. The write queue
+    // coalesces the pending flushes to the latest, dropping the intermediate
+    // one, so the diff baseline must still advance only on a landed write for
+    // the net per-type result to be correct.
+    editingTab.write({ vertices: [styleForType(typeX)] });
+    editingTab.write(prev => ({
+      vertices: [...(prev.vertices ?? []), styleForType(typeY)],
+    }));
+    editingTab.write(prev => ({
+      vertices: [...(prev.vertices ?? []), styleForType(typeZ)],
+    }));
+    await editingTab.flush();
+
+    const persisted = await readPersistedValue<UserStyling>(key);
+    const persistedTypes = new Set(
+      persisted?.vertices?.map(vertex => vertex.type),
+    );
+
+    expect(persistedTypes).toEqual(new Set([siblingType, typeX, typeY, typeZ]));
+  });
 });

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -6,6 +6,8 @@ import type {
   VertexPreferencesStorageModel,
 } from "@/core/StateProvider/userPreferences";
 
+import { reconcileUserStyling } from "@/core/StateProvider/userPreferences";
+
 import { openPersistenceTab, readPersistedValue } from "./persistence";
 import { createRandomVertexType } from "./randomData";
 
@@ -99,52 +101,41 @@ describe("per-test storage isolation", () => {
 });
 
 /**
- * REGRESSION — #1820 cross-tab styling clobber
+ * REGRESSION — #1820 cross-tab styling clobber, fixed by #1831
  *
  * Two tabs share one IndexedDB but each keeps its own in-memory copy of the
- * user styling collection. `atomWithLocalForage` writes the whole collection
- * back on every change, so a tab with a stale in-memory copy silently drops
- * entries another tab added.
+ * user styling collection. Without reconciliation, the whole collection is
+ * written back on every change, so a tab with a stale in-memory copy silently
+ * drops entries another tab added.
  *
  * Scenario from the issue: Tab A styles vertex type X and persists it. Tab B —
  * opened before that write and never having seen X — styles type Y and persists
- * its stale collection, clobbering X.
- *
- * Two assertions encode this:
- *
- * 1. A normal, currently-passing test that pins the CLOBBER as it behaves today
- *    — type X is dropped, only type Y survives. This is the deterministic guard:
- *    if the scenario ever stops reproducing (setup breaks, the bug changes
- *    shape), this test fails loudly instead of silently passing.
- * 2. A `test.fails` describing the DESIRED behaviour — both types survive. It
- *    turns green when reconciliation (#1831) lands, signalling that the fix
- *    works and this whole block should be collapsed into a single passing test.
- *
- * The fixture runs in `beforeAll`, OUTSIDE both tests. `test.fails` passes on
- * any throw, so building the fixture inside it would let a setup failure keep
- * the test green for the wrong reason. Keeping setup out means only the final
- * assertion can satisfy (or break) the expectation.
- *
- * TODO #1820 / #1831: collapse into one passing test once reconciliation lands.
+ * its stale collection. With per-type diff-merge reconciliation wired into the
+ * user styling atom, both types survive instead of X being clobbered.
  */
 describe("cross-tab user styling reconciliation", () => {
-  let persistedTypes: Set<string>;
-  let typeX: VertexType;
-  let typeY: VertexType;
-
-  beforeAll(async () => {
+  test("preserves styling written concurrently by two tabs", async () => {
     const key = createRandomName("user-styling");
-    typeX = createRandomVertexType();
-    typeY = createRandomVertexType();
+    const typeX = createRandomVertexType();
+    const typeY = createRandomVertexType();
 
     const styleForType = (type: VertexType): VertexPreferencesStorageModel => ({
       type,
       color: "#ff0000",
     });
 
-    // Both tabs open against empty styling.
-    const tabA = await openPersistenceTab<UserStyling>(key, {});
-    const tabB = await openPersistenceTab<UserStyling>(key, {});
+    // Both tabs open against empty styling, using the same reconciler the real
+    // user styling atom is wired with.
+    const tabA = await openPersistenceTab<UserStyling>(
+      key,
+      {},
+      reconcileUserStyling,
+    );
+    const tabB = await openPersistenceTab<UserStyling>(
+      key,
+      {},
+      reconcileUserStyling,
+    );
 
     // Tab A styles type X and persists.
     tabA.write({ vertices: [styleForType(typeX)] });
@@ -154,17 +145,13 @@ describe("cross-tab user styling reconciliation", () => {
     tabB.write(prev => ({
       vertices: [...(prev.vertices ?? []), styleForType(typeY)],
     }));
-
     await tabB.flush();
+
     const persisted = await readPersistedValue<UserStyling>(key);
-    persistedTypes = new Set(persisted?.vertices?.map(vertex => vertex.type));
-  });
+    const persistedTypes = new Set(
+      persisted?.vertices?.map(vertex => vertex.type),
+    );
 
-  test("clobbers type X today — only the stale tab's type Y survives", () => {
-    expect(persistedTypes).toEqual(new Set([typeY]));
-  });
-
-  test.fails("should preserve styling from both tabs (fixed by #1831)", () => {
     expect(persistedTypes).toEqual(new Set([typeX, typeY]));
   });
 });

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -1,15 +1,17 @@
 import { createRandomName } from "@shared/utils/testing";
 
 import type { VertexType } from "@/core/entities/vertex";
+import type { SchemaStorageModel } from "@/core/StateProvider/schema";
 import type {
   UserStyling,
   VertexPreferencesStorageModel,
 } from "@/core/StateProvider/userPreferences";
 
+import { reconcileMapByKey } from "@/core/StateProvider/atomWithLocalForage";
 import { reconcileUserStyling } from "@/core/StateProvider/userPreferences";
 
 import { openPersistenceTab, readPersistedValue } from "./persistence";
-import { createRandomVertexType } from "./randomData";
+import { createRandomSchema, createRandomVertexType } from "./randomData";
 
 describe("persistence test helpers", () => {
   test("a tab reads back the value it persisted", async () => {
@@ -202,5 +204,55 @@ describe("cross-tab user styling reconciliation", () => {
     );
 
     expect(persistedTypes).toEqual(new Set([siblingType, typeX, typeY, typeZ]));
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab schema clobber
+ *
+ * The schema atom stores `Map<ConfigurationId, SchemaStorageModel>` — one entry
+ * per connection. Two tabs each hold their own in-memory copy of that map, so a
+ * tab that syncs one connection's schema would, on a blind whole-map write,
+ * silently drop a schema another tab discovered for a different connection.
+ *
+ * Because the merge unit is the native map key (a whole connection's schema),
+ * the same `atomWithReconciledLocalForage` seam fixes this with the generic
+ * `reconcileMapByKey` reconciler — no per-collection diffing like styling needs.
+ */
+describe("cross-tab schema reconciliation", () => {
+  test("preserves schemas discovered concurrently by two tabs", async () => {
+    const key = createRandomName("schema");
+    const connectionA = createRandomName("connection");
+    const connectionB = createRandomName("connection");
+    const schemaA = createRandomSchema();
+    const schemaB = createRandomSchema();
+
+    type SchemaMap = Map<string, SchemaStorageModel>;
+
+    // Both tabs open against an empty schema map.
+    const tabA = await openPersistenceTab<SchemaMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<SchemaMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A discovers connection A's schema and persists.
+    tabA.write(prev => new Map(prev).set(connectionA, schemaA));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, discovers connection B and
+    // persists its stale map.
+    tabB.write(prev => new Map(prev).set(connectionB, schemaB));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<SchemaMap>(key);
+
+    expect(persisted?.get(connectionA)).toEqual(schemaA);
+    expect(persisted?.get(connectionB)).toEqual(schemaB);
   });
 });

--- a/packages/graph-explorer/src/utils/testing/persistence.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.ts
@@ -2,8 +2,12 @@ import { createStore } from "jotai";
 import localforage from "localforage";
 
 import type { AppStore } from "@/core";
+import type { ReconcileWrite } from "@/core/StateProvider/atomWithLocalForage";
 
-import { atomWithLocalForage } from "@/core/StateProvider/atomWithLocalForage";
+import {
+  atomWithLocalForage,
+  atomWithReconciledLocalForage,
+} from "@/core/StateProvider/atomWithLocalForage";
 import { persistenceStatusStore } from "@/core/StateProvider/persistence";
 
 type SetStateAction<Value> = Value | ((prev: Value) => Value);
@@ -58,13 +62,19 @@ export class PersistenceTab<T> {
  * Opens a new {@link PersistenceTab} for the given key, preloading whatever is
  * currently persisted (or the initial value when storage is empty), mirroring
  * how the app loads a localForage atom at startup.
+ *
+ * Pass the same `reconcile` the real atom is wired with to exercise cross-tab
+ * reconciliation; omit it to model a plain whole-value-overwrite atom.
  */
 export async function openPersistenceTab<T>(
   key: string,
   initialValue: T,
+  reconcile?: ReconcileWrite<T>,
 ): Promise<PersistenceTab<T>> {
   const store = createStore();
-  const atom = await atomWithLocalForage<T>(key, initialValue);
+  const atom = reconcile
+    ? await atomWithReconciledLocalForage<T>(key, initialValue, reconcile)
+    : await atomWithLocalForage<T>(key, initialValue);
   return new PersistenceTab(store, atom);
 }
 


### PR DESCRIPTION
> **🚧 Work in progress — for early feedback, not final review.** The implementation approach is still in flux and **likely to change** — I'm especially looking for a gut-check on the reconciliation design. Don't review for polish yet.

## What this is

Cross-tab diff-merge reconciliation for all four shared IndexedDB-backed collections — **User Preferences** (#1831) plus **Schema, Connections, and Sessions** (#1832), under parent #1820.

Two same-origin tabs share one IndexedDB but each holds its own in-memory copy of a collection. A blind whole-value write lets a tab with a stale copy silently drop entries another tab added. This reconciles at the `flush` seam: re-read live storage → merge this tab's per-key change → write.

## The design question 👀

There are **two reconcilers**, and the difference is driven entirely by the stored *shape*:

- **`reconcileMapByKey`** (schema, connections, sessions) — the stored value is already a `Map` keyed by the merge unit (a connection id), replaced wholesale per write. So it's a ~5-line per-key map merge keyed on **reference equality** — no deep compare, one collection. All three Map-shaped atoms share it.
- **`reconcileUserStyling`** (styling) — styling is stored as **arrays** of `{ type, … }` across **two** collections (`vertices`, `edges`), so it projects each array into a map, diffs with `lodash` `isEqual`, and spreads back.

The styling machinery only exists because of that array-of-objects shape. **Open question for the team:** is the styling complexity worth it, or should `UserStyling` move to a `Map`-shaped store so it reconciles as cheaply as the rest (at the cost of a persisted-shape migration + backward-compat handling)?

## Seam

All four atoms use one new factory, `atomWithReconciledLocalForage`, which puts the merge inside the `flush` thunk handed to the write queue. The plain `atomWithLocalForage` stays a blind whole-value write — atoms opt in per the per-key diff-merge reconciliation ADR. Scalar settings (user-layout, flags) stay plain.

**Accepted scope boundary:** cross-*entry* edits are protected (two tabs editing different connections/types both survive). Two tabs editing the *same* entry remain last-writer-wins — that's nested below the per-connection merge granularity and documented in the ADR.

## How to read
1. [atomWithLocalForage.ts](https://github.com/aws/graph-explorer/pull/1862/files#diff-91cfdf9fecb4c3a6a253a8515fcf2ff526baf0221b43a7c08fb5808ed0d943fe) — start here: the `atomWithReconciledLocalForage` seam + the generic `reconcileMapByKey`
2. [userPreferences.ts](https://github.com/aws/graph-explorer/pull/1862/files#diff-33d187c2920841f962bcf3cb1c06f79d48674699c7f9c6fb70b125761c9acab3) — the more complex `reconcileUserStyling`
3. [storageAtoms.ts](https://github.com/aws/graph-explorer/pull/1862/files#diff-2e6c435d81a94fe56fa689cd77b26189f05c931ae3c10ec77bc8a3900c1c1442) — which atoms opt in (styling, schema, configuration, graph-sessions)
4. [persistence.test.ts](https://github.com/aws/graph-explorer/pull/1862/files#diff-51157de97df3a9da81e5a22e834c77f6e6abc0153530005b4d3bd60a4404c6e8) — cross-tab regression tests for every reconciled collection, synchronized on `waitForIdle()`

## Status
All checks and the full suite (1882 tests) pass. The #1820 styling-clobber regression marker is flipped green.

- Part of #1820
- Closes #1831
- Closes #1832
