### PR TITLE
Skip reset when clicking the already-active connection

### DIFF
--- a/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.test.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test } from "vitest";
+
+import { TooltipProvider } from "@/components";
+import {
+  activeConfigurationAtom,
+  configurationAtom,
+  getAppStore,
+  nodesAtom,
+  toNodeMap,
+} from "@/core";
+import { createQueryClient } from "@/core/queryClient";
+import {
+  createRandomRawConfiguration,
+  createRandomVertex,
+} from "@/utils/testing";
+import { TestProvider } from "@/utils/testing";
+
+import { ConnectionRow } from "./ConnectionRow";
+
+describe("ConnectionRow", () => {
+  test("clicking the already-active connection does not reset session state", async () => {
+    const user = userEvent.setup();
+    const store = getAppStore();
+    const connection = createRandomRawConfiguration();
+    const vertex = createRandomVertex();
+
+    store.set(configurationAtom, new Map([[connection.id, connection]]));
+    store.set(activeConfigurationAtom, connection.id);
+    store.set(nodesAtom, toNodeMap([vertex]));
+
+    const queryClient = createQueryClient();
+
+    render(
+      <TestProvider client={queryClient} store={store}>
+        <TooltipProvider>
+          <ConnectionRow
+            connection={connection}
+            isSelected={true}
+            isDisabled={false}
+          />
+        </TooltipProvider>
+      </TestProvider>,
+    );
+
+    const row = screen.getByText(connection.displayLabel || connection.id);
+    await user.click(row);
+
+    const nodesAfterClick = store.get(nodesAtom);
+    expect(nodesAfterClick.size).toBe(1);
+    expect(nodesAfterClick.get(vertex.id)).toBeDefined();
+  });
+
+  test("clicking a different connection resets session state", async () => {
+    const user = userEvent.setup();
+    const store = getAppStore();
+    const activeConnection = createRandomRawConfiguration();
+    const otherConnection = createRandomRawConfiguration();
+    const vertex = createRandomVertex();
+
+    store.set(
+      configurationAtom,
+      new Map([
+        [activeConnection.id, activeConnection],
+        [otherConnection.id, otherConnection],
+      ]),
+    );
+    store.set(activeConfigurationAtom, activeConnection.id);
+    store.set(nodesAtom, toNodeMap([vertex]));
+
+    const queryClient = createQueryClient();
+
+    render(
+      <TestProvider client={queryClient} store={store}>
+        <TooltipProvider>
+          <ConnectionRow
+            connection={otherConnection}
+            isSelected={false}
+            isDisabled={false}
+          />
+        </TooltipProvider>
+      </TestProvider>,
+    );
+
+    const row = screen.getByText(
+      otherConnection.displayLabel || otherConnection.id,
+    );
+    await user.click(row);
+
+    const nodesAfterClick = store.get(nodesAtom);
+    expect(nodesAfterClick.size).toBe(0);
+  });
+});

--- a/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
@@ -65,7 +65,10 @@ function useSetActiveConfigCallback(configId: ConfigurationId) {
   const resetState = useResetState();
   return useAtomCallback(
     useCallback(
-      (_get, set) => {
+      (get, set) => {
+        if (get(activeConfigurationAtom) === configId) {
+          return;
+        }
         logger.debug("Setting active connection to", configId);
         set(activeConfigurationAtom, configId);
         resetState();


### PR DESCRIPTION
## Description

Clicking the already-active connection on the connections screen was unconditionally calling `resetState()`, wiping the in-progress graph session. Now `useSetActiveConfigCallback` reads the current active config and returns early when the clicked connection already matches — making it a no-op instead of a destructive reset.

## How to read

1. [`ConnectionRow.tsx`](https://github.com/aws/graph-explorer/pull/1924/files#diff-f7ee1ffcea3e5ff799ab1dc7e463112e45bc69cfc84254e729081a92c9e9b493) — the 3-line guard in `useSetActiveConfigCallback`
2. [`ConnectionRow.test.tsx`](https://github.com/aws/graph-explorer/pull/1924/files#diff-98e4fdb4ae5124395ed0fb75a23bedd85b9ba0585a23c6f19b3750c559b5d28c) — two test cases: active-connection click preserves state, different-connection click resets state

## Validation

- `pnpm checks` passes
- `pnpm test` passes (2081 tests)
- New tests cover both the fix and the existing reset-on-switch behavior

## Related Issues

- Closes #1900

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.