### PR TITLE
Add settings navigation link to styles sidebar header

### DIFF
--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaExplorerSidebar.test.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/SchemaExplorerSidebar.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "jotai";
+import { MemoryRouter } from "react-router";
 import { describe, expect, test, vi } from "vitest";
 
 import { TooltipProvider } from "@/components";
@@ -45,13 +46,15 @@ function renderSidebar(state: DbState) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
-        <TooltipProvider>
-          <SchemaExplorerSidebar selection={null} />
-        </TooltipProvider>
-      </Provider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <TooltipProvider>
+            <SchemaExplorerSidebar selection={null} />
+          </TooltipProvider>
+        </Provider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 

--- a/packages/graph-explorer/src/modules/Styles/Styles.test.tsx
+++ b/packages/graph-explorer/src/modules/Styles/Styles.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "jotai";
+import { MemoryRouter } from "react-router";
 import { describe, expect, test, vi } from "vitest";
 
 import { TooltipProvider } from "@/components";
@@ -34,13 +35,15 @@ function renderStyles(state: DbState) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>
-      <Provider store={store}>
-        <TooltipProvider>
-          <Styles onClose={() => {}} tabAtom={graphViewStylesTabAtom} />
-        </TooltipProvider>
-      </Provider>
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <TooltipProvider>
+            <Styles onClose={() => {}} tabAtom={graphViewStylesTabAtom} />
+          </TooltipProvider>
+        </Provider>
+      </QueryClientProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -53,6 +56,14 @@ describe("Styles", () => {
     renderStyles(state);
 
     expect(screen.getByText("Airport")).toBeInTheDocument();
+  });
+
+  test("has a link to the styles settings page", () => {
+    const state = new DbState();
+    renderStyles(state);
+
+    const link = screen.getByRole("link", { name: "Style settings" });
+    expect(link).toHaveAttribute("href", "/settings/styles");
   });
 
   test("shows edge styling after switching to the edges tab", async () => {

--- a/packages/graph-explorer/src/modules/Styles/Styles.tsx
+++ b/packages/graph-explorer/src/modules/Styles/Styles.tsx
@@ -1,11 +1,15 @@
 import { atom, type PrimitiveAtom, useAtom } from "jotai";
+import { SettingsIcon } from "lucide-react";
+import { Link } from "react-router";
 
 import {
+  Button,
   Panel,
   PanelContent,
   PanelHeader,
   PanelHeaderActions,
   PanelHeaderCloseButton,
+  PanelHeaderDivider,
   PanelTitle,
 } from "@/components";
 import {
@@ -49,6 +53,17 @@ export function Styles({ onClose, tabAtom }: StylesProps) {
       <PanelHeader>
         <PanelTitle>{LABELS.SIDEBAR.STYLES}</PanelTitle>
         <PanelHeaderActions>
+          <Button
+            asChild
+            tooltip="Style settings"
+            variant="ghost"
+            size="icon-small"
+          >
+            <Link to="/settings/styles">
+              <SettingsIcon />
+            </Link>
+          </Button>
+          <PanelHeaderDivider />
           <PanelHeaderCloseButton onClose={onClose} />
         </PanelHeaderActions>
       </PanelHeader>


### PR DESCRIPTION
## Description

Adds a gear icon button to the Styles sidebar panel header that navigates to `/settings/styles`. Uses `Button asChild` with a react-router `Link`, matching the existing `EntityDetails` header pattern (ghost icon button → divider → close).

## Validation

- Gear icon appears in the Styles sidebar header (both Graph view and Schema view)
- Clicking it navigates to the Styles settings page
- `pnpm checks` passes
- `pnpm test` passes (new test asserts link presence and href)

## Related Issues

- Closes #1937
- Related to #1896

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.