### PR TITLE
Add buffered NumberInput for decimal-friendly width editing

### DIFF
--- a/packages/graph-explorer/src/components/NumberInput.test.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { fireEvent, render, screen } from "@testing-library/react";
-import { useState } from "react";
+import { useDeferredValue, useState } from "react";
 
 import { NumberInput } from "./NumberInput";
 
@@ -105,5 +105,53 @@ describe("NumberInput", () => {
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
 
     expect(widthInput()).toHaveValue(7);
+  });
+
+  it("should reset after editing when value is deferred", () => {
+    function DeferredParent() {
+      const [raw, setRaw] = useState<number | undefined>(0);
+      const deferred = useDeferredValue(raw);
+      return (
+        <>
+          <NumberInput
+            aria-label="width"
+            value={deferred}
+            onValueChange={setRaw}
+          />
+          <button onClick={() => setRaw(0)}>reset</button>
+        </>
+      );
+    }
+    render(<DeferredParent />);
+
+    fireEvent.change(widthInput(), { target: { value: "3.5" } });
+    expect(widthInput().value).toBe("3.5");
+
+    fireEvent.click(screen.getByRole("button", { name: "reset" }));
+    expect(widthInput()).toHaveValue(0);
+  });
+
+  it("should reset after clearing when value is deferred", () => {
+    function DeferredParent() {
+      const [raw, setRaw] = useState<number | undefined>(2);
+      const deferred = useDeferredValue(raw);
+      return (
+        <>
+          <NumberInput
+            aria-label="width"
+            value={deferred}
+            onValueChange={setRaw}
+          />
+          <button onClick={() => setRaw(2)}>reset</button>
+        </>
+      );
+    }
+    render(<DeferredParent />);
+
+    fireEvent.change(widthInput(), { target: { value: "5" } });
+    fireEvent.change(widthInput(), { target: { value: "" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "reset" }));
+    expect(widthInput()).toHaveValue(2);
   });
 });

--- a/packages/graph-explorer/src/components/NumberInput.test.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.test.tsx
@@ -27,7 +27,7 @@ function Harness({
 }
 
 function widthInput() {
-  return screen.getByLabelText("width") as HTMLInputElement;
+  return screen.getByLabelText<HTMLInputElement>("width");
 }
 
 // The browser reports the raw editing buffer (e.g. "1.") through the change
@@ -105,13 +105,5 @@ describe("NumberInput", () => {
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
 
     expect(widthInput()).toHaveValue(7);
-  });
-
-  it("should pass step, min, and max to the underlying input", () => {
-    render(<Harness initialValue={1} step={0.5} min={0} max={10} />);
-
-    expect(widthInput()).toHaveAttribute("step", "0.5");
-    expect(widthInput()).toHaveAttribute("min", "0");
-    expect(widthInput()).toHaveAttribute("max", "10");
   });
 });

--- a/packages/graph-explorer/src/components/NumberInput.test.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.test.tsx
@@ -127,6 +127,8 @@ describe("NumberInput", () => {
     fireEvent.change(widthInput(), { target: { value: "3.5" } });
     expect(widthInput().value).toBe("3.5");
 
+    // Clicking a button in a real browser blurs the input first
+    fireEvent.blur(widthInput());
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
     expect(widthInput()).toHaveValue(0);
   });
@@ -151,6 +153,7 @@ describe("NumberInput", () => {
     fireEvent.change(widthInput(), { target: { value: "5" } });
     fireEvent.change(widthInput(), { target: { value: "" } });
 
+    fireEvent.blur(widthInput());
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
     expect(widthInput()).toHaveValue(2);
   });
@@ -175,6 +178,7 @@ describe("NumberInput", () => {
     fireEvent.change(widthInput(), { target: { value: "1.40" } });
     expect(widthInput().value).toBe("1.40");
 
+    fireEvent.blur(widthInput());
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
     expect(widthInput()).toHaveValue(0);
   });
