### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "description": "Graph Explorer",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Graph Explorer",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "description": "Shared types and functions across client and server.",
   "keywords": [],


### PR DESCRIPTION
## Description

Bumps the workspace version from 3.1.0 to 3.2.0 across the root and all three package manifests (`graph-explorer`, `graph-explorer-proxy-server`, `@graph-explorer/shared`).

Version-only change, matching the prior bump (#1809). Per convention, the changelog release notes land separately at release time.

## Validation

`git diff` shows four identical one-line `"version"` edits; no code, dependency, or lockfile changes.

## Related Issues

- N/A