### PR TITLE
Strip orphaned dark mode fragments

### DIFF
--- a/packages/graph-explorer/src/components/Checkbox.tsx
+++ b/packages/graph-explorer/src/components/Checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       className={cn(
         "focus-visible:ring-ring-3 group peer border-primary-main bg-primary-main size-[16px] shrink-0 rounded-sm border text-white focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-        "data-[state=unchecked]:bg-background-default data-[state=unchecked]:border-gray-400 dark:data-[state=unchecked]:border-gray-600",
+        "data-[state=unchecked]:bg-background-default data-[state=unchecked]:border-gray-400",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -99,7 +99,6 @@ export function SidebarTabsTrigger({
               className={cn(
                 "text-brand-900 active:bg-brand-300 data-[state=active]:bg-brand-500 inline-flex size-10 items-center justify-center rounded-md bg-transparent p-2 ring-0 transition-colors duration-100 focus:shadow-none active:text-white disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-white [&_svg]:size-6",
                 "hover:data-[state=active]:bg-brand-400 hover:bg-primary-subtle-hover",
-                "dark:text-brand-300 dark:data-[state=active]:bg-brand-400 dark:hover:data-[state=active]:bg-brand-500 dark:hover:bg-gray-800 dark:data-[state=active]:text-white",
                 "focus-visible:ring-brand-500 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-hidden active:ring-0",
                 className,
               )}

--- a/packages/graph-explorer/src/components/DropdownMenu.tsx
+++ b/packages/graph-explorer/src/components/DropdownMenu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Field.tsx
+++ b/packages/graph-explorer/src/components/Field.tsx
@@ -114,7 +114,7 @@ function FieldLabel({
       className={cn(
         "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
-        "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+        "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -1,17 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-/*
- * Use `dark` class name to indicate dark mode.
- *
- * We will need to slowly build up dark mode support component by component, so
- * this is a way to force dark mode to be off, unless we explicitly set `dark`
- * in the classes in the root component.
- *
- * https://github.com/aws/graph-explorer/issues/645
- */
-@custom-variant dark (&:where(.dark, .dark *));
-
 /* Radix UI uses data-state="open"/"closed" on interactive elements */
 @custom-variant data-open (&[data-state="open"]);
 @custom-variant data-closed (&[data-state="closed"]);


### PR DESCRIPTION
## Description

Removes the incomplete dark mode infrastructure that was never functional:

- **`@custom-variant dark`** declaration and its comment block from `index.css`
- **4 orphaned `dark:` class usages** across Field, DropdownMenu, Checkbox, and CollapsibleSidebar — these never rendered correctly because no full dark token set exists

Dark mode is an intended future goal. When implemented, it will use CSS `light-dark()` on the semantic token definitions, so components won't need `dark:` classes at all.

## Validation

- `pnpm checks` passes
- `pnpm test` passes (2178 tests)
- Visual: no change in light mode (dark mode was never active)

## Related Issues

- Closes #1955
- Part of #1952

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.