### PR TITLE
Restructure issue-tracker agent doc and fix issue-creation conventions

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,16 +5,45 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 - Never delete an issue or PR, or change its status, unless explicitly requested
 - Never mention CVEs, security vulnerabilities, or advisories in issues or PRs. Describe the change as a dependency update (e.g. "Update fast-xml-parser to latest version", not "Fix CVE-2026-25896").
 
-## Commands
+## Issue commands
 
-- **Create**: `gh issue create --title "..." --body "..."` (heredoc for multi-line bodies)
 - **Read**: `gh issue view <number> --comments`
 - **List**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with `--label` / `--state` filters as needed
 - **Comment**: `gh issue comment <number> --body "..."`
 - **Label**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
 - **Close**: `gh issue close <number> --comment "..."`
+- **Create**: see [Creating issues](#creating-issues) — a real issue needs `--type`, often `--parent`, and sometimes dependency flags
 
 When a skill says "publish to the issue tracker", create a GitHub issue. When it says "fetch the relevant ticket", run `gh issue view <number> --comments`.
+
+## Creating issues
+
+- Assign the issue type, parent, and any dependencies in the single create command (requires `gh` 2.94.0+):
+
+  ```bash
+  gh issue create --title "..." --body "..." --label "..." --type "<type>" \
+    --parent <parent-number-or-url> \
+    --blocked-by <numbers> --blocking <numbers>
+  ```
+
+  `--type` is one of `Bug`, `Feature`, `Epic`, `Task`, or `Spike`. `--parent` links the issue as a sub-issue. `--blocked-by`/`--blocking` mark dependencies (comma-separated numbers or URLs). Omit any flag you don't need.
+
+- The issue type is set with `--type`, never as a label.
+- Use the matching template in `.github/ISSUE_TEMPLATE/`: Bug → `01-bug-report.md`, Feature → `02-feature-request.md`, Epic → `03-epic.md`, Task → `04-task.md`, Spike → `05-spike.md`
+- Fill in detail from the codebase or web when creating issues
+- A `Task` or `Spike` generally has a parent issue typed `Bug`, `Feature`, or `Epic` — pass it with `--parent`
+- Only apply labels from the existing set; never create new labels, and don't add or remove labels unless explicitly requested
+- Audience labels (internal vs. community) and their footers: see `docs/agents/issue-audience.md`
+
+To change these on an existing issue, use `gh issue edit <number>` — note the flag names differ from create: `--parent <n>` / `--remove-parent`, `--add-blocked-by <n>` / `--remove-blocked-by <n>`, `--add-blocking <n>` / `--remove-blocking <n>`, and `--add-sub-issue <n>` / `--remove-sub-issue <n>`.
+
+## Pull requests
+
+- Always publish as a draft, and set up remote tracking when publishing a branch
+- Title describes the change conceptually (e.g. "Add vertex filtering to graph view"); no conventional-commit prefixes (`docs:`, `fix:`, etc.)
+- Follow `.github/pull_request_template.md`; link the issue when one exists (e.g. `Fixes #123`)
+- Keep the description concise: a bulleted list of conceptual changes with the reason for each so reviewers can scan
+- Only check a template checklist item if that action was actually performed this session (e.g. only check `pnpm checks`/`pnpm test` if you ran them and they passed); leave unchecked when unsure
 
 ## Pull requests as a triage surface
 
@@ -26,30 +55,14 @@ When a skill says "publish to the issue tracker", create a GitHub issue. When it
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 
-## Issues
-
-- Assign an issue type on creation: `Bug`, `Feature`, `Epic`, `Task`, or `Spike`. Set it via REST after creation: `gh api -X PATCH repos/{owner}/{repo}/issues/{number} --field type={type_name}`
-- Use the matching template in `.github/ISSUE_TEMPLATE/`: Bug → `01-bug-report.md`, Feature → `02-feature-request.md`, Epic → `03-epic.md`, Task → `04-task.md`, Spike → `05-spike.md`
-- Fill in detail from the codebase or web when creating issues
-- A `Task` or `Spike` must have a parent issue typed `Bug`, `Feature`, or `Epic`
-- Only apply labels from the existing set; never create new labels, and don't add or remove labels unless explicitly requested
-- Audience labels (internal vs. community) and their footers: see `docs/agents/issue-audience.md`
-
-## Sub-issues
-
-`gh issue create` has no `--parent`. Create the child first, then link via GraphQL:
-
-```bash
-PARENT_ID=$(gh issue view <parent-number> --json id --jq '.id')
-CHILD_ID=$(gh issue view <child-number> --json id --jq '.id')
-gh api graphql \
-  -H "GraphQL-Features: sub_issues" \
-  -f query="mutation { addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$CHILD_ID\" }) { issue { title } subIssue { title } } }"
-```
-
 ## Related issues
 
-When an issue or PR relates to another, add a `## Related Issues` section as a list (always a list, even for one item — GitHub expands the reference into the item's title). Prefix each with a relationship descriptor: `Fixes`/`Resolves` (closes it), `Part of` (larger effort), `Parent`, `Duplicate`, or another brief one.
+Both issues and PRs can carry a `## Related Issues` section in their body — a list (always a list, even for one item; GitHub expands each reference into the linked item's title). Prefix each entry with a relationship descriptor:
+
+- An **issue** links to other issues: `Part of` (larger effort), `Parent`, `Duplicate`, `Blocked by`/`Blocking`, or another brief one.
+- A **PR** links to its originating issue with `Fixes`/`Resolves` (closes it on merge), and to any other related issues or PRs with the same descriptors.
+
+**Parent** and **blocked-by/blocking** are native GitHub fields — set them with the `gh` flags (see [Creating issues](#creating-issues)), not prose alone. Listing them here as well is fine, but the relationship must exist as the structural field, never only in prose.
 
 ```markdown
 ## Related Issues
@@ -57,11 +70,3 @@ When an issue or PR relates to another, add a `## Related Issues` section as a l
 - Resolves #123
 - Part of #456
 ```
-
-## Pull requests
-
-- Always publish as a draft, and set up remote tracking when publishing a branch
-- Title describes the change conceptually (e.g. "Add vertex filtering to graph view"); no conventional-commit prefixes (`docs:`, `fix:`, etc.)
-- Follow `.github/pull_request_template.md`; link the issue when one exists (e.g. `Fixes #123`)
-- Keep the description concise: a bulleted list of conceptual changes with the reason for each so reviewers can scan
-- Only check a template checklist item if that action was actually performed this session (e.g. only check `pnpm checks`/`pnpm test` if you ran them and they passed); leave unchecked when unsure


### PR DESCRIPTION
## Description

Reworks `docs/agents/issue-tracker.md` so agents follow the correct, current `gh` CLI conventions for creating issues, and reorganizes the doc by topic so it's easier to read.

The doc previously interleaved issue and PR guidance and described two stale workarounds: setting the issue type via a post-creation REST `PATCH`, and linking a parent via a GraphQL `addSubIssue` mutation (with a comment claiming `gh issue create` has no `--parent`). Both are obsolete as of `gh` 2.94.0.

- **Correct issue-creation conventions** — type, parent, and dependencies are now set in a single `gh issue create` call (`--type`/`--parent`/`--blocked-by`/`--blocking`), with `gh issue edit` flags documented for changing them afterward.
- **Require structural relationships** — parent and blocked-by/blocking must exist as native GitHub fields, not prose alone.
- **Restructured by topic** — grouped into Issue commands → Creating issues → Pull requests → PR triage → Related issues, instead of alternating between issues and PRs. Creation is now described in one place rather than two.
- **Related Issues section** clarified to apply to both issue and PR bodies, with the descriptors each uses.

## Validation

Docs-only change. `pnpm check:format` passes. Verified the documented `gh issue create`/`gh issue edit` flags against `gh` 2.94.0 (`--type`, `--parent`, `--blocked-by`/`--blocking`, and the `--add-`/`--remove-` edit variants). Confirmed the wording the engineering skills depend on (the "PRs as a request surface" flag, the "publish to the issue tracker"/"fetch the relevant ticket" mapping, and the `## Related Issues` block) is preserved.

## Related Issues

<!-- none -->

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.