### PR TITLE
Eliminate direct palette scale references in components

### DIFF
--- a/docs/agents/design.md
+++ b/docs/agents/design.md
@@ -23,16 +23,18 @@ The Tailwind neutral scales (`slate`, `zinc`, `neutral`, `stone`) are removed. `
 
 **Base layer** — surface-agnostic defaults:
 
-| Token              | Purpose                                   | Value    |
-| ------------------ | ----------------------------------------- | -------- |
-| `foreground`       | Default text color                        | gray-900 |
-| `background`       | App background                            | white    |
-| `background-alt`   | Alternate background (e.g. sidebar area)  | gray-50  |
-| `muted`            | Muted/deemphasized surface                | gray-100 |
-| `muted-foreground` | Secondary/deemphasized text (any surface) | gray-500 |
-| `border`           | Default border color                      | gray-200 |
-| `input-background` | Form input fill                           | white    |
-| `input-border`     | Form input border                         | gray-300 |
+| Token              | Purpose                                     | Value     |
+| ------------------ | ------------------------------------------- | --------- |
+| `foreground`       | Default text color                          | gray-900  |
+| `background`       | App background                              | white     |
+| `background-alt`   | Alternate background (e.g. sidebar area)    | gray-50   |
+| `workspace`        | Tinted workspace background panels float in | brand-100 |
+| `workspace-canvas` | Graph/schema canvas surface                 | brand-50  |
+| `muted`            | Muted/deemphasized surface                  | gray-100  |
+| `muted-foreground` | Secondary/deemphasized text (any surface)   | gray-500  |
+| `border`           | Default border color                        | gray-200  |
+| `input-background` | Form input fill                             | white     |
+| `input-border`     | Form input border                           | gray-300  |
 
 **Role colors** — each role follows a consistent slot pattern:
 

--- a/packages/graph-explorer/src/components/Button/Button.tsx
+++ b/packages/graph-explorer/src/components/Button/Button.tsx
@@ -12,7 +12,7 @@ const buttonStyles = cva({
       primary:
         "bg-primary hover:bg-primary-hover data-open:bg-primary-hover text-white",
       secondary:
-        "text-foreground bg-gray-100 hover:bg-gray-200 data-open:bg-gray-200",
+        "text-foreground bg-neutral-subtle hover:bg-neutral-subtle-hover data-open:bg-neutral-subtle-hover",
       ghost:
         "text-primary-foreground hover:bg-primary-subtle data-open:bg-primary-subtle",
       outline:

--- a/packages/graph-explorer/src/components/Checkbox.tsx
+++ b/packages/graph-explorer/src/components/Checkbox.tsx
@@ -13,8 +13,8 @@ function Checkbox({
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        "focus-visible:ring-ring-3 group peer border-primary bg-primary size-[16px] shrink-0 rounded-sm border text-white focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-        "data-[state=unchecked]:bg-background data-[state=unchecked]:border-gray-400",
+        "focus-visible:ring-ring-3 group peer border-primary bg-primary size-[16px] shrink-0 rounded-sm border text-white shadow-xs focus-visible:ring-1 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+        "data-[state=unchecked]:bg-background data-[state=unchecked]:border-input-border",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/packages/graph-explorer/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -97,9 +97,9 @@ export function SidebarTabsTrigger({
               value={value}
               onClick={onToggle}
               className={cn(
-                "text-brand-900 active:bg-brand-300 data-[state=active]:bg-brand-500 inline-flex size-10 items-center justify-center rounded-md bg-transparent p-2 ring-0 transition-colors duration-100 focus:shadow-none active:text-white disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-white [&_svg]:size-6",
+                "text-primary-foreground active:bg-brand-300 data-[state=active]:bg-primary inline-flex size-10 items-center justify-center rounded-md bg-transparent p-2 ring-0 transition-colors duration-100 focus:shadow-none active:text-white disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-white [&_svg]:size-6",
                 "hover:data-[state=active]:bg-brand-400 hover:bg-primary-subtle-hover",
-                "focus-visible:ring-brand-500 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-hidden active:ring-0",
+                "focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-hidden active:ring-0",
                 className,
               )}
               {...props}

--- a/packages/graph-explorer/src/components/EmptyState.tsx
+++ b/packages/graph-explorer/src/components/EmptyState.tsx
@@ -26,9 +26,9 @@ const emptyStateIconStyles = cva({
   base: "mb-6 flex size-24 items-center justify-center rounded-full text-7xl text-white group-data-[size=small]/empty:mb-3 group-data-[size=small]/empty:size-10 [&>svg]:size-1/2",
   variants: {
     variant: {
-      info: "from-primary to-brand-300 bg-linear-to-b shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
+      info: "bg-empty-info-gradient shadow-[0_0_20px_2px_hsl(205,95%,71%,70%)]",
       error:
-        "from-danger bg-linear-to-b to-red-300 shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
+        "bg-empty-error-gradient shadow-[0_0_20px_2px_rgba(255,144,119,0.7)]",
       subtle: "bg-muted text-muted-foreground rounded-lg",
     },
   },

--- a/packages/graph-explorer/src/components/Panel.tsx
+++ b/packages/graph-explorer/src/components/Panel.tsx
@@ -16,7 +16,7 @@ export function PanelGroup({
     <div
       data-slot="panel-group"
       className={cn(
-        "bg-brand-100 flex min-h-0 min-w-0 flex-1 gap-2 p-2",
+        "bg-workspace flex min-h-0 min-w-0 flex-1 gap-2 p-2",
         className,
       )}
       {...props}

--- a/packages/graph-explorer/src/components/PanelError.tsx
+++ b/packages/graph-explorer/src/components/PanelError.tsx
@@ -96,7 +96,7 @@ function ErrorDetailsButton({ error }: { error: unknown }) {
           {errorData ? (
             <FormItem>
               <Label>Error data</Label>
-              <div className="grid min-h-64 overflow-auto rounded-lg border bg-gray-50 shadow-xs">
+              <div className="bg-background-alt grid min-h-64 overflow-auto rounded-lg border shadow-xs">
                 <CodeEditor
                   defaultLanguage="json"
                   value={errorData}

--- a/packages/graph-explorer/src/components/PersistenceStatusIndicator/PersistenceStatusIndicator.tsx
+++ b/packages/graph-explorer/src/components/PersistenceStatusIndicator/PersistenceStatusIndicator.tsx
@@ -64,7 +64,7 @@ export function PersistenceStatusIndicator() {
           </FormItem>
           <FormItem>
             <Label>Failed writes</Label>
-            <div className="grid min-h-64 overflow-auto rounded-lg border bg-gray-50 shadow-xs">
+            <div className="bg-background-alt grid min-h-64 overflow-auto rounded-lg border shadow-xs">
               <CodeEditor
                 defaultLanguage="json"
                 value={JSON.stringify(failures, null, 2)}

--- a/packages/graph-explorer/src/components/SearchResult.tsx
+++ b/packages/graph-explorer/src/components/SearchResult.tsx
@@ -16,7 +16,7 @@ export function SearchResult({
       {...props}
       className={cn(
         "content-auto intrinsic-size-[4.75rem] rounded-xl border shadow-xs",
-        isEven(level) ? "bg-gray-50" : "bg-background",
+        isEven(level) ? "bg-background-alt" : "bg-background",
         className,
       )}
     />
@@ -37,7 +37,7 @@ export function SearchResultCollapsible({
       {...props}
       className={cn(
         "group ring-border content-auto intrinsic-size-[4.75rem] rounded-xl shadow-xs ring-1 transition duration-100 ease-in-out",
-        isEven(level) ? "bg-gray-50" : "bg-background",
+        isEven(level) ? "bg-background-alt" : "bg-background",
         highlighted
           ? "shadow-primary-foreground/50 ring-primary-foreground/75"
           : "",
@@ -141,7 +141,7 @@ export function SearchResultAttribute({
       {...props}
       className={cn(
         "flex w-full flex-wrap justify-between gap-2 rounded-xl border px-4 py-2 shadow-xs",
-        isEven(level) ? "bg-gray-50" : "bg-background",
+        isEven(level) ? "bg-background-alt" : "bg-background",
         className,
       )}
     />

--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
@@ -21,7 +21,7 @@ const TabularHeader = <T extends object>({
     <tr
       key={key}
       {...otherProps}
-      className="grow-0 border border-x-transparent border-t-transparent bg-gray-50"
+      className="bg-background-alt grow-0 border border-x-transparent border-t-transparent"
     >
       {headerGroup.headers.map(column => {
         const { key, ...headerProps } = column.getHeaderProps(

--- a/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularRow.tsx
@@ -49,7 +49,7 @@ const TabularRow = <T extends object>({
   return (
     <tr
       {...rowProps}
-      className="group/tr text-foreground data-selected:text-primary-foreground data-selected:border-primary-foreground data-selected:bg-primary-subtle grow-0 border border-x-transparent border-t-transparent data-[selection-mode='row']:hover:cursor-pointer data-[selection-mode='row']:hover:bg-gray-50 data-[selection-mode='row']:data-selected:hover:bg-blue-200/75"
+      className="group/tr text-foreground data-selected:text-primary-foreground data-selected:border-primary-foreground data-selected:bg-primary-subtle data-[selection-mode='row']:hover:bg-background-alt data-[selection-mode='row']:data-selected:hover:bg-primary-subtle-hover/75 grow-0 border border-x-transparent border-t-transparent data-[selection-mode='row']:hover:cursor-pointer"
       onClick={() =>
         rowSelectionMode === "row" && selectable && row.toggleRowSelected()
       }

--- a/packages/graph-explorer/src/components/Tabular/builders/makeIconToggleCell.tsx
+++ b/packages/graph-explorer/src/components/Tabular/builders/makeIconToggleCell.tsx
@@ -26,7 +26,7 @@ export default function makeIconActionCell<T extends object>({
         variant="ghost"
         tooltip={title}
         onClick={() => onPress?.(props)}
-        className="active:bg-brand-100 text-brand-600 hover:text-brand-800 w-full cursor-pointer hover:bg-transparent"
+        className="active:bg-primary-subtle-hover text-primary hover:text-primary-foreground w-full cursor-pointer hover:bg-transparent"
       >
         {getValue(props) ? on : off}
       </Button>

--- a/packages/graph-explorer/src/index.css
+++ b/packages/graph-explorer/src/index.css
@@ -13,6 +13,18 @@
     #3334b9 87.02%
   );
 
+  /* Empty state icon gradients */
+  --background-image-empty-info-gradient: linear-gradient(
+    to bottom,
+    var(--color-primary),
+    var(--color-brand-300)
+  );
+  --background-image-empty-error-gradient: linear-gradient(
+    to bottom,
+    var(--color-danger),
+    var(--color-red-300)
+  );
+
   /* Max widths */
   --max-width-paragraph: 36rem;
 
@@ -86,6 +98,12 @@
   --color-foreground: var(--color-gray-900);
   --color-background: var(--color-white);
   --color-background-alt: var(--color-gray-50);
+
+  /* The tinted workspace background that panels float in */
+  --color-workspace: var(--color-brand-100);
+
+  /* The graph/schema canvas surface */
+  --color-workspace-canvas: var(--color-brand-50);
 
   --color-muted-foreground: var(--color-gray-500);
   --color-muted: var(--color-gray-100);

--- a/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
+++ b/packages/graph-explorer/src/modules/AvailableConnections/AvailableConnections.tsx
@@ -115,7 +115,7 @@ const AvailableConnections = ({ isSync }: AvailableConnectionsProps) => {
                 >
                   <div
                     key={connection.id}
-                    className="has-[:checked]:bg-primary-subtle group has-[:checked]:ring-primary rounded-lg ring-1 ring-gray-200 has-[:checked]:ring-2"
+                    className="has-[:checked]:bg-primary-subtle group has-[:checked]:ring-primary ring-border rounded-lg ring-1 has-[:checked]:ring-2"
                   >
                     <ConnectionRow
                       connection={connection}

--- a/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/GraphViewer.tsx
@@ -184,7 +184,7 @@ function GraphViewerContent({
             </Button>
           </PanelHeaderActions>
         </PanelHeader>
-        <PanelContent className="bg-primary-subtle grid" ref={parentRef}>
+        <PanelContent className="bg-workspace-canvas grid" ref={parentRef}>
           <Graph
             nodes={nodes}
             edges={edges}

--- a/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/SchemaGraph.tsx
@@ -96,7 +96,7 @@ export default function SchemaGraph({ className, ...props }: SchemaGraphProps) {
       <PanelGroup>
         <Panel className="min-h-0 min-w-0 flex-1">
           <SchemaGraphToolbar />
-          <PanelContent className="bg-primary-subtle size-full min-h-0 min-w-0">
+          <PanelContent className="bg-workspace-canvas size-full min-h-0 min-w-0">
             {!hasSchemaData ? (
               <NoNodeTypesEmptyState />
             ) : (

--- a/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
+++ b/packages/graph-explorer/src/modules/SchemaGraph/Sidebar/Details.tsx
@@ -236,7 +236,7 @@ function ClickableTypeText({
         <button
           type="button"
           className={cn(
-            "hover:text-foreground hover:bg-brand-300/25 focus-visible:ring-ring-3 cursor-pointer bg-transparent p-0 font-[inherit] focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
+            "hover:text-foreground hover:bg-primary-subtle focus-visible:ring-ring-3 cursor-pointer bg-transparent p-0 font-[inherit] focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden",
             className,
           )}
           style={style}

--- a/packages/graph-explorer/src/modules/SearchSidebar/ShowRawResponseDialog.tsx
+++ b/packages/graph-explorer/src/modules/SearchSidebar/ShowRawResponseDialog.tsx
@@ -38,7 +38,7 @@ export function ShowRawResponseDialogButton({
           </DialogDescription>
         </DialogHeader>
         <DialogBody className="grid min-h-0 py-3">
-          <div className="overflow-auto rounded-lg border bg-gray-50 shadow-xs">
+          <div className="bg-background-alt overflow-auto rounded-lg border shadow-xs">
             <CodeEditor
               defaultLanguage="json"
               value={rawResponseText}


### PR DESCRIPTION
## Description

Replaces raw palette color values (`gray-*`, `brand-*`, `blue-*`) in components with semantic tokens wherever a clear mapping exists. After this, the only remaining palette references are the CollapsibleSidebar's intermediate interaction shades (`brand-300`, `brand-400`) which have no semantic token at those exact values.

**New semantic tokens** (gaps discovered during migration):

| Token | Value | Purpose |
|---|---|---|
| `workspace` | brand-100 | The tinted workspace background that panels float in |
| `workspace-canvas` | brand-50 | The graph/schema canvas surface |
| `empty-info-gradient` | primary → brand-300 | Info empty state icon gradient |
| `empty-error-gradient` | danger → red-300 | Error empty state icon gradient |

**Semantic replacements:**

| Old | New | Sites |
|---|---|---|
| `bg-gray-50` | `bg-background-alt` | 7 (alternate subtle backgrounds) |
| `bg-gray-100` / `bg-gray-200` | `bg-neutral-subtle` / `bg-neutral-subtle-hover` | Button secondary |
| `bg-brand-100` | `bg-workspace` | Panel group (workspace) |
| `bg-primary-subtle` | `bg-workspace-canvas` | GraphViewer + SchemaGraph canvas |
| `border-gray-400` | `border-input-border` | Checkbox unchecked |
| `ring-gray-200` | `ring-border` | Connection cards |
| `bg-blue-200/75` | `bg-primary-subtle-hover/75` | Table selected row hover |
| `from-primary to-brand-300` | `bg-empty-info-gradient` | EmptyState info icon |
| `from-danger to-red-300` | `bg-empty-error-gradient` | EmptyState error icon |
| `text-brand-600` / `hover:text-brand-800` | `text-primary` / `hover:text-primary-foreground` | Icon toggle cell |
| `hover:bg-brand-300/25` | `hover:bg-primary-subtle` | Schema details hover |
| `text-brand-900` | `text-primary-foreground` | Sidebar tab icons |
| `data-[state=active]:bg-brand-500` | `data-[state=active]:bg-primary` | Sidebar active tab |
| `ring-brand-500` | `ring-primary` | Sidebar focus ring |

**Documented palette one-offs (kept):**
- CollapsibleSidebar: `active:bg-brand-300`, `hover:…bg-brand-400` — intermediate interaction shades not covered by the 5-slot semantic system

## Validation

- `pnpm checks` passes
- `pnpm test` passes (2178 tests)
- Minor visual shift: icon toggle and sidebar tabs use brand-700 (primary-foreground) instead of brand-900/brand-600 — semantically correct, slightly different shade. Table selected-row hover shifts from Tailwind blue-200 to brand-100 (aligns with brand palette).

## Related Issues

- Closes #1958
- Part of #1952

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.