### PR TITLE
Ignore Claude worktrees and add agent scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,11 @@
 # Local planning docs
 plans/
 
+# Claude Code worktrees
+.claude/worktrees/
+
+# Scratch space for agent temporary files
+.scratch/
+
 # Local-only files (settings, overrides, secrets)
 *.local.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Don't hard-wrap Markdown prose to a fixed column width, let it soft-wrap
 - When possible, create failing tests first then implement the logic to make the tests pass
 - Add or update tests for the code you change, even if nobody asked
+- Write temporary files (scratch notes, intermediate output) to the git-ignored `.scratch/` directory at the repo root, never elsewhere in the tree
 
 ## Code Quality Standards
 


### PR DESCRIPTION
## Description

Two `.gitignore` additions to support agent workflows, plus a matching convention in `AGENTS.md`:

- `.claude/worktrees/` — the directory Claude Code uses for git worktrees, so worktree-based parallel work doesn't get committed.
- `.scratch/` — a git-ignored spot for agents to drop temporary files (scratch notes, intermediate output).

`AGENTS.md` now directs agents to write temp files to `.scratch/` rather than scattering them through the tree.

## Validation

Non-functional change (ignore rules + docs). Confirmed `.claude/worktrees/` is the correct path Claude Code uses per its docs.

## Related Issues

None.

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.