### PR TITLE
Add draft design.md for the visual design system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Correct behavior is necessary but not sufficient — structural quality is a har
 
 Read the relevant doc before working in that area:
 
+- `docs/agents/design.md` — visual design system: color tokens, dark mode policy, Tailwind conventions
 - `docs/agents/react.md` — components, hooks, query-language translation
 - `docs/agents/tailwind.md` — Tailwind v4 styling, responsive, data attributes
 - `docs/agents/testing.md` — Vitest patterns, DbState, factories, backward-compat

--- a/docs/agents/design.md
+++ b/docs/agents/design.md
@@ -1,0 +1,116 @@
+# Design System
+
+The visual design system for Graph Explorer. Read this before modifying UI styling, adding color tokens, or writing Tailwind classes in components.
+
+> [!NOTE]
+> **Migration in progress.** This document describes the _target_ state; the cleanup is tracked in [#1952](https://github.com/aws/graph-explorer/issues/1952). Until it completes, the codebase deviates in known ways: `tailwind.config.ts` still exists and owns fonts, weights, z-index, keyframes, and some utilities; legacy color aliases (`text-text-primary`, `bg-background-default`, `primary-main`, etc.) are still in use pending migration to the canonical tokens below; a few `dark:` classes and shadcn compat tokens (`destructive`, `popover`) remain pending removal; and the custom font weight classes (`font-base`, `font-extraBold`) are still active — `font-semibold` does not exist until the weight migration lands. When touching styled code during the transition, migrate toward this document, not away from it.
+
+## Color Architecture
+
+### Palette → Semantic → Component
+
+Colors flow in one direction:
+
+1. **Palette scales** — raw oklch color ramps defined in `@theme` (e.g. `brand-50` through `brand-950`, `gray-50` through `gray-950`). These are the source values.
+2. **Semantic tokens** — named roles that reference palette values (e.g. `--color-primary: var(--color-brand-500)`). Defined in `@theme` in `index.css`.
+3. **Components** — use semantic tokens via Tailwind classes (`bg-primary`, `text-foreground`). Components should not reach for palette scales directly.
+
+### The gray palette
+
+The Tailwind neutral scales (`slate`, `zinc`, `neutral`, `stone`) are removed. `gray-*` is redefined with zinc's oklch values — a single neutral scale under a familiar name. When you write `bg-gray-100`, you get zinc-100. This is intentional and documented, not an accident.
+
+### Semantic token vocabulary
+
+**Base layer** — surface-agnostic defaults:
+
+| Token              | Purpose                                   | Value    |
+| ------------------ | ----------------------------------------- | -------- |
+| `foreground`       | Default text color                        | gray-900 |
+| `background`       | App background                            | white    |
+| `background-alt`   | Alternate background (e.g. sidebar area)  | gray-50  |
+| `muted`            | Muted/deemphasized surface                | gray-100 |
+| `muted-foreground` | Secondary/deemphasized text (any surface) | gray-500 |
+| `border`           | Default border color                      | gray-200 |
+| `input-background` | Form input fill                           | white    |
+| `input-border`     | Form input border                         | gray-300 |
+
+**Role colors** — each role follows a consistent slot pattern:
+
+| Slot             | Meaning                                       |
+| ---------------- | --------------------------------------------- |
+| `X`              | Solid surface fill (the role's primary color) |
+| `X-hover`        | Solid surface fill on hover                   |
+| `X-foreground`   | Role-colored text on a normal background      |
+| `X-subtle`       | Tinted/light surface fill                     |
+| `X-subtle-hover` | Tinted surface fill on hover                  |
+
+Roles: `primary`, `danger`, `warning`, `success`, `neutral`.
+
+**Accent** is an alias group used for highlight/selection states — `accent` → `primary-subtle`, `accent-hover` → `primary-subtle-hover`, `accent-foreground` → `primary-foreground`. Whether it survives as a distinct abstraction or gets inlined to the primary tokens is an open question for the migration ([#1956](https://github.com/aws/graph-explorer/issues/1956)).
+
+### Using color in components
+
+**Strong preference: use semantic tokens.** Write `bg-primary-subtle text-primary-foreground`, not `bg-brand-50 text-brand-700`.
+
+**Palette scales are legal for genuine one-offs** — a decorative gradient, a unique illustration element — but if you find yourself reaching for a palette value in a reusable component, consider whether a new semantic token should exist instead.
+
+**When neither fits:** If a component needs a color that isn't covered by existing semantic tokens and isn't a one-off, propose a new token. Add it to the `@theme` block in `index.css` with a comment explaining its role, and update this document.
+
+### Text on colored surfaces
+
+- On solid role surfaces (`bg-primary`, `bg-danger`): use `text-white`.
+- On tinted role surfaces (`bg-primary-subtle`): use `text-primary-foreground`.
+- On normal backgrounds (`bg-background`, `bg-background-alt`): use `text-foreground` for body text, `text-muted-foreground` for secondary text, `text-primary-foreground` for brand emphasis.
+
+## Dark Mode
+
+Dark mode is a planned future feature. The semantic token structure is designed to support it via CSS `light-dark()` on the token definitions — when dark mode arrives, components should not need `dark:` classes because the semantic tokens themselves will resolve to appropriate values per mode.
+
+**Policy:** Do not add new `dark:` variant classes. A few legacy usages remain pending removal ([#1955](https://github.com/aws/graph-explorer/issues/1955)).
+
+## Tailwind Conventions
+
+- Use **Tailwind v4 CSS syntax** — `@theme`, `@utility`, `@custom-variant` blocks in CSS.
+- Prefer **data attributes** for conditional styles. Tailwind v4 provides two forms:
+  - `data-open:` / `data-closed:` — shorthand variants (defined via `@custom-variant` in the config, matching `[data-state="open"]` / `[data-state="closed"]`). These are the Radix convention used throughout the codebase (~27 usages). Also: `aria-invalid:` for form validation.
+  - `data-[attr=value]:` — arbitrary-value form for one-off attributes.
+- Prefer **Tailwind responsive directives and container queries** over `ResizeObserver` for responsive layout changes.
+- Reference: https://tailwindcss.com/docs
+
+### Custom utilities
+
+Custom utilities are defined with `@utility` in `index.css`:
+
+- `stack` — CSS grid overlay (all children occupy the same grid cell)
+- `gx-wrap-break-word` — safe word-breaking for long content
+- `content-auto` / `content-hidden` / `content-visible` — `content-visibility` for virtualization performance
+- `intrinsic-size-*` — `contain-intrinsic-size` mapped to the spacing scale
+
+### Z-index scale
+
+A semantic z-index scale prevents stacking conflicts:
+
+| Token       | Value | Use                 |
+| ----------- | ----- | ------------------- |
+| `z-appBar`  | 1000  | Top navigation bar  |
+| `z-panes`   | 1100  | Side panes / panels |
+| `z-modal`   | 1200  | Modal dialogs       |
+| `z-popover` | 1300  | Popovers            |
+| `z-menu`    | 1400  | Dropdown menus      |
+| `z-tooltip` | 1500  | Tooltips            |
+
+### Typography
+
+- Font family: Tailwind's default sans stack (`ui-sans-serif, system-ui, sans-serif, ...`). The app renders in the platform system font (San Francisco on macOS, Segoe UI on Windows). No custom font is loaded.
+- Font weights: Tailwind's default scale. In practice the app uses `font-normal` (400), `font-medium` (500), `font-semibold` (600), and `font-bold` (700).
+- Base font size: 14px (set on `html`)
+
+### Animations
+
+Two shared keyframes for collapsible regions: `expand` and `collapse` (0.2s, `cubic-bezier(0.87, 0, 0.13, 1)` — a sharp ease-in-out-quint curve).
+
+The `tw-animate-css` library is imported and provides enter/exit animation utilities (`animate-in`, `animate-out`, `fade-in-0`, `zoom-in-95`, etc.) used by popovers, dialogs, and dropdown menus.
+
+## Source of Truth
+
+The target is a single source of truth: `packages/graph-explorer/src/index.css` — all tokens, utilities, and theme values in one CSS file with no separate JS config. Until the migration completes, `tailwind.config.ts` still exists (loaded via `@config`) and owns fonts, weights, z-index, keyframes, and the content-visibility plugin utilities.


### PR DESCRIPTION
## Description

Adds `docs/agents/design.md` — a living draft documenting Graph Explorer's visual design system. This is step 1 of the design system alignment effort (#1952): establish the target spec before the migration work begins.

The doc covers:
- Color architecture (palette → semantic token → component)
- Semantic token vocabulary (base layer + role colors)
- Gray-is-zinc remapping
- Dark mode future posture (CSS `light-dark()`, no `dark:` classes)
- Tailwind v4 conventions (data-attribute variants, responsive directives)
- Custom utilities, z-index scale, typography, animations

A migration-in-progress banner at the top notes where the codebase still deviates from the target state. Subsequent PRs in this stack will bring the code into alignment.

Also wires design.md into the AGENTS.md conventions list for immediate discoverability.

## How to read

1. [docs/agents/design.md](https://github.com/aws/graph-explorer/pull/1962/files#diff-149bd56f33e3ccc1a6adaf4c67a609ba6b52f9980f407c4201472d8130cf9955) — the new design system doc (start here)
2. [AGENTS.md](https://github.com/aws/graph-explorer/pull/1962/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) — one-line addition to conventions list

## Validation

- `pnpm checks` passes
- Documentation only — no runtime behavior change

## Related Issues

- Closes #1953
- Part of #1952

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.