### PR TITLE
Migrate legacy color token aliases to canonical semantic tokens

### DIFF
--- a/packages/graph-explorer/src/components/Button/Button.tsx
+++ b/packages/graph-explorer/src/components/Button/Button.tsx
@@ -10,21 +10,21 @@ const buttonStyles = cva({
   variants: {
     variant: {
       primary:
-        "bg-brand hover:bg-brand-hover data-open:bg-brand-hover text-white",
+        "bg-primary hover:bg-primary-hover data-open:bg-primary-hover text-white",
       secondary:
-        "text-text-primary bg-gray-100 hover:bg-gray-200 data-open:bg-gray-200",
+        "text-foreground bg-gray-100 hover:bg-gray-200 data-open:bg-gray-200",
       ghost:
         "text-primary-foreground hover:bg-primary-subtle data-open:bg-primary-subtle",
       outline:
-        "text-text-primary border-input hover:bg-muted data-open:border-primary-main border bg-transparent font-normal shadow-xs",
+        "text-foreground border-input-border hover:bg-muted data-open:border-primary border bg-transparent font-normal shadow-xs",
       "outline-danger":
-        "text-danger border-input hover:bg-danger-subtle data-open:bg-danger-subtle border bg-transparent font-normal shadow-xs",
+        "text-danger-foreground border-input-border hover:bg-danger-subtle data-open:bg-danger-subtle border bg-transparent font-normal shadow-xs",
       "primary-danger":
         "bg-danger hover:bg-danger-hover data-open:bg-danger-hover text-white",
       danger:
-        "bg-danger-subtle text-danger hover:bg-danger-subtle-hover data-open:bg-danger-subtle-hover",
+        "bg-danger-subtle text-danger-foreground hover:bg-danger-subtle-hover data-open:bg-danger-subtle-hover",
       "danger-ghost":
-        "text-danger hover:bg-danger-subtle data-open:bg-danger-subtle",
+        "text-danger-foreground hover:bg-danger-subtle data-open:bg-danger-subtle",
     },
     size: {
       small: "h-8 rounded-md px-3 text-sm [&_svg]:size-4",

--- a/packages/graph-explorer/src/components/Button/LinkButton.tsx
+++ b/packages/graph-explorer/src/components/Button/LinkButton.tsx
@@ -11,7 +11,7 @@ export function LinkButton({
       {...props}
       className={cn(
         className,
-        "text-primary-main m-0 cursor-pointer border-0 bg-transparent p-0 underline underline-offset-2 hover:no-underline",
+        "text-primary m-0 cursor-pointer border-0 bg-transparent p-0 underline underline-offset-2 hover:no-underline",
       )}
     />
   );

--- a/packages/graph-explorer/src/components/Checkbox.tsx
+++ b/packages/graph-explorer/src/components/Checkbox.tsx
@@ -13,8 +13,8 @@ function Checkbox({
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        "focus-visible:ring-ring-3 group peer border-primary-main bg-primary-main size-[16px] shrink-0 rounded-sm border text-white focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-        "data-[state=unchecked]:bg-background-default data-[state=unchecked]:border-gray-400",
+        "focus-visible:ring-ring-3 group peer border-primary bg-primary size-[16px] shrink-0 rounded-sm border text-white focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=unchecked]:bg-background data-[state=unchecked]:border-gray-400",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Chip.tsx
+++ b/packages/graph-explorer/src/components/Chip.tsx
@@ -11,12 +11,12 @@ const chip = cva({
       neutral: "bg-neutral",
       "neutral-subtle":
         "bg-neutral-subtle text-neutral-foreground border-neutral-foreground/25 border",
-      primary: "bg-primary-main",
+      primary: "bg-primary",
       "primary-subtle":
         "bg-primary-subtle text-primary-foreground border-primary-foreground/25 border",
-      success: "bg-success-main",
-      error: "bg-error-main",
-      warning: "bg-warning-main",
+      success: "bg-success",
+      error: "bg-danger",
+      warning: "bg-warning",
     },
   },
   defaultVariants: {

--- a/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -52,7 +52,7 @@ export function SidebarTabs({
   return (
     <TabsPrimitive.Root
       className={cn(
-        "bg-background-default shadow-primary-dark/25 grid size-full min-h-0 flex-none shrink-0 grid-cols-[auto_1fr] shadow",
+        "bg-background shadow-primary-foreground/25 grid size-full min-h-0 flex-none shrink-0 grid-cols-[auto_1fr] shadow",
         className,
       )}
       {...props}
@@ -138,7 +138,7 @@ function BadgeIndicator({
       {value ? (
         <span
           aria-description="badge"
-          className="bg-error-main pointer-events-none -mt-0.5 -mr-0.5 size-2.5 place-self-start justify-self-end rounded-full"
+          className="bg-danger pointer-events-none -mt-0.5 -mr-0.5 size-2.5 place-self-start justify-self-end rounded-full"
         />
       ) : null}
     </div>

--- a/packages/graph-explorer/src/components/Dialog.tsx
+++ b/packages/graph-explorer/src/components/Dialog.tsx
@@ -41,7 +41,7 @@ function DialogContent({
       <div className="fixed inset-0 z-50 flex h-full w-full items-center justify-center p-20">
         <DialogPrimitive.Content
           className={cn(
-            "bg-background-default data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative flex max-h-full w-[500px] flex-col overflow-hidden rounded-lg shadow-2xl duration-200",
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative flex max-h-full w-[500px] flex-col overflow-hidden rounded-lg shadow-2xl duration-200",
             className,
           )}
           {...props}
@@ -126,7 +126,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       className={cn(
-        "text-text-secondary gx-wrap-break-word text-sm",
+        "text-muted-foreground gx-wrap-break-word text-sm",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/DropdownMenu.tsx
+++ b/packages/graph-explorer/src/components/DropdownMenu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-primary-subtle focus:text-primary-foreground data-[variant=destructive]:text-danger data-[variant=destructive]:focus:bg-danger/10 data-[variant=destructive]:focus:text-danger data-[variant=destructive]:*:[svg]:text-danger not-data-[variant=destructive]:focus:**:text-primary-foreground group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-primary-subtle focus:text-primary-foreground data-[variant=destructive]:text-danger-foreground data-[variant=destructive]:focus:bg-danger/10 data-[variant=destructive]:focus:text-danger-foreground data-[variant=destructive]:*:[svg]:text-danger-foreground not-data-[variant=destructive]:focus:**:text-primary-foreground group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-3 py-2 text-base outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/EdgeSymbol.tsx
+++ b/packages/graph-explorer/src/components/EdgeSymbol.tsx
@@ -12,7 +12,7 @@ export function EdgeSymbol({
 }: ComponentPropsWithoutRef<"div">) {
   return (
     <SearchResultSymbol
-      className={cn("bg-primary-main/20 text-primary-main", className)}
+      className={cn("bg-primary/20 text-primary", className)}
       {...props}
     >
       <EdgeIcon className="size-full" />

--- a/packages/graph-explorer/src/components/EmptyState.tsx
+++ b/packages/graph-explorer/src/components/EmptyState.tsx
@@ -26,9 +26,9 @@ const emptyStateIconStyles = cva({
   base: "mb-6 flex size-24 items-center justify-center rounded-full text-7xl text-white group-data-[size=small]/empty:mb-3 group-data-[size=small]/empty:size-10 [&>svg]:size-1/2",
   variants: {
     variant: {
-      info: "from-primary-main to-primary-light bg-linear-to-b shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
+      info: "from-primary to-brand-300 bg-linear-to-b shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
       error:
-        "from-error-main to-error-light bg-linear-to-b shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
+        "from-danger bg-linear-to-b to-red-300 shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
       subtle: "bg-muted text-muted-foreground rounded-lg",
     },
   },
@@ -75,7 +75,7 @@ function EmptyStateTitle({
   return (
     <h3
       className={cn(
-        "text-text-primary gx-wrap-break-word text-lg font-semibold text-balance group-data-[size=small]/empty:text-sm",
+        "text-foreground gx-wrap-break-word text-lg font-semibold text-balance group-data-[size=small]/empty:text-sm",
         className,
       )}
       {...props}
@@ -93,7 +93,7 @@ function EmptyStateDescription({
   return (
     <div
       className={cn(
-        "text-text-primary/75 gx-wrap-break-word text-base font-normal group-data-[size=small]/empty:text-sm",
+        "text-foreground/75 gx-wrap-break-word text-base font-normal group-data-[size=small]/empty:text-sm",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Field.tsx
+++ b/packages/graph-explorer/src/components/Field.tsx
@@ -54,7 +54,7 @@ function FieldGroup({ className, ...props }: ComponentPropsWithRef<"div">) {
 }
 
 const fieldVariants = cva({
-  base: "group/field data-[invalid=true]:text-danger flex w-full gap-3",
+  base: "group/field data-[invalid=true]:text-danger-foreground flex w-full gap-3",
   variants: {
     orientation: {
       vertical: ["flex-col *:w-full [&>.sr-only]:w-auto"],
@@ -223,7 +223,7 @@ function FieldError({
     <div
       role="alert"
       data-slot="field-error"
-      className={cn("text-danger text-sm font-normal", className)}
+      className={cn("text-danger-foreground text-sm font-normal", className)}
       {...props}
     >
       {content}

--- a/packages/graph-explorer/src/components/Form.tsx
+++ b/packages/graph-explorer/src/components/Form.tsx
@@ -88,7 +88,7 @@ function FormLabel({
 
   return (
     <Label
-      className={cn(error && "text-error-main", className)}
+      className={cn(error && "text-danger-foreground", className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -124,7 +124,7 @@ function FormDescription({
   return (
     <p
       id={formDescriptionId}
-      className={cn("text-text-secondary text-sm", className)}
+      className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
   );
@@ -154,7 +154,7 @@ function FormError({
 }: React.ComponentPropsWithRef<"p">) {
   return (
     <p
-      className={cn("text-error-main text-sm font-medium", className)}
+      className={cn("text-danger-foreground text-sm font-medium", className)}
       {...props}
     >
       {children}

--- a/packages/graph-explorer/src/components/Graph/SelectLayout.tsx
+++ b/packages/graph-explorer/src/components/Graph/SelectLayout.tsx
@@ -30,7 +30,9 @@ export function SelectLayout({
     >
       <SelectTrigger {...props}>
         <div className="flex flex-col items-start justify-center gap-0">
-          <div className="text-text-secondary text-xs leading-none">Layout</div>
+          <div className="text-muted-foreground text-xs leading-none">
+            Layout
+          </div>
           <SelectValue placeholder="Select a layout" />
         </div>
       </SelectTrigger>

--- a/packages/graph-explorer/src/components/Group.tsx
+++ b/packages/graph-explorer/src/components/Group.tsx
@@ -38,7 +38,7 @@ function GroupHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "bg-neutral-subtle/50 text-text-secondary group-data-[variant=danger]/group:bg-danger-subtle/50 group-data-[variant=danger]/group:text-danger group-data-[variant=success]/group:bg-success-subtle/50 group-data-[variant=success]/group:text-success-main group-data-[variant=warning]/group:bg-warning-subtle/50 group-data-[variant=warning]/group:text-warning-main flex items-center gap-2 px-5 py-3 group-data-[size=small]/group:px-3 group-data-[size=small]/group:py-2",
+        "bg-neutral-subtle/50 text-muted-foreground group-data-[variant=danger]/group:bg-danger-subtle/50 group-data-[variant=danger]/group:text-danger-foreground group-data-[variant=success]/group:bg-success-subtle/50 group-data-[variant=success]/group:text-success group-data-[variant=warning]/group:bg-warning-subtle/50 group-data-[variant=warning]/group:text-warning flex items-center gap-2 px-5 py-3 group-data-[size=small]/group:px-3 group-data-[size=small]/group:py-2",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/IconPicker.tsx
+++ b/packages/graph-explorer/src/components/IconPicker.tsx
@@ -126,7 +126,7 @@ function PagerFooter({
 }) {
   return (
     <div className="flex flex-row items-center justify-end gap-2">
-      <p className="text-text-secondary text-sm">
+      <p className="text-muted-foreground text-sm">
         Page {page + 1} of {pageCount}
       </p>
       <div className="flex">

--- a/packages/graph-explorer/src/components/Input.tsx
+++ b/packages/graph-explorer/src/components/Input.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/utils";
  */
 
 export const inputStyles = cva({
-  base: "border-input bg-input-background text-text-primary placeholder:text-text-secondary invalid:border-error-main focus-visible:border-primary-main aria-invalid:border-error-main flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-xs transition-colors file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+  base: "border-input-border bg-input-background text-foreground placeholder:text-muted-foreground invalid:border-danger focus-visible:border-primary aria-invalid:border-danger flex h-10 w-full rounded-md border px-3 py-1 text-sm shadow-xs transition-colors file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
 });
 
 export type InputProps = React.ComponentPropsWithRef<"input">;

--- a/packages/graph-explorer/src/components/InputField/InputField.tsx
+++ b/packages/graph-explorer/src/components/InputField/InputField.tsx
@@ -77,7 +77,7 @@ export function InputField({
             disabled={isDisabled}
             {...inputProps}
           />
-          <div className="text-text-secondary absolute top-1.5 left-3 text-xs leading-none">
+          <div className="text-muted-foreground absolute top-1.5 left-3 text-xs leading-none">
             {label}
           </div>
         </div>

--- a/packages/graph-explorer/src/components/KeyboardKey.tsx
+++ b/packages/graph-explorer/src/components/KeyboardKey.tsx
@@ -9,7 +9,7 @@ export function KeyboardKey({
   return (
     <div
       className={cn(
-        "border-text-secondary inline rounded-sm border bg-transparent px-1 py-0.5 font-mono text-xs leading-none tracking-wider [&_svg]:inline [&_svg]:size-[10px]",
+        "border-muted-foreground inline rounded-sm border bg-transparent px-1 py-0.5 font-mono text-xs leading-none tracking-wider [&_svg]:inline [&_svg]:size-[10px]",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/LabelledSetting.tsx
+++ b/packages/graph-explorer/src/components/LabelledSetting.tsx
@@ -16,11 +16,11 @@ export function LabelledSetting({
         htmlFor={htmlFor}
         className="block flex-1 space-y-1 group-has-disabled/labelled-setting:cursor-not-allowed group-has-disabled/labelled-setting:opacity-70"
       >
-        <p className="text-text-primary text-base leading-none font-medium text-pretty">
+        <p className="text-foreground text-base leading-none font-medium text-pretty">
           {label}
         </p>
         {description ? (
-          <p className="text-text-secondary text-sm leading-normal font-normal text-pretty">
+          <p className="text-muted-foreground text-sm leading-normal font-normal text-pretty">
             {description}
           </p>
         ) : null}

--- a/packages/graph-explorer/src/components/ListRow.tsx
+++ b/packages/graph-explorer/src/components/ListRow.tsx
@@ -12,8 +12,8 @@ export function ListRow({
   return (
     <div
       className={cn(
-        "bg-secondary-subtle text-primary-dark ring-primary-main flex items-center gap-4 overflow-hidden rounded-lg px-4 py-2 hover:ring-1",
-        "has-checked:bg-secondary-subtle has-checked:border-primary-main has-checked:ring-primary-main has-checked:ring-[1.5px]",
+        "bg-primary-subtle text-primary-foreground ring-primary flex items-center gap-4 overflow-hidden rounded-lg px-4 py-2 hover:ring-1",
+        "has-checked:bg-primary-subtle has-checked:border-primary has-checked:ring-primary has-checked:ring-[1.5px]",
         isDisabled && "pointer-events-none",
         className,
       )}

--- a/packages/graph-explorer/src/components/NavBar.tsx
+++ b/packages/graph-explorer/src/components/NavBar.tsx
@@ -16,7 +16,7 @@ export function NavBar({
     <div
       data-slot="nav-bar"
       className={cn(
-        "bg-background-default text-text-primary flex min-h-16 flex-row items-center gap-3 border-b pr-3",
+        "bg-background text-foreground flex min-h-16 flex-row items-center gap-3 border-b pr-3",
         !logoVisible && "pl-3",
         className,
       )}
@@ -113,7 +113,7 @@ export function NavBarTitle({
           </div>
         )}
         {subtitle && (
-          <div className="text-text-secondary line-clamp-1 overflow-hidden text-sm leading-tight font-medium">
+          <div className="text-muted-foreground line-clamp-1 overflow-hidden text-sm leading-tight font-medium">
             {subtitle}
           </div>
         )}

--- a/packages/graph-explorer/src/components/Panel.tsx
+++ b/packages/graph-explorer/src/components/Panel.tsx
@@ -29,7 +29,7 @@ function Panel({ variant = "default", className, ...props }: PanelProps) {
     <div
       data-slot="panel"
       className={cn(
-        "bg-background-default flex h-full flex-col overflow-hidden",
+        "bg-background flex h-full flex-col overflow-hidden",
         variant === "default" &&
           "shadow-primary-foreground/25 rounded-lg shadow",
         className,
@@ -47,7 +47,7 @@ function PanelContent({
   return (
     <div
       className={cn(
-        "bg-background-default flex h-full w-full grow flex-col overflow-y-auto",
+        "bg-background flex h-full w-full grow flex-col overflow-y-auto",
         className,
       )}
       {...props}
@@ -64,7 +64,7 @@ function PanelHeader({
   return (
     <div
       className={cn(
-        "bg-background-default flex min-h-[48px] w-full shrink-0 items-center gap-4 overflow-x-auto border-b px-3 py-1",
+        "bg-background flex min-h-[48px] w-full shrink-0 items-center gap-4 overflow-x-auto border-b px-3 py-1",
         className,
       )}
       {...props}
@@ -82,10 +82,7 @@ function PanelFooter({
 }: React.PropsWithChildren<React.ComponentPropsWithRef<"div">>) {
   return (
     <div
-      className={cn(
-        "bg-background-default w-full border-t px-3 py-3",
-        className,
-      )}
+      className={cn("bg-background w-full border-t px-3 py-3", className)}
       {...props}
     >
       {children}
@@ -101,7 +98,7 @@ function PanelTitle({
   return (
     <div
       className={cn(
-        "text-text-primary inline-flex shrink-0 items-center gap-2 text-base leading-none font-semibold whitespace-nowrap",
+        "text-foreground inline-flex shrink-0 items-center gap-2 text-base leading-none font-semibold whitespace-nowrap",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Popover.tsx
+++ b/packages/graph-explorer/src/components/Popover.tsx
@@ -23,7 +23,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-popover bg-background-default text-text-primary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md border p-4 shadow-md outline-hidden",
+          "z-popover bg-background text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/packages/graph-explorer/src/components/SearchBar.tsx
+++ b/packages/graph-explorer/src/components/SearchBar.tsx
@@ -20,7 +20,7 @@ export default function SearchBar({
 }: SearchBarProps) {
   return (
     <div className={cn("relative w-full", className)}>
-      <SearchIcon className="text-text-secondary absolute top-[9px] left-4 size-5" />
+      <SearchIcon className="text-muted-foreground absolute top-[9px] left-4 size-5" />
       <Input
         value={search}
         onChange={event => onSearch(event.target.value)}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -16,7 +16,7 @@ export function SearchResult({
       {...props}
       className={cn(
         "content-auto intrinsic-size-[4.75rem] rounded-xl border shadow-xs",
-        isEven(level) ? "bg-gray-50" : "bg-default",
+        isEven(level) ? "bg-gray-50" : "bg-background",
         className,
       )}
     />
@@ -37,8 +37,10 @@ export function SearchResultCollapsible({
       {...props}
       className={cn(
         "group ring-border content-auto intrinsic-size-[4.75rem] rounded-xl shadow-xs ring-1 transition duration-100 ease-in-out",
-        isEven(level) ? "bg-gray-50" : "bg-default",
-        highlighted ? "shadow-primary-dark/50 ring-primary-dark/75" : "",
+        isEven(level) ? "bg-gray-50" : "bg-background",
+        highlighted
+          ? "shadow-primary-foreground/50 ring-primary-foreground/75"
+          : "",
         className,
       )}
     />
@@ -60,7 +62,7 @@ export function SearchResultCollapsibleTrigger({
       >
         <ChevronRightIcon
           className={cn(
-            "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[state=open]/search-result-collapsible-trigger:rotate-90",
+            "text-primary-foreground/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-[state=open]/search-result-collapsible-trigger:rotate-90",
           )}
         />
         {children}
@@ -77,7 +79,7 @@ export function SearchResultTitle({
     <div
       {...props}
       className={cn(
-        "text-text-primary gx-wrap-break-word line-clamp-2 text-base leading-snug font-semibold",
+        "text-foreground gx-wrap-break-word line-clamp-2 text-base leading-snug font-semibold",
         className,
       )}
     />
@@ -92,7 +94,7 @@ export function SearchResultSubtitle({
     <div
       {...props}
       className={cn(
-        "text-text-secondary gx-wrap-break-word line-clamp-2 text-base leading-snug",
+        "text-muted-foreground gx-wrap-break-word line-clamp-2 text-base leading-snug",
         className,
       )}
     />
@@ -121,7 +123,7 @@ export function SearchResultExpandChevron({
   return (
     <ChevronRightIcon
       className={cn(
-        "text-primary-dark/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-closed:rotate-0 group-data-open:rotate-90",
+        "text-primary-foreground/50 size-5 shrink-0 transition-transform duration-200 ease-in-out group-data-closed:rotate-0 group-data-open:rotate-90",
         className,
       )}
       {...props}
@@ -139,7 +141,7 @@ export function SearchResultAttribute({
       {...props}
       className={cn(
         "flex w-full flex-wrap justify-between gap-2 rounded-xl border px-4 py-2 shadow-xs",
-        isEven(level) ? "bg-gray-50" : "bg-default",
+        isEven(level) ? "bg-gray-50" : "bg-background",
         className,
       )}
     />
@@ -169,7 +171,7 @@ export function SearchResultAttributeValue({
     <div
       {...props}
       className={cn(
-        "flex-[2 1 150px] text-text-primary gx-wrap-break-word text-base leading-snug",
+        "flex-[2 1 150px] text-foreground gx-wrap-break-word text-base leading-snug",
         className,
       )}
     />

--- a/packages/graph-explorer/src/components/Select.tsx
+++ b/packages/graph-explorer/src/components/Select.tsx
@@ -18,7 +18,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "ring-offset-background border-input bg-input-background text-text-primary placeholder:text-text-secondary focus-visible:border-primary-main data-open:border-primary-main flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-colors duration-100 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-ellipsis",
+        "ring-offset-background border-input-border bg-input-background text-foreground placeholder:text-muted-foreground focus-visible:border-primary data-open:border-primary flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-colors duration-100 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-ellipsis",
         className,
       )}
       {...props}
@@ -79,7 +79,7 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          "z-menu bg-background-default text-text-primary data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          "z-menu bg-background text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
@@ -96,8 +96,8 @@ function SelectContent({
         >
           {children}
         </SelectPrimitive.Viewport>
-        <SelectScrollUpButton className="from-background-default absolute inset-x-0 top-0 bg-gradient-to-b to-transparent" />
-        <SelectScrollDownButton className="to-background-default absolute inset-x-0 bottom-0 bg-gradient-to-b from-transparent" />
+        <SelectScrollUpButton className="from-background absolute inset-x-0 top-0 bg-gradient-to-b to-transparent" />
+        <SelectScrollDownButton className="to-background absolute inset-x-0 bottom-0 bg-gradient-to-b from-transparent" />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );
@@ -111,7 +111,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       className={cn(
-        "text-text-secondary px-3 py-1.5 text-sm font-normal",
+        "text-muted-foreground px-3 py-1.5 text-sm font-normal",
         className,
       )}
       {...props}
@@ -128,7 +128,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        "focus:bg-background-secondary relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-9 pl-3 text-base outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "focus:bg-primary-subtle relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-9 pl-3 text-base outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/SelectField.tsx
+++ b/packages/graph-explorer/src/components/SelectField.tsx
@@ -52,7 +52,7 @@ function SelectField({
       <Select value={value} onValueChange={onValueChange}>
         <SelectTrigger className={cn("h-11 py-1", className)} {...props}>
           <div className="flex flex-col items-start justify-center gap-0">
-            <div className="text-text-secondary text-xs leading-none">
+            <div className="text-muted-foreground text-xs leading-none">
               {label}
             </div>
             <SelectValue>

--- a/packages/graph-explorer/src/components/SidebarTabs.tsx
+++ b/packages/graph-explorer/src/components/SidebarTabs.tsx
@@ -23,7 +23,7 @@ function SidebarTabsList({
   return (
     <TabsPrimitive.List
       className={cn(
-        "bg-default text-muted-foreground sticky top-0 flex w-full flex-row items-center border-b",
+        "bg-background text-muted-foreground sticky top-0 flex w-full flex-row items-center border-b",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ function SidebarTabsTrigger({
   return (
     <TabsPrimitive.Trigger
       className={cn(
-        "focus-visible:ring-ring-3 bg-background-default text-text-secondary ring-offset-muted data-[state=active]:border-b-primary-foreground data-[state=active]:text-primary-foreground inline-flex grow items-center justify-center gap-2 border-y-2 border-transparent border-y-transparent px-4 py-2 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:font-medium [&_svg]:size-4",
+        "focus-visible:ring-ring-3 bg-background text-muted-foreground ring-offset-muted data-[state=active]:border-b-primary-foreground data-[state=active]:text-primary-foreground inline-flex grow items-center justify-center gap-2 border-y-2 border-transparent border-y-transparent px-4 py-2 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 data-[state=active]:font-medium [&_svg]:size-4",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Switch.tsx
+++ b/packages/graph-explorer/src/components/Switch.tsx
@@ -10,14 +10,14 @@ function Switch({
   return (
     <SwitchPrimitives.Root
       className={cn(
-        "focus-visible:ring-offset-background peer focus-visible:ring-primary-main data-[state=checked]:bg-primary-main data-[state=unchecked]:bg-input-border inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        "focus-visible:ring-offset-background peer focus-visible:ring-primary data-[state=checked]:bg-primary data-[state=unchecked]:bg-input-border inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}
     >
       <SwitchPrimitives.Thumb
         className={cn(
-          "bg-background-default pointer-events-none block h-4 w-4 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+          "bg-background pointer-events-none block h-4 w-4 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
         )}
       />
     </SwitchPrimitives.Root>

--- a/packages/graph-explorer/src/components/Tabular/Tabular.tsx
+++ b/packages/graph-explorer/src/components/Tabular/Tabular.tsx
@@ -161,7 +161,7 @@ const TabularContent = <T extends object>({
     <div
       ref={tableRef}
       className={cn(
-        "bg-background-default text-text-primary flex h-full max-h-full w-full max-w-full flex-col overflow-hidden",
+        "bg-background text-foreground flex h-full max-h-full w-full max-w-full flex-col overflow-hidden",
         className,
       )}
       style={{

--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
@@ -36,7 +36,7 @@ const TabularHeader = <T extends object>({
             className={cn(
               "group/th text-muted-foreground grid grid-cols-[1fr_auto] grid-rows-[auto_auto] gap-1 border-r px-2 py-1 font-medium transition-[background,border] duration-150 last:border-none",
               (column.isResizing || isResizing(column.id)) &&
-                "border-primary-dark cursor-col-resize! border-dashed",
+                "border-primary-foreground cursor-col-resize! border-dashed",
               column.canSort && "cursor-pointer",
             )}
           >

--- a/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
@@ -49,7 +49,7 @@ const TabularRow = <T extends object>({
   return (
     <tr
       {...rowProps}
-      className="group/tr text-text-primary data-selected:text-primary-dark data-selected:border-primary-dark data-selected:bg-background-secondary grow-0 border border-x-transparent border-t-transparent data-[selection-mode='row']:hover:cursor-pointer data-[selection-mode='row']:hover:bg-gray-50 data-[selection-mode='row']:data-selected:hover:bg-blue-200/75"
+      className="group/tr text-foreground data-selected:text-primary-foreground data-selected:border-primary-foreground data-selected:bg-primary-subtle grow-0 border border-x-transparent border-t-transparent data-[selection-mode='row']:hover:cursor-pointer data-[selection-mode='row']:hover:bg-gray-50 data-[selection-mode='row']:data-selected:hover:bg-blue-200/75"
       onClick={() =>
         rowSelectionMode === "row" && selectable && row.toggleRowSelected()
       }
@@ -67,9 +67,9 @@ const TabularRow = <T extends object>({
             key={key}
             {...cellProps}
             className={cn(
-              "group-data-selected/tr:border-primary-dark/25 relative grid items-center border-r px-2 py-1 transition-[border] duration-150 last:border-none data-[align='right']:text-right",
+              "group-data-selected/tr:border-primary-foreground/25 relative grid items-center border-r px-2 py-1 transition-[border] duration-150 last:border-none data-[align='right']:text-right",
               (cell.column.isResizing || isResizing(cell.column.id)) &&
-                "border-primary-dark cursor-col-resize! border-dashed",
+                "border-primary-foreground cursor-col-resize! border-dashed",
             )}
             data-align={cell.column.align}
           >

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/ExternalExportControl.tsx
@@ -125,7 +125,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
         <div className="flex flex-col gap-2">
           {exportableColumnOrder.map(columnId =>
             !visibleColumns[columnId] ? null : (
-              <Label key={columnId} className="text-text-primary">
+              <Label key={columnId} className="text-foreground">
                 <Checkbox
                   aria-label={`choose ${columnId}`}
                   checked={selectedColumns[columnId]}
@@ -147,7 +147,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
         <div className="space-y-3">
           <div className="text-base font-medium">Options</div>
           <div className="flex flex-col gap-2">
-            <Label className="text-text-primary">
+            <Label className="text-foreground">
               <Checkbox
                 aria-label="Keep filtering and sorting"
                 checked={options["include-filters"]}
@@ -161,7 +161,7 @@ function ExportOptionsModal<T extends Record<string, unknown>>({
               Keep filtering and sorting
             </Label>
             {forceOnlyPage ? null : (
-              <Label className="text-text-primary">
+              <Label className="text-foreground">
                 <Checkbox
                   aria-label="Only current page"
                   checked={options["only-page"]}

--- a/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/PaginationControl.tsx
@@ -68,7 +68,7 @@ export function PaginationControl({
         className,
       )}
     >
-      <div className="text-text-secondary">
+      <div className="text-muted-foreground">
         {totalRows > 0
           ? `Displaying ${pageRange} of ${toHumanString(totalRows)} results`
           : `No results`}

--- a/packages/graph-explorer/src/components/Tabular/controls/TabularFooterControls.tsx
+++ b/packages/graph-explorer/src/components/Tabular/controls/TabularFooterControls.tsx
@@ -19,7 +19,7 @@ const TabularFooterControls: FC<TabularFooterControlsProps> = ({
   return (
     <div
       className={cn(
-        "bg-background-default text-text-primary sticky left-0 flex w-full flex-wrap items-center justify-between border-t px-3 py-2",
+        "bg-background text-foreground sticky left-0 flex w-full flex-wrap items-center justify-between border-t px-3 py-2",
         !disableSticky && "-bottom-px z-3",
         className,
       )}

--- a/packages/graph-explorer/src/components/TextArea.tsx
+++ b/packages/graph-explorer/src/components/TextArea.tsx
@@ -9,7 +9,7 @@ export function TextArea({
   return (
     <textarea
       className={cn(
-        "border-input bg-input-background text-text-primary placeholder:text-text-secondary invalid:border-error-main focus-visible:border-primary-main aria-invalid:border-error-main flex w-full rounded-md border px-3 py-2 text-sm shadow-xs transition-colors file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        "border-input-border bg-input-background text-foreground placeholder:text-muted-foreground invalid:border-danger focus-visible:border-primary aria-invalid:border-danger flex w-full rounded-md border px-3 py-2 text-sm shadow-xs transition-colors file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Tooltip/InfoTooltip.tsx
+++ b/packages/graph-explorer/src/components/Tooltip/InfoTooltip.tsx
@@ -7,7 +7,7 @@ export default function InfoTooltip({ children }: PropsWithChildren) {
   return (
     <Tooltip>
       <TooltipTrigger>
-        <InfoIcon className="text-text-secondary size-6" />
+        <InfoIcon className="text-muted-foreground size-6" />
       </TooltipTrigger>
       <TooltipContent>{children}</TooltipContent>
     </Tooltip>

--- a/packages/graph-explorer/src/components/Tooltip/Tooltip.tsx
+++ b/packages/graph-explorer/src/components/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ function TooltipContent({
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
         className={cn(
-          "z-tooltip bg-text-primary text-background-default animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-96 overflow-hidden rounded-md px-3 py-1.5 text-sm",
+          "z-tooltip bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-96 overflow-hidden rounded-md px-3 py-1.5 text-sm",
           className,
         )}
         {...props}

--- a/packages/graph-explorer/src/components/Typography.tsx
+++ b/packages/graph-explorer/src/components/Typography.tsx
@@ -14,7 +14,7 @@ export function PageHeading({
   return (
     <h1
       className={cn(
-        "text-text-primary text-4xl leading-snug font-bold",
+        "text-foreground text-4xl leading-snug font-bold",
         className,
       )}
       {...props}
@@ -28,7 +28,7 @@ export function Paragraph({ className, ...props }: ComponentProps<"p">) {
   return (
     <p
       className={cn(
-        "text-text-secondary my-2 text-base font-light text-pretty",
+        "text-muted-foreground my-2 text-base font-light text-pretty",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/Workspace.tsx
+++ b/packages/graph-explorer/src/components/Workspace.tsx
@@ -10,7 +10,7 @@ export function Workspace({
     <div
       data-slot="workspace"
       className={cn(
-        "bg-background-secondary flex min-h-0 flex-1 flex-col overflow-hidden",
+        "bg-primary-subtle flex min-h-0 flex-1 flex-col overflow-hidden",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/core/AppErrorPage.tsx
+++ b/packages/graph-explorer/src/core/AppErrorPage.tsx
@@ -15,8 +15,8 @@ export default function AppErrorPage(props: FallbackProps) {
   const displayError = createDisplayError(props.error);
 
   return (
-    <div className="bg-background-default flex h-full w-full flex-col items-center justify-center p-6">
-      <ErrorIcon className="text-warning-main h-[8rem] w-[8rem]" />
+    <div className="bg-background flex h-full w-full flex-col items-center justify-center p-6">
+      <ErrorIcon className="text-warning h-[8rem] w-[8rem]" />
       <div className="flex flex-col items-center gap-6">
         <div className="text-center">
           <PageHeading>{displayError.title}</PageHeading>

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -124,40 +124,6 @@
 
   --color-input-background: var(--color-white);
   --color-input-border: var(--color-gray-300);
-
-  /* Legacy colors */
-
-  --color-text-primary: var(--color-foreground);
-  --color-text-secondary: var(--color-muted-foreground);
-
-  --color-background-default: var(--color-background);
-  --color-background-secondary: var(--color-primary-subtle);
-
-  --color-primary-light: var(--color-brand-300);
-  --color-primary-main: var(--color-primary);
-  --color-primary-dark: var(--color-primary-foreground);
-
-  --color-error-light: var(--color-red-300);
-  --color-error-main: var(--color-danger);
-  --color-error-dark: var(--color-danger-foreground);
-
-  --color-success-main: var(--color-success);
-
-  --color-warning-main: var(--color-warning);
-
-  --background-color-default: var(--color-background);
-  --background-color-secondary: var(--color-muted);
-  --background-color-secondary-subtle: var(--color-primary-subtle);
-
-  --background-color-brand: var(--color-primary);
-  --background-color-brand-hover: var(--color-primary-hover);
-  --background-color-brand-subtle: var(--color-primary-subtle);
-  --background-color-brand-subtle-hover: var(--color-primary-subtle-hover);
-
-  --text-color-danger: var(--color-danger-foreground);
-  --text-color-brand: var(--color-primary-foreground);
-
-  --border-color-input: var(--color-input-border);
 }
 
 @layer base {
@@ -172,7 +138,7 @@
   }
 
   body {
-    @apply bg-background-default text-text-primary h-screen w-full overflow-hidden overscroll-none font-sans;
+    @apply bg-background text-foreground h-screen w-full overflow-hidden overscroll-none font-sans;
   }
 
   #root {

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -115,7 +115,7 @@ const AvailableConnections = ({ isSync }: AvailableConnectionsProps) => {
                 >
                   <div
                     key={connection.id}
-                    className="has-[:checked]:bg-secondary-subtle group has-[:checked]:ring-primary-main rounded-lg ring-1 ring-gray-200 has-[:checked]:ring-2"
+                    className="has-[:checked]:bg-primary-subtle group has-[:checked]:ring-primary rounded-lg ring-1 ring-gray-200 has-[:checked]:ring-2"
                   >
                     <ConnectionRow
                       connection={connection}

--- a/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/ConnectionRow.tsx
@@ -40,7 +40,7 @@ function ConnectionRow({
       onClick={setActiveConfig}
       className="@container flex flex-row items-center gap-4 px-6 py-4 hover:cursor-pointer"
     >
-      <DatabaseIcon className="text-primary-main hidden size-8 shrink-0 @md:block" />
+      <DatabaseIcon className="text-primary hidden size-8 shrink-0 @md:block" />
       <ListRowContent>
         <ListRowTitle className="inline-flex items-center gap-1">
           {connection.displayLabel || connection.id}

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionData.tsx
@@ -118,7 +118,7 @@ function Row({ config }: { config: DisplayVertexTypeConfig }) {
             {config.attributes.length} {unit}
           </ListRowSubtitle>
         </ListRowContent>
-        <ChevronRightIcon className="text-text-secondary size-5" />
+        <ChevronRightIcon className="text-muted-foreground size-5" />
       </div>
     </Link>
   );

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
@@ -54,7 +54,7 @@ export default function ConnectionDeleteButton({
           <DialogBody>
             <div className="flex flex-row items-start gap-8">
               <div className="py-1">
-                <ErrorIcon className="text-warning-main size-16" />
+                <ErrorIcon className="text-warning size-16" />
               </div>
               <Paragraph>
                 Are you sure you want to delete the connection,{" "}

--- a/packages/graph-explorer/src/modules/ConnectionDetail/InfoBar.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/InfoBar.tsx
@@ -21,7 +21,7 @@ function InfoItemIcon({
   return (
     <div
       className={cn(
-        "bg-secondary-subtle text-primary-main hidden aspect-square h-12 items-center justify-center rounded-lg @lg:flex [&_svg]:size-6",
+        "bg-primary-subtle text-primary hidden aspect-square h-12 items-center justify-center rounded-lg @lg:flex [&_svg]:size-6",
         className,
       )}
       {...props}
@@ -52,7 +52,7 @@ function InfoItemLabel({
   return (
     <div
       className={cn(
-        "text-text-secondary text-sm text-balance break-words",
+        "text-muted-foreground text-sm text-balance break-words",
         className,
       )}
       {...props}
@@ -67,7 +67,7 @@ function InfoItemValue({
   return (
     <div
       className={cn(
-        "text-text-primary inline-flex items-center gap-1 text-base font-medium text-balance break-words",
+        "text-foreground inline-flex items-center gap-1 text-base font-medium text-balance break-words",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/modules/EntityDetails/EntityAttribute.tsx
+++ b/packages/graph-explorer/src/modules/EntityDetails/EntityAttribute.tsx
@@ -19,10 +19,10 @@ export default function EntityAttribute({
       className={cn("space-y-0.5", className)}
       {...props}
     >
-      <div className="text-text-secondary text-sm text-balance break-words">
+      <div className="text-muted-foreground text-sm text-balance break-words">
         {attribute.displayLabel}
       </div>
-      <div className="text-text-primary font-medium text-balance break-words">
+      <div className="text-foreground font-medium text-balance break-words">
         {attribute.displayValue}
       </div>
     </li>

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -184,7 +184,7 @@ function GraphViewerContent({
             </Button>
           </PanelHeaderActions>
         </PanelHeader>
-        <PanelContent className="bg-background-secondary grid" ref={parentRef}>
+        <PanelContent className="bg-primary-subtle grid" ref={parentRef}>
           <Graph
             nodes={nodes}
             edges={edges}

--- a/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/internalComponents/ContextMenu.tsx
@@ -347,9 +347,7 @@ function useContextMenuClose() {
 
 function ContextMenuContent({ children }: PropsWithChildren) {
   return (
-    <div className="bg-background-default rounded-lg p-1 shadow-lg">
-      {children}
-    </div>
+    <div className="bg-background rounded-lg p-1 shadow-lg">{children}</div>
   );
 }
 
@@ -369,7 +367,7 @@ function ContextMenuItem({
   return (
     <button
       className={cn(
-        "text-text-primary [&_svg]:text-primary-dark hover:bg-background-secondary line-clamp-1 flex w-full flex-row items-center gap-3 rounded-sm px-3 py-2 hover:cursor-pointer [&_svg]:size-5",
+        "text-foreground [&_svg]:text-primary-foreground hover:bg-primary-subtle line-clamp-1 flex w-full flex-row items-center gap-3 rounded-sm px-3 py-2 hover:cursor-pointer [&_svg]:size-5",
         className,
       )}
       onClick={handleClick}
@@ -385,7 +383,7 @@ function ContextMenuTitle({
   return (
     <div
       className={cn(
-        "text-text-primary [&_svg]:text-primary-dark line-clamp-1 flex flex-row items-center gap-3 rounded-sm px-3 py-2 font-semibold [&_svg]:size-5",
+        "text-foreground [&_svg]:text-primary-foreground line-clamp-1 flex flex-row items-center gap-3 rounded-sm px-3 py-2 font-semibold [&_svg]:size-5",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/CommonPrefixes.tsx
@@ -66,7 +66,7 @@ function Row({ prefix }: { prefix: PrefixData }) {
   return (
     <div className="px-3 py-1.5">
       <ListRow className="min-h-12">
-        <NamespaceIcon className="text-primary-main size-5 shrink-0" />
+        <NamespaceIcon className="text-primary size-5 shrink-0" />
         <ListRowContent>
           <ListRowTitle>{prefix.titleComponent}</ListRowTitle>
           <ListRowSubtitle className="break-all">

--- a/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/GeneratedPrefixes.tsx
@@ -99,7 +99,7 @@ function Row({ prefix }: { prefix: PrefixData }) {
   return (
     <div className="px-3 py-1.5">
       <ListRow className="min-h-12">
-        <NamespaceIcon className="text-primary-main size-5 shrink-0" />
+        <NamespaceIcon className="text-primary size-5 shrink-0" />
         <ListRowContent>
           <ListRowTitle>{prefix.titleComponent}</ListRowTitle>
           <ListRowSubtitle className="break-all">

--- a/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
+++ b/packages/graph-explorer/src/modules/Namespaces/UserPrefixes.tsx
@@ -118,7 +118,7 @@ function Row({ prefix }: { prefix: PrefixTypeConfig }) {
   return (
     <div className="px-3 py-1.5">
       <ListRow className="min-h-12">
-        <NamespaceIcon className="text-primary-main size-5 shrink-0" />
+        <NamespaceIcon className="text-primary size-5 shrink-0" />
         <ListRowContent>
           <ListRowTitle>{prefix.prefix}</ListRowTitle>
           <ListRowSubtitle className="break-all">{prefix.uri}</ListRowSubtitle>

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -209,7 +209,7 @@ function Section({ children }: PropsWithChildren) {
 
 function SectionTitle({ children }: PropsWithChildren) {
   return (
-    <div className="text-text-primary flex justify-between gap-2 text-base font-medium">
+    <div className="text-foreground flex justify-between gap-2 text-base font-medium">
       {children}
     </div>
   );

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -240,7 +240,7 @@ function Content({ vertexType }: { vertexType: VertexType }) {
 
               <Field className="col-start-2 row-span-2 w-auto">
                 <FieldLabel>Preview</FieldLabel>
-                <div className="bg-background-secondary border-input grid rounded-lg border shadow-xs">
+                <div className="bg-primary-subtle border-input-border grid rounded-lg border shadow-xs">
                   <div className="flex flex-col items-center justify-center px-6">
                     <VertexSymbol
                       vertexStyle={vertexStyle}

--- a/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
@@ -96,7 +96,7 @@ export default function SchemaGraph({ className, ...props }: SchemaGraphProps) {
       <PanelGroup>
         <Panel className="min-h-0 min-w-0 flex-1">
           <SchemaGraphToolbar />
-          <PanelContent className="bg-background-secondary size-full min-h-0 min-w-0">
+          <PanelContent className="bg-primary-subtle size-full min-h-0 min-w-0">
             {!hasSchemaData ? (
               <NoNodeTypesEmptyState />
             ) : (

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
@@ -66,7 +66,7 @@ export function DetailsValue({
   return (
     <div
       className={cn(
-        "text-text-secondary gx-wrap-break-word text-base leading-tight font-medium",
+        "text-muted-foreground gx-wrap-break-word text-base leading-tight font-medium",
         className,
       )}
       {...props}
@@ -236,7 +236,7 @@ function ClickableTypeText({
         <button
           type="button"
           className={cn(
-            "hover:text-text-primary hover:bg-brand-300/25 focus-visible:ring-ring-3 cursor-pointer bg-transparent p-0 font-[inherit] focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+            "hover:text-foreground hover:bg-brand-300/25 focus-visible:ring-ring-3 cursor-pointer bg-transparent p-0 font-[inherit] focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
             className,
           )}
           style={style}
@@ -266,7 +266,7 @@ function EdgeTypeText({
       label={displayLabel}
       selected={selected}
       onClick={onClick}
-      className="data-selected:text-text-primary italic data-selected:font-semibold"
+      className="data-selected:text-foreground italic data-selected:font-semibold"
     >
       {displayLabel}
     </ClickableTypeText>
@@ -290,7 +290,7 @@ function VertexTypeText({
       label={displayLabel}
       selected={selected}
       onClick={onClick}
-      className="data-selected:text-text-primary underline decoration-2 underline-offset-4 data-selected:font-semibold"
+      className="data-selected:text-foreground underline decoration-2 underline-offset-4 data-selected:font-semibold"
       style={{ textDecorationColor: style.color }}
     >
       {displayLabel}

--- a/packages/graph-explorer/src/modules/SearchSidebar/BundleSearchResult.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/BundleSearchResult.tsx
@@ -30,7 +30,7 @@ export function BundleSearchResult({
   return (
     <SearchResultCollapsible level={level}>
       <SearchResultCollapsibleTrigger>
-        <SearchResultSymbol className="bg-primary-main/20 text-primary-main rounded-lg">
+        <SearchResultSymbol className="bg-primary/20 text-primary rounded-lg">
           <BracketsIcon className="size-5" />
         </SearchResultSymbol>
         <div>

--- a/packages/graph-explorer/src/modules/SearchSidebar/FilterSearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/FilterSearchTabContent.tsx
@@ -43,7 +43,7 @@ export function FilterSearchTabContent() {
   } = useKeywordSearch();
 
   return (
-    <div className="bg-background-default flex h-full flex-col gap-3">
+    <div className="bg-background flex h-full flex-col gap-3">
       <div className="flex flex-col gap-4 p-3">
         <div className="grid w-full grid-cols-2 gap-4">
           <FormItem>

--- a/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/QuerySearchTabContent.tsx
@@ -85,7 +85,7 @@ export function QuerySearchTabContent() {
   };
 
   return (
-    <div className="bg-background-default flex h-full flex-col">
+    <div className="bg-background flex h-full flex-col">
       <Form {...form}>
         <form
           className="shrink-0 space-y-3 p-3"

--- a/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/SearchResultsList.tsx
@@ -110,7 +110,7 @@ function ResultCounts({ results }: { results: PatchedResultEntity[] }) {
   const count = results.length;
   const label = count === 1 ? `${count} Item` : `${count} Items`;
 
-  return <p className="text-text-secondary text-sm text-pretty">{label}</p>;
+  return <p className="text-muted-foreground text-sm text-pretty">{label}</p>;
 }
 
 function AddAllToGraphButton({

--- a/packages/graph-explorer/src/routes/Settings/LoadConfigButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/LoadConfigButton.tsx
@@ -113,7 +113,7 @@ function ConfirmationModal({
         <DialogBody>
           <div className="flex flex-row items-start gap-8">
             <div className="py-1">
-              <ErrorIcon className="text-warning-main size-16" />
+              <ErrorIcon className="text-warning size-16" />
             </div>
             <div className="flex grow flex-col gap-8">
               <div>
@@ -173,7 +173,7 @@ function ParseFailureModal({
         <DialogBody>
           <div className="flex flex-row items-start gap-8">
             <div className="py-1">
-              <ErrorIcon className="text-warning-main size-16" />
+              <ErrorIcon className="text-warning size-16" />
             </div>
             <div>
               <Paragraph>
@@ -207,7 +207,7 @@ function SuccessModal({ success }: { success: boolean }) {
         <DialogBody>
           <div className="flex flex-row items-start gap-8">
             <div className="py-1">
-              <CheckIcon className="text-success-main size-16" />
+              <CheckIcon className="text-success size-16" />
             </div>
             <Paragraph className="w-full min-w-0">
               All data was restored successfully. Please reload{" "}

--- a/packages/graph-explorer/src/routes/Settings/LoadStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/LoadStylesButton.tsx
@@ -241,7 +241,7 @@ function LoadFailedContent({ error }: { error: DisplayError }) {
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogMedia className="bg-danger-subtle text-danger">
+        <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
           <AlertTriangleIcon />
         </AlertDialogMedia>
         <AlertDialogTitle>{error.title}</AlertDialogTitle>
@@ -258,7 +258,7 @@ function LoadInvalidContent({ issues }: { issues: ImportIssue[] }) {
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogMedia className="bg-danger-subtle text-danger">
+        <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
           <AlertTriangleIcon />
         </AlertDialogMedia>
         <AlertDialogTitle>Load Failed</AlertDialogTitle>
@@ -279,7 +279,7 @@ function LoadEmptyContent() {
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogMedia className="bg-warning-subtle text-warning-main">
+        <AlertDialogMedia className="bg-warning-subtle text-warning">
           <AlertTriangleIcon />
         </AlertDialogMedia>
         <AlertDialogTitle>No Styles Found</AlertDialogTitle>
@@ -304,7 +304,7 @@ function LoadCompleteContent({
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogMedia className="bg-success-subtle text-success-main">
+        <AlertDialogMedia className="bg-success-subtle text-success">
           <CheckCircleIcon />
         </AlertDialogMedia>
         <AlertDialogTitle>Styles Loaded</AlertDialogTitle>
@@ -431,13 +431,13 @@ function EntryIssuesGroup({
       {issues.map((issue, i) => (
         <GroupItem key={i} className="gx-wrap-break-word space-y-1 text-xs">
           <div>
-            <span className="text-text-primary font-mono font-medium">
+            <span className="text-foreground font-mono font-medium">
               {issue.typeName}
             </span>
             {" → "}
             <span className="font-mono">{issue.field}</span>: {issue.message}
           </div>
-          <div className="text-text-secondary">
+          <div className="text-muted-foreground">
             value:{" "}
             <span className="font-mono">{formatIssueValue(issue.value)}</span>
           </div>

--- a/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetAllStylesButton.tsx
@@ -44,7 +44,7 @@ export default function ResetAllStylesButton() {
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogMedia className="bg-danger-subtle text-danger">
+          <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
             <Trash2Icon />
           </AlertDialogMedia>
           <AlertDialogTitle>Reset All Styles</AlertDialogTitle>

--- a/packages/graph-explorer/src/routes/Settings/ResetCustomStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetCustomStylesButton.tsx
@@ -38,7 +38,7 @@ export default function ResetCustomStylesButton() {
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogMedia className="bg-danger-subtle text-danger">
+          <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
             <Trash2Icon />
           </AlertDialogMedia>
           <AlertDialogTitle>Reset Your Styles</AlertDialogTitle>

--- a/packages/graph-explorer/src/routes/Settings/ResetSharedStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/ResetSharedStylesButton.tsx
@@ -38,7 +38,7 @@ export default function ResetSharedStylesButton() {
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogMedia className="bg-danger-subtle text-danger">
+          <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
             <Trash2Icon />
           </AlertDialogMedia>
           <AlertDialogTitle>Reset Shared Styles</AlertDialogTitle>

--- a/packages/graph-explorer/src/routes/Settings/SaveStylesButton.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SaveStylesButton.tsx
@@ -112,7 +112,7 @@ function SaveFailedContent({ error }: { error: DisplayError }) {
   return (
     <AlertDialogContent>
       <AlertDialogHeader>
-        <AlertDialogMedia className="bg-danger-subtle text-danger">
+        <AlertDialogMedia className="bg-danger-subtle text-danger-foreground">
           <TriangleAlertIcon />
         </AlertDialogMedia>
         <AlertDialogTitle>{error.title}</AlertDialogTitle>

--- a/packages/graph-explorer/src/routes/Settings/SettingsRoot.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SettingsRoot.tsx
@@ -86,7 +86,7 @@ function SideBarItem(props: PropsWithChildren<{ to: To }>) {
       className={({ isActive }) =>
         cn(
           "flex w-full flex-row items-center gap-2 rounded-lg px-3 py-2 text-base tracking-wide [&_svg]:size-4.5",
-          isActive && "bg-brand text-white",
+          isActive && "bg-primary text-white",
           !isActive && "text-foreground hover:bg-neutral-subtle",
         )
       }

--- a/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
+++ b/packages/graph-explorer/src/routes/Settings/SettingsStyles.tsx
@@ -124,9 +124,9 @@ function SharedStylesStatus({
   return (
     <div className="flex gap-2 text-sm" role="status">
       <div className="grid h-lh place-items-center">
-        <span className="bg-primary-main size-2 rounded-full" />
+        <span className="bg-primary size-2 rounded-full" />
       </div>
-      <p className="text-text-secondary">
+      <p className="text-muted-foreground">
         {parts.join(" and ")}{" "}
         {vertexCount + edgeCount === 1 ? "type has" : "types have"} shared
         styles


### PR DESCRIPTION
## Description

The big cleanup: migrates all ~117 usages of legacy color token aliases to their canonical semantic equivalents and deletes the entire legacy alias section from `index.css` (30+ lines of dead-weight aliasing).

**Key insight discovered during migration:** The legacy section included Tailwind v4 namespace-specific overrides (`--text-color-*`, `--background-color-*`, `--border-color-*`) that silently remapped values. For example, `text-danger` resolved to red-700 (via `--text-color-danger`) instead of the expected red-500 (`--color-danger`). Each such usage was migrated to the token that produces the identical rendered value (e.g. `text-danger` → `text-danger-foreground`).

**Full replacement map:**

| Legacy | Canonical | Rendered value |
|---|---|---|
| `text-text-primary` | `text-foreground` | gray-900 |
| `text-text-secondary` | `text-muted-foreground` | gray-500 |
| `bg-background-default` / `bg-default` | `bg-background` | white |
| `bg-background-secondary` / `bg-secondary-subtle` | `bg-primary-subtle` | brand-50 |
| `*-primary-main` | `*-primary` | brand-500 |
| `*-primary-dark` | `*-primary-foreground` | brand-700 |
| `*-primary-light` | `*-brand-300` | brand-300 (palette one-off) |
| `*-error-main` | `*-danger` | red-500 |
| `*-error-light` | `*-red-300` | red-300 (palette one-off) |
| `*-success-main` | `*-success` | emerald-500 |
| `*-warning-main` | `*-warning` | amber-500 |
| `text-danger` | `text-danger-foreground` | red-700 |
| `border-input` | `border-input-border` | gray-300 |
| `bg-brand` | `bg-primary` | brand-500 |

## Validation

- `pnpm checks` passes
- `pnpm test` passes (2178 tests)
- `pnpm build` passes
- Zero visual change — every replacement maps to the same rendered CSS value

## Related Issues

- Closes #1957
- Part of #1952

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.