### PR TITLE
Seed view layout through DbState with random defaults

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: Node (in code)
 A directed relationship between two vertices (source → target), with a type and optional attributes. Always directed in the data model regardless of graph type.
 _Avoid_: Relationship, link
 
+**Graph Database**:
+The external graph database a user connects to and explores — the source of all vertices and edges, reached over HTTP via a Connection. It is the user's own data, brought along and queried live; distinct from the local persisted app state (connections, schema cache, styles, sessions, layout) that Graph Explorer keeps in the browser's IndexedDB.
+_Avoid_: Database (ambiguous — clarify remote graph database vs. local persisted state)
+
 **Connection**:
 A saved database profile — the URL, query engine, authentication settings, and proxy routing needed to reach a graph database. Users create and manage these in the UI.
 _Avoid_: Configuration (legacy term being phased out — previously bundled connection + schema + Styles into one object)

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -4,17 +4,17 @@ Vitest. Tests co-locate with source as `*.test.ts` (or `*.test.tsx` for componen
 
 ## Rules
 
-- Use `renderHookWithState` for hooks, not `renderHook` or `renderHookWithJotai`
-- Use `DbState` to set up Jotai state, not manual atom wiring
+- Use `renderHookWithState` for hooks, not `renderHook`
+- Set up state with `DbState`, not manual atom wiring or `renderHookWithJotai`. When `DbState` can't express what a test needs, extend `DbState` — growing it is the intended path, not working around it.
 - Mock only external systems (network, etc.); don't mock internal modules
-- Use random factories for any data that doesn't affect the assertion; specify only the fields that matter
+- Constrained non-determinism: randomize everything the assertion doesn't depend on, pin only what it does. A flake on random data is an unpinned dependency — pin the field, don't narrow the factory.
 - Assert full expected values with `toStrictEqual([...])`, not length checks plus per-index `toEqual`
 - Test behavior, not implementation. Don't assert on CSS classes, element types, or layout — those break on harmless visual changes. A purely presentational component with no branching needs no test.
 - `setupTests.ts` handles environment (UTC, en-US), mock cleanup, and a real localForage backend on `fake-indexeddb` (fresh per test). Don't re-do this setup; assume it.
 
 ## Key helpers (`@/utils/testing`)
 
-- `DbState` — build graph/schema/styling state, then `renderHookWithState(useThing, state)`
+- `DbState` — set up the persisted app state a test needs, then `renderHookWithState(useThing, state)`. Extend it when it lacks a capability.
 - `createTestableVertex()` / `createTestableEdge()` — fluent builders: `.with({...})`, `.withSource()`, `.withTarget()`, `.withRdfValues()`, `.asVertex()`, `.asResult()`
 - `createMockExplorer` / `FakeExplorer` — explorer test doubles
 - SPARQL: `createUriValue`, `createLiteralValue`, `createQuadBindingsForEntities`, `createQuadSparqlResponse` (`sparqlHelpers.ts`)
@@ -73,6 +73,6 @@ Commands are in AGENTS.md.
 
 Anything persisted to IndexedDB via localForage/Jotai may be reloaded in an older shape after a type change, silently breaking logic that assumes the new shape. So: **when you change the shape of a persisted type, add tests that exercise the old shape alongside the new** — old shape loads without error, consuming logic produces correct results for both, and old/new can coexist in a collection.
 
-Group them in a dedicated `describe("backward compatibility: ...")` with a comment block stating the old shape, why the tests exist, and a "do not delete without confirming migration" warning. Cast legacy fixtures with `as TypeName` to bypass compile-time checks. See `src/utils/parseConnectionFile.test.ts` for a worked example.
+Group them in a dedicated `describe("backward compatibility: ...")` with a comment block stating the old shape, why the tests exist, and a "do not delete without confirming migration" warning. Cast legacy fixtures with `as TypeName` to bypass compile-time checks. See `src/utils/parseConnectionFile.test.ts` or `src/core/StateProvider/graphViewLayout.test.ts` for worked examples.
 
-Persisted types that require this when modified: `SchemaStorageModel`, `PrefixTypeConfig`, `VertexTypeConfig`, `EdgeTypeConfig`, `RawConfiguration`, and the style storage models (`VertexStyleStorage`, `EdgeStyleStorage`). Triggers: removing/renaming a property, changing a property's type, adding a required property, or changing a property's semantics.
+Applies to any object type persisted via `atomWithLocalForage`. Triggers: removing/renaming a property, changing a property's type, adding a required property, or changing a property's semantics.

--- a/packages/graph-explorer/src/core/StateProvider/graphViewLayout.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphViewLayout.test.ts
@@ -1,11 +1,7 @@
 // @vitest-environment happy-dom
 import { act } from "react";
 
-import {
-  DbState,
-  renderHookWithJotai,
-  renderHookWithState,
-} from "@/utils/testing";
+import { DbState, renderHookWithState } from "@/utils/testing";
 
 import type { GraphViewLayout } from "./graphViewLayout";
 
@@ -14,18 +10,39 @@ import {
   useTableViewSize,
   useViewToggles,
 } from "./graphViewLayout";
-import { graphViewLayoutAtom } from "./storageAtoms";
+import {
+  DEFAULT_SIDEBAR_WIDTH,
+  DEFAULT_TABLE_VIEW_HEIGHT,
+} from "./graphViewLayoutDefaults";
+
+const baseLayout: GraphViewLayout = {
+  activeSidebarItem: "search",
+  activeToggles: new Set(["graph-viewer", "table-view"]),
+  sidebar: { width: DEFAULT_SIDEBAR_WIDTH },
+  tableView: { height: DEFAULT_TABLE_VIEW_HEIGHT },
+};
+
+/** Seeds a graph view layout, overriding only the fields a test pins. */
+function stateWithLayout(overrides: Partial<GraphViewLayout> = {}) {
+  return new DbState().withGraphViewLayout({ ...baseLayout, ...overrides });
+}
 
 describe("useViewToggles", () => {
-  it("should default to both views open", () => {
-    const { result } = renderHookWithState(() => useViewToggles());
+  it("should reflect both views open when seeded", () => {
+    const { result } = renderHookWithState(
+      () => useViewToggles(),
+      stateWithLayout(),
+    );
 
     expect(result.current.isGraphVisible).toBe(true);
     expect(result.current.isTableVisible).toBe(true);
   });
 
   it("should toggle graph view", () => {
-    const { result } = renderHookWithState(() => useViewToggles());
+    const { result } = renderHookWithState(
+      () => useViewToggles(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggleGraphVisibility());
 
@@ -39,7 +56,10 @@ describe("useViewToggles", () => {
   });
 
   it("should toggle table view", () => {
-    const { result } = renderHookWithState(() => useViewToggles());
+    const { result } = renderHookWithState(
+      () => useViewToggles(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggleTableVisibility());
 
@@ -54,14 +74,20 @@ describe("useViewToggles", () => {
 });
 
 describe("useGraphViewSidebar", () => {
-  it("should default to sidebar open", () => {
-    const { result } = renderHookWithJotai(() => useGraphViewSidebar());
+  it("should reflect the seeded open sidebar", () => {
+    const { result } = renderHookWithState(
+      () => useGraphViewSidebar(),
+      stateWithLayout(),
+    );
 
     expect(result.current.isSidebarOpen).toBe(true);
   });
 
   it("should change to the given sidebar item", () => {
-    const { result } = renderHookWithJotai(() => useGraphViewSidebar());
+    const { result } = renderHookWithState(
+      () => useGraphViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggleSidebar("details"));
     expect(result.current.isSidebarOpen).toBe(true);
@@ -73,14 +99,9 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should close the sidebar if toggling to the same item", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "details",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-        } satisfies GraphViewLayout),
+      stateWithLayout({ activeSidebarItem: "details" }),
     );
 
     act(() => result.current.toggleSidebar("details"));
@@ -90,7 +111,10 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should close the sidebar", () => {
-    const { result } = renderHookWithJotai(() => useGraphViewSidebar());
+    const { result } = renderHookWithState(
+      () => useGraphViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.closeSidebar());
 
@@ -98,20 +122,10 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should show namespaces when the connection is a SPARQL connection", () => {
-    const dbState = new DbState();
-    dbState.activeConfig.connection!.queryEngine = "sparql";
+    const state = stateWithLayout({ activeSidebarItem: "namespaces" });
+    state.activeConfig.connection!.queryEngine = "sparql";
 
-    const { result } = renderHookWithJotai(
-      () => useGraphViewSidebar(),
-      store => {
-        dbState.applyTo(store);
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "namespaces",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-        } satisfies GraphViewLayout);
-      },
-    );
+    const { result } = renderHookWithState(() => useGraphViewSidebar(), state);
 
     expect(result.current.isSidebarOpen).toBe(true);
     expect(result.current.activeSidebarItem).toBe("namespaces");
@@ -119,20 +133,10 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should be closed when active item is namespaces but connection is not RDF", () => {
-    const dbState = new DbState();
-    dbState.activeConfig.connection!.queryEngine = "gremlin";
+    const state = stateWithLayout({ activeSidebarItem: "namespaces" });
+    state.activeConfig.connection!.queryEngine = "gremlin";
 
-    const { result } = renderHookWithJotai(
-      () => useGraphViewSidebar(),
-      store => {
-        dbState.applyTo(store);
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "namespaces",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-        } satisfies GraphViewLayout);
-      },
-    );
+    const { result } = renderHookWithState(() => useGraphViewSidebar(), state);
 
     expect(result.current.isSidebarOpen).toBe(false);
     expect(result.current.activeSidebarItem).toBeNull();
@@ -140,39 +144,31 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should return persisted sidebar width", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 500 },
-        } satisfies GraphViewLayout),
+      stateWithLayout({ sidebar: { width: 500 } }),
     );
 
     expect(result.current.sidebarWidth).toBe(500);
   });
 
   it("should adjust sidebar width by delta", () => {
-    const { result } = renderHookWithJotai(() => useGraphViewSidebar());
+    const { result } = renderHookWithState(
+      () => useGraphViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.setSidebarWidth(100));
-    expect(result.current.sidebarWidth).toBe(500);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH + 100);
 
     act(() => result.current.setSidebarWidth(-200));
-    expect(result.current.sidebarWidth).toBe(300);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH - 100);
   });
 
   it("should auto-open details when detailsAutoOpenOnSelection is true", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-          detailsAutoOpenOnSelection: true,
-        } satisfies GraphViewLayout),
+      stateWithLayout({ detailsAutoOpenOnSelection: true }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -181,15 +177,9 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should not auto-open details when detailsAutoOpenOnSelection is false", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-          detailsAutoOpenOnSelection: false,
-        } satisfies GraphViewLayout),
+      stateWithLayout({ detailsAutoOpenOnSelection: false }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -198,14 +188,9 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should auto-open details when detailsAutoOpenOnSelection is undefined (legacy data)", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-        } satisfies GraphViewLayout),
+      stateWithLayout(),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -213,23 +198,13 @@ describe("useGraphViewSidebar", () => {
     expect(result.current.activeSidebarItem).toBe("details");
   });
 
-  it("should report detailsAutoOpenOnSelection as enabled by default", () => {
-    const { result } = renderHookWithJotai(() => useGraphViewSidebar());
+  it("should toggle detailsAutoOpenOnSelection from true to false", () => {
+    const { result } = renderHookWithState(
+      () => useGraphViewSidebar(),
+      stateWithLayout({ detailsAutoOpenOnSelection: true }),
+    );
 
     expect(result.current.detailsAutoOpenOnSelection).toBe(true);
-  });
-
-  it("should toggle detailsAutoOpenOnSelection from true to false", () => {
-    const { result } = renderHookWithJotai(
-      () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-          detailsAutoOpenOnSelection: true,
-        } satisfies GraphViewLayout),
-    );
 
     act(() => result.current.toggleDetailsAutoOpen());
 
@@ -237,15 +212,9 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should toggle detailsAutoOpenOnSelection from false to true", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-          detailsAutoOpenOnSelection: false,
-        } satisfies GraphViewLayout),
+      stateWithLayout({ detailsAutoOpenOnSelection: false }),
     );
 
     act(() => result.current.toggleDetailsAutoOpen());
@@ -254,14 +223,9 @@ describe("useGraphViewSidebar", () => {
   });
 
   it("should toggle detailsAutoOpenOnSelection from undefined (enabled) to false", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store =>
-        store.set(graphViewLayoutAtom, {
-          activeSidebarItem: "search",
-          activeToggles: new Set(),
-          sidebar: { width: 400 },
-        } satisfies GraphViewLayout),
+      stateWithLayout(),
     );
 
     // The button shows enabled (undefined reads as `?? true`), so toggling
@@ -273,17 +237,14 @@ describe("useGraphViewSidebar", () => {
 });
 
 describe("useTableViewSize", () => {
-  it("should default to DEFAULT_TABLE_VIEW_HEIGHT", () => {
-    const { result } = renderHookWithState(() => useTableViewSize());
-
-    expect(result.current[0]).toBe(300);
-  });
-
   it("should return 100% when graph viewer is hidden", () => {
-    const { result } = renderHookWithState(() => ({
-      tableView: useTableViewSize(),
-      toggles: useViewToggles(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        tableView: useTableViewSize(),
+        toggles: useViewToggles(),
+      }),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggles.toggleGraphVisibility());
 
@@ -291,13 +252,16 @@ describe("useTableViewSize", () => {
   });
 
   it("should adjust height by delta", () => {
-    const { result } = renderHookWithState(() => useTableViewSize());
+    const { result } = renderHookWithState(
+      () => useTableViewSize(),
+      stateWithLayout(),
+    );
 
     act(() => result.current[1](50));
-    expect(result.current[0]).toBe(350);
+    expect(result.current[0]).toBe(DEFAULT_TABLE_VIEW_HEIGHT + 50);
 
     act(() => result.current[1](-100));
-    expect(result.current[0]).toBe(250);
+    expect(result.current[0]).toBe(DEFAULT_TABLE_VIEW_HEIGHT - 50);
   });
 });
 
@@ -310,6 +274,10 @@ describe("useTableViewSize", () => {
  * persisted data may not have the `sidebar` field at all. These tests verify
  * that the hooks still work correctly with the old shape.
  *
+ * These seed the legacy shape verbatim via `withGraphViewLayout` (not the
+ * `stateWithLayout` spread helper, which would re-add the absent `sidebar`
+ * field and mask the fallback under test).
+ *
  * DO NOT delete or weaken these tests without confirming that all persisted
  * data has been migrated or that the old shape is no longer in the wild.
  */
@@ -321,12 +289,12 @@ describe("backward compatibility: missing sidebar field", () => {
       detailsAutoOpenOnSelection: true,
     } as GraphViewLayout;
 
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store => store.set(graphViewLayoutAtom, legacyLayout),
+      new DbState().withGraphViewLayout(legacyLayout),
     );
 
-    expect(result.current.sidebarWidth).toBe(400);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH);
     expect(result.current.isSidebarOpen).toBe(true);
   });
 
@@ -336,12 +304,12 @@ describe("backward compatibility: missing sidebar field", () => {
       activeToggles: new Set(),
     } as GraphViewLayout;
 
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useGraphViewSidebar(),
-      store => store.set(graphViewLayoutAtom, legacyLayout),
+      new DbState().withGraphViewLayout(legacyLayout),
     );
 
     act(() => result.current.setSidebarWidth(50));
-    expect(result.current.sidebarWidth).toBe(450);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH + 50);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/graphViewLayoutDefaults.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphViewLayoutDefaults.ts
@@ -1,15 +1,18 @@
 /** The two main content views that can be toggled on or off. */
-export type ToggleableView = "graph-viewer" | "table-view";
+export const toggleableViews = ["graph-viewer", "table-view"] as const;
+export type ToggleableView = (typeof toggleableViews)[number];
 
 /** Identifiers for the graph view sidebar panels. */
-export type GraphViewSidebarItem =
-  | "search"
-  | "details"
-  | "filters"
-  | "expand"
-  | "nodes-styling"
-  | "edges-styling"
-  | "namespaces";
+export const graphViewSidebarItems = [
+  "search",
+  "details",
+  "filters",
+  "expand",
+  "nodes-styling",
+  "edges-styling",
+  "namespaces",
+] as const;
+export type GraphViewSidebarItem = (typeof graphViewSidebarItems)[number];
 
 /** Persisted layout preferences for the graph view. */
 export type GraphViewLayout = {

--- a/packages/graph-explorer/src/core/StateProvider/schemaViewLayoutDefaults.ts
+++ b/packages/graph-explorer/src/core/StateProvider/schemaViewLayoutDefaults.ts
@@ -1,10 +1,12 @@
 import { DEFAULT_SIDEBAR_WIDTH } from "./graphViewLayoutDefaults";
 
 /** Identifiers for the schema view sidebar panels. */
-export type SchemaViewSidebarItem =
-  | "details"
-  | "nodes-styling"
-  | "edges-styling";
+export const schemaViewSidebarItems = [
+  "details",
+  "nodes-styling",
+  "edges-styling",
+] as const;
+export type SchemaViewSidebarItem = (typeof schemaViewSidebarItems)[number];
 
 /** Persisted layout preferences for the schema view. */
 export type SchemaViewLayout = {

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphSelection.test.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphSelection.test.ts
@@ -2,10 +2,24 @@
 import { act } from "react";
 
 import { useGraphViewSidebar } from "@/core";
-import { renderHookWithState } from "@/utils/testing";
+import { DbState, renderHookWithState } from "@/utils/testing";
 import { createRandomEdgeId, createRandomVertexId } from "@/utils/testing";
 
 import { useGraphSelection } from "./useGraphSelection";
+
+/**
+ * Seeds a known pre-selection layout — sidebar open on Search with auto-open
+ * enabled — so the auto-open assertions measure the selection's effect rather
+ * than the random default layout DbState would otherwise apply.
+ */
+function stateWithSearchTabAndAutoOpen() {
+  return new DbState().withGraphViewLayout({
+    activeSidebarItem: "search",
+    activeToggles: new Set(),
+    sidebar: { width: 400 },
+    detailsAutoOpenOnSelection: true,
+  });
+}
 
 describe("useGraphSelection", () => {
   test("should return empty selection initially", () => {
@@ -163,10 +177,13 @@ describe("useGraphSelection", () => {
   });
 
   test("should auto-open details when selecting single vertex", () => {
-    const { result } = renderHookWithState(() => ({
-      selection: useGraphSelection(),
-      sidebar: useGraphViewSidebar(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        selection: useGraphSelection(),
+        sidebar: useGraphViewSidebar(),
+      }),
+      stateWithSearchTabAndAutoOpen(),
+    );
 
     const vertexId = createRandomVertexId();
 
@@ -180,10 +197,13 @@ describe("useGraphSelection", () => {
   });
 
   test("should auto-open details when selecting single edge", () => {
-    const { result } = renderHookWithState(() => ({
-      selection: useGraphSelection(),
-      sidebar: useGraphViewSidebar(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        selection: useGraphSelection(),
+        sidebar: useGraphViewSidebar(),
+      }),
+      stateWithSearchTabAndAutoOpen(),
+    );
 
     const edgeId = createRandomEdgeId();
 
@@ -197,10 +217,13 @@ describe("useGraphSelection", () => {
   });
 
   test("should not auto-open details when selecting multiple entities", () => {
-    const { result } = renderHookWithState(() => ({
-      selection: useGraphSelection(),
-      sidebar: useGraphViewSidebar(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        selection: useGraphSelection(),
+        sidebar: useGraphViewSidebar(),
+      }),
+      stateWithSearchTabAndAutoOpen(),
+    );
 
     const vertexId1 = createRandomVertexId();
     const vertexId2 = createRandomVertexId();
@@ -215,10 +238,13 @@ describe("useGraphSelection", () => {
   });
 
   test("should not auto-open details when disableSideEffects is true", () => {
-    const { result } = renderHookWithState(() => ({
-      selection: useGraphSelection(),
-      sidebar: useGraphViewSidebar(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        selection: useGraphSelection(),
+        sidebar: useGraphViewSidebar(),
+      }),
+      stateWithSearchTabAndAutoOpen(),
+    );
 
     const vertexId = createRandomVertexId();
 
@@ -233,10 +259,13 @@ describe("useGraphSelection", () => {
   });
 
   test("should not auto-open details when clearing selection", () => {
-    const { result } = renderHookWithState(() => ({
-      selection: useGraphSelection(),
-      sidebar: useGraphViewSidebar(),
-    }));
+    const { result } = renderHookWithState(
+      () => ({
+        selection: useGraphSelection(),
+        sidebar: useGraphViewSidebar(),
+      }),
+      stateWithSearchTabAndAutoOpen(),
+    );
 
     act(() =>
       result.current.selection.replaceGraphSelection({

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaExplorerSidebar.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaExplorerSidebar.test.tsx
@@ -25,6 +25,17 @@ vi.mock("react-virtuoso", () => ({
   }) => data?.map((item, index) => itemContent(index, item)),
 }));
 
+/**
+ * Seeds the sidebar open on the Details tab so tests that assert the default
+ * rendered content aren't affected by the random layout DbState applies.
+ */
+function stateWithDetailsTab() {
+  return new DbState().withSchemaViewLayout({
+    activeSidebarItem: "details",
+    sidebar: { width: 400 },
+  });
+}
+
 function renderSidebar(state: DbState) {
   const store = getAppStore();
   state.applyTo(store);
@@ -46,8 +57,7 @@ function renderSidebar(state: DbState) {
 
 describe("SchemaExplorerSidebar", () => {
   test("renders details tab by default with empty selection message", () => {
-    const state = new DbState();
-    renderSidebar(state);
+    renderSidebar(stateWithDetailsTab());
 
     expect(screen.getByText("Empty Selection")).toBeInTheDocument();
   });
@@ -62,7 +72,7 @@ describe("SchemaExplorerSidebar", () => {
 
   test("renders node styling content when clicking second tab", async () => {
     const user = userEvent.setup();
-    const state = new DbState();
+    const state = stateWithDetailsTab();
     const vertex = createTestableVertex().with({ types: ["Airport"] });
     state.addTestableVertexToGraph(vertex);
 
@@ -76,7 +86,7 @@ describe("SchemaExplorerSidebar", () => {
 
   test("renders edge styling content when clicking third tab", async () => {
     const user = userEvent.setup();
-    const state = new DbState();
+    const state = stateWithDetailsTab();
     const source = createTestableVertex().with({ types: ["Airport"] });
     const target = createTestableVertex().with({ types: ["City"] });
     const edge = createTestableEdge()
@@ -95,8 +105,7 @@ describe("SchemaExplorerSidebar", () => {
 
   test("collapses sidebar when clicking the active tab", async () => {
     const user = userEvent.setup();
-    const state = new DbState();
-    renderSidebar(state);
+    renderSidebar(stateWithDetailsTab());
 
     expect(screen.getByText("Empty Selection")).toBeInTheDocument();
 
@@ -108,7 +117,7 @@ describe("SchemaExplorerSidebar", () => {
 
   test("reopens sidebar when clicking a tab while collapsed", async () => {
     const user = userEvent.setup();
-    const state = new DbState();
+    const state = stateWithDetailsTab();
     const vertex = createTestableVertex().with({ types: ["Airport"] });
     state.addTestableVertexToGraph(vertex);
 

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/schemaViewLayout.test.ts
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/schemaViewLayout.test.ts
@@ -1,15 +1,29 @@
 // @vitest-environment happy-dom
 import { act } from "react";
 
+import type { SchemaViewLayout } from "@/core/StateProvider/schemaViewLayoutDefaults";
+
 import { DEFAULT_SIDEBAR_WIDTH } from "@/core/StateProvider/graphViewLayoutDefaults";
-import { schemaViewLayoutAtom } from "@/core/StateProvider/storageAtoms";
-import { renderHookWithJotai } from "@/utils/testing";
+import { DbState, renderHookWithState } from "@/utils/testing";
 
 import { useSchemaViewSidebar } from "./schemaViewLayout";
 
+const baseLayout: SchemaViewLayout = {
+  activeSidebarItem: "details",
+  sidebar: { width: DEFAULT_SIDEBAR_WIDTH },
+};
+
+/** Seeds a schema view layout, overriding only the fields a test pins. */
+function stateWithLayout(overrides: Partial<SchemaViewLayout> = {}) {
+  return new DbState().withSchemaViewLayout({ ...baseLayout, ...overrides });
+}
+
 describe("useSchemaViewSidebar", () => {
-  it("should default to sidebar open with details tab", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+  it("should reflect the seeded active tab and width", () => {
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout(),
+    );
 
     expect(result.current.isSidebarOpen).toBe(true);
     expect(result.current.activeSidebarItem).toBe("details");
@@ -17,7 +31,10 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should toggle to a different tab", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggleSidebar("nodes-styling"));
 
@@ -26,7 +43,10 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should close the sidebar when toggling the active tab", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.toggleSidebar("details"));
 
@@ -35,13 +55,9 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should open the sidebar when toggling from closed state", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: null,
-          sidebar: { width: 350 },
-        }),
+      stateWithLayout({ activeSidebarItem: null }),
     );
 
     act(() => result.current.toggleSidebar("edges-styling"));
@@ -51,7 +67,10 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should close the sidebar with closeSidebar", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.closeSidebar());
 
@@ -60,24 +79,25 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should persist sidebar width changes", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout(),
+    );
 
     act(() => result.current.setSidebarWidth(50));
-    expect(result.current.sidebarWidth).toBe(450);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH + 50);
 
     act(() => result.current.setSidebarWidth(-100));
-    expect(result.current.sidebarWidth).toBe(350);
+    expect(result.current.sidebarWidth).toBe(DEFAULT_SIDEBAR_WIDTH - 50);
   });
 
   it("should auto-open details tab when enabled and selection changes", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "nodes-styling",
-          sidebar: { width: 350 },
-          detailsAutoOpenOnSelection: true,
-        }),
+      stateWithLayout({
+        activeSidebarItem: "nodes-styling",
+        detailsAutoOpenOnSelection: true,
+      }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -86,14 +106,12 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should not auto-open details when disabled", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "nodes-styling",
-          sidebar: { width: 350 },
-          detailsAutoOpenOnSelection: false,
-        }),
+      stateWithLayout({
+        activeSidebarItem: "nodes-styling",
+        detailsAutoOpenOnSelection: false,
+      }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -102,13 +120,9 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should auto-open details when detailsAutoOpenOnSelection is undefined (legacy data)", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "nodes-styling",
-          sidebar: { width: 350 },
-        }),
+      stateWithLayout({ activeSidebarItem: "nodes-styling" }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -117,14 +131,12 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should open a closed sidebar to details when auto-open is enabled", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: null,
-          sidebar: { width: 350 },
-          detailsAutoOpenOnSelection: true,
-        }),
+      stateWithLayout({
+        activeSidebarItem: null,
+        detailsAutoOpenOnSelection: true,
+      }),
     );
 
     act(() => result.current.autoOpenDetails());
@@ -133,22 +145,13 @@ describe("useSchemaViewSidebar", () => {
     expect(result.current.isSidebarOpen).toBe(true);
   });
 
-  it("should default detailsAutoOpenOnSelection to enabled", () => {
-    const { result } = renderHookWithJotai(() => useSchemaViewSidebar());
+  it("should toggle detailsAutoOpenOnSelection from true to false", () => {
+    const { result } = renderHookWithState(
+      () => useSchemaViewSidebar(),
+      stateWithLayout({ detailsAutoOpenOnSelection: true }),
+    );
 
     expect(result.current.detailsAutoOpenOnSelection).toBe(true);
-  });
-
-  it("should toggle detailsAutoOpenOnSelection from true to false", () => {
-    const { result } = renderHookWithJotai(
-      () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "details",
-          sidebar: { width: 350 },
-          detailsAutoOpenOnSelection: true,
-        }),
-    );
 
     act(() => result.current.toggleDetailsAutoOpen());
 
@@ -156,14 +159,9 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should toggle detailsAutoOpenOnSelection from false to true", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "details",
-          sidebar: { width: 350 },
-          detailsAutoOpenOnSelection: false,
-        }),
+      stateWithLayout({ detailsAutoOpenOnSelection: false }),
     );
 
     act(() => result.current.toggleDetailsAutoOpen());
@@ -172,13 +170,9 @@ describe("useSchemaViewSidebar", () => {
   });
 
   it("should toggle detailsAutoOpenOnSelection from undefined (enabled) to false", () => {
-    const { result } = renderHookWithJotai(
+    const { result } = renderHookWithState(
       () => useSchemaViewSidebar(),
-      store =>
-        store.set(schemaViewLayoutAtom, {
-          activeSidebarItem: "details",
-          sidebar: { width: 350 },
-        }),
+      stateWithLayout(),
     );
 
     // The button shows enabled (undefined reads as `?? true`), so toggling

--- a/packages/graph-explorer/src/utils/testing/DbState.ts
+++ b/packages/graph-explorer/src/utils/testing/DbState.ts
@@ -1,4 +1,5 @@
 import type { Explorer } from "@/connector";
+import type { SchemaViewLayout } from "@/core/StateProvider/schemaViewLayoutDefaults";
 
 import {
   activeConfigurationAtom,
@@ -14,6 +15,8 @@ import {
   edgesTypesFilteredAtom,
   type EdgeType,
   explorerForTestingAtom,
+  type GraphViewLayout,
+  graphViewLayoutAtom,
   mapEdgeToTypeConfig,
   mapVertexToTypeConfigs,
   nodesAtom,
@@ -22,6 +25,7 @@ import {
   type RawConfiguration,
   schemaAtom,
   type SchemaStorageModel,
+  schemaViewLayoutAtom,
   toEdgeMap,
   toNodeMap,
   type Vertex,
@@ -34,8 +38,10 @@ import {
 import { createMockExplorer } from "./createMockExplorer";
 import {
   createRandomEdge,
+  createRandomGraphViewLayout,
   createRandomRawConfiguration,
   createRandomSchema,
+  createRandomSchemaViewLayout,
   createRandomVertex,
   createRandomEdgeStyles,
   createRandomVertexStyles,
@@ -51,6 +57,8 @@ export class DbState {
   activeConfig: RawConfiguration;
   vertexStyles: Map<VertexType, VertexStyleStorage>;
   edgeStyles: Map<EdgeType, EdgeStyleStorage>;
+  graphViewLayout: GraphViewLayout;
+  schemaViewLayout: SchemaViewLayout;
 
   explorer: Explorer;
 
@@ -69,6 +77,9 @@ export class DbState {
 
     this.vertexStyles = createRandomVertexStyles();
     this.edgeStyles = createRandomEdgeStyles();
+
+    this.graphViewLayout = createRandomGraphViewLayout();
+    this.schemaViewLayout = createRandomSchemaViewLayout();
 
     this.explorer = explorer;
   }
@@ -182,6 +193,28 @@ export class DbState {
     return composedStyle;
   }
 
+  /* View Layout Helpers */
+
+  /**
+   * Sets the graph view layout, replacing the random default. Applied verbatim
+   * so callers can seed legacy shapes (cast with `as GraphViewLayout`) to
+   * exercise backward-compat handling.
+   */
+  withGraphViewLayout(layout: GraphViewLayout) {
+    this.graphViewLayout = layout;
+    return this;
+  }
+
+  /**
+   * Sets the schema view layout, replacing the random default. Applied verbatim
+   * so callers can seed legacy shapes (cast with `as SchemaViewLayout`) to
+   * exercise backward-compat handling.
+   */
+  withSchemaViewLayout(layout: SchemaViewLayout) {
+    this.schemaViewLayout = layout;
+    return this;
+  }
+
   /** Applies the state to the given Jotai store. */
   applyTo(store: AppStore) {
     // Config
@@ -202,6 +235,10 @@ export class DbState {
     // Styling
     store.set(userVertexStylesAtom, this.vertexStyles);
     store.set(userEdgeStylesAtom, this.edgeStyles);
+
+    // View Layout
+    store.set(graphViewLayoutAtom, this.graphViewLayout);
+    store.set(schemaViewLayoutAtom, this.schemaViewLayout);
 
     // Vertices
     store.set(nodesAtom, toNodeMap(this.vertices));

--- a/packages/graph-explorer/src/utils/testing/randomData.ts
+++ b/packages/graph-explorer/src/utils/testing/randomData.ts
@@ -49,6 +49,7 @@ import {
   type EntityProperties,
   type EntityRawId,
   type FeatureFlags,
+  type GraphViewLayout,
   type LineStyle,
   type PrefixTypeConfig,
   type RawConfiguration,
@@ -62,6 +63,14 @@ import {
   type VertexType,
   type VertexTypeConfig,
 } from "@/core";
+import {
+  graphViewSidebarItems,
+  toggleableViews,
+} from "@/core/StateProvider/graphViewLayoutDefaults";
+import {
+  type SchemaViewLayout,
+  schemaViewSidebarItems,
+} from "@/core/StateProvider/schemaViewLayoutDefaults";
 import {
   createExportedGraph,
   type ExportedGraphConnection,
@@ -778,4 +787,59 @@ export function createRandomeResultScalar() {
     name: createRandomName("name"),
     value: createRandomScalarValue(),
   });
+}
+
+/** Picks a random subset (possibly empty) of the given values. */
+function randomSubset<T>(values: readonly T[]): Set<T> {
+  return new Set(values.filter(() => createRandomBoolean()));
+}
+
+// Arbitrary but plausible pixel bounds for randomized panel dimensions. The
+// exact values carry no meaning — they only need to be positive and varied so
+// tests reading a width or height pin their own expected value.
+const RANDOM_PANEL_MIN_PX = 100;
+const RANDOM_PANEL_MAX_PX = 800;
+
+/**
+ * Creates a random {@link GraphViewLayout}. Every field spans its full
+ * production domain — a closed sidebar (`null`), an empty toggle set, and
+ * `undefined` optionals are all reachable — so tests that read layout must pin
+ * the fields they depend on rather than relying on a convenient default.
+ */
+export function createRandomGraphViewLayout(): GraphViewLayout {
+  return {
+    activeSidebarItem: pickRandomElement([...graphViewSidebarItems, null]),
+    sidebar: {
+      width: createRandomInteger({
+        min: RANDOM_PANEL_MIN_PX,
+        max: RANDOM_PANEL_MAX_PX,
+      }),
+    },
+    activeToggles: randomSubset(toggleableViews),
+    tableView: randomlyUndefined({
+      height: createRandomInteger({
+        min: RANDOM_PANEL_MIN_PX,
+        max: RANDOM_PANEL_MAX_PX,
+      }),
+    }),
+    detailsAutoOpenOnSelection: randomlyUndefined(createRandomBoolean()),
+  };
+}
+
+/**
+ * Creates a random {@link SchemaViewLayout}. As with the graph view layout,
+ * every field spans its full production domain, including a closed sidebar and
+ * an `undefined` auto-open flag.
+ */
+export function createRandomSchemaViewLayout(): SchemaViewLayout {
+  return {
+    activeSidebarItem: pickRandomElement([...schemaViewSidebarItems, null]),
+    sidebar: {
+      width: createRandomInteger({
+        min: RANDOM_PANEL_MIN_PX,
+        max: RANDOM_PANEL_MAX_PX,
+      }),
+    },
+    detailsAutoOpenOnSelection: randomlyUndefined(createRandomBoolean()),
+  };
 }


### PR DESCRIPTION
## Description

Test-infrastructure follow-up to the Schema View sidebar work (#1875). It closes a documentation gap flagged in that review: `docs/agents/testing.md` said to always use `renderHookWithState`, but the layout-hook tests had to fall back to `renderHookWithJotai` because `DbState` couldn't seed the view-layout atoms.

The fix teaches `DbState` to own view layout, so layout-hook tests use the standard `DbState` + `renderHookWithState` path like every other hook test.

Core change:
- `DbState` gains `graphViewLayout` / `schemaViewLayout` fields, seeded with **random** values in the constructor and written to their atoms in `applyTo`. New `withGraphViewLayout` / `withSchemaViewLayout` setters override them, applied verbatim so legacy-shape backward-compat tests still work.
- Two new fully-anonymous factories, `createRandomGraphViewLayout` / `createRandomSchemaViewLayout`, where each field spans its full production domain (nullable active tab, empty toggle sets, `undefined` optionals). This is constrained non-determinism: seeding random layout everywhere forces any test that reads layout to pin the field it depends on.

Supporting changes:
- The two layout test files migrate to `DbState` + `renderHookWithState`.
- Unconditional random seeding surfaced two tests with an undeclared dependency on the old default layout (`useGraphSelection`, `SchemaExplorerSidebar`); both now pin their starting layout explicitly.
- `renderHookWithJotai` is **kept** — 12 other test files still use it — and reframed in the docs as the escape hatch for atoms `DbState` doesn't model.
- Docs: a constrained-non-determinism rule in `testing.md`, the layout types added to the persisted-types backward-compat list, and a `Graph Database` glossary entry in `CONTEXT.md`.

## Validation

- `pnpm checks` passes (types, lint, format).
- `pnpm test` passes (1925 tests), run repeatedly to shake out the new random seeding — no intermittent failures.
- No production source changed; this is test builders, factories, test migrations, and docs.

## How to read

1. [randomData.ts](https://github.com/aws/graph-explorer/pull/1893/files#diff-62def8d257296973e45d37367a5e408f82bdfc3613ac82756f474c0dcd948a2f) — the two random layout factories (full-domain anonymous values)
2. [DbState.ts](https://github.com/aws/graph-explorer/pull/1893/files#diff-752315a3d158c3fd14fbd6b1c7967d00629cc42525e0190111cd35087d5c7b2f) — layout fields, `with*Layout` setters, and unconditional seeding in `applyTo`
3. [graphViewLayout.test.ts](https://github.com/aws/graph-explorer/pull/1893/files#diff-18e6eac5a45b19cdb2187c344ef6a70c0bd914a826a0aed9c97a45be40331387) — the migrated layout tests (base-layout + override helper); `schemaViewLayout.test.ts` mirrors this
4. [testing.md](https://github.com/aws/graph-explorer/pull/1893/files#diff-d00af24f807aed3edd173c6e7d4bcf4a694b2ccf26b17a19105e534d94f43164) — the constrained-non-determinism rule and `renderHookWithJotai` escape-hatch framing

## Related Issues

- Related to #1875

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
