### PR TITLE
Reconcile all Map-keyed storage atoms across tabs

### DIFF
--- a/docs/adr/20260616-per-key-diff-merge-cross-tab-reconciliation.md
+++ b/docs/adr/20260616-per-key-diff-merge-cross-tab-reconciliation.md
@@ -16,13 +16,29 @@ Scalar atoms (e.g. active connection) are unaffected — each write is a complet
 
 ## Decision
 
-Reconcile at the **storage layer**, inside the `atomWithLocalForage` write path, using a **per-key, diff-the-output merge**. On each persist:
+Reconcile at the **storage layer**, using a **per-key, diff-the-output merge** applied inside the write path. On each persist:
 
 1. **Re-read** the current persisted value from IndexedDB (it may reflect writes by other tabs since this tab loaded).
 2. **Diff this tab's output** — compare the value this tab is about to write against this tab's _previous in-memory value_ to determine exactly which keys this tab changed.
 3. **Apply only those changed keys** onto the freshly-read value, and persist the result.
 
 The unit of reconciliation is the **key** (collection entry — e.g. one **Vertex Type**'s styling, one **Connection**, one **Schema** entry), so a tab editing entry Y never overwrites entry X that another tab added. The diff is computed from the _resulting_ values, not by replaying the updater function.
+
+### Opt-in seam, not a transparent rewrite
+
+Reconciliation is an **optional `reconcile` parameter on `atomWithLocalForage`**, not separate machinery. An atom opts in by being created with a reconciler function; without one the atom does a blind whole-value write (the parameter selects the flush at creation — a plain `storage.setItem`, or the re-read-merge-write built by `createReconcilingFlush`). This is deliberately **opt-in rather than required** because reconciliation is correct for only a minority of atoms:
+
+- **Map-keyed shared collections reconcile.** The five `Map`-keyed atoms — **Connections** (`configuration`), **Schema**, **User Preferences** (`user-vertex-styles`, `user-edge-styles`, since #1867 split styling into type-keyed maps), and **Sessions** (`graph-sessions`) — all pass the one generic reconciler, `reconcileMapByKey`.
+- **Scalars must not.** Layout and the boolean/number settings have no sibling entries to preserve — each write is the whole intended value — so a per-key merge is meaningless for them.
+- **`activeConfiguration` must not.** It deliberately _diverges_ per tab (the #1788 inverse); reconciling it would reintroduce the very behaviour that decision avoids.
+
+There is also no universal default reconciler: a reconciler must know the value is key-addressable (`reconcileMapByKey` only works on `Map`s). Making reconciliation _required_ would force every scalar atom to pass a nonsensical reconciler, so "required" would in practice still be "choose a reconciler" with worse ergonomics. The cost of opt-in is that a **new** `Map`-keyed shared collection added with plain `atomWithLocalForage` would silently clobber across tabs until someone notices — mitigated by the rule below rather than by flipping the default.
+
+**Rule for new atoms:** a new `Map`-keyed collection shared across tabs must pass `reconcileMapByKey` as `atomWithLocalForage`'s `reconcile` argument. Reach for a bespoke reconciler only for a shape `reconcileMapByKey` cannot serve (e.g. a non-`Map` collection); diff the _resulting_ values, never replay the updater.
+
+### Reference-equality merge
+
+`reconcileMapByKey` decides whether a key changed by **reference** (`Object.is`), not a deep compare: it upserts keys whose value differs by reference from this tab's previous value, drops keys this tab removed, and leaves every other key untouched. This is sound because every write site replaces a whole entry (`new Map(prev).set(id, …)`) rather than mutating one in place, so an unchanged entry keeps its identity and a changed one is a fresh object. The corollary is a contract on callers: **mutating a Map entry in place would be invisible to the merge** and must not be done.
 
 ### Scope boundary — durability only
 
@@ -33,15 +49,15 @@ This decision fixes **durability** of concurrent writes to _different_ entries. 
 
 ## Considered Options
 
-- **Per-key diff-merge re-read at write (chosen).** Smallest change that fixes the clobber for sibling entries; lives entirely in the storage layer so all 32 call sites are fixed without touching them. Does not fix stale reads.
+- **Per-key diff-merge re-read at write (chosen).** Smallest change that fixes the clobber for sibling entries; lives entirely in the storage layer behind `atomWithLocalForage`'s `reconcile` parameter, so the many write sites of an opted-in collection are all fixed without touching them. Does not fix stale reads.
 - **Replay-the-updater on the re-read value.** Re-run the `prev => next` updater against the freshly-read persisted value instead of diffing outputs. **Rejected: unsafe for non-idempotent updaters** — an updater like "append X" or "increment" applied to an already-updated base double-applies. Diffing the _output_ is update-function-agnostic and safe.
 - **Cross-tab live sync (BroadcastChannel / `storage` events).** Keeps in-memory copies live and would also fix stale reads. **Deferred:** larger surface, and freshness is out of scope here. Can be layered on later without contradicting this decision.
 - **Web Locks to serialize writes.** Heaviest option, with **availability caveats** across our deploy targets (not guaranteed in all embedding contexts, e.g. some notebook/proxy environments). Rejected for this fix.
 
 ## Consequences
 
-- The write path becomes **read-modify-write against live IndexedDB** rather than a blind whole-value overwrite, adding one re-read per persist. Acceptable for the mutation frequencies involved (User Preferences is the highest, still human-interaction-paced).
-- The merge needs each tab's **previous in-memory value** to compute its diff — `atomWithLocalForage` already holds this in its base atom, so no new state is introduced.
+- The write path of a reconciling atom becomes **read-modify-write against live IndexedDB** rather than a blind whole-value overwrite, adding one re-read per persist. Acceptable for the mutation frequencies involved (User Preferences is the highest, still human-interaction-paced). Non-reconciling atoms keep the blind write and pay nothing.
+- The merge needs each tab's **previous in-memory value** (the last value it persisted) to compute its diff — `createReconcilingFlush` holds this in a closure that advances only once a write lands, so coalesced intermediate writes never shift the baseline.
 - Reconciliation is **per key**, so the persisted collections must be key-addressable (objects/maps keyed by entry id or type, or arrays reducible to such). Collections shaped as opaque blobs would not benefit.
 - **Same-entry conflicts and stale reads persist by design** — anyone surprised by either should read this ADR's scope boundary before "fixing" it, and the live-sync follow-up is the intended home for the freshness work.
 - This is the **inverse** of the per-tab active-connection decision (#1788): those scalars want each tab to _diverge_; these collections are genuinely shared and must _reconcile_. The two ship separately and must not be conflated.

--- a/docs/adr/20260619-storage-layer-owns-persistence-failure.md
+++ b/docs/adr/20260619-storage-layer-owns-persistence-failure.md
@@ -22,7 +22,7 @@ The **storage layer owns the write, so it owns the failure.** Concretely:
 
 ### Internal seams (deep ≠ monolithic)
 
-The depth is hidden behind composition, not crammed into one file: `classifyStorageError` (pure taxonomy) · per-key write queue (coalesce + retry, knows only a `flush` thunk) · the merge-flush (the re-read-diff-write from the cross-tab ADR) · the global status store (write-only from the queue's side). `atomWithLocalForage` composes them.
+The depth is hidden behind composition, not crammed into one file: `classifyStorageError` (pure taxonomy) · per-key write queue (coalesce + retry, knows only a `flush` thunk) · the merge-flush (the re-read-diff-write from the cross-tab ADR, built by `createReconcilingFlush`) · the global status store (write-only from the queue's side). `atomWithLocalForage` composes the queue, taxonomy, and status store; by default its flush is a blind whole-value write, and when given a `reconcile` function it instead composes the merge-flush — opted into per atom.
 
 ## Considered Options
 

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.test.ts
@@ -2,7 +2,7 @@ import { createStore } from "jotai";
 import localforage from "localforage";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import { atomWithLocalForage } from "./atomWithLocalForage";
+import { atomWithLocalForage, reconcileMapByKey } from "./atomWithLocalForage";
 import { persistenceStatusStore } from "./persistence";
 
 describe("atomWithLocalForage", () => {
@@ -165,5 +165,125 @@ describe("atomWithLocalForage", () => {
     );
     store.set(objAtom, { b: 2 });
     expect(store.get(objAtom)).toEqual({ b: 2 });
+  });
+});
+
+describe("reconcileMapByKey", () => {
+  test("preserves a sibling key another tab added", () => {
+    // This tab loaded empty and added its own key.
+    const previous = new Map<string, string>();
+    const next = new Map([["own", "mine"]]);
+    // Another tab persisted a sibling key in the meantime.
+    const persisted = new Map([["sibling", "theirs"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.size).toBe(2);
+    expect(merged.get("sibling")).toBe("theirs");
+    expect(merged.get("own")).toBe("mine");
+  });
+
+  test("applies this tab's update over the persisted entry for the same key", () => {
+    const previous = new Map([["shared", "before"]]);
+    const next = new Map([["shared", "after"]]);
+    const persisted = new Map([["shared", "concurrent"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.size).toBe(1);
+    expect(merged.get("shared")).toBe("after");
+  });
+
+  test("drops a key this tab removed while keeping a sibling", () => {
+    const previous = new Map([["removed", "gone"]]);
+    const next = new Map<string, string>();
+    const persisted = new Map([
+      ["removed", "gone"],
+      ["sibling", "theirs"],
+    ]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.size).toBe(1);
+    expect(merged.get("sibling")).toBe("theirs");
+  });
+
+  test("leaves a key this tab never touched at the value another tab wrote", () => {
+    // This tab only ever edited "own"; "sibling" stayed identical between its
+    // previous and next, so another tab's concurrent change to it must win.
+    const previous = new Map([
+      ["own", "before"],
+      ["sibling", "stale"],
+    ]);
+    const next = new Map([
+      ["own", "after"],
+      ["sibling", "stale"],
+    ]);
+    const persisted = new Map([["sibling", "concurrent"]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.get("sibling")).toBe("concurrent");
+    expect(merged.get("own")).toBe("after");
+  });
+
+  test("preserves this tab's keys when persisted has been wiped", () => {
+    // Storage was cleared (or never written) between preload and persist.
+    const previous = new Map<string, string>();
+    const next = new Map([
+      ["x", "mine-x"],
+      ["y", "mine-y"],
+    ]);
+    const persisted = new Map<string, string>();
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.size).toBe(2);
+    expect(merged.get("x")).toBe("mine-x");
+    expect(merged.get("y")).toBe("mine-y");
+  });
+
+  test("drops every previous key while preserving a foreign sibling in persisted", () => {
+    // This tab cleared all its known entries; meanwhile another tab wrote a
+    // foreign key the removal sweep must leave alone.
+    const previous = new Map([
+      ["x", "had-x"],
+      ["y", "had-y"],
+    ]);
+    const next = new Map<string, string>();
+    const persisted = new Map([
+      ["x", "had-x"],
+      ["y", "had-y"],
+      ["z", "from-another-tab"],
+    ]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    expect(merged.size).toBe(1);
+    expect(merged.get("z")).toBe("from-another-tab");
+  });
+
+  test("does not detect an entry mutated in place — write sites must replace entries, not mutate them", () => {
+    // The reference-equality diff only works because every production write
+    // site replaces a whole entry (`new Map(prev).set(id, freshEntry)`) rather
+    // than mutating one in place. This pins that contract: if a tab mutates the
+    // SAME entry object (so `previous` and `next` hold one shared reference),
+    // `Object.is` sees no change, the mutation is NOT upserted, and a concurrent
+    // value another tab wrote for that key survives instead.
+    const sharedEntry = { value: "original" };
+    const previous = new Map([["key", sharedEntry]]);
+
+    // Mutate in place and reuse the same reference as `next`.
+    sharedEntry.value = "mutated-in-place";
+    const next = new Map([["key", sharedEntry]]);
+
+    const concurrentEntry = { value: "from-another-tab" };
+    const persisted = new Map([["key", concurrentEntry]]);
+
+    const merged = reconcileMapByKey({ persisted, previous, next });
+
+    // The in-place mutation is invisible to the diff, so the concurrent value
+    // wins — demonstrating why write sites must construct fresh entries.
+    expect(merged.get("key")).toBe(concurrentEntry);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
+++ b/packages/graph-explorer/src/core/StateProvider/atomWithLocalForage.ts
@@ -25,6 +25,51 @@ function createLocalForageStorage<T>(key: string, initialValue: T) {
   };
 }
 
+/** Persists a single value to localForage under one key. */
+type LocalForageStorage<T> = ReturnType<typeof createLocalForageStorage<T>>;
+
+/**
+ * Merges this tab's change (`next`, against its last-persisted `previous`
+ * baseline) onto the freshly-read stored value (`persisted`). See the
+ * `reconcile` parameter of {@link atomWithLocalForage} for how and why this is
+ * applied.
+ */
+export type ReconcileWrite<T> = (args: {
+  persisted: T;
+  previous: T;
+  next: T;
+}) => T;
+
+/**
+ * Builds the flush a reconciling atom hands to the write queue: re-read the
+ * live stored value, merge this tab's change onto it via `reconcile`, then
+ * persist the result, so a tab with a stale in-memory copy cannot clobber an
+ * entry another tab wrote.
+ *
+ * The merge baseline (`previous`) is the value this tab last persisted; it
+ * advances only once a write lands. The per-key write queue this flush runs
+ * inside coalesces rapid writes — the dropped intermediate thunks never
+ * execute, so the baseline correctly skips them and stays in sync with what
+ * was actually written.
+ */
+function createReconcilingFlush<T>(
+  storage: LocalForageStorage<T>,
+  reconcile: ReconcileWrite<T>,
+  preloadValue: T,
+) {
+  let lastPersistedValue = preloadValue;
+
+  return async (nextValue: T) => {
+    const merged = reconcile({
+      persisted: await storage.getItem(),
+      previous: lastPersistedValue,
+      next: nextValue,
+    });
+    await storage.setItem(merged);
+    lastPersistedValue = nextValue;
+  };
+}
+
 /**
  * Creates an atom that persists its value in localForage.
  *
@@ -35,17 +80,75 @@ function createLocalForageStorage<T>(key: string, initialValue: T) {
  * After initialization, the atom provides synchronous read/write operations
  * while persistence happens asynchronously in the background.
  *
+ * By default each write blindly overwrites the whole stored value. Pass
+ * `reconcile` for an atom backing a collection shared across tabs: each persist
+ * then re-reads live storage and merges this tab's change onto it (see
+ * {@link createReconcilingFlush}), so concurrent edits to different entries by
+ * other tabs survive. This is opt-in because reconciliation is meaningless for
+ * scalar atoms and wrong for per-tab atoms; see the per-key diff-merge
+ * reconciliation ADR.
+ *
  * @param key The key to use for the stored value in localForage
  * @param initialValue The initial value if none is found in storage
+ * @param reconcile Optional merge applied against live storage before each write
  * @returns An atom that persists to localForage
  */
-export async function atomWithLocalForage<T>(key: string, initialValue: T) {
+export async function atomWithLocalForage<T>(
+  key: string,
+  initialValue: T,
+  reconcile?: ReconcileWrite<T>,
+) {
   const storage = createLocalForageStorage<T>(key, initialValue);
   const preloadValue = await storage.getItem();
 
+  const flush = reconcile
+    ? createReconcilingFlush(storage, reconcile, preloadValue)
+    : storage.setItem;
+
   return createWriteThroughAtom<T>(
     preloadValue,
-    nextValue => persistThroughQueue(key, () => storage.setItem(nextValue)),
+    nextValue => persistThroughQueue(key, () => flush(nextValue)),
     `atomWithLocalForage(${key})`,
   );
+}
+
+/**
+ * The reconciler for any atom whose stored value is a `Map` keyed by the merge
+ * unit — one entry per connection, per id, etc. Applies this tab's net per-key
+ * changes onto the freshly-read map: keys this tab added or changed are
+ * upserted, keys it removed are dropped, and every other key another tab wrote
+ * is left untouched.
+ *
+ * Whether a key changed is decided by reference (`Object.is`), since these
+ * atoms replace a whole entry on every write (e.g. `new Map(prev).set(id, …)`)
+ * rather than mutating it in place — so an unchanged entry keeps its identity
+ * and a changed one is a fresh object. No deep compare is needed, unlike the
+ * per-`type` styling merge whose array entries are rebuilt structurally.
+ */
+export function reconcileMapByKey<K, V>({
+  persisted,
+  previous,
+  next,
+}: {
+  persisted: Map<K, V>;
+  previous: Map<K, V>;
+  next: Map<K, V>;
+}): Map<K, V> {
+  const merged = new Map(persisted);
+
+  // Upsert keys this tab added or changed.
+  for (const [key, value] of next) {
+    if (!Object.is(previous.get(key), value)) {
+      merged.set(key, value);
+    }
+  }
+
+  // Drop keys this tab removed.
+  for (const key of previous.keys()) {
+    if (!next.has(key)) {
+      merged.delete(key);
+    }
+  }
+
+  return merged;
 }

--- a/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
+++ b/packages/graph-explorer/src/core/StateProvider/storageAtoms.ts
@@ -11,7 +11,7 @@ import type {
 } from "./userPreferences";
 
 import { createActiveConfigurationAtom } from "./activeConnectionStorage";
-import { atomWithLocalForage } from "./atomWithLocalForage";
+import { atomWithLocalForage, reconcileMapByKey } from "./atomWithLocalForage";
 import { runUserStylingMigration } from "./migrateUserStyling";
 import { defaultUserLayout } from "./userLayoutDefaults";
 
@@ -75,9 +75,14 @@ const [
   atomWithLocalForage<Map<ConfigurationId, RawConfiguration>>(
     "configuration",
     new Map(),
+    reconcileMapByKey,
   ),
   /** All the stored schemas */
-  atomWithLocalForage("schema", new Map<string, SchemaStorageModel>()),
+  atomWithLocalForage(
+    "schema",
+    new Map<string, SchemaStorageModel>(),
+    reconcileMapByKey,
+  ),
   /**
    * User-defined vertex style overrides, keyed by type. The `user-` prefix
    * marks the user-defined layer of the planned `<layer>-<entity>-styles` set
@@ -86,17 +91,20 @@ const [
   atomWithLocalForage(
     "user-vertex-styles",
     new Map<VertexType, VertexPreferencesStorageModel>(),
+    reconcileMapByKey,
   ),
   /** User-defined edge style overrides, keyed by type. See above. */
   atomWithLocalForage(
     "user-edge-styles",
     new Map<EdgeType, EdgePreferencesStorageModel>(),
+    reconcileMapByKey,
   ),
   atomWithLocalForage("user-layout", defaultUserLayout),
   /** Stores the graph session data for each connection. */
   atomWithLocalForage<Map<ConfigurationId, GraphSessionStorageModel>>(
     "graph-sessions",
     new Map(),
+    reconcileMapByKey,
   ),
   /*
    * General App Settings

--- a/packages/graph-explorer/src/utils/testing/persistence.test.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.test.ts
@@ -1,12 +1,32 @@
 import { createRandomName } from "@shared/utils/testing";
 
-import type { VertexType } from "@/core/entities/vertex";
-import type { VertexPreferencesStorageModel } from "@/core/StateProvider/userPreferences";
+import type {
+  ConfigurationId,
+  RawConfiguration,
+} from "@/core/ConfigurationProvider";
+import type { EdgeType, VertexType } from "@/core/entities";
+import type { GraphSessionStorageModel } from "@/core/StateProvider/graphSession/storage";
+import type { SchemaStorageModel } from "@/core/StateProvider/schema";
+import type {
+  EdgePreferencesStorageModel,
+  VertexPreferencesStorageModel,
+} from "@/core/StateProvider/userPreferences";
+
+import { reconcileMapByKey } from "@/core/StateProvider/atomWithLocalForage";
 
 import { openPersistenceTab, readPersistedValue } from "./persistence";
-import { createRandomVertexType } from "./randomData";
+import {
+  createRandomConfigurationId,
+  createRandomEdgeId,
+  createRandomEdgeType,
+  createRandomRawConfiguration,
+  createRandomSchema,
+  createRandomVertexId,
+  createRandomVertexType,
+} from "./randomData";
 
 type VertexStyles = Map<VertexType, VertexPreferencesStorageModel>;
+type EdgeStyles = Map<EdgeType, EdgePreferencesStorageModel>;
 
 describe("persistence test helpers", () => {
   test("a tab reads back the value it persisted", async () => {
@@ -98,70 +118,356 @@ describe("per-test storage isolation", () => {
 });
 
 /**
- * REGRESSION — #1820 cross-tab styling clobber
+ * REGRESSION — #1820 cross-tab styling clobber, fixed by #1831
  *
  * Two tabs share one IndexedDB but each keeps its own in-memory copy of the
- * vertex styling map. `atomWithLocalForage` writes the whole map back on every
- * change, so a tab with a stale in-memory copy silently drops entries another
- * tab added.
+ * vertex styling map. Without reconciliation, the whole map is written back on
+ * every change, so a tab with a stale in-memory copy silently drops entries
+ * another tab added.
  *
  * Scenario from the issue: Tab A styles vertex type X and persists it. Tab B —
  * opened before that write and never having seen X — styles type Y and persists
- * its stale map, clobbering X.
- *
- * Two assertions encode this:
- *
- * 1. A normal, currently-passing test that pins the CLOBBER as it behaves today
- *    — type X is dropped, only type Y survives. This is the deterministic guard:
- *    if the scenario ever stops reproducing (setup breaks, the bug changes
- *    shape), this test fails loudly instead of silently passing.
- * 2. A `test.fails` describing the DESIRED behaviour — both types survive. It
- *    turns green when reconciliation (#1831) lands, signalling that the fix
- *    works and this whole block should be collapsed into a single passing test.
- *
- * The fixture runs in `beforeAll`, OUTSIDE both tests. `test.fails` passes on
- * any throw, so building the fixture inside it would let a setup failure keep
- * the test green for the wrong reason. Keeping setup out means only the final
- * assertion can satisfy (or break) the expectation.
- *
- * TODO #1820 / #1831: collapse into one passing test once reconciliation lands.
+ * its stale map. With the per-key map merge wired into the styling atoms, both
+ * types survive instead of X being clobbered.
  */
 describe("cross-tab user styling reconciliation", () => {
-  let persistedTypes: Set<string>;
-  let typeX: VertexType;
-  let typeY: VertexType;
-
-  beforeAll(async () => {
+  test("preserves vertex styling when one tab writes against a stale memory copy", async () => {
     const key = createRandomName("user-vertex-styles");
-    typeX = createRandomVertexType();
-    typeY = createRandomVertexType();
+    const typeX = createRandomVertexType();
+    const typeY = createRandomVertexType();
 
     const styleForType = (type: VertexType): VertexPreferencesStorageModel => ({
       type,
       color: "#ff0000",
     });
 
-    // Both tabs open against empty styling.
-    const tabA = await openPersistenceTab<VertexStyles>(key, new Map());
-    const tabB = await openPersistenceTab<VertexStyles>(key, new Map());
+    // Both tabs open against empty styling, using the same reconciler the real
+    // styling atoms are wired with.
+    const tabA = await openPersistenceTab<VertexStyles>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<VertexStyles>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
 
     // Tab A styles type X and persists.
-    tabA.write(new Map([[typeX, styleForType(typeX)]]));
+    tabA.write(prev => new Map(prev).set(typeX, styleForType(typeX)));
     await tabA.flush();
 
     // Tab B, still holding its stale empty copy, styles type Y and persists.
     tabB.write(prev => new Map(prev).set(typeY, styleForType(typeY)));
-
     await tabB.flush();
+
     const persisted = await readPersistedValue<VertexStyles>(key);
-    persistedTypes = new Set(persisted?.keys());
+
+    expect(new Set(persisted?.keys())).toEqual(new Set([typeX, typeY]));
   });
 
-  test("clobbers type X today — only the stale tab's type Y survives", () => {
-    expect(persistedTypes).toEqual(new Set([typeY]));
+  test("preserves edge styling when one tab writes against a stale memory copy", async () => {
+    const key = createRandomName("user-edge-styles");
+    const typeX = createRandomEdgeType();
+    const typeY = createRandomEdgeType();
+
+    const styleForType = (type: EdgeType): EdgePreferencesStorageModel => ({
+      type,
+      lineColor: "#ff0000",
+    });
+
+    const tabA = await openPersistenceTab<EdgeStyles>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<EdgeStyles>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    tabA.write(prev => new Map(prev).set(typeX, styleForType(typeX)));
+    await tabA.flush();
+
+    tabB.write(prev => new Map(prev).set(typeY, styleForType(typeY)));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<EdgeStyles>(key);
+
+    expect(new Set(persisted?.keys())).toEqual(new Set([typeX, typeY]));
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab schema clobber
+ *
+ * The schema atom stores `Map<ConfigurationId, SchemaStorageModel>` — one entry
+ * per connection. Two tabs each hold their own in-memory copy of that map, so a
+ * tab that syncs one connection's schema would, on a blind whole-map write,
+ * silently drop a schema another tab discovered for a different connection. The
+ * same per-key map merge protects it.
+ */
+describe("cross-tab schema reconciliation", () => {
+  test("preserves schemas when one tab writes against a stale memory copy", async () => {
+    const key = createRandomName("schema");
+    const connectionA = createRandomName("connection");
+    const connectionB = createRandomName("connection");
+    const schemaA = createRandomSchema();
+    const schemaB = createRandomSchema();
+
+    type SchemaMap = Map<string, SchemaStorageModel>;
+
+    const tabA = await openPersistenceTab<SchemaMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<SchemaMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A discovers connection A's schema and persists.
+    tabA.write(prev => new Map(prev).set(connectionA, schemaA));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, discovers connection B and
+    // persists its stale map.
+    tabB.write(prev => new Map(prev).set(connectionB, schemaB));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<SchemaMap>(key);
+
+    expect(persisted?.get(connectionA)).toEqual(schemaA);
+    expect(persisted?.get(connectionB)).toEqual(schemaB);
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab connection clobber
+ *
+ * The configuration atom stores `Map<ConfigurationId, RawConfiguration>` — one
+ * entry per connection. Creating a connection in one tab while another tab
+ * holds a stale copy would, on a blind whole-map write, silently drop the
+ * connection the other tab created. The same per-key map merge protects it.
+ */
+describe("cross-tab connection reconciliation", () => {
+  test("preserves connections when one tab writes against a stale memory copy", async () => {
+    const key = createRandomName("configuration");
+    const connectionX = createRandomRawConfiguration();
+    const connectionY = createRandomRawConfiguration();
+
+    type ConfigMap = Map<ConfigurationId, RawConfiguration>;
+
+    const tabA = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A creates connection X and persists.
+    tabA.write(prev => new Map(prev).set(connectionX.id, connectionX));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, creates connection Y.
+    tabB.write(prev => new Map(prev).set(connectionY.id, connectionY));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<ConfigMap>(key);
+
+    expect(persisted?.get(connectionX.id)).toEqual(connectionX);
+    expect(persisted?.get(connectionY.id)).toEqual(connectionY);
   });
 
-  test.fails("should preserve styling from both tabs (fixed by #1831)", () => {
-    expect(persistedTypes).toEqual(new Set([typeX, typeY]));
+  test("drops a connection one tab removed while preserving a sibling another added", async () => {
+    const key = createRandomName("configuration");
+    const connectionX = createRandomRawConfiguration();
+    const connectionY = createRandomRawConfiguration();
+    const connectionZ = createRandomRawConfiguration();
+
+    type ConfigMap = Map<ConfigurationId, RawConfiguration>;
+
+    // Tab A creates connections X and Y, then a later tab preloads both.
+    const tabA = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    tabA.write(
+      new Map([
+        [connectionX.id, connectionX],
+        [connectionY.id, connectionY],
+      ]),
+    );
+    await tabA.flush();
+
+    // Tab B opens after that write, so it preloads {X, Y}.
+    const tabB = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Another tab creates connection Z — Tab B never sees it.
+    tabA.write(prev => new Map(prev).set(connectionZ.id, connectionZ));
+    await tabA.flush();
+
+    // Tab B removes connection X from its stale {X, Y} copy.
+    tabB.write(prev => {
+      const next = new Map(prev);
+      next.delete(connectionX.id);
+      return next;
+    });
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<ConfigMap>(key);
+
+    // X is dropped (Tab B removed it), Y survives (untouched), and Z survives
+    // even though Tab B never saw it — the removal merges onto live storage.
+    expect(persisted?.has(connectionX.id)).toBe(false);
+    expect(persisted?.get(connectionY.id)).toEqual(connectionY);
+    expect(persisted?.get(connectionZ.id)).toEqual(connectionZ);
+  });
+});
+
+/**
+ * REGRESSION — #1820 cross-tab session clobber
+ *
+ * The graph-sessions atom stores `Map<ConfigurationId, GraphSessionStorageModel>`
+ * — one session per connection. Concurrent session changes for different
+ * connections must not clobber each other; the per-key map merge keeps each
+ * connection's session intact.
+ */
+describe("cross-tab session reconciliation", () => {
+  test("preserves sessions when one tab writes against a stale memory copy", async () => {
+    const key = createRandomName("graph-sessions");
+    const connectionA = createRandomConfigurationId();
+    const connectionB = createRandomConfigurationId();
+    const sessionA: GraphSessionStorageModel = {
+      vertices: new Set([createRandomVertexId()]),
+      edges: new Set([createRandomEdgeId()]),
+    };
+    const sessionB: GraphSessionStorageModel = {
+      vertices: new Set([createRandomVertexId()]),
+      edges: new Set([createRandomEdgeId()]),
+    };
+
+    type SessionMap = Map<ConfigurationId, GraphSessionStorageModel>;
+
+    const tabA = await openPersistenceTab<SessionMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<SessionMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Tab A records connection A's session and persists.
+    tabA.write(prev => new Map(prev).set(connectionA, sessionA));
+    await tabA.flush();
+
+    // Tab B, still holding its stale empty map, records connection B's session.
+    tabB.write(prev => new Map(prev).set(connectionB, sessionB));
+    await tabB.flush();
+
+    const persisted = await readPersistedValue<SessionMap>(key);
+
+    expect(persisted?.get(connectionA)).toEqual(sessionA);
+    expect(persisted?.get(connectionB)).toEqual(sessionB);
+  });
+});
+
+/**
+ * The stale-memory scenarios above each await one tab's flush before the next
+ * tab writes. These exercise the harder path: two writes still in flight when a
+ * later write enters the same per-key queue, so the reconcile flush must merge
+ * against in-progress live storage and the merge baseline must advance
+ * correctly across coalesced drops.
+ */
+describe("cross-tab reconciliation under in-flight writes", () => {
+  test("coalesces rapid same-tab writes while merging onto another tab's concurrent sibling", async () => {
+    const key = createRandomName("configuration");
+    const siblingConnection = createRandomRawConfiguration();
+    const connectionX = createRandomRawConfiguration();
+    const connectionY = createRandomRawConfiguration();
+    const connectionZ = createRandomRawConfiguration();
+
+    type ConfigMap = Map<ConfigurationId, RawConfiguration>;
+
+    // A sibling tab persists its connection first, so it is already in storage
+    // when this tab — which opened stale against an empty map — writes.
+    const siblingTab = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const editingTab = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    siblingTab.write(new Map([[siblingConnection.id, siblingConnection]]));
+    await siblingTab.flush();
+
+    // Three rapid writes without awaiting between them. The write queue
+    // coalesces pending flushes to the latest, dropping the intermediate one,
+    // so the baseline must only advance for the writes that actually run for
+    // the net per-key result to be correct.
+    editingTab.write(new Map([[connectionX.id, connectionX]]));
+    editingTab.write(prev => new Map(prev).set(connectionY.id, connectionY));
+    editingTab.write(prev => new Map(prev).set(connectionZ.id, connectionZ));
+    await editingTab.flush();
+
+    const persisted = await readPersistedValue<ConfigMap>(key);
+
+    expect(persisted?.get(siblingConnection.id)).toEqual(siblingConnection);
+    expect(persisted?.get(connectionX.id)).toEqual(connectionX);
+    expect(persisted?.get(connectionY.id)).toEqual(connectionY);
+    expect(persisted?.get(connectionZ.id)).toEqual(connectionZ);
+  });
+
+  test("two tabs whose writes are still in flight both land without clobber", async () => {
+    const key = createRandomName("configuration");
+    const connectionA = createRandomRawConfiguration();
+    const connectionB = createRandomRawConfiguration();
+
+    type ConfigMap = Map<ConfigurationId, RawConfiguration>;
+
+    const tabA = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+    const tabB = await openPersistenceTab<ConfigMap>(
+      key,
+      new Map(),
+      reconcileMapByKey,
+    );
+
+    // Both tabs write before either flush resolves — neither has seen the
+    // other's write land in storage. The shared per-key write queue serializes
+    // the two flushes, and the second flush's reconcile re-reads live storage
+    // (now containing the first flush's output) and merges against its own
+    // stale baseline, so both connections survive.
+    tabA.write(new Map([[connectionA.id, connectionA]]));
+    tabB.write(new Map([[connectionB.id, connectionB]]));
+    await Promise.all([tabA.flush(), tabB.flush()]);
+
+    const persisted = await readPersistedValue<ConfigMap>(key);
+
+    expect(persisted?.get(connectionA.id)).toEqual(connectionA);
+    expect(persisted?.get(connectionB.id)).toEqual(connectionB);
   });
 });

--- a/packages/graph-explorer/src/utils/testing/persistence.ts
+++ b/packages/graph-explorer/src/utils/testing/persistence.ts
@@ -2,6 +2,7 @@ import { createStore } from "jotai";
 import localforage from "localforage";
 
 import type { AppStore } from "@/core";
+import type { ReconcileWrite } from "@/core/StateProvider/atomWithLocalForage";
 
 import { atomWithLocalForage } from "@/core/StateProvider/atomWithLocalForage";
 import { persistenceStatusStore } from "@/core/StateProvider/persistence";
@@ -58,13 +59,17 @@ export class PersistenceTab<T> {
  * Opens a new {@link PersistenceTab} for the given key, preloading whatever is
  * currently persisted (or the initial value when storage is empty), mirroring
  * how the app loads a localForage atom at startup.
+ *
+ * Pass the same `reconcile` the real atom is wired with to exercise cross-tab
+ * reconciliation; omit it to model a plain whole-value-overwrite atom.
  */
 export async function openPersistenceTab<T>(
   key: string,
   initialValue: T,
+  reconcile?: ReconcileWrite<T>,
 ): Promise<PersistenceTab<T>> {
   const store = createStore();
-  const atom = await atomWithLocalForage<T>(key, initialValue);
+  const atom = await atomWithLocalForage<T>(key, initialValue, reconcile);
   return new PersistenceTab(store, atom);
 }
 

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -30,6 +30,7 @@ import { createRdfEdgeId } from "@/connector/sparql/createRdfEdgeId";
 import {
   type ArrowStyle,
   type AttributeConfig,
+  type ConfigurationId,
   type ConnectionWithId,
   createEdge,
   createEdgeId,
@@ -260,6 +261,11 @@ export function createRandomVertexId(): VertexId {
 /** Creates a random edge ID. */
 export function createRandomEdgeId(): EdgeId {
   return createEdgeId(createRandomName("EdgeId"));
+}
+
+/** Creates a random configuration (connection) ID. */
+export function createRandomConfigurationId(): ConfigurationId {
+  return createNewConfigurationId();
 }
 
 export function createRandomVertexType(): VertexType {


### PR DESCRIPTION
## Description

Two same-origin tabs share one IndexedDB but each holds its own in-memory copy of a collection. A blind whole-value write lets a tab with a stale copy silently drop entries another tab added. This adds an optional `reconcile` parameter to `atomWithLocalForage`: when set, each persist re-reads live storage, merges this tab's per-key change onto it, then writes. One generic reconciler — `reconcileMapByKey` — covers the five Map-keyed shared collections (Connections, Schema, vertex + edge styles, Sessions); scalars and the per-tab active connection stay plain. Same-key conflicts remain last-writer-wins; the per-key diff-merge ADR has the rationale.

Suggested reading order:

1. [atomWithLocalForage.ts](https://github.com/aws/graph-explorer/pull/1869/files#diff-91cfdf9fecb4c3a6a253a8515fcf2ff526baf0221b43a7c08fb5808ed0d943fe) — the seam: optional `reconcile` parameter, `createReconcilingFlush`, `reconcileMapByKey`
2. [storageAtoms.ts](https://github.com/aws/graph-explorer/pull/1869/files#diff-2e6c435d81a94fe56fa689cd77b26189f05c931ae3c10ec77bc8a3900c1c1442) — which atoms opt in
3. [persistence.test.ts](https://github.com/aws/graph-explorer/pull/1869/files#diff-51157de97df3a9da81e5a22e834c77f6e6abc0153530005b4d3bd60a4404c6e8) — cross-tab regression tests for all five collections, plus in-flight interleaving and removal tests
4. [20260616-per-key-diff-merge-cross-tab-reconciliation.md](https://github.com/aws/graph-explorer/pull/1869/files#diff-cac6e3f9ae903797f84de3918605007e900c66985b2fa221096fa0f4bfb9b4c0) — updated ADR

## Validation

- Open two tabs side by side, edit a different vertex style in each, reload — both styles survive (previously one would silently disappear). Repeat for creating different connections, syncing different connections' schemas, and recording sessions on different connections.
- New cross-tab regression tests in `persistence.test.ts` cover all five collections, plus in-flight interleaving (rapid coalesced writes + two tabs queued simultaneously) and the removal path. `pnpm checks` and `pnpm test` pass clean.

## Related Issues

- Closes #1831
- Closes #1832
- Part of #1820
- Replaces #1862 (closed; opened under the prior branch name when the scope was narrower)

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
