### PR TITLE
Add edge preview to the edge style dialog

### DIFF
--- a/docs/adr/20260720-svg-geometry-ports-for-style-previews.md
+++ b/docs/adr/20260720-svg-geometry-ports-for-style-previews.md
@@ -1,0 +1,35 @@
+# ADR — Re-implement cytoscape geometry in SVG for style previews
+
+- **Status:** Accepted
+- **Date:** 2026-07-20
+- **Related:** PR #1929 (node-shape preview); issue #1947 (edge preview). Cytoscape 3.34.0 is the pinned and latest published version. Affects `components/VertexSymbol/nodeShapes.ts` and `components/EdgePreview/arrowShapes.ts`.
+
+## Context
+
+The node and edge style dialogs show a live preview of how a styled vertex or edge will look on the graph canvas. The canvas is rendered by cytoscape, which rasterizes node shapes and edge arrow heads to a `<canvas>` using geometry it computes internally (`math.mjs`, `arrow-shapes.mjs`). The preview is a small SVG in a React dialog, not a cytoscape instance.
+
+For the preview to be trustworthy it must match the canvas closely — a "triangle" arrow or a "barrel" node must look the same in the dialog as it will once applied. The geometry cytoscape uses is non-trivial: fitted n-gon polygons, round-corner arc math, barrel bezier curves, and per-arrow-shape point arrays with distinct spacing/gap positioning rules.
+
+## Decision
+
+Port the relevant cytoscape geometry **verbatim** from the pinned cytoscape version into standalone SVG-path builders, rather than instantiating cytoscape or rasterizing to an offscreen canvas:
+
+- `nodeShapes.ts` — `resolveShapeGeometry` ports the node-shape point lists, round-polygon corner math, round-rectangle, cut-rectangle, and barrel builders from `math.mjs`.
+- `arrowShapes.ts` — `resolveArrowGeometry` ports every arrow-shape point array plus the `getArrowWidth` size formula and per-shape `spacing`/`gap` values from `arrow-shapes.mjs` and `edge-arrows.mjs`.
+
+Each file carries a header comment naming the cytoscape source and version, and each has a sibling test (`nodeShapes.test.ts`, `arrowShapes.test.ts`) exercising every shape/style value.
+
+**This geometry is pinned to cytoscape 3.34.0 and must be re-verified against the upstream source whenever cytoscape is upgraded.** The round-polygon defect captured in ADR `coerce-retired-round-polygon-shapes` is direct evidence that cytoscape geometry both matters and changes: a preview built on stale geometry silently drifts from the canvas.
+
+## Considered Options
+
+- **Verbatim SVG geometry port (chosen).** The preview renders with plain SVG — no cytoscape instance, no canvas, no layout engine — so it is cheap, synchronous, testable as pure functions, and styleable with CSS/Tailwind (dark mode, hover). Cost: the geometry is duplicated from cytoscape and must be re-checked on upgrade.
+- **Instantiate a headless cytoscape per preview.** Exact by construction, but heavy: a cytoscape instance and canvas per dialog row, async layout, and no straightforward way to theme it. Overkill for a static single-element preview.
+- **Rasterize shapes to bundled images.** Loses the user's live color/size/style choices — the preview must reflect the current form state, not a fixed sprite.
+- **Extract cytoscape's geometry as a shared dependency.** Cytoscape does not export this math as public API; depending on internal module paths is more fragile than a reviewed, tested port with a documented source reference.
+
+## Consequences
+
+- Previews match the canvas without the weight of a cytoscape instance, and render as themeable, testable SVG.
+- The geometry is a **pinned copy** — every cytoscape version bump requires re-verifying `nodeShapes.ts` and `arrowShapes.ts` against upstream `math.mjs`, `arrow-shapes.mjs`, and `edge-arrows.mjs`. The sibling tests guard the port's internal invariants but cannot detect upstream geometry changes; that check is manual and belongs in any cytoscape-upgrade review.
+- A third preview built on the same pattern should follow suit (port + header reference + sibling test) rather than reaching for a cytoscape instance.

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.test.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+
+import { appDefaultEdgeStyle, createEdgeType, type EdgeStyle } from "@/core";
+
+import { EdgePreview } from "./EdgePreview";
+
+function edgeStyle(overrides?: Partial<EdgeStyle>): EdgeStyle {
+  return {
+    ...appDefaultEdgeStyle,
+    type: createEdgeType("KNOWS"),
+    ...overrides,
+  };
+}
+
+describe("EdgePreview", () => {
+  it("renders the provided label rather than deriving one from the edge type", () => {
+    render(
+      <EdgePreview
+        edgeStyle={edgeStyle({ type: createEdgeType("http://x/knows") })}
+        label="skos:broadMatch"
+      />,
+    );
+
+    expect(screen.getByText("skos:broadMatch")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "skos:broadMatch edge preview" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
@@ -118,8 +118,11 @@ function EdgeLine({
     arrowHeight(targetArrow),
   );
 
-  // Space reserved on each side so the label never overlaps an arrow.
-  const labelInset = lineInsetLeft + lineInsetRight + 8;
+  // The label is centered, so reserving space on the wider-reaching side must
+  // be mirrored on both. Reserve twice the deepest arrow reach (plus a small
+  // gap) so the centered label truncates before it touches either arrow head.
+  const labelInset =
+    2 * Math.max(arrowReach(sourceArrow), arrowReach(targetArrow)) + 8;
 
   return (
     <div className="relative w-full" style={{ height: containerHeight }}>
@@ -165,6 +168,15 @@ function EdgeLine({
 function arrowHeight(geometry: ArrowGeometry | null): number {
   if (!geometry) return 0;
   return geometry.bbox.maxY - geometry.bbox.minY;
+}
+
+/**
+ * How far an arrow head reaches inward from the node boundary: its tip sits
+ * `spacing` in, and its body extends the bbox width further toward the center.
+ */
+function arrowReach(geometry: ArrowGeometry | null): number {
+  if (!geometry) return 0;
+  return geometry.spacing + (geometry.bbox.maxX - geometry.bbox.minX);
 }
 
 // --- Arrow head ---

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
@@ -1,0 +1,223 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import type { EdgeStyle } from "@/core";
+
+import { cn } from "@/utils";
+
+import { LabelPreview } from "../LabelPreview";
+import {
+  type ArrowGeometry,
+  type ArrowPrimitive,
+  getArrowWidth,
+  resolveArrowGeometry,
+} from "./arrowShapes";
+
+/**
+ * Pixels per cytoscape unit. Cytoscape renders 1:1 (1 unit = 1px at zoom 1);
+ * we render at 2× so the preview is crisp, and callers can CSS-`zoom` down.
+ */
+const RENDER_SCALE = 2;
+
+/** A neutral placeholder node representing an endpoint of the edge. */
+function VertexPlaceholder({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "bg-primary-subtle-hover border-primary-foreground/25 size-12 shrink-0 rounded-full border-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+interface EdgePreviewProps {
+  edgeStyle: EdgeStyle;
+  className?: string;
+}
+
+/**
+ * Full edge preview: two placeholder nodes connected by the styled edge with
+ * the type name as the label. Line thickness, arrow geometry, and the gap
+ * between line and arrow are ported verbatim from cytoscape so the preview
+ * matches the canvas. Apply CSS `zoom` via className to scale it down.
+ */
+export function EdgePreview({ edgeStyle, className }: EdgePreviewProps) {
+  const lineWidthPx = edgeStyle.lineThickness * RENDER_SCALE;
+  const arrowUnit = getArrowWidth(edgeStyle.lineThickness) * RENDER_SCALE;
+
+  const sourceArrow = resolveArrowGeometry(
+    edgeStyle.sourceArrowStyle,
+    arrowUnit,
+    lineWidthPx,
+  );
+  const targetArrow = resolveArrowGeometry(
+    edgeStyle.targetArrowStyle,
+    arrowUnit,
+    lineWidthPx,
+  );
+
+  const labelText =
+    edgeStyle.displayLabel ?? String(edgeStyle.type).replace(/^__/, "");
+
+  return (
+    <div
+      className={cn("flex w-full items-center px-4 py-3", className)}
+      role="img"
+      aria-label={`${labelText} edge preview`}
+    >
+      <VertexPlaceholder />
+
+      <div className="flex min-w-24 flex-1 items-center self-center">
+        <EdgeLine
+          edgeStyle={edgeStyle}
+          labelText={labelText}
+          lineWidthPx={lineWidthPx}
+          sourceArrow={sourceArrow}
+          targetArrow={targetArrow}
+        />
+      </div>
+
+      <VertexPlaceholder />
+    </div>
+  );
+}
+
+// --- Edge line with arrows and label ---
+
+function EdgeLine({
+  edgeStyle,
+  labelText,
+  lineWidthPx,
+  sourceArrow,
+  targetArrow,
+}: {
+  edgeStyle: EdgeStyle;
+  labelText: string;
+  lineWidthPx: number;
+  sourceArrow: ArrowGeometry | null;
+  targetArrow: ArrowGeometry | null;
+}) {
+  // Cytoscape stops the line short of the node boundary by `gap` and places the
+  // arrow tip short by `spacing`. Here "the boundary" is each node's inner edge
+  // (the container's left/right). We inset the line by `gap` and anchor each
+  // arrow tip `spacing` in from the boundary.
+  const lineInsetLeft = sourceArrow?.gap ?? 0;
+  const lineInsetRight = targetArrow?.gap ?? 0;
+
+  // The container needs a height since every child is absolutely positioned.
+  // Use the tallest arrow (or the line thickness) so vertical centering works.
+  const containerHeight = Math.max(
+    lineWidthPx,
+    arrowHeight(sourceArrow),
+    arrowHeight(targetArrow),
+  );
+
+  // Space reserved on each side so the label never overlaps an arrow.
+  const labelInset = lineInsetLeft + lineInsetRight + 8;
+
+  return (
+    <div className="relative w-full" style={{ height: containerHeight }}>
+      {/* Line — spans the full width, inset to each arrow's gap */}
+      <div
+        className="absolute top-1/2 -translate-y-1/2"
+        style={{
+          left: lineInsetLeft,
+          right: lineInsetRight,
+          borderTopWidth: lineWidthPx,
+          borderTopStyle: edgeStyle.lineStyle,
+          borderTopColor: edgeStyle.lineColor,
+        }}
+      />
+
+      {sourceArrow && (
+        <ArrowHead
+          geometry={sourceArrow}
+          color={edgeStyle.lineColor}
+          side="source"
+        />
+      )}
+      {targetArrow && (
+        <ArrowHead
+          geometry={targetArrow}
+          color={edgeStyle.lineColor}
+          side="target"
+        />
+      )}
+
+      <LabelPreview
+        labelStyle={edgeStyle}
+        scale={RENDER_SCALE}
+        className="absolute inset-x-0 top-1/2 mx-auto -translate-y-1/2"
+        style={{ maxWidth: `calc(100% - ${labelInset}px)` }}
+      >
+        {labelText}
+      </LabelPreview>
+    </div>
+  );
+}
+
+function arrowHeight(geometry: ArrowGeometry | null): number {
+  if (!geometry) return 0;
+  return geometry.bbox.maxY - geometry.bbox.minY;
+}
+
+// --- Arrow head ---
+
+/**
+ * Renders a resolved arrow geometry as an absolutely-positioned SVG. The
+ * arrow's tip is at cytoscape-frame origin; we position the SVG so the tip
+ * lands `spacing` px in from the node boundary (the container edge).
+ */
+function ArrowHead({
+  geometry,
+  color,
+  side,
+}: {
+  geometry: ArrowGeometry;
+  color: string;
+  side: "source" | "target";
+}) {
+  const { bbox, spacing } = geometry;
+  const width = bbox.maxX - bbox.minX;
+  const height = bbox.maxY - bbox.minY;
+
+  // The arrow tip is at frame origin (viewBox x=0), which sits `bbox.maxX` from
+  // the SVG's right edge. To land the tip `spacing` in from the node boundary,
+  // offset the SVG edge by `spacing - bbox.maxX`. (maxX is 0 for most shapes;
+  // for circle/circle-triangle the shape pokes past the tip so maxX > 0.)
+  const edgeOffset = spacing - bbox.maxX;
+  return (
+    <svg
+      className="absolute top-1/2"
+      viewBox={`${bbox.minX} ${bbox.minY} ${width} ${height}`}
+      width={width}
+      height={height}
+      style={{
+        [side === "target" ? "right" : "left"]: edgeOffset,
+        marginTop: -height / 2,
+        transform: side === "source" ? "scaleX(-1)" : undefined,
+        overflow: "visible",
+      }}
+      fill={color}
+    >
+      {geometry.primitives.map((primitive, i) => (
+        <ArrowPrimitiveShape key={i} primitive={primitive} />
+      ))}
+    </svg>
+  );
+}
+
+function ArrowPrimitiveShape({ primitive }: { primitive: ArrowPrimitive }) {
+  if (primitive.kind === "circle") {
+    return <circle cx={primitive.cx} cy={primitive.cy} r={primitive.r} />;
+  }
+  if (primitive.kind === "path") {
+    return <path d={primitive.d} />;
+  }
+  const points = primitive.points.map(([x, y]) => `${x},${y}`).join(" ");
+  return <polygon points={points} />;
+}

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
@@ -13,10 +13,12 @@ import {
 } from "./arrowShapes";
 
 /**
- * Pixels per cytoscape unit. Cytoscape renders 1:1 (1 unit = 1px at zoom 1);
- * we render at 2× so the preview is crisp, and callers can CSS-`zoom` down.
+ * Pixels per cytoscape unit. Cytoscape renders 1:1 (1 unit = 1px at zoom 1),
+ * which is small for a dialog preview, so we scale up by default to land near a
+ * comfortable viewing size. Everything (SVG geometry and label) scales
+ * uniformly, so callers can still CSS-`zoom` from here without losing crispness.
  */
-const RENDER_SCALE = 2;
+const DEFAULT_ZOOM = 2;
 
 /** A neutral placeholder node representing an endpoint of the edge. */
 function VertexPlaceholder({
@@ -43,11 +45,11 @@ interface EdgePreviewProps {
  * Full edge preview: two placeholder nodes connected by the styled edge with
  * the type name as the label. Line thickness, arrow geometry, and the gap
  * between line and arrow are ported verbatim from cytoscape so the preview
- * matches the canvas. Apply CSS `zoom` via className to scale it down.
+ * matches the canvas. Apply CSS `zoom` via className to scale from DEFAULT_ZOOM.
  */
 export function EdgePreview({ edgeStyle, className }: EdgePreviewProps) {
-  const lineWidthPx = edgeStyle.lineThickness * RENDER_SCALE;
-  const arrowUnit = getArrowWidth(edgeStyle.lineThickness) * RENDER_SCALE;
+  const lineWidthPx = edgeStyle.lineThickness * DEFAULT_ZOOM;
+  const arrowUnit = getArrowWidth(edgeStyle.lineThickness) * DEFAULT_ZOOM;
 
   const sourceArrow = resolveArrowGeometry(
     edgeStyle.sourceArrowStyle,
@@ -150,7 +152,7 @@ function EdgeLine({
 
       <LabelPreview
         labelStyle={edgeStyle}
-        scale={RENDER_SCALE}
+        scale={DEFAULT_ZOOM}
         className="absolute inset-x-0 top-1/2 mx-auto -translate-y-1/2"
         style={{ maxWidth: `calc(100% - ${labelInset}px)` }}
       >

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
@@ -38,16 +38,17 @@ function VertexPlaceholder({
 
 interface EdgePreviewProps {
   edgeStyle: EdgeStyle;
+  label: string;
   className?: string;
 }
 
 /**
  * Full edge preview: two placeholder nodes connected by the styled edge with
- * the type name as the label. Line thickness, arrow geometry, and the gap
- * between line and arrow are ported verbatim from cytoscape so the preview
- * matches the canvas. Apply CSS `zoom` via className to scale from DEFAULT_ZOOM.
+ * the given label. Line thickness, arrow geometry, and the gap between line and
+ * arrow are ported verbatim from cytoscape so the preview matches the canvas.
+ * Apply CSS `zoom` via className to scale from DEFAULT_ZOOM.
  */
-export function EdgePreview({ edgeStyle, className }: EdgePreviewProps) {
+export function EdgePreview({ edgeStyle, label, className }: EdgePreviewProps) {
   const lineWidthPx = edgeStyle.lineThickness * DEFAULT_ZOOM;
   const arrowUnit = getArrowWidth(edgeStyle.lineThickness) * DEFAULT_ZOOM;
 
@@ -62,21 +63,18 @@ export function EdgePreview({ edgeStyle, className }: EdgePreviewProps) {
     lineWidthPx,
   );
 
-  const labelText =
-    edgeStyle.displayLabel ?? String(edgeStyle.type).replace(/^__/, "");
-
   return (
     <div
       className={cn("flex w-full items-center px-4 py-3", className)}
       role="img"
-      aria-label={`${labelText} edge preview`}
+      aria-label={`${label} edge preview`}
     >
       <VertexPlaceholder />
 
       <div className="flex min-w-24 flex-1 items-center self-center">
         <EdgeLine
           edgeStyle={edgeStyle}
-          labelText={labelText}
+          labelText={label}
           lineWidthPx={lineWidthPx}
           sourceArrow={sourceArrow}
           targetArrow={targetArrow}

--- a/packages/graph-explorer/src/components/EdgePreview/arrowShapes.test.ts
+++ b/packages/graph-explorer/src/components/EdgePreview/arrowShapes.test.ts
@@ -24,7 +24,7 @@ describe("getArrowWidth", () => {
 });
 
 describe("resolveArrowGeometry", () => {
-  const UNIT = 58; // getArrowWidth(2) * RENDER_SCALE ≈ real usage
+  const UNIT = 58; // getArrowWidth(2) * DEFAULT_ZOOM ≈ real usage
   const LINE_WIDTH = 4;
 
   it("returns null for none", () => {

--- a/packages/graph-explorer/src/components/EdgePreview/arrowShapes.test.ts
+++ b/packages/graph-explorer/src/components/EdgePreview/arrowShapes.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import { ARROW_STYLES, type ArrowStyle } from "@/core";
+
+import { getArrowWidth, resolveArrowGeometry } from "./arrowShapes";
+
+/** Every arrow style except "none", which resolves to null. */
+const DRAWN_STYLES = ARROW_STYLES.filter(
+  (style): style is ArrowStyle => style !== "none",
+);
+
+describe("getArrowWidth", () => {
+  it("floors at 29 for thin edges", () => {
+    expect(getArrowWidth(0)).toBe(29);
+    expect(getArrowWidth(1)).toBe(29);
+  });
+
+  it("grows above the floor for thick edges", () => {
+    const thin = getArrowWidth(2);
+    const thick = getArrowWidth(20);
+    expect(thick).toBeGreaterThan(thin);
+    expect(thin).toBeGreaterThanOrEqual(29);
+  });
+});
+
+describe("resolveArrowGeometry", () => {
+  const UNIT = 58; // getArrowWidth(2) * RENDER_SCALE ≈ real usage
+  const LINE_WIDTH = 4;
+
+  it("returns null for none", () => {
+    expect(resolveArrowGeometry("none", UNIT, LINE_WIDTH)).toBeNull();
+  });
+
+  it.each(DRAWN_STYLES)(
+    "%s resolves to primitives with a finite bbox",
+    style => {
+      const result = resolveArrowGeometry(style, UNIT, LINE_WIDTH);
+      expect(result).not.toBeNull();
+      const geometry = result!;
+      expect(geometry.primitives.length).toBeGreaterThan(0);
+
+      const { minX, minY, maxX, maxY } = geometry.bbox;
+      for (const value of [minX, minY, maxX, maxY]) {
+        expect(Number.isFinite(value)).toBe(true);
+      }
+      expect(maxX).toBeGreaterThanOrEqual(minX);
+      expect(maxY).toBeGreaterThanOrEqual(minY);
+      expect(Number.isFinite(geometry.spacing)).toBe(true);
+      expect(Number.isFinite(geometry.gap)).toBe(true);
+    },
+  );
+
+  it.each(DRAWN_STYLES)("%s anchors its tip at the frame origin", style => {
+    // The tip sits at cytoscape-frame origin, so the bbox must contain (0,0):
+    // the body extends into negative X and the tip is the rightmost point (or
+    // the shape straddles the origin, as with circle/tee).
+    const { bbox } = resolveArrowGeometry(style, UNIT, LINE_WIDTH)!;
+    expect(bbox.minX).toBeLessThanOrEqual(0);
+    expect(bbox.maxX).toBeGreaterThanOrEqual(0);
+    expect(bbox.minY).toBeLessThanOrEqual(0);
+    expect(bbox.maxY).toBeGreaterThanOrEqual(0);
+  });
+
+  describe("per-shape spacing and gap (verbatim from cytoscape)", () => {
+    const standardGap = LINE_WIDTH * 2;
+
+    it("triangle uses zero spacing and standard gap", () => {
+      const { spacing, gap } = resolveArrowGeometry(
+        "triangle",
+        UNIT,
+        LINE_WIDTH,
+      )!;
+      expect(spacing).toBe(0);
+      expect(gap).toBe(standardGap);
+    });
+
+    it("vee gap is standardGap * 0.525", () => {
+      const { gap } = resolveArrowGeometry("vee", UNIT, LINE_WIDTH)!;
+      expect(gap).toBeCloseTo(standardGap * 0.525);
+    });
+
+    it("triangle-backcurve gap is standardGap * 0.8", () => {
+      const { gap } = resolveArrowGeometry(
+        "triangle-backcurve",
+        UNIT,
+        LINE_WIDTH,
+      )!;
+      expect(gap).toBeCloseTo(standardGap * 0.8);
+    });
+
+    it("diamond gap is the line width", () => {
+      const { gap } = resolveArrowGeometry("diamond", UNIT, LINE_WIDTH)!;
+      expect(gap).toBe(LINE_WIDTH);
+    });
+
+    it("tee uses a literal 1px spacing and gap", () => {
+      const { spacing, gap } = resolveArrowGeometry("tee", UNIT, LINE_WIDTH)!;
+      expect(spacing).toBe(1);
+      expect(gap).toBe(1);
+    });
+
+    it("circle spacing is unit * radius (0.15)", () => {
+      const { spacing } = resolveArrowGeometry("circle", UNIT, LINE_WIDTH)!;
+      expect(spacing).toBeCloseTo(UNIT * 0.15);
+    });
+
+    it("circle-triangle spacing is unit * radius (0.15)", () => {
+      const { spacing } = resolveArrowGeometry(
+        "circle-triangle",
+        UNIT,
+        LINE_WIDTH,
+      )!;
+      expect(spacing).toBeCloseTo(UNIT * 0.15);
+    });
+  });
+
+  describe("compound shapes emit multiple primitives", () => {
+    it.each(["triangle-tee", "triangle-cross", "circle-triangle"] as const)(
+      "%s emits two primitives",
+      style => {
+        const { primitives } = resolveArrowGeometry(style, UNIT, LINE_WIDTH)!;
+        expect(primitives.length).toBe(2);
+      },
+    );
+  });
+
+  it("triangle-backcurve emits a path primitive", () => {
+    const { primitives } = resolveArrowGeometry(
+      "triangle-backcurve",
+      UNIT,
+      LINE_WIDTH,
+    )!;
+    expect(primitives[0].kind).toBe("path");
+  });
+
+  it("circle emits a circle primitive centered at the origin", () => {
+    const { primitives } = resolveArrowGeometry("circle", UNIT, LINE_WIDTH)!;
+    const [primitive] = primitives;
+    expect.assert(primitive.kind === "circle");
+    expect(primitive.cx).toBe(0);
+    expect(primitive.cy).toBe(0);
+    expect(primitive.r).toBeCloseTo(UNIT * 0.15);
+  });
+
+  it("scales geometry with the unit", () => {
+    const small = resolveArrowGeometry("triangle", 10, LINE_WIDTH)!;
+    const large = resolveArrowGeometry("triangle", 100, LINE_WIDTH)!;
+    const smallWidth = small.bbox.maxX - small.bbox.minX;
+    const largeWidth = large.bbox.maxX - large.bbox.minX;
+    expect(largeWidth).toBeCloseTo(smallWidth * 10);
+  });
+});

--- a/packages/graph-explorer/src/components/EdgePreview/arrowShapes.ts
+++ b/packages/graph-explorer/src/components/EdgePreview/arrowShapes.ts
@@ -1,0 +1,214 @@
+import type { ArrowStyle } from "@/core";
+
+/**
+ * Verbatim port of cytoscape 3.34.0's arrow-shape geometry so an SVG preview
+ * draws the exact same arrow heads cytoscape rasterizes to canvas.
+ *
+ * Cytoscape authors each arrow in a normalized frame (arrow-shapes.mjs:13-16):
+ *   (0, 0)  is the arrow TIP
+ *   (0, 1)  is the direction TOWARD the node
+ *   (1, 0)  is "right" relative to the edge
+ *
+ * The preview draws a horizontal edge with the arrow pointing right (toward a
+ * node on the right), so we map the cytoscape frame to screen space with:
+ *   screenX = y * unit   (toward-node axis → rightward; tip at 0, body at x<0)
+ *   screenY = x * unit   (right axis → down; shapes are vertically symmetric)
+ * A source arrow is the mirror of a target arrow (flip horizontally).
+ *
+ * `unit` is pixels-per-cytoscape-unit — the `size` value cytoscape multiplies
+ * every normalized point by: `getArrowWidth(width) * renderScale`.
+ */
+
+/**
+ * Cytoscape's arrow size (edge-arrows.mjs:167): the multiplier applied to the
+ * normalized points, with a hard floor of 29 and sub-linear growth. arrowScale
+ * defaults to 1 and Graph Explorer never overrides it.
+ */
+export function getArrowWidth(edgeWidth: number): number {
+  return Math.max(Math.pow(edgeWidth * 13.37, 0.9), 29);
+}
+
+/** Cytoscape's `standardGap` (arrow-shapes.mjs:77): width * arrowScale * 2. */
+function standardGap(lineWidthPx: number): number {
+  return lineWidthPx * 2;
+}
+
+type Vec2 = readonly [number, number];
+
+/** Flat cytoscape point array [x0,y0,x1,y1,…] → screen point pairs. */
+function toScreen(points: readonly number[], unit: number): Vec2[] {
+  const out: Vec2[] = [];
+  for (let i = 0; i < points.length; i += 2) {
+    out.push([points[i + 1] * unit, points[i] * unit]);
+  }
+  return out;
+}
+
+// --- Cytoscape normalized point arrays (arrow-shapes.mjs) ---
+
+const TRIANGLE = [-0.15, -0.3, 0, 0, 0.15, -0.3];
+const VEE = [-0.15, -0.3, 0, 0, 0.15, -0.3, 0, -0.15];
+const SQUARE = [-0.15, 0.0, 0.15, 0.0, 0.15, -0.3, -0.15, -0.3];
+const DIAMOND = [-0.15, -0.15, 0, -0.3, 0.15, -0.15, 0, 0];
+const TEE = [-0.15, 0, -0.15, -0.1, 0.15, -0.1, 0.15, 0];
+const TRIANGLE_TEE_TRI = [0, 0, 0.15, -0.3, -0.15, -0.3, 0, 0];
+const TRIANGLE_TEE_BAR = [-0.15, -0.4, -0.15, -0.5, 0.15, -0.5, 0.15, -0.4];
+const CIRCLE_TRIANGLE_TRI = [0, -0.15, 0.15, -0.45, -0.15, -0.45, 0, -0.15];
+const BACKCURVE_CONTROL = [0, -0.15];
+const CIRCLE_RADIUS = 0.15;
+
+/**
+ * The cross bar for `triangle-cross`, whose thickness tracks the edge width
+ * (arrow-shapes.mjs:226): base points at y=-0.4, far edge shifted by
+ * edgeWidth/size so the drawn bar is exactly one line-width thick.
+ */
+function triangleCrossBar(lineWidthPx: number, size: number): number[] {
+  const shift = lineWidthPx / size;
+  return [-0.15, -0.4, -0.15, -0.4 - shift, 0.15, -0.4 - shift, 0.15, -0.4];
+}
+
+// --- Rendered geometry ---
+
+export type ArrowPrimitive =
+  | { readonly kind: "polygon"; readonly points: Vec2[] }
+  | { readonly kind: "path"; readonly d: string; readonly bounds: Vec2[] }
+  | {
+      readonly kind: "circle";
+      readonly cx: number;
+      readonly cy: number;
+      readonly r: number;
+    };
+
+export type ArrowGeometry = {
+  readonly primitives: ArrowPrimitive[];
+  /** Screen-space bounding box of all primitives (tip is at 0,0). */
+  readonly bbox: { minX: number; minY: number; maxX: number; maxY: number };
+  /** Distance from the node boundary to the arrow tip (px). */
+  readonly spacing: number;
+  /** Distance from the node boundary to where the edge line stops (px). */
+  readonly gap: number;
+};
+
+function polygon(points: readonly number[], unit: number): ArrowPrimitive {
+  return { kind: "polygon", points: toScreen(points, unit) };
+}
+
+/**
+ * The `triangle-backcurve` shape (arrow-shapes.mjs:141): the triangle points
+ * connected by straight lines, then a quadratic curve from the last point back
+ * to the first, bowing the base inward through the control point. The curve
+ * stays inside the triangle, so the triangle points bound it.
+ */
+function backcurvePath(unit: number): ArrowPrimitive {
+  const points = toScreen(TRIANGLE, unit);
+  const [p0, p1, p2] = points;
+  const [ctrlX, ctrlY] = toScreen(BACKCURVE_CONTROL, unit)[0];
+  const d = `M ${p0[0]} ${p0[1]} L ${p1[0]} ${p1[1]} L ${p2[0]} ${p2[1]} Q ${ctrlX} ${ctrlY} ${p0[0]} ${p0[1]} Z`;
+  return { kind: "path", d, bounds: points };
+}
+
+function boundingBox(primitives: ArrowPrimitive[]) {
+  let minX = 0;
+  let minY = 0;
+  let maxX = 0;
+  let maxY = 0;
+  for (const p of primitives) {
+    if (p.kind === "circle") {
+      minX = Math.min(minX, p.cx - p.r);
+      maxX = Math.max(maxX, p.cx + p.r);
+      minY = Math.min(minY, p.cy - p.r);
+      maxY = Math.max(maxY, p.cy + p.r);
+    } else {
+      const points = p.kind === "polygon" ? p.points : p.bounds;
+      for (const [x, y] of points) {
+        minX = Math.min(minX, x);
+        maxX = Math.max(maxX, x);
+        minY = Math.min(minY, y);
+        maxY = Math.max(maxY, y);
+      }
+    }
+  }
+  return { minX, minY, maxX, maxY };
+}
+
+/**
+ * Resolves a cytoscape arrow style into SVG-ready primitives (tip at origin,
+ * body extending to negative X) plus the spacing/gap that position it against
+ * the node. Returns null for `none`.
+ *
+ * @param style the cytoscape arrow-shape name
+ * @param unit pixels per cytoscape unit — `getArrowWidth(width) * renderScale`
+ * @param lineWidthPx the rendered line thickness in px (for gap + cross bar)
+ */
+export function resolveArrowGeometry(
+  style: ArrowStyle,
+  unit: number,
+  lineWidthPx: number,
+): ArrowGeometry | null {
+  const primitives: ArrowPrimitive[] = [];
+  let spacing = 0;
+  let gap = standardGap(lineWidthPx);
+
+  switch (style) {
+    case "none":
+      return null;
+    case "triangle":
+      primitives.push(polygon(TRIANGLE, unit));
+      break;
+    case "vee":
+      primitives.push(polygon(VEE, unit));
+      gap = standardGap(lineWidthPx) * 0.525;
+      break;
+    case "square":
+      primitives.push(polygon(SQUARE, unit));
+      break;
+    case "diamond":
+      primitives.push(polygon(DIAMOND, unit));
+      gap = lineWidthPx;
+      break;
+    case "tee":
+      primitives.push(polygon(TEE, unit));
+      // Cytoscape uses a literal 1px spacing/gap for tee (arrow-shapes.mjs:296),
+      // not a width-proportional value; kept verbatim rather than RENDER_SCALEd.
+      spacing = 1;
+      gap = 1;
+      break;
+    case "triangle-tee":
+      primitives.push(polygon(TRIANGLE_TEE_TRI, unit));
+      primitives.push(polygon(TRIANGLE_TEE_BAR, unit));
+      break;
+    case "triangle-cross":
+      primitives.push(polygon(TRIANGLE_TEE_TRI, unit));
+      primitives.push(polygon(triangleCrossBar(lineWidthPx, unit), unit));
+      break;
+    case "triangle-backcurve":
+      primitives.push(backcurvePath(unit));
+      gap = standardGap(lineWidthPx) * 0.8;
+      break;
+    case "circle":
+      primitives.push({
+        kind: "circle",
+        cx: 0,
+        cy: 0,
+        r: CIRCLE_RADIUS * unit,
+      });
+      spacing = unit * CIRCLE_RADIUS;
+      break;
+    case "circle-triangle":
+      primitives.push({
+        kind: "circle",
+        cx: 0,
+        cy: 0,
+        r: CIRCLE_RADIUS * unit,
+      });
+      primitives.push(polygon(CIRCLE_TRIANGLE_TRI, unit));
+      spacing = unit * CIRCLE_RADIUS;
+      break;
+    default:
+      style satisfies never;
+      primitives.push(polygon(TRIANGLE, unit));
+      break;
+  }
+
+  return { primitives, bbox: boundingBox(primitives), spacing, gap };
+}

--- a/packages/graph-explorer/src/components/EdgePreview/arrowShapes.ts
+++ b/packages/graph-explorer/src/components/EdgePreview/arrowShapes.ts
@@ -169,7 +169,7 @@ export function resolveArrowGeometry(
     case "tee":
       primitives.push(polygon(TEE, unit));
       // Cytoscape uses a literal 1px spacing/gap for tee (arrow-shapes.mjs:296),
-      // not a width-proportional value; kept verbatim rather than RENDER_SCALEd.
+      // not a width-proportional value; kept verbatim rather than zoom-scaled.
       spacing = 1;
       gap = 1;
       break;

--- a/packages/graph-explorer/src/components/EdgePreview/index.ts
+++ b/packages/graph-explorer/src/components/EdgePreview/index.ts
@@ -1,0 +1,1 @@
+export { EdgePreview } from "./EdgePreview";

--- a/packages/graph-explorer/src/components/LabelPreview.test.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+
+import { appDefaultNodeLabelStyle, type LabelVisualStyle } from "@/core";
+
+import { LabelPreview } from "./LabelPreview";
+
+function labelStyle(overrides?: Partial<LabelVisualStyle>): LabelVisualStyle {
+  return { ...appDefaultNodeLabelStyle, ...overrides };
+}
+
+function renderLabel(style: LabelVisualStyle, scale = 2) {
+  render(
+    <LabelPreview labelStyle={style} scale={scale}>
+      label
+    </LabelPreview>,
+  );
+  return screen.getByText("label");
+}
+
+describe("LabelPreview", () => {
+  describe("text color follows label darkness for contrast", () => {
+    it("uses white text on a dark label color", () => {
+      const el = renderLabel(labelStyle({ labelColor: "#1d2531" }));
+      expect(el.style.color).toBe("#ffffff");
+    });
+
+    it("uses black text on a light label color", () => {
+      const el = renderLabel(labelStyle({ labelColor: "#f0f0f0" }));
+      expect(el.style.color).toBe("#000000");
+    });
+  });
+
+  describe("border is applied only when width is positive", () => {
+    it("omits border styling at width 0", () => {
+      const el = renderLabel(labelStyle({ labelBorderWidth: 0 }));
+      expect(el.style.borderWidth).toBe("");
+      expect(el.style.borderStyle).toBe("");
+      expect(el.style.borderColor).toBe("");
+    });
+
+    it("applies border styling at a positive width", () => {
+      const el = renderLabel(
+        labelStyle({
+          labelBorderWidth: 1,
+          labelBorderStyle: "dashed",
+          labelBorderColor: "#ff0000",
+        }),
+        2,
+      );
+      // width scales by the render scale (1 * 2)
+      expect(el.style.borderWidth).toBe("2px");
+      expect(el.style.borderStyle).toBe("dashed");
+      expect(el.style.borderColor).toBe("#ff0000");
+    });
+  });
+
+  it("scales font size, padding, and radius by the render scale", () => {
+    const el = renderLabel(labelStyle(), 2);
+    // constants are 7 / 2 / 2 model units, multiplied by the scale
+    expect(el.style.fontSize).toBe("14px");
+    expect(el.style.padding).toBe("4px");
+    expect(el.style.borderRadius).toBe("4px");
+  });
+});

--- a/packages/graph-explorer/src/components/LabelPreview.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.tsx
@@ -1,0 +1,89 @@
+import type React from "react";
+
+import Color from "color";
+
+import type { LabelVisualStyle } from "@/core";
+
+import { cn } from "@/utils";
+
+/**
+ * Cytoscape model-unit constants for label rendering.
+ * Matches defaultNodeStyle.ts and defaultEdgeStyle.ts.
+ */
+const FONT_SIZE = 7;
+const PADDING = 2;
+const BORDER_RADIUS = 2;
+
+interface LabelPreviewProps {
+  /** The label text to display. */
+  children: string;
+  /** The label visual style (colors, border, opacity). */
+  labelStyle: LabelVisualStyle;
+  /**
+   * Scale factor: model units → pixels.
+   * (e.g., 2 means 1 model unit = 2px, rendering font at 14px)
+   */
+  scale: number;
+  className?: string;
+  /** Additional inline styles (e.g., max-width constraints). */
+  style?: React.CSSProperties;
+}
+
+/**
+ * A label badge preview that faithfully matches cytoscape's canvas rendering
+ * at any scale. Text color is derived from `labelColor` darkness (white on dark,
+ * black on light) — same logic as `useGraphStyles.ts`.
+ *
+ * Used for both vertex and edge label previews.
+ */
+export function LabelPreview({
+  children,
+  labelStyle,
+  scale,
+  className,
+  style: styleProp,
+}: LabelPreviewProps) {
+  return (
+    <span
+      className={cn(
+        "block w-fit max-w-full overflow-hidden text-center leading-none font-medium text-ellipsis whitespace-nowrap",
+        className,
+      )}
+      style={{
+        fontSize: FONT_SIZE * scale,
+        padding: PADDING * scale,
+        borderRadius: BORDER_RADIUS * scale,
+        color: new Color(labelStyle.labelColor).isDark()
+          ? "#ffffff"
+          : "#000000",
+        backgroundColor: `color-mix(in srgb, ${labelStyle.labelColor} ${labelStyle.labelBackgroundOpacity * 100}%, transparent)`,
+        borderWidth: labelStyle.labelBorderWidth * scale || undefined,
+        borderStyle:
+          labelStyle.labelBorderWidth > 0
+            ? labelStyle.labelBorderStyle
+            : undefined,
+        borderColor:
+          labelStyle.labelBorderWidth > 0
+            ? labelStyle.labelBorderColor
+            : undefined,
+        ...styleProp,
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+/**
+ * The default label style matching cytoscape's node label appearance. Values
+ * mirror the canonical node label config in
+ * `components/Graph/styles/defaultNodeStyle.ts` (`color`, `opacity`) — keep in
+ * sync if that changes.
+ */
+export const defaultNodeLabelStyle: LabelVisualStyle = {
+  labelColor: "#1d2531",
+  labelBackgroundOpacity: 0.7,
+  labelBorderColor: "#1d2531",
+  labelBorderStyle: "solid",
+  labelBorderWidth: 0,
+};

--- a/packages/graph-explorer/src/components/LabelPreview.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.tsx
@@ -73,17 +73,3 @@ export function LabelPreview({
     </span>
   );
 }
-
-/**
- * The default label style matching cytoscape's node label appearance. Values
- * mirror the canonical node label config in
- * `components/Graph/styles/defaultNodeStyle.ts` (`color`, `opacity`) — keep in
- * sync if that changes.
- */
-export const defaultNodeLabelStyle: LabelVisualStyle = {
-  labelColor: "#1d2531",
-  labelBackgroundOpacity: 0.7,
-  labelBorderColor: "#1d2531",
-  labelBorderStyle: "solid",
-  labelBorderWidth: 0,
-};

--- a/packages/graph-explorer/src/components/PreviewSurface.tsx
+++ b/packages/graph-explorer/src/components/PreviewSurface.tsx
@@ -1,0 +1,23 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@/utils";
+
+/**
+ * The bordered canvas-tinted surface that a style preview (vertex or edge)
+ * floats on inside a style dialog. Centers its content and matches the graph
+ * canvas background so the preview reads as "how this looks on the canvas".
+ */
+export function PreviewSurface({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "bg-workspace-canvas border-input-border grid place-items-center rounded-lg border px-6 py-4 shadow-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { QueryClient } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+import {
+  appDefaultVertexStyle,
+  createVertexType,
+  getAppStore,
+  type VertexStyle,
+} from "@/core";
+import { TestProvider } from "@/utils/testing/renderHookWithJotai";
+
+import { VertexPreview } from "./VertexPreview";
+
+function vertexStyle(overrides?: Partial<VertexStyle>): VertexStyle {
+  return {
+    ...appDefaultVertexStyle,
+    type: createVertexType("Person"),
+    ...overrides,
+  };
+}
+
+describe("VertexPreview", () => {
+  it("renders the provided label rather than deriving one from the vertex type", () => {
+    render(
+      <TestProvider store={getAppStore()} client={new QueryClient()}>
+        <VertexPreview
+          vertexStyle={vertexStyle({
+            type: createVertexType("http://x/Person"),
+          })}
+          label="foaf:Person"
+        />
+      </TestProvider>,
+    );
+
+    expect(screen.getByText("foaf:Person")).toBeInTheDocument();
+  });
+});

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
@@ -34,5 +34,9 @@ describe("VertexPreview", () => {
     );
 
     expect(screen.getByText("foaf:Person")).toBeInTheDocument();
+    // The symbol renders its own accessible name from the vertex style.
+    expect(
+      screen.getByRole("img", { name: "http://x/Person symbol" }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
@@ -1,0 +1,46 @@
+import type { VertexStyle } from "@/core";
+
+import { cn } from "@/utils";
+
+import { defaultNodeLabelStyle, LabelPreview } from "../LabelPreview";
+import { VertexSymbol } from "./VertexSymbol";
+
+/**
+ * The internal rendering size of the node in pixels. The VertexSymbol SVG has
+ * a viewBox of 96×96, so we render at that native size for maximum fidelity.
+ * The label scale maps cytoscape's 24 model-unit node to this render size.
+ */
+const RENDER_PX = 96;
+const LABEL_SCALE = RENDER_PX / 24;
+
+interface VertexPreviewProps {
+  vertexStyle: VertexStyle;
+  label: string;
+  className?: string;
+}
+
+/**
+ * A vertex shape preview with a label badge beneath it, matching the canvas
+ * appearance. Rendered at a fixed internal size (96px) and CSS-scaled to the
+ * desired display size — node and label zoom as a single unit.
+ */
+export function VertexPreview({
+  vertexStyle,
+  label,
+  className,
+}: VertexPreviewProps) {
+  return (
+    <div className={cn("shrink-0", className)}>
+      <div className="flex origin-top-left flex-col items-center">
+        <VertexSymbol vertexStyle={vertexStyle} className="size-[96px]" />
+        <LabelPreview
+          labelStyle={defaultNodeLabelStyle}
+          scale={LABEL_SCALE}
+          className="-mt-3"
+        >
+          {label}
+        </LabelPreview>
+      </div>
+    </div>
+  );
+}

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
@@ -2,7 +2,7 @@ import { appDefaultNodeLabelStyle, type VertexStyle } from "@/core";
 import { cn } from "@/utils";
 
 import { LabelPreview } from "../LabelPreview";
-import { MODEL_TO_VIEWBOX_SCALE, VertexSymbol } from "./VertexSymbol";
+import { PREVIEW_SCALE, VertexSymbol } from "./VertexSymbol";
 
 interface VertexPreviewProps {
   vertexStyle: VertexStyle;
@@ -27,7 +27,7 @@ export function VertexPreview({
         <VertexSymbol vertexStyle={vertexStyle} className="size-[96px]" />
         <LabelPreview
           labelStyle={appDefaultNodeLabelStyle}
-          scale={MODEL_TO_VIEWBOX_SCALE}
+          scale={PREVIEW_SCALE}
           className="-mt-3"
         >
           {label}

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
@@ -1,8 +1,7 @@
-import type { VertexStyle } from "@/core";
-
+import { appDefaultNodeLabelStyle, type VertexStyle } from "@/core";
 import { cn } from "@/utils";
 
-import { defaultNodeLabelStyle, LabelPreview } from "../LabelPreview";
+import { LabelPreview } from "../LabelPreview";
 import { VertexSymbol } from "./VertexSymbol";
 
 /**
@@ -30,11 +29,12 @@ export function VertexPreview({
   className,
 }: VertexPreviewProps) {
   return (
-    <div className={cn("shrink-0", className)}>
-      <div className="flex origin-top-left flex-col items-center">
+    <div className={cn("w-full min-w-0", className)}>
+      {/* min-w-0 lets the column shrink so a long label truncates instead of overflowing */}
+      <div className="flex min-w-0 flex-col items-center">
         <VertexSymbol vertexStyle={vertexStyle} className="size-[96px]" />
         <LabelPreview
-          labelStyle={defaultNodeLabelStyle}
+          labelStyle={appDefaultNodeLabelStyle}
           scale={LABEL_SCALE}
           className="-mt-3"
         >

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
@@ -2,15 +2,7 @@ import { appDefaultNodeLabelStyle, type VertexStyle } from "@/core";
 import { cn } from "@/utils";
 
 import { LabelPreview } from "../LabelPreview";
-import { VertexSymbol } from "./VertexSymbol";
-
-/**
- * The internal rendering size of the node in pixels. The VertexSymbol SVG has
- * a viewBox of 96×96, so we render at that native size for maximum fidelity.
- * The label scale maps cytoscape's 24 model-unit node to this render size.
- */
-const RENDER_PX = 96;
-const LABEL_SCALE = RENDER_PX / 24;
+import { MODEL_TO_VIEWBOX_SCALE, VertexSymbol } from "./VertexSymbol";
 
 interface VertexPreviewProps {
   vertexStyle: VertexStyle;
@@ -20,8 +12,8 @@ interface VertexPreviewProps {
 
 /**
  * A vertex shape preview with a label badge beneath it, matching the canvas
- * appearance. Rendered at a fixed internal size (96px) and CSS-scaled to the
- * desired display size — node and label zoom as a single unit.
+ * appearance. The label uses the same model→viewBox scale the symbol renders
+ * at, so node and label stay proportional as the caller CSS-zooms the preview.
  */
 export function VertexPreview({
   vertexStyle,
@@ -35,7 +27,7 @@ export function VertexPreview({
         <VertexSymbol vertexStyle={vertexStyle} className="size-[96px]" />
         <LabelPreview
           labelStyle={appDefaultNodeLabelStyle}
-          scale={LABEL_SCALE}
+          scale={MODEL_TO_VIEWBOX_SCALE}
           className="-mt-3"
         >
           {label}

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexSymbol.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexSymbol.tsx
@@ -9,9 +9,13 @@ import { useIconDataUrl } from "./useIconDataUrl";
 const VIEWBOX = 96;
 const ICON_RATIO = 0.6;
 const CANVAS_NODE_SIZE = 24;
-/** Scale from cytoscape model units (a 24px node) to the SVG viewBox (96). */
-export const MODEL_TO_VIEWBOX_SCALE = VIEWBOX / CANVAS_NODE_SIZE;
-const BORDER_SCALE = MODEL_TO_VIEWBOX_SCALE;
+/**
+ * How much larger the preview draws things than the graph canvas: the ratio of
+ * the SVG viewBox (96) to a canvas node's size in cytoscape units (24). Applied
+ * to any canvas-unit length (border width, label font/padding) to render it at
+ * preview size.
+ */
+export const PREVIEW_SCALE = VIEWBOX / CANVAS_NODE_SIZE;
 
 interface Props {
   vertexStyle: VertexStyle;
@@ -22,7 +26,7 @@ export function VertexSymbol({ vertexStyle, className }: Props) {
   const iconDataUrl = useIconDataUrl(vertexStyle);
   // SVG url(#...) references reject the colons in React's raw useId format.
   const clipId = `vs-${useId().replace(/:/g, "")}`;
-  const strokeWidth = vertexStyle.borderWidth * BORDER_SCALE;
+  const strokeWidth = vertexStyle.borderWidth * PREVIEW_SCALE;
   const insetSize = Math.max(1, VIEWBOX - strokeWidth * 2);
   const geometry = resolveShapeGeometry(vertexStyle.shape, insetSize);
 

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexSymbol.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexSymbol.tsx
@@ -9,7 +9,9 @@ import { useIconDataUrl } from "./useIconDataUrl";
 const VIEWBOX = 96;
 const ICON_RATIO = 0.6;
 const CANVAS_NODE_SIZE = 24;
-const BORDER_SCALE = VIEWBOX / CANVAS_NODE_SIZE;
+/** Scale from cytoscape model units (a 24px node) to the SVG viewBox (96). */
+export const MODEL_TO_VIEWBOX_SCALE = VIEWBOX / CANVAS_NODE_SIZE;
+const BORDER_SCALE = MODEL_TO_VIEWBOX_SCALE;
 
 interface Props {
   vertexStyle: VertexStyle;

--- a/packages/graph-explorer/src/components/VertexSymbol/index.ts
+++ b/packages/graph-explorer/src/components/VertexSymbol/index.ts
@@ -1,1 +1,2 @@
 export { VertexSymbol, VertexSymbolByType } from "./VertexSymbol";
+export { VertexPreview } from "./VertexPreview";

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -26,6 +26,7 @@ export { default as PanelError } from "./PanelError";
 export * from "./Dialog";
 export { default as Divider } from "./Divider";
 
+export * from "./EdgePreview";
 export * from "./EdgeRow";
 export * from "./EdgeSymbol";
 export * from "./EmptyState";
@@ -44,6 +45,8 @@ export * from "./icons";
 export * from "./Input";
 export * from "./NumberInput";
 export * from "./LabelledSetting";
+export * from "./LabelPreview";
+export * from "./PreviewSurface";
 export { default as InputField } from "./InputField";
 export * from "./InputField";
 

--- a/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
@@ -96,13 +96,17 @@ export type VertexTypeStyle = {
   longDisplayNameAttribute: string;
 };
 
-/** The visual appearance of an edge, shared by per-type styles and defaults. */
-export type EdgeVisualStyle = {
+/** The visual appearance of a label badge (shared by edge and vertex labels). */
+export type LabelVisualStyle = {
   labelColor: string;
   labelBackgroundOpacity: number;
   labelBorderColor: string;
   labelBorderStyle: LineStyle;
   labelBorderWidth: number;
+};
+
+/** The visual appearance of an edge, shared by per-type styles and defaults. */
+export type EdgeVisualStyle = LabelVisualStyle & {
   lineColor: string;
   lineThickness: number;
   lineStyle: LineStyle;

--- a/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
@@ -154,6 +154,22 @@ export const appDefaultVertexStyle = {
   borderStyle: "solid",
 } as const satisfies Omit<VertexStyle, "type">;
 
+/**
+ * The default appearance of a node's label badge. Nodes have no per-type label
+ * styling (see {@link VertexVisualStyle}), so this is the single source for how
+ * a node label looks. Values mirror the node label config in
+ * `components/Graph/styles/defaultNodeStyle.ts` (`text.background` →
+ * `labelColor`, `text.opacity` → `labelBackgroundOpacity`) — keep in sync if
+ * that canvas style changes.
+ */
+export const appDefaultNodeLabelStyle = {
+  labelColor: "#1d2531",
+  labelBackgroundOpacity: 0.7,
+  labelBorderColor: "#1d2531",
+  labelBorderStyle: "solid",
+  labelBorderWidth: 0,
+} as const satisfies LabelVisualStyle;
+
 /** The default values to use when no user provided value is given. */
 export const appDefaultEdgeStyle = {
   displayNameAttribute: RESERVED_TYPES_PROPERTY,

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -3,12 +3,14 @@ import { atom, useAtom, useSetAtom } from "jotai";
 import {
   Button,
   ColorPopover,
+  EdgePreview,
   Field,
   FieldGroup,
   FieldLabel,
   FieldLegend,
   FieldSet,
   NumberInput,
+  PreviewSurface,
   Select,
   SelectContent,
   SelectItem,
@@ -104,6 +106,13 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
         </DialogHeader>
         <DialogBody>
           <FieldSet>
+            <Field>
+              <FieldLabel className="sr-only">Preview</FieldLabel>
+              <PreviewSurface>
+                <EdgePreview edgeStyle={edgeStyle} className="zoom-90" />
+              </PreviewSurface>
+            </Field>
+
             {hideDisplayNameAttribute ? null : (
               <FieldGroup>
                 <Field>

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -109,7 +109,11 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
             <Field>
               <FieldLabel className="sr-only">Preview</FieldLabel>
               <PreviewSurface>
-                <EdgePreview edgeStyle={edgeStyle} className="zoom-90" />
+                <EdgePreview
+                  edgeStyle={edgeStyle}
+                  label={displayConfig.displayLabel}
+                  className="zoom-90"
+                />
               </PreviewSurface>
             </Field>
 

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -12,12 +12,13 @@ import {
   FileButton,
   IconPicker,
   NumberInput,
+  PreviewSurface,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  VertexSymbol,
+  VertexPreview,
 } from "@/components";
 import {
   Dialog,
@@ -240,17 +241,13 @@ function Content({ vertexType }: { vertexType: VertexType }) {
 
               <Field className="col-start-2 row-span-2 w-auto">
                 <FieldLabel>Preview</FieldLabel>
-                <div className="bg-primary-subtle border-input-border grid rounded-lg border shadow-xs">
-                  <div className="flex flex-col items-center justify-center px-6">
-                    <VertexSymbol
-                      vertexStyle={vertexStyle}
-                      className="size-16"
-                    />
-                    <span className="-mt-2 rounded-md bg-[#1d2531]/80 px-3 py-1.5 text-sm leading-none font-medium tracking-wide text-white">
-                      {displayConfig.displayLabel}
-                    </span>
-                  </div>
-                </div>
+                <PreviewSurface className="flex-1">
+                  <VertexPreview
+                    vertexStyle={vertexStyle}
+                    label={displayConfig.displayLabel}
+                    className="zoom-50"
+                  />
+                </PreviewSurface>
               </Field>
             </FieldGroup>
             <FieldGroup>

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -189,7 +189,7 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 </Select>
               </Field>
             </FieldGroup>
-            <FieldGroup className="grid grid-cols-[1fr_auto] gap-4">
+            <FieldGroup className="grid grid-cols-2 gap-4">
               <Field className="col-start-1 row-start-1">
                 <FieldLabel>Shape</FieldLabel>
                 <Select
@@ -239,7 +239,7 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 </div>
               </Field>
 
-              <Field className="col-start-2 row-span-2 w-auto">
+              <Field className="col-start-2 row-span-2">
                 <FieldLabel>Preview</FieldLabel>
                 <PreviewSurface className="flex-1">
                   <VertexPreview


### PR DESCRIPTION
## Description

Adds a canvas-faithful **edge preview** to the edge style dialog, mirroring the node preview already in the node style dialog. The preview shows two placeholder endpoint nodes connected by the styled edge — line color, thickness, dash style, source/target arrow heads — with the edge type as a styled label.

The core of the change is a **verbatim port of cytoscape 3.34.0's arrow-shape geometry** into standalone SVG builders, so the preview matches what cytoscape rasterizes to the graph canvas (every arrow shape's point array, the `getArrowWidth` size formula, and per-shape line/arrow `gap`/`spacing`).

Supporting refactors (behavior-preserving):
- Extracted `LabelVisualStyle` out of `EdgeVisualStyle` and a shared `LabelPreview` component, reused by both the edge and vertex previews.
- Extracted `PreviewSurface`, the shared bordered canvas-tinted container both style dialogs render their preview on (collapsed two divergent hand-rolled containers into one).

An ADR documents that these geometry ports are pinned to a specific cytoscape version and must be re-verified on every cytoscape upgrade.

## How to read

1. [arrowShapes.ts](https://github.com/aws/graph-explorer/pull/1980/files#diff-e875ad5f48c5efcba6861ddcfb185481fdb296bc6852e2842203d0621fee4963) — start here; the cytoscape geometry port (point arrays, gap/spacing, `resolveArrowGeometry`)
2. [EdgePreview.tsx](https://github.com/aws/graph-explorer/pull/1980/files#diff-824b802627e2e57149321c9df2de09e59d7da15590069bb8c1a55e88beb6a3b3) — how the geometry is laid out as line + arrows + label
3. [graphStyles.ts](https://github.com/aws/graph-explorer/pull/1980/files#diff-c74e391b64e2ba875770babdadd809403a3fb96c6a17dc101a35bd77370dbc38) — the `LabelVisualStyle` split (the shared contract)
4. [LabelPreview.tsx](https://github.com/aws/graph-explorer/pull/1980/files#diff-75a39eb9223de0ad49a214bbb1805934a80453d60c257b0f057fc2ac97acf14d) — shared label badge used by both previews
5. [PreviewSurface.tsx](https://github.com/aws/graph-explorer/pull/1980/files#diff-262ba30991a01111cea3577867affb7c2cc8849fef1943c113a6590b44277ffa) — shared preview container
6. [ADR: SVG geometry ports for style previews](https://github.com/aws/graph-explorer/pull/1980/files#diff-7c7c74f31f64fb0cba219cdcbbd881eee35835a97ea027f379b8aa2f5a252a54) — the maintenance contract

## Validation

- `pnpm checks` and `pnpm test` pass. New `arrowShapes.test.ts` covers every arrow style (geometry, bbox, per-shape gap/spacing) — the counterpart to the existing `nodeShapes.test.ts`.
- Open the edge style dialog and cycle through arrow styles / line styles / colors; the preview matches the graph canvas. Sibling check: the node style dialog preview renders on the same surface.
- Manually inspected all arrow styles for accuracy

<img width="3002" height="2310" alt="CleanShot 2026-07-20 at 16 32 05@2x" src="https://github.com/user-attachments/assets/0be5b4ec-9aef-4316-826d-74d9d9bb3339" />

## Related Issues

- Closes #1960
- Closes #1934
- Related to #1946

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
