### PR TITLE
Add canvas-style node preview to the style dialog

### DIFF
--- a/packages/graph-explorer/src/components/IconPicker.test.tsx
+++ b/packages/graph-explorer/src/components/IconPicker.test.tsx
@@ -10,9 +10,13 @@ import { TooltipProvider } from "./Tooltip";
 // The icon tooltips require a TooltipProvider ancestor, which the app supplies
 // globally in DefaultLayout.
 function renderPicker(props: Partial<ComponentProps<typeof IconPicker>> = {}) {
-  return render(<IconPicker onSelect={vi.fn()} {...props} />, {
-    wrapper: TooltipProvider,
-  });
+  const { children = <button>Browse</button>, ...rest } = props;
+  return render(
+    <IconPicker onSelect={vi.fn()} {...rest}>
+      {children}
+    </IconPicker>,
+    { wrapper: TooltipProvider },
+  );
 }
 
 // Icon buttons are the only buttons in the picker with `aria-pressed`, and

--- a/packages/graph-explorer/src/components/IconPicker.tsx
+++ b/packages/graph-explorer/src/components/IconPicker.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeftIcon, ChevronRightIcon, SearchIcon } from "lucide-react";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { DynamicIcon } from "lucide-react/dynamic";
 import { useState } from "react";
 
@@ -26,6 +26,7 @@ const PAGE_SIZE = 64;
 export function IconPicker({
   currentIconUrl,
   onSelect,
+  children,
 }: {
   /**
    * The vertex's currently stored iconUrl. When this is a `lucide:<name>`
@@ -38,6 +39,8 @@ export function IconPicker({
    * Resolution to a data URI happens at render time, not here.
    */
   onSelect: (iconUrl: string, iconImageType: string) => void;
+  /** The trigger element for the popover (must be a single element for Radix `asChild`). */
+  children: React.ReactElement;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -69,12 +72,7 @@ export function IconPicker({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" className="rounded-full">
-          <SearchIcon className="size-4" />
-          Browse
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         side="bottom"
         align="start"

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -1,5 +1,5 @@
 import { atom, useAtom, useSetAtom } from "jotai";
-import { ImageUpIcon } from "lucide-react";
+import { ImageUpIcon, SearchIcon } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -188,56 +188,70 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 </Select>
               </Field>
             </FieldGroup>
-            <FieldGroup className="flex w-full flex-row gap-4">
-              <div className="flex-1">
-                <Field>
-                  <FieldLabel>Shape</FieldLabel>
-                  <Select
-                    value={vertexStyle.shape}
-                    onValueChange={value =>
-                      setVertexStyle({ shape: value as ShapeStyle })
+            <FieldGroup className="grid grid-cols-[1fr_auto] gap-4">
+              <Field className="col-start-1 row-start-1">
+                <FieldLabel>Shape</FieldLabel>
+                <Select
+                  value={vertexStyle.shape}
+                  onValueChange={value =>
+                    setVertexStyle({ shape: value as ShapeStyle })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Choose shape" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {NODE_SHAPE.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field className="col-start-1 row-start-2">
+                <FieldLabel>Icon</FieldLabel>
+                <div className="grid grid-cols-2 items-center gap-2">
+                  <IconPicker
+                    currentIconUrl={vertexStyle.iconUrl}
+                    onSelect={(iconUrl, iconImageType) =>
+                      setVertexStyle({ iconUrl, iconImageType })
                     }
                   >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Choose shape" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {NODE_SHAPE.map(option => (
-                        <SelectItem key={option.value} value={option.value}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Field>
-              </div>
-              <div>
-                <Field>
-                  <FieldLabel>Icon</FieldLabel>
-                  <div className="flex flex-row items-center gap-2">
-                    <IconPicker
-                      currentIconUrl={vertexStyle.iconUrl}
-                      onSelect={(iconUrl, iconImageType) =>
-                        setVertexStyle({ iconUrl, iconImageType })
+                    <Button variant="outline">
+                      <SearchIcon className="size-4" />
+                      Browse
+                    </Button>
+                  </IconPicker>
+                  <FileButton
+                    accept="image/*"
+                    onChange={file => {
+                      if (file) {
+                        convertImageToBase64AndSetNewIcon(file);
                       }
+                    }}
+                    variant="outline"
+                  >
+                    <ImageUpIcon />
+                    Upload
+                  </FileButton>
+                </div>
+              </Field>
+
+              <Field className="col-start-2 row-span-2 w-auto">
+                <FieldLabel>Preview</FieldLabel>
+                <div className="bg-background-secondary border-input grid rounded-lg border shadow-xs">
+                  <div className="flex flex-col items-center justify-center px-6">
+                    <VertexSymbol
+                      vertexStyle={vertexStyle}
+                      className="size-16"
                     />
-                    <FileButton
-                      accept="image/*"
-                      onChange={file => {
-                        if (file) {
-                          convertImageToBase64AndSetNewIcon(file);
-                        }
-                      }}
-                      variant="outline"
-                      className="rounded-full"
-                    >
-                      <ImageUpIcon />
-                      Upload
-                    </FileButton>
-                    <VertexSymbol vertexStyle={vertexStyle} />
+                    <span className="-mt-2 rounded-md bg-[#1d2531]/80 px-3 py-1.5 text-sm leading-none font-medium tracking-wide text-white">
+                      {displayConfig.displayLabel}
+                    </span>
                   </div>
-                </Field>
-              </div>
+                </div>
+              </Field>
             </FieldGroup>
             <FieldGroup>
               <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Description

The node style dialog showed a tiny inline preview that was easy to miss (#1907). Now there's a prominent live preview with the node's type label rendered exactly as it appears on the canvas — dark pill background, white text — so users can see the effect of style changes at a glance.

Also refactors IconPicker to accept `children` as its trigger element, giving callers control over the button appearance.

### How to read

1. [NodeStyleDialog.tsx](https://github.com/aws/graph-explorer/pull/1935/files#diff-f41c824f187ba0971bb71f59e715c0b4f5b5292f25f77636130d0cbe8fb550df) — the layout restructure: grid with shape/icon controls on the left, preview field on the right
2. [IconPicker.tsx](https://github.com/aws/graph-explorer/pull/1935/files#diff-3bfa1834dd23cfa73188896a365088818aa7910332cdfc5e4b758b5540244c74) — accepts `children` as the trigger element instead of hardcoding the button
3. [IconPicker.test.tsx](https://github.com/aws/graph-explorer/pull/1935/files#diff-d9dcbe720a4a72650a38633f92e6cdbcb441e475919b4854a1f7593339f5eec6) — test helper updated for the new required `children` prop

## Validation

Open the node style dialog (Nodes Styling panel → click the customize button on any node type). The preview should render a large node with the type label below it in a dark pill, updating live as you change shape, icon, color, or border settings.

<img width="580" alt="Node style dialog with canvas-style preview" src="https://github.com/user-attachments/assets/87e5af66-2502-4dbb-adf3-0b957eda0765" />

## Related Issues

- Closes #1907
- Related to #1896
- Related to #1934

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.