### PR TITLE
Regroup Styles settings into Your Styles and Shared Styles groups

### DIFF
--- a/packages/graph-explorer/src/components/Group.tsx
+++ b/packages/graph-explorer/src/components/Group.tsx
@@ -7,7 +7,6 @@ const groupVariants = cva({
   variants: {
     variant: {
       default: "border-border divide-border",
-      danger: "border-danger-foreground/25 divide-danger-foreground/25",
       success: "border-success-foreground/25 divide-success-foreground/25",
       warning: "border-warning-foreground/25 divide-warning-foreground/25",
     },
@@ -38,7 +37,7 @@ function GroupHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "bg-neutral-subtle/50 text-text-secondary group-data-[variant=danger]/group:bg-danger-subtle/50 group-data-[variant=danger]/group:text-danger group-data-[variant=success]/group:bg-success-subtle/50 group-data-[variant=success]/group:text-success-main group-data-[variant=warning]/group:bg-warning-subtle/50 group-data-[variant=warning]/group:text-warning-main flex items-center gap-2 px-5 py-3 group-data-[size=small]/group:px-3 group-data-[size=small]/group:py-2",
+        "bg-neutral-subtle/50 text-text-secondary group-data-[variant=success]/group:bg-success-subtle/50 group-data-[variant=success]/group:text-success-main group-data-[variant=warning]/group:bg-warning-subtle/50 group-data-[variant=warning]/group:text-warning-main flex items-center gap-2 px-5 py-3 group-data-[size=small]/group:px-3 group-data-[size=small]/group:py-2",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/routes/Settings/LoadStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/LoadStylesButton.tsx
@@ -167,7 +167,7 @@ export default function LoadStylesButton() {
       >
         <Button className="min-w-28" disabled={isPending}>
           <UploadIcon />
-          Load from File
+          Load
         </Button>
       </FileButton>
 

--- a/packages/graph-explorer/src/routes/Settings/ResetCustomStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetCustomStylesButton.tsx
@@ -31,9 +31,13 @@ export default function ResetCustomStylesButton() {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="danger" className="min-w-28">
+        <Button
+          variant="danger"
+          className="min-w-28"
+          aria-label="Reset your styles"
+        >
           <Trash2Icon />
-          Reset Your Styles
+          Reset
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/packages/graph-explorer/src/routes/Settings/ResetSharedStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetSharedStylesButton.tsx
@@ -31,9 +31,13 @@ export default function ResetSharedStylesButton() {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="danger" className="min-w-28">
+        <Button
+          variant="danger"
+          className="min-w-28"
+          aria-label="Reset shared styles"
+        >
           <Trash2Icon />
-          Reset Shared Styles
+          Reset
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/packages/graph-explorer/src/routes/Settings/SaveStylesButton.test.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SaveStylesButton.test.tsx
@@ -32,7 +32,7 @@ function renderButton() {
 }
 
 function saveButton() {
-  return screen.getByRole("button", { name: "Save to File" });
+  return screen.getByRole("button", { name: "Save" });
 }
 
 describe("SaveStylesButton", () => {

--- a/packages/graph-explorer/src/routes/Settings/SaveStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SaveStylesButton.tsx
@@ -94,7 +94,7 @@ export default function SaveStylesButton() {
         disabled={isPending}
       >
         <DownloadIcon />
-        Save to File
+        Save
       </Button>
       <AlertDialog
         open={state.kind !== "closed"}

--- a/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
@@ -1,11 +1,10 @@
 import { useAtomValue } from "jotai";
-import { SwatchBookIcon, TriangleAlertIcon } from "lucide-react";
+import { SwatchBookIcon } from "lucide-react";
 
 import {
   Group,
   GroupHeader,
   GroupItem,
-  GroupMedia,
   GroupTitle,
   LabelledSetting,
   SettingsPageDescription,
@@ -43,7 +42,7 @@ export default function SettingsStyles() {
 
       <Group>
         <GroupHeader>
-          <GroupTitle>Style Sharing</GroupTitle>
+          <GroupTitle>Manage Your Styles</GroupTitle>
         </GroupHeader>
         <GroupItem>
           <LabelledSetting
@@ -53,6 +52,20 @@ export default function SettingsStyles() {
             <SaveStylesButton />
           </LabelledSetting>
         </GroupItem>
+        <GroupItem>
+          <LabelledSetting
+            label="Reset your styles"
+            description="Clear the styles you've set yourself. Shared styles remain."
+          >
+            <ResetCustomStylesButton />
+          </LabelledSetting>
+        </GroupItem>
+      </Group>
+
+      <Group>
+        <GroupHeader>
+          <GroupTitle>Manage Shared Styles</GroupTitle>
+        </GroupHeader>
         <GroupItem className="space-y-2">
           <LabelledSetting
             label="Load shared styles"
@@ -64,23 +77,6 @@ export default function SettingsStyles() {
             vertexCount={sharedVertexStyles.size}
             edgeCount={sharedEdgeStyles.size}
           />
-        </GroupItem>
-      </Group>
-
-      <Group variant="danger">
-        <GroupHeader>
-          <GroupMedia>
-            <TriangleAlertIcon />
-          </GroupMedia>
-          <GroupTitle>Danger Zone</GroupTitle>
-        </GroupHeader>
-        <GroupItem>
-          <LabelledSetting
-            label="Reset your styles"
-            description="Clear the styles you've set yourself. Shared styles remain."
-          >
-            <ResetCustomStylesButton />
-          </LabelledSetting>
         </GroupItem>
         <GroupItem>
           <LabelledSetting


### PR DESCRIPTION
## Description

Restructures the **Styles** settings screen into two action groups that mirror the "Manage Configuration Data" group in General settings:

- **Manage Your Styles** — save-to-file and reset-your-styles actions
- **Manage Shared Styles** — load-from-file and reset-shared-styles actions

With the actions grouped by what they act on, the buttons drop to single words (**Save**, **Load**, **Reset**) instead of the previous full phrases. Each **Reset** button carries a distinct `aria-label` so the two remain distinguishable to screen readers.

The old layout paired a "Style Sharing" group with a separate danger-variant "Danger Zone" group; that danger grouping is intentionally gone, so the now-unused `danger` variant is dropped from the shared `Group` component (it can be reintroduced later if needed).

This keeps the existing "shared styles" terminology unchanged — the rename to "theme" is a separate follow-up.

## How to read

1. [`SettingsStyles.tsx`](https://github.com/aws/graph-explorer/pull/1909/files#diff-2d08149acd39ca54fcc11ec4116a47ec186c1cb05a61c71d9b5ea0fe0f667cc7) — the core change: the two-group layout
2. [`Group.tsx`](https://github.com/aws/graph-explorer/pull/1909/files#diff-245acd88da1944b92723c559c9a39ce999d77b7dd06d0fad413575d2607e844c) — supporting cleanup: removes the dead `danger` variant

The button files (`Save`/`Load`/`Reset*StylesButton.tsx`) are small single-word label swaps plus `aria-label`s on the two Reset triggers.

## Validation

- `pnpm checks` passes
- `pnpm test` passes (Settings suite: 13 tests, including the updated `SaveStylesButton` label assertion)

## Related Issues

- Part of #1896
- Closes #1898