@@ -198,6 +202,7 @@ describe("NumberInput", () => {
     fireEvent.change(widthInput(), { target: { value: "3" } });
     expect(widthInput().value).toBe("3");
 
+    fireEvent.blur(widthInput());
     fireEvent.click(screen.getByRole("button", { name: "set-external" }));
     expect(widthInput().value).toBe("9.5");
   });

--- a/packages/graph-explorer/src/components/NumberInput.test.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+
+import { NumberInput } from "./NumberInput";
+
+function Harness({
+  initialValue,
+  onChange = () => {},
+  ...props
+}: {
+  initialValue: number | undefined;
+  onChange?: (value: number | undefined) => void;
+} & Omit<React.ComponentProps<typeof NumberInput>, "value" | "onValueChange">) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <NumberInput
+      aria-label="width"
+      value={value}
+      onValueChange={next => {
+        setValue(next);
+        onChange(next);
+      }}
+      {...props}
+    />
+  );
+}
+
+function widthInput() {
+  return screen.getByLabelText("width") as HTMLInputElement;
+}
+
+// The browser reports the raw editing buffer (e.g. "1.") through the change
+// event. These tests fire those buffers directly, which is exactly what
+// user typing produces in a real browser.
+describe("NumberInput", () => {
+  it("should render the numeric value", () => {
+    render(<Harness initialValue={1.4} />);
+    expect(widthInput()).toHaveValue(1.4);
+  });
+
+  it("should render empty when the value is undefined", () => {
+    render(<Harness initialValue={undefined} />);
+    expect(widthInput().value).toBe("");
+  });
+
+  it("should preserve a trailing decimal point while editing", () => {
+    // Regression for aws/graph-explorer#1906: deleting the 4 from "1.4"
+    // collapsed "1." back to "1", destroying the decimal point.
+    const onChange = vi.fn();
+    render(<Harness initialValue={1.4} onChange={onChange} />);
+
+    fireEvent.change(widthInput(), { target: { value: "1." } });
+
+    expect(widthInput().value).toBe("1.");
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it("should allow retyping a decimal digit after deleting one", () => {
+    const onChange = vi.fn();
+    render(<Harness initialValue={1.4} onChange={onChange} />);
+
+    fireEvent.change(widthInput(), { target: { value: "1." } });
+    fireEvent.change(widthInput(), { target: { value: "1.2" } });
+
+    expect(widthInput().value).toBe("1.2");
+    expect(onChange).toHaveBeenLastCalledWith(1.2);
+  });
+
+  it("should clear with a single deletion and report undefined", () => {
+    const onChange = vi.fn();
+    render(<Harness initialValue={5} onChange={onChange} />);
+
+    fireEvent.change(widthInput(), { target: { value: "" } });
+
+    expect(widthInput().value).toBe("");
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("should reformat to the canonical value on blur", () => {
+    render(<Harness initialValue={1.4} />);
+
+    fireEvent.change(widthInput(), { target: { value: "1." } });
+    fireEvent.blur(widthInput());
+
+    expect(widthInput()).toHaveValue(1);
+  });
+
+  it("should reflect external value changes when not editing", () => {
+    function ExternalChange() {
+      const [value, setValue] = useState<number | undefined>(1);
+      return (
+        <>
+          <NumberInput
+            aria-label="width"
+            value={value}
+            onValueChange={setValue}
+          />
+          <button onClick={() => setValue(7)}>reset</button>
+        </>
+      );
+    }
+    render(<ExternalChange />);
+
+    fireEvent.click(screen.getByRole("button", { name: "reset" }));
+
+    expect(widthInput()).toHaveValue(7);
+  });
+
+  it("should pass step, min, and max to the underlying input", () => {
+    render(<Harness initialValue={1} step={0.5} min={0} max={10} />);
+
+    expect(widthInput()).toHaveAttribute("step", "0.5");
+    expect(widthInput()).toHaveAttribute("min", "0");
+    expect(widthInput()).toHaveAttribute("max", "10");
+  });
+});

--- a/packages/graph-explorer/src/components/NumberInput.test.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.test.tsx
@@ -154,4 +154,63 @@ describe("NumberInput", () => {
     fireEvent.click(screen.getByRole("button", { name: "reset" }));
     expect(widthInput()).toHaveValue(2);
   });
+
+  it("should reset after an edit that did not change the parsed value", () => {
+    function Parent() {
+      const [value, setValue] = useState<number | undefined>(1.4);
+      return (
+        <>
+          <NumberInput
+            aria-label="width"
+            value={value}
+            onValueChange={setValue}
+          />
+          <button onClick={() => setValue(0)}>reset</button>
+        </>
+      );
+    }
+    render(<Parent />);
+
+    // Trailing zero: "1.40" still parses to 1.4, so value prop doesn't change
+    fireEvent.change(widthInput(), { target: { value: "1.40" } });
+    expect(widthInput().value).toBe("1.40");
+
+    fireEvent.click(screen.getByRole("button", { name: "reset" }));
+    expect(widthInput()).toHaveValue(0);
+  });
+
+  it("should accept an external value change to a non-default value", () => {
+    function Parent() {
+      const [value, setValue] = useState<number | undefined>(1);
+      return (
+        <>
+          <NumberInput
+            aria-label="width"
+            value={value}
+            onValueChange={setValue}
+          />
+          <button onClick={() => setValue(9.5)}>set-external</button>
+        </>
+      );
+    }
+    render(<Parent />);
+
+    fireEvent.change(widthInput(), { target: { value: "3" } });
+    expect(widthInput().value).toBe("3");
+
+    fireEvent.click(screen.getByRole("button", { name: "set-external" }));
+    expect(widthInput().value).toBe("9.5");
+  });
+
+  it("should preserve buffer across rapid edits", () => {
+    const onChange = vi.fn();
+    render(<Harness initialValue={1} onChange={onChange} />);
+
+    fireEvent.change(widthInput(), { target: { value: "1." } });
+    fireEvent.change(widthInput(), { target: { value: "1.5" } });
+    fireEvent.change(widthInput(), { target: { value: "1.55" } });
+
+    expect(widthInput().value).toBe("1.55");
+    expect(onChange).toHaveBeenLastCalledWith(1.55);
+  });
 });

--- a/packages/graph-explorer/src/components/NumberInput.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.tsx
@@ -26,18 +26,18 @@ export function NumberInput({
 }: NumberInputProps) {
   const [buffer, setBuffer] = useState(formatValue(value));
   const [syncedValue, setSyncedValue] = useState(value);
-  const [editing, setEditing] = useState(false);
+  // The last parsed value we reported upward via onValueChange.
+  const [reportedValue, setReportedValue] = useState(value);
 
   if (value !== syncedValue) {
     setSyncedValue(value);
-    // When the value prop changes because of our own edit (the parent echoes
-    // back the parsed number), keep the raw buffer so intermediate states like
-    // "1." or "" aren't overwritten. When it changes for any other reason
-    // (e.g. Reset to Default), force the buffer to match.
-    if (!editing) {
+    // When the value prop changes to match what we just reported (the parent
+    // echoes back our edit), keep the raw buffer so intermediate states like
+    // "1." or "" aren't overwritten. When it changes to anything else (e.g.
+    // Reset to Default, external update), force the buffer to match.
+    if (value !== reportedValue) {
       setBuffer(formatValue(value));
     }
-    setEditing(false);
   }
 
   return (
@@ -45,9 +45,10 @@ export function NumberInput({
       type="number"
       value={buffer}
       onChange={e => {
-        setEditing(true);
+        const parsed = parseNumberSafely(e.target.value);
         setBuffer(e.target.value);
-        onValueChange(parseNumberSafely(e.target.value));
+        setReportedValue(parsed);
+        onValueChange(parsed);
       }}
       onBlur={() => setBuffer(formatValue(value))}
       {...props}

--- a/packages/graph-explorer/src/components/NumberInput.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+import { parseNumberSafely } from "@/utils/parseNumberSafely";
+
+import { Input, type InputProps } from "./Input";
+
+export interface NumberInputProps extends Omit<
+  InputProps,
+  "type" | "value" | "onChange"
+> {
+  value: number | undefined;
+  onValueChange: (value: number | undefined) => void;
+}
+
+/**
+ * A numeric input that keeps the raw editing buffer (e.g. "1." or "") on
+ * screen while reporting parsed numbers upward. Binding a controlled input
+ * directly to a number destroys intermediate states — `Number("1.")` is `1`,
+ * so the decimal point vanishes as soon as it is typed or exposed by
+ * deleting a digit.
+ */
+export function NumberInput({
+  value,
+  onValueChange,
+  ...props
+}: NumberInputProps) {
+  const [buffer, setBuffer] = useState(formatValue(value));
+  const [syncedValue, setSyncedValue] = useState(value);
+
+  // Resync the buffer when the value changes externally (e.g. reset to
+  // default), but not when the change is our own edit echoing back.
+  if (value !== syncedValue) {
+    setSyncedValue(value);
+    if (parseNumberSafely(buffer) !== value) {
+      setBuffer(formatValue(value));
+    }
+  }
+
+  return (
+    <Input
+      type="number"
+      value={buffer}
+      onChange={e => {
+        setBuffer(e.target.value);
+        onValueChange(parseNumberSafely(e.target.value));
+      }}
+      onBlur={() => setBuffer(formatValue(value))}
+      {...props}
+    />
+  );
+}
+
+function formatValue(value: number | undefined) {
+  return value === undefined ? "" : String(value);
+}

--- a/packages/graph-explorer/src/components/NumberInput.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.tsx
@@ -18,39 +18,27 @@ export interface NumberInputProps extends Omit<
  * directly to a number destroys intermediate states — `Number("1.")` is `1`,
  * so the decimal point vanishes as soon as it is typed or exposed by
  * deleting a digit.
+ *
+ * While the user is editing, the draft string owns the display. Outside of an
+ * edit the display derives directly from the value prop, so external changes
+ * (e.g. Reset to Default, which blurs the input by taking focus) always show.
  */
 export function NumberInput({
   value,
   onValueChange,
   ...props
 }: NumberInputProps) {
-  const [buffer, setBuffer] = useState(formatValue(value));
-  const [syncedValue, setSyncedValue] = useState(value);
-  // The last parsed value we reported upward via onValueChange.
-  const [reportedValue, setReportedValue] = useState(value);
-
-  if (value !== syncedValue) {
-    setSyncedValue(value);
-    // When the value prop changes to match what we just reported (the parent
-    // echoes back our edit), keep the raw buffer so intermediate states like
-    // "1." or "" aren't overwritten. When it changes to anything else (e.g.
-    // Reset to Default, external update), force the buffer to match.
-    if (value !== reportedValue) {
-      setBuffer(formatValue(value));
-    }
-  }
+  const [draft, setDraft] = useState<string | null>(null);
 
   return (
     <Input
       type="number"
-      value={buffer}
+      value={draft ?? formatValue(value)}
       onChange={e => {
-        const parsed = parseNumberSafely(e.target.value);
-        setBuffer(e.target.value);
-        setReportedValue(parsed);
-        onValueChange(parsed);
+        setDraft(e.target.value);
+        onValueChange(parseNumberSafely(e.target.value));
       }}
-      onBlur={() => setBuffer(formatValue(value))}
+      onBlur={() => setDraft(null)}
       {...props}
     />
   );

--- a/packages/graph-explorer/src/components/NumberInput.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.tsx
@@ -26,14 +26,18 @@ export function NumberInput({
 }: NumberInputProps) {
   const [buffer, setBuffer] = useState(formatValue(value));
   const [syncedValue, setSyncedValue] = useState(value);
+  const [editing, setEditing] = useState(false);
 
-  // Resync the buffer when the value changes externally (e.g. reset to
-  // default), but not when the change is our own edit echoing back.
   if (value !== syncedValue) {
     setSyncedValue(value);
-    if (parseNumberSafely(buffer) !== value) {
+    // When the value prop changes because of our own edit (the parent echoes
+    // back the parsed number), keep the raw buffer so intermediate states like
+    // "1." or "" aren't overwritten. When it changes for any other reason
+    // (e.g. Reset to Default), force the buffer to match.
+    if (!editing) {
       setBuffer(formatValue(value));
     }
+    setEditing(false);
   }
 
   return (
@@ -41,6 +45,7 @@ export function NumberInput({
       type="number"
       value={buffer}
       onChange={e => {
+        setEditing(true);
         setBuffer(e.target.value);
         onValueChange(parseNumberSafely(e.target.value));
       }}

--- a/packages/graph-explorer/src/components/NumberInput.tsx
+++ b/packages/graph-explorer/src/components/NumberInput.tsx
@@ -6,7 +6,7 @@ import { Input, type InputProps } from "./Input";
 
 export interface NumberInputProps extends Omit<
   InputProps,
-  "type" | "value" | "onChange"
+  "type" | "value" | "onChange" | "onBlur"
 > {
   value: number | undefined;
   onValueChange: (value: number | undefined) => void;

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -42,6 +42,7 @@ export * from "./numberFormat";
 export * from "./icons";
 
 export * from "./Input";
+export * from "./NumberInput";
 export * from "./LabelledSetting";
 export { default as InputField } from "./InputField";
 export * from "./InputField";

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -8,7 +8,7 @@ import {
   FieldLabel,
   FieldLegend,
   FieldSet,
-  Input,
+  NumberInput,
   Select,
   SelectContent,
   SelectItem,
@@ -36,7 +36,7 @@ import {
   useEdgeStyling,
 } from "@/core/StateProvider/graphStyles";
 import useTranslations from "@/hooks/useTranslations";
-import { parseNumberSafely, RESERVED_TYPES_PROPERTY } from "@/utils";
+import { RESERVED_TYPES_PROPERTY } from "@/utils";
 
 import { ARROW_STYLE_OPTIONS } from "./arrowsStyling";
 import { LINE_STYLE_OPTIONS } from "./lineStyling";
@@ -141,18 +141,13 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
                 </Field>
                 <Field>
                   <FieldLabel>Background Opacity</FieldLabel>
-                  <Input
-                    type="number"
+                  <NumberInput
                     min={0}
                     max={1}
                     step={0.1}
                     value={edgeStyle.labelBackgroundOpacity}
-                    onChange={e =>
-                      setEdgeStyle({
-                        labelBackgroundOpacity: parseNumberSafely(
-                          e.target.value,
-                        ),
-                      })
+                    onValueChange={labelBackgroundOpacity =>
+                      setEdgeStyle({ labelBackgroundOpacity })
                     }
                   />
                 </Field>
@@ -169,14 +164,12 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
                 </Field>
                 <Field>
                   <FieldLabel>Border Width</FieldLabel>
-                  <Input
-                    type="number"
+                  <NumberInput
                     min={0}
+                    step={0.5}
                     value={edgeStyle.labelBorderWidth}
-                    onChange={e =>
-                      setEdgeStyle({
-                        labelBorderWidth: parseNumberSafely(e.target.value),
-                      })
+                    onValueChange={labelBorderWidth =>
+                      setEdgeStyle({ labelBorderWidth })
                     }
                   />
                 </Field>
@@ -218,14 +211,12 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
 
                 <Field>
                   <FieldLabel>Line Thickness</FieldLabel>
-                  <Input
-                    type="number"
+                  <NumberInput
                     min={1}
+                    step={0.5}
                     value={edgeStyle.lineThickness}
-                    onChange={e =>
-                      setEdgeStyle({
-                        lineThickness: parseNumberSafely(e.target.value),
-                      })
+                    onValueChange={lineThickness =>
+                      setEdgeStyle({ lineThickness })
                     }
                   />
                 </Field>

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -11,7 +11,7 @@ import {
   FieldSet,
   FileButton,
   IconPicker,
-  Input,
+  NumberInput,
   Select,
   SelectContent,
   SelectItem,
@@ -37,7 +37,6 @@ import {
 } from "@/core/StateProvider/graphStyles";
 import { isAllowedIconValue } from "@/core/styling";
 import useTranslations from "@/hooks/useTranslations";
-import { parseNumberSafely } from "@/utils";
 import {
   RESERVED_ID_PROPERTY,
   RESERVED_TYPES_PROPERTY,
@@ -251,16 +250,13 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 </Field>
                 <Field>
                   <FieldLabel>Background Opacity</FieldLabel>
-                  <Input
-                    type="number"
+                  <NumberInput
                     min={0}
                     max={1}
                     step={0.1}
                     value={vertexStyle.backgroundOpacity}
-                    onChange={e =>
-                      setVertexStyle({
-                        backgroundOpacity: parseNumberSafely(e.target.value),
-                      })
+                    onValueChange={backgroundOpacity =>
+                      setVertexStyle({ backgroundOpacity })
                     }
                   />
                 </Field>
@@ -277,14 +273,12 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 </Field>
                 <Field>
                   <FieldLabel>Border Width</FieldLabel>
-                  <Input
-                    type="number"
+                  <NumberInput
                     min={0}
+                    step={0.5}
                     value={vertexStyle.borderWidth}
-                    onChange={e =>
-                      setVertexStyle({
-                        borderWidth: parseNumberSafely(e.target.value),
-                      })
+                    onValueChange={borderWidth =>
+                      setVertexStyle({ borderWidth })
                     }
                   />
                 </Field>


### PR DESCRIPTION
## Description

Editing width values in the style dialogs was awkward: the fields bound a controlled input directly to a parsed number, so every keystroke round-tripped through `Number()` → `String()`, collapsing intermediate editing states (`"1."` became `"1"`, destroying the decimal point mid-edit). The steppers also moved by whole units, which is a big jump in Cytoscape.

This adds a `NumberInput` component using a focused-draft pattern: while the user is editing, a raw draft string owns the display (so `"1."` and `""` survive); on blur the draft is discarded and the display derives directly from the value prop. Because there is no persistent local buffer, external changes — Reset to Default, loading a styles file, another tab — always show without any sync logic. All five numeric fields across the node and edge style dialogs now use it, and the three width/thickness fields get `step={0.5}` (opacity keeps `step={0.1}`).

### How to read

1. [NumberInput.tsx](https://github.com/aws/graph-explorer/pull/1919/files#diff-1cc169f72b7ac3ba98d3c7821f37358f20d7542af8a1d81c8eaac73543305bab) — the new component; one `draft` state and a `??` is the whole mechanism
2. [NumberInput.test.tsx](https://github.com/aws/graph-explorer/pull/1919/files#diff-1216bcbf38456609e1b19a482c8277ee159a2bea6d0383793abfb8acf8554c6e) — regression tests; they fire raw change-event buffers directly since happy-dom can't drive native number-input keyboard editing
3. [NodeStyleDialog.tsx](https://github.com/aws/graph-explorer/pull/1919/files#diff-f41c824f187ba0971bb71f59e715c0b4f5b5292f25f77636130d0cbe8fb550df) and [EdgeStyleDialog.tsx](https://github.com/aws/graph-explorer/pull/1919/files#diff-0c8636066dedbd8d28ca81da3ef4bb9a3b2947d1038ea502563628b9fe742979) — mechanical adoption at the five call sites

## Validation

- Regression tests cover decimal preservation, single-press clearing, external resets (including through `useDeferredValue`, which the style hooks use), edits that don't change the parsed value, and blur canonicalisation.
- Manually verified in the running app: deleting a digit from `1.4` no longer drops the decimal point, clearing takes one delete, steppers move by 0.5, and Reset to Default restores the fields.
- `pnpm checks` and `pnpm test` (2078 tests) pass.

## Related Issues

- Fixes #1906
- Part of #1896

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
