### PR TITLE
Fix AlertDialog footer padding inset

### DIFF
--- a/packages/graph-explorer/src/components/AlertDialog.tsx
+++ b/packages/graph-explorer/src/components/AlertDialog.tsx
@@ -109,7 +109,7 @@ function AlertDialogFooter({
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "bg-muted/50 -mx-4 -mb-4 flex flex-col-reverse gap-3 rounded-b-xl border-t p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        "bg-muted/50 -mx-6 -mb-6 flex flex-col-reverse gap-3 rounded-b-xl border-t p-6 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Description

The shared `AlertDialogFooter` used `-mx-4 -mb-4 … p-4` while its container `AlertDialogContent` pads with `p-6`. The 0.5rem mismatch left a thin inset strip around the footer, so its `bg-muted/50` fill and `border-t` stopped short of the content edges. Matching the footer to `-mx-6 -mb-6 … p-6` makes it bleed flush to the edges.

Because the fix is on the shared primitive, it corrects every `AlertDialog` modal — the styles-import conflict prompt (#1899's report), delete-connection, reset-styles, and others.

## Validation

`pnpm checks` passes. Change is a one-line className adjustment on a purely presentational component. Visually, the footer background and top border now reach the content edges with no surrounding gap.

## Related Issues

- Closes #1899
- Part of #1896

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
