### PR TITLE
fix: show a friendly Access denied message for 403 responses

### DIFF
--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -178,6 +178,30 @@ describe("createDisplayError", () => {
     });
   });
 
+  it("Should handle access denied error", () => {
+    const result = createDisplayError(
+      new NetworkError("Network error", 403, null),
+    );
+    expect(result).toStrictEqual({
+      title: "Access denied",
+      message:
+        "The server refused this request. Check that your connection credentials and permissions are correct, then try again.",
+    });
+  });
+
+  it("Should handle access denied error ignoring raw server data", () => {
+    const result = createDisplayError(
+      new NetworkError("Network error", 403, {
+        message: '{"requestId":"abc","code":"AccessDeniedException"}',
+      }),
+    );
+    expect(result).toStrictEqual({
+      title: "Access denied",
+      message:
+        "The server refused this request. Check that your connection credentials and permissions are correct, then try again.",
+    });
+  });
+
   it("Should handle too many requests error", () => {
     const result = createDisplayError(
       new NetworkError("Network error", 429, null),

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -122,6 +122,17 @@ export function createDisplayError(error: any): DisplayError {
       };
     }
 
+    if (error.statusCode === 403) {
+      // A 403 can be caused by several things (credentials, permissions,
+      // proxy configuration), so the message stays generic and points the
+      // user at what they can reasonably check.
+      return {
+        title: "Access denied",
+        message:
+          "The server refused this request. Check that your connection credentials and permissions are correct, then try again.",
+      };
+    }
+
     if (error.statusCode === 429) {
       return {
         title: "Too Many Requests",


### PR DESCRIPTION
Closes #1977

403 responses fell through to the catch-all `NetworkError` branch, showing "Network Response 403" with the raw server response. Added a dedicated 403 branch with the copy from the issue. The message stays generic since a 403 can mean credentials, permissions, or proxy configuration. The raw response is still available via Error Details.

Tested against a local stub returning a Neptune-style `AccessDeniedException` 403, triggered via schema sync.

**Before:**

<img width="1280" height="900" alt="before-403" src="https://github.com/user-attachments/assets/52b7eb78-8c60-4f9e-93f5-100b86fb3dbb" />


**After:**

<img width="1280" height="900" alt="after-403" src="https://github.com/user-attachments/assets/e0975055-71c5-4416-977f-e6c12139b17b" />
