### PR TITLE
Update public roadmap for Q3/Q4 2026

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,11 +7,12 @@ We encourage you to participate in the discussion within the individual roadmap 
 > [!IMPORTANT]
 > These items are subject to change.
 
-## Q1 2026
+## Q3 2026
 
-- [Schema visualization](https://github.com/aws/graph-explorer/issues/685)
+- [Schema Explorer enhancements](https://github.com/aws/graph-explorer/issues/1486)
+- [Query editor enhancements](https://github.com/aws/graph-explorer/issues/810)
 
-## Q2 2026
+## Q4 2026
 
 - [Improved graph rendering](https://github.com/aws/graph-explorer/issues/691)
 


### PR DESCRIPTION
## Summary

The public roadmap was stuck on Q1/Q2 2026 with a shipped item still listed. This brings it current:

- Remove the completed Schema Visualization entry (shipped March 2026)
- Add [Schema Explorer enhancements](https://github.com/aws/graph-explorer/issues/1486) and [Query editor enhancements](https://github.com/aws/graph-explorer/issues/810) to Q3
- Move Improved graph rendering to Q4
- Keep Persisted and shared user settings in backlog

## Related Issues

- Part of #1486
- Part of #810
- Part of #691