### PR TITLE
Align style dialog wording with the Settings screen

### DIFF
--- a/packages/graph-explorer/src/hooks/translations/gremlin-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/gremlin-translations.json
@@ -19,12 +19,6 @@
   "edge-connections": "Relationships",
   "query-language": "PG-Gremlin",
 
-  "nodes-styling": {
-    "title": "Node Label Styling"
-  },
-  "edges-styling": {
-    "title": "Edge Label Styling"
-  },
   "keyword-search": {
     "node-type-placeholder": "Select a node label",
     "node-attribute-placeholder": "Select a property"

--- a/packages/graph-explorer/src/hooks/translations/openCypher-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/openCypher-translations.json
@@ -19,12 +19,6 @@
   "edge-connections": "Relationships",
   "query-language": "PG-openCypher",
 
-  "nodes-styling": {
-    "title": "Node Label Styling"
-  },
-  "edges-styling": {
-    "title": "Relationship Type Styling"
-  },
   "keyword-search": {
     "node-type-placeholder": "Select a node label",
     "node-attribute-placeholder": "Select a property"

--- a/packages/graph-explorer/src/hooks/translations/sparql-translations.json
+++ b/packages/graph-explorer/src/hooks/translations/sparql-translations.json
@@ -19,12 +19,6 @@
   "edge-connections": "Object Properties",
   "query-language": "RDF-SPARQL",
 
-  "nodes-styling": {
-    "title": "Resource Styling"
-  },
-  "edges-styling": {
-    "title": "Predicate Styling"
-  },
   "keyword-search": {
     "node-type-placeholder": "Select a class",
     "node-attribute-placeholder": "Select a predicate"

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -97,9 +97,9 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
     <DialogContent className="max-w-2xl">
       <form className="flex min-h-0 flex-col">
         <DialogHeader>
-          <DialogTitle>{t("edges-styling.title")}</DialogTitle>
+          <DialogTitle>Customize Your {t("edge")} Style</DialogTitle>
           <DialogDescription>
-            Customize styling for {displayConfig.displayLabel}
+            Changes here become your custom style and override shared styles.
           </DialogDescription>
         </DialogHeader>
         <DialogBody>
@@ -301,7 +301,7 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
             variant="outline-danger"
             onClick={resetEdgeStyle}
           >
-            Reset to Default
+            Clear Customization
           </Button>
           <DialogClose asChild>
             <Button type="button" variant="primary">

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -138,9 +138,9 @@ function Content({ vertexType }: { vertexType: VertexType }) {
     <DialogContent className="max-w-2xl">
       <form className="flex min-h-0 flex-col">
         <DialogHeader>
-          <DialogTitle>{t("nodes-styling.title")}</DialogTitle>
+          <DialogTitle>Customize Your {t("node")} Style</DialogTitle>
           <DialogDescription>
-            Customize styling for {displayConfig.displayLabel}
+            Changes here become your custom style and override shared styles.
           </DialogDescription>
         </DialogHeader>
 
@@ -312,7 +312,7 @@ function Content({ vertexType }: { vertexType: VertexType }) {
             variant="outline-danger"
             onClick={resetVertexStyle}
           >
-            Reset to Default
+            Clear Customization
           </Button>
           <DialogClose asChild>
             <Button type="button" variant="primary">


### PR DESCRIPTION
## Description

The node/edge style dialogs used wording that didn't match the Styles settings screen. This updates three pieces of copy to speak the same language:

- **Title**: "Node Label Styling" → "Customize Your Node Style" (adapts per query language via existing `t("node")` / `t("edge")` translations)
- **Description**: "Customize styling for {type}" → "Changes here become your custom style and override shared styles." — teaches the cascade without embedding the type name (which can be long in RDF)
- **Reset button**: "Reset to Default" → "Clear Customization"

Also removes the now-dead `nodes-styling` and `edges-styling` translation keys from all three translation files.

## How to read

1. [NodeStyleDialog.tsx](https://github.com/aws/graph-explorer/pull/1927/files#diff-f41c824f187ba0971bb71f59e715c0b4f5b5292f25f77636130d0cbe8fb550df) — title, description, and reset button changes
2. [EdgeStyleDialog.tsx](https://github.com/aws/graph-explorer/pull/1927/files#diff-0c8636066dedbd8d28ca81da3ef4bb9a3b2947d1038ea502563628b9fe742979) — same pattern for edges
3. [gremlin-translations.json](https://github.com/aws/graph-explorer/pull/1927/files#diff-2942572139a5ee3d862b7f2b5a3cd9b7bbde4e57c65ac69fd4c870653487d0e9) — dead key removal (openCypher and SPARQL are identical)

## Validation

- `pnpm checks` passes (types, lint, format)
- `pnpm test` passes (2093 tests, 183 files)
- Visual: open any node or edge style dialog and confirm the title, description, and reset button use the updated wording

## Related Issues

- Closes #1901

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.