### PR TITLE
Add "Reset all styles" action to the Styles settings screen

### DIFF
--- a/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.test.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+
+import { TooltipProvider } from "@/components";
+import {
+  getAppStore,
+  sharedEdgeStylesAtom,
+  sharedVertexStylesAtom,
+  userEdgeStylesAtom,
+  userVertexStylesAtom,
+} from "@/core";
+import { createQueryClient } from "@/core/queryClient";
+import { DbState, TestProvider } from "@/utils/testing";
+
+import ResetAllStylesButton from "./ResetAllStylesButton";
+
+function renderButton(state = new DbState()) {
+  const store = getAppStore();
+  state.applyTo(store);
+  const queryClient = createQueryClient();
+  render(
+    <TestProvider client={queryClient} store={store}>
+      <TooltipProvider>
+        <ResetAllStylesButton />
+      </TooltipProvider>
+    </TestProvider>,
+  );
+  return store;
+}
+
+function triggerButton() {
+  return screen.getByRole("button", { name: "Reset All Styles" });
+}
+
+describe("ResetAllStylesButton", () => {
+  test("renders a trigger button", () => {
+    renderButton();
+    expect(triggerButton()).toBeInTheDocument();
+  });
+
+  test("opens a confirmation dialog when clicked", async () => {
+    const user = userEvent.setup();
+    renderButton();
+
+    await user.click(triggerButton());
+
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(
+      screen.getByText(/clear all your styles and all shared styles/),
+    ).toBeInTheDocument();
+  });
+
+  test("resets all user and shared styles when confirmed", async () => {
+    const user = userEvent.setup();
+    const store = renderButton();
+
+    await user.click(triggerButton());
+    await user.click(screen.getByRole("button", { name: "Reset All Styles" }));
+
+    expect(store.get(userVertexStylesAtom)).toStrictEqual(new Map());
+    expect(store.get(userEdgeStylesAtom)).toStrictEqual(new Map());
+    expect(store.get(sharedVertexStylesAtom)).toStrictEqual(new Map());
+    expect(store.get(sharedEdgeStylesAtom)).toStrictEqual(new Map());
+  });
+
+  test("does nothing when cancelled", async () => {
+    const user = userEvent.setup();
+    const store = renderButton();
+
+    const expectedUserVertex = new Map(store.get(userVertexStylesAtom));
+    const expectedUserEdge = new Map(store.get(userEdgeStylesAtom));
+    const expectedSharedVertex = new Map(store.get(sharedVertexStylesAtom));
+    const expectedSharedEdge = new Map(store.get(sharedEdgeStylesAtom));
+
+    await user.click(triggerButton());
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(store.get(userVertexStylesAtom)).toStrictEqual(expectedUserVertex);
+    expect(store.get(userEdgeStylesAtom)).toStrictEqual(expectedUserEdge);
+    expect(store.get(sharedVertexStylesAtom)).toStrictEqual(
+      expectedSharedVertex,
+    );
+    expect(store.get(sharedEdgeStylesAtom)).toStrictEqual(expectedSharedEdge);
+  });
+});

--- a/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.tsx
@@ -1,0 +1,68 @@
+import { useSetAtom } from "jotai";
+import { Trash2Icon } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Button,
+} from "@/components";
+import {
+  sharedEdgeStylesAtom,
+  sharedVertexStylesAtom,
+  userEdgeStylesAtom,
+  userVertexStylesAtom,
+} from "@/core/StateProvider/storageAtoms";
+
+export default function ResetAllStylesButton() {
+  const setUserVertexStyles = useSetAtom(userVertexStylesAtom);
+  const setUserEdgeStyles = useSetAtom(userEdgeStylesAtom);
+  const setSharedVertexStyles = useSetAtom(sharedVertexStylesAtom);
+  const setSharedEdgeStyles = useSetAtom(sharedEdgeStylesAtom);
+
+  function resetAllStyles() {
+    setUserVertexStyles(new Map());
+    setUserEdgeStyles(new Map());
+    setSharedVertexStyles(new Map());
+    setSharedEdgeStyles(new Map());
+  }
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="danger" className="min-w-28">
+          <Trash2Icon />
+          Reset All Styles
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogMedia className="bg-danger-subtle text-danger">
+            <Trash2Icon />
+          </AlertDialogMedia>
+          <AlertDialogTitle>Reset All Styles</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="block">
+              This will clear all your styles and all shared styles, returning
+              everything to defaults. Consider saving first.
+            </span>
+            <span className="mbs-4 block">This cannot be undone.</span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="primary-danger" onClick={resetAllStyles}>
+            Reset All Styles
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/core/StateProvider/storageAtoms";
 
 import LoadStylesButton from "./LoadStylesButton";
+import ResetAllStylesButton from "./ResetAllStylesButton";
 import ResetCustomStylesButton from "./ResetCustomStylesButton";
 import ResetSharedStylesButton from "./ResetSharedStylesButton";
 import SaveStylesButton from "./SaveStylesButton";
@@ -88,6 +89,14 @@ export default function SettingsStyles() {
             description="Remove the shared styles. Your styles remain."
           >
             <ResetSharedStylesButton />
+          </LabelledSetting>
+        </GroupItem>
+        <GroupItem>
+          <LabelledSetting
+            label="Reset all styles"
+            description="Clear both your styles and shared styles, returning everything to defaults."
+          >
+            <ResetAllStylesButton />
           </LabelledSetting>
         </GroupItem>
       </Group>

--- a/packages/graph-explorer/src/utils/testing/DbState.ts
+++ b/packages/graph-explorer/src/utils/testing/DbState.ts
@@ -11,7 +11,6 @@ import {
   type EdgeStyleStorage,
   edgesAtom,
   edgesFilteredIdsAtom,
-  userEdgeStylesAtom,
   edgesTypesFilteredAtom,
   type EdgeType,
   explorerForTestingAtom,
@@ -26,11 +25,14 @@ import {
   schemaAtom,
   type SchemaStorageModel,
   schemaViewLayoutAtom,
+  sharedEdgeStylesAtom,
+  sharedVertexStylesAtom,
   toEdgeMap,
   toNodeMap,
   type Vertex,
   type VertexId,
   type VertexStyleStorage,
+  userEdgeStylesAtom,
   userVertexStylesAtom,
   type VertexType,
 } from "@/core";
@@ -57,6 +59,8 @@ export class DbState {
   activeConfig: RawConfiguration;
   vertexStyles: Map<VertexType, VertexStyleStorage>;
   edgeStyles: Map<EdgeType, EdgeStyleStorage>;
+  sharedVertexStyles: Map<VertexType, VertexStyleStorage>;
+  sharedEdgeStyles: Map<EdgeType, EdgeStyleStorage>;
   graphViewLayout: GraphViewLayout;
   schemaViewLayout: SchemaViewLayout;
 
@@ -77,6 +81,8 @@ export class DbState {
 
     this.vertexStyles = createRandomVertexStyles();
     this.edgeStyles = createRandomEdgeStyles();
+    this.sharedVertexStyles = createRandomVertexStyles();
+    this.sharedEdgeStyles = createRandomEdgeStyles();
 
     this.graphViewLayout = createRandomGraphViewLayout();
     this.schemaViewLayout = createRandomSchemaViewLayout();
@@ -161,10 +167,10 @@ export class DbState {
     this.filteredEdgeTypes.add(edgeType);
   }
 
-  /* User Styling Helpers */
+  /* User Styles Helpers */
 
   /**
-   * Adds a style configuration for the vertex type to the user styling.
+   * Adds a style configuration for the vertex type to the user styles.
    * @param vertexType The type of the vertex to add the style to.
    * @param style The style configuration to add.
    * @returns The fully composed style configuration.
@@ -179,7 +185,7 @@ export class DbState {
   }
 
   /**
-   * Adds a style configuration for the edge type to the user styling.
+   * Adds a style configuration for the edge type to the user styles.
    * @param edgeType The type of the edge to add the style to.
    * @param style The style configuration to add.
    * @returns The fully composed style configuration.
@@ -190,6 +196,38 @@ export class DbState {
   ): EdgeStyleStorage {
     const composedStyle = { ...style, type: edgeType };
     this.edgeStyles.set(edgeType, composedStyle);
+    return composedStyle;
+  }
+
+  /* Shared Styles Helpers */
+
+  /**
+   * Adds a style configuration for the vertex type to the shared styles.
+   * @param vertexType The type of the vertex to add the style to.
+   * @param style The style configuration to add.
+   * @returns The fully composed style configuration.
+   */
+  addSharedVertexStyle(
+    vertexType: VertexType,
+    style: Omit<VertexStyleStorage, "type">,
+  ): VertexStyleStorage {
+    const composedStyle = { ...style, type: vertexType };
+    this.sharedVertexStyles.set(vertexType, composedStyle);
+    return composedStyle;
+  }
+
+  /**
+   * Adds a style configuration for the edge type to the shared styles.
+   * @param edgeType The type of the edge to add the style to.
+   * @param style The style configuration to add.
+   * @returns The fully composed style configuration.
+   */
+  addSharedEdgeStyle(
+    edgeType: EdgeType,
+    style: Omit<EdgeStyleStorage, "type">,
+  ): EdgeStyleStorage {
+    const composedStyle = { ...style, type: edgeType };
+    this.sharedEdgeStyles.set(edgeType, composedStyle);
     return composedStyle;
   }
 
@@ -235,6 +273,8 @@ export class DbState {
     // Styling
     store.set(userVertexStylesAtom, this.vertexStyles);
     store.set(userEdgeStylesAtom, this.edgeStyles);
+    store.set(sharedVertexStylesAtom, this.sharedVertexStyles);
+    store.set(sharedEdgeStylesAtom, this.sharedEdgeStyles);
 
     // View Layout
     store.set(graphViewLayoutAtom, this.graphViewLayout);


### PR DESCRIPTION
## Description

Adds a "Reset all styles" action to Settings → Styles that clears both your styles and any loaded shared styles in one confirmed step. Previously each scope had to be reset separately.

The button sits in the existing Danger Zone group alongside the per-scope reset actions, guarded by the same confirmation-dialog pattern.

### How to read

1. [ResetAllStylesButton.tsx](https://github.com/aws/graph-explorer/pull/1916/files#diff-6517311f4bc06614958a9882390ee6c287cc6aad9cd6c2ae769df65b2a945272) — the core change; clears all four style atoms behind an AlertDialog confirmation
2. [SettingsStyles.tsx](https://github.com/aws/graph-explorer/pull/1916/files#diff-2d08149acd39ca54fcc11ec4116a47ec186c1cb05a61c71d9b5ea0fe0f667cc7) — wires the button into the Danger Zone group as a third item
3. [ResetAllStylesButton.test.tsx](https://github.com/aws/graph-explorer/pull/1916/files#diff-d464e1f7640d377075b5a49e3d06c406aec32f21cf55546c2a145d4258b7bcef) — render/confirm/cancel coverage; asserts full map equality before and after
4. [DbState.ts](https://github.com/aws/graph-explorer/pull/1916/files#diff-752315a3d158c3fd14fbd6b1c7967d00629cc42525e0190111cd35087d5c7b2f) — supporting test-infra: DbState now seeds and applies shared styles (random by default, like user styles) with `addSharedVertexStyle`/`addSharedEdgeStyle` helpers

## Validation

- All 2067 tests pass (`pnpm test`), including 4 new tests covering the render, confirm, and cancel paths
- `pnpm checks` passes with no errors
- The confirm path asserts all four style atoms strictly equal empty maps; the cancel path asserts they are untouched

## Related Issues

- Fixes #1897

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.