### PR TITLE
Add filtering, search, and bulk selection to the style import modal

### DIFF
--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -6,7 +6,10 @@
 
 - **Default Neighbor Expansion Limit:** This setting will allow you to enable or disable the default limit applied during neighbor expansion. This applies to both double click expansion and the expand sidebar. This setting can be overridden by a similar setting on the connection itself.
 - **Save Configuration:** This action will export all the configuration data within the Graph Explorer local database. This will not store any data from the connected graph databases. However, the export may contain the shape of the schema for your databases and the connection URL.
-- **Load Configuration:** This action will replace all the Graph Explorer configuration data you currently have with the data in the provided configuration file. This is a destructive act and can not be undone. It is **strongly** suggested that you perform a **Save Configuration** action before performing a **Load Configuration** action to preserve any existing configuration data.
+- **Load Configuration:** This action replaces all the Graph Explorer configuration data you currently have with the data in the provided configuration file.
+
+> [!CAUTION]
+> Loading a configuration cannot be undone. Run **Save Configuration** first to preserve your existing configuration data.
 
 ## Styles
 
@@ -26,11 +29,14 @@ Loading opens a preview so you can see what each type looks like now next to wha
 
 Only the types you select change. Anything not in the file stays as it is, and any type that already looks the way the file describes is left out of the preview, so you only ever review real changes.
 
-For larger files, filter the preview by **All**, **Nodes**, **Edges**, **New** (types you haven't styled yet), or **Existing** (types that already have a style the file would replace), or search by type name. **Select all** toggles just the types currently shown. Filtering only changes what you see — your selections are preserved, so **Load N selected** always applies every type you kept checked, across every tab.
+For larger files, filter the preview by **All**, **Nodes**, **Edges**, **New** (types you haven't styled yet), or **Existing** (types that already have a style the file would replace), or search by type name. **Select all** toggles just the types currently shown. Filtering only changes what you see. Your selections are preserved, so **Load N selected** always applies every type you kept checked, across every tab.
 
 ### Reset your styles
 
-Clears all your node and edge styles, returning every type to the defaults. This cannot be undone, so consider saving first.
+Clears all your node and edge styles, returning every type to the defaults.
+
+> [!CAUTION]
+> Resetting cannot be undone. Run **Save styles** first if you might want your current look back.
 
 ## About
 

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -26,6 +26,8 @@ Loading opens a preview so you can see what each type looks like now next to wha
 
 Only the types you select change. Anything not in the file stays as it is, and any type that already looks the way the file describes is left out of the preview, so you only ever review real changes.
 
+For larger files, filter the preview by **All**, **Nodes**, **Edges**, or **Conflicts** (types that already have a style the file would replace), or search by type name. **Select all** toggles just the types currently shown. Filtering only changes what you see — your selections are preserved, so **Load N selected** always applies every type you kept checked, across every tab.
+
 ### Reset your styles
 
 Clears all your node and edge styles, returning every type to the defaults. This cannot be undone, so consider saving first.

--- a/docs/features/settings.md
+++ b/docs/features/settings.md
@@ -26,7 +26,7 @@ Loading opens a preview so you can see what each type looks like now next to wha
 
 Only the types you select change. Anything not in the file stays as it is, and any type that already looks the way the file describes is left out of the preview, so you only ever review real changes.
 
-For larger files, filter the preview by **All**, **Nodes**, **Edges**, or **Conflicts** (types that already have a style the file would replace), or search by type name. **Select all** toggles just the types currently shown. Filtering only changes what you see — your selections are preserved, so **Load N selected** always applies every type you kept checked, across every tab.
+For larger files, filter the preview by **All**, **Nodes**, **Edges**, **New** (types you haven't styled yet), or **Existing** (types that already have a style the file would replace), or search by type name. **Select all** toggles just the types currently shown. Filtering only changes what you see — your selections are preserved, so **Load N selected** always applies every type you kept checked, across every tab.
 
 ### Reset your styles
 

--- a/packages/graph-explorer/src/components/Toggle.tsx
+++ b/packages/graph-explorer/src/components/Toggle.tsx
@@ -1,0 +1,43 @@
+import { cva, type VariantProps } from "cva";
+import { Toggle as TogglePrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/utils";
+
+const toggleVariants = cva({
+  base: "hover:bg-muted hover:text-muted-foreground data-[state=on]:bg-primary-subtle data-[state=on]:text-primary-foreground focus-visible:ring-primary aria-invalid:ring-danger/20 aria-invalid:border-danger inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap outline-hidden transition-[color,box-shadow] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  variants: {
+    variant: {
+      default: "bg-transparent",
+      outline:
+        "border-input-border hover:bg-primary-subtle hover:text-primary-foreground border bg-transparent shadow-xs",
+    },
+    size: {
+      default: "h-9 min-w-9 px-2",
+      sm: "h-8 min-w-8 px-1.5",
+      lg: "h-10 min-w-10 px-2.5",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/packages/graph-explorer/src/components/Toggle.tsx
+++ b/packages/graph-explorer/src/components/Toggle.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "@/utils";
 
 const toggleVariants = cva({
-  base: "hover:bg-muted hover:text-muted-foreground data-[state=on]:bg-primary-subtle data-[state=on]:text-primary-foreground focus-visible:ring-primary aria-invalid:ring-danger/20 aria-invalid:border-danger inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap outline-hidden transition-[color,box-shadow] focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  base: "group/toggle hover:bg-muted hover:text-muted-foreground aria-invalid:border-danger aria-invalid:ring-danger/20 aria-pressed:bg-primary-subtle aria-pressed:text-primary-foreground data-[state=on]:bg-primary-subtle data-[state=on]:text-primary-foreground inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-1 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   variants: {
     variant: {
       default: "bg-transparent",
@@ -13,9 +13,10 @@ const toggleVariants = cva({
         "border-input-border hover:bg-primary-subtle hover:text-primary-foreground border bg-transparent shadow-xs",
     },
     size: {
-      default: "h-9 min-w-9 px-2",
-      sm: "h-8 min-w-8 px-1.5",
-      lg: "h-10 min-w-10 px-2.5",
+      default:
+        "h-9 min-w-9 px-2 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+      sm: "h-8 min-w-8 px-1.5 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1",
+      lg: "h-10 min-w-10 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
     },
   },
   defaultVariants: {
@@ -26,8 +27,8 @@ const toggleVariants = cva({
 
 function Toggle({
   className,
-  variant,
-  size,
+  variant = "default",
+  size = "default",
   ...props
 }: React.ComponentProps<typeof TogglePrimitive.Root> &
   VariantProps<typeof toggleVariants>) {

--- a/packages/graph-explorer/src/components/ToggleGroup.tsx
+++ b/packages/graph-explorer/src/components/ToggleGroup.tsx
@@ -1,0 +1,89 @@
+import type { VariantProps } from "cva";
+
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
+import * as React from "react";
+
+import { cn } from "@/utils";
+
+import { toggleVariants } from "./Toggle";
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+    orientation?: "horizontal" | "vertical";
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/packages/graph-explorer/src/components/index.ts
+++ b/packages/graph-explorer/src/components/index.ts
@@ -92,6 +92,9 @@ export * from "./Switch";
 
 export * from "./TextArea";
 
+export * from "./Toggle";
+export * from "./ToggleGroup";
+
 export { default as TextAreaField } from "./TextAreaField";
 export * from "./TextAreaField";
 

--- a/packages/graph-explorer/src/modules/StyleImport/EdgeStyleImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/EdgeStyleImportCard.tsx
@@ -26,7 +26,7 @@ export function EdgeStyleImportCard({
     <ImportCard label={item.type} checked={selected} onCheckedChange={onToggle}>
       <ImportCardSurface className="flex flex-col items-center gap-(--card-spacing)">
         <PreviewLabel className="opacity-60">
-          {item.status === "conflict" ? "Current" : "Default"}
+          {item.status === "existing" ? "Current" : "Default"}
         </PreviewLabel>
         <EdgePreview
           edgeStyle={item.currentStyle}

--- a/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
@@ -274,6 +274,27 @@ describe("LoadStylesButton", () => {
     ).toBe(false);
   });
 
+  test("shows an empty state when the search matches no type", async () => {
+    const user = userEvent.setup();
+    renderButton();
+
+    await user.upload(
+      fileInput(),
+      stylingFile({ vertices: { Airport: { color: "#abc" } }, edges: {} }),
+    );
+
+    await user.type(
+      await screen.findByPlaceholderText("Search by type name"),
+      "zzz",
+    );
+
+    expect(screen.getByText("No matching types")).toBeInTheDocument();
+    // The card is gone but the modal is still open for editing the search.
+    expect(
+      screen.queryByRole("checkbox", { name: "Load Airport style" }),
+    ).not.toBeInTheDocument();
+  });
+
   test("surfaces an envelope-level error for the wrong file kind", async () => {
     const user = userEvent.setup();
     renderButton();

--- a/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
@@ -6,10 +6,13 @@ import { describe, expect, test, vi } from "vitest";
 
 import { TooltipProvider } from "@/components";
 import { getAppStore } from "@/core";
-import { createVertexType } from "@/core/entities";
+import { createEdgeType, createVertexType } from "@/core/entities";
 import { createFileEnvelope } from "@/core/fileEnvelope";
 import { createQueryClient } from "@/core/queryClient";
-import { userVertexStylesAtom } from "@/core/StateProvider/storageAtoms";
+import {
+  userEdgeStylesAtom,
+  userVertexStylesAtom,
+} from "@/core/StateProvider/storageAtoms";
 import { DbState, TestProvider } from "@/utils/testing";
 
 import { LoadStylesButton } from "./LoadStylesButton";
@@ -224,6 +227,51 @@ describe("LoadStylesButton", () => {
     ).toBeInTheDocument();
     // Both edge previews render, each labelled by the resolved edge type.
     expect(screen.getAllByLabelText("route edge preview")).toHaveLength(2);
+  });
+
+  test("Select all within a filter and search only toggles the matching items", async () => {
+    const user = userEvent.setup();
+    const store = renderButton();
+
+    await user.upload(
+      fileInput(),
+      stylingFile({
+        vertices: { Airport: { color: "#abc" } },
+        edges: {
+          airRoute: { lineColor: "#111" },
+          seaRoute: { lineColor: "#222" },
+          contains: { lineColor: "#333" },
+        },
+      }),
+    );
+
+    // Everything starts selected; clear it so Select-All's effect is isolated.
+    await user.click(
+      await screen.findByRole("checkbox", { name: "Select all" }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Load 0 selected" }),
+    ).toBeInTheDocument();
+
+    // Filter to edges, then search "route" — leaves airRoute and seaRoute.
+    await user.click(screen.getByRole("radio", { name: "Edges 3" }));
+    await user.type(
+      screen.getByPlaceholderText("Search by type name"),
+      "route",
+    );
+
+    // Select all now toggles only the two visible, matching edges.
+    await user.click(screen.getByRole("checkbox", { name: "Select all" }));
+    await user.click(screen.getByRole("button", { name: "Load 2 selected" }));
+
+    const styles = store.get(userEdgeStylesAtom);
+    expect(styles.has(createEdgeType("airRoute"))).toBe(true);
+    expect(styles.has(createEdgeType("seaRoute"))).toBe(true);
+    // The vertex and the non-matching edge stayed unselected.
+    expect(styles.has(createEdgeType("contains"))).toBe(false);
+    expect(
+      store.get(userVertexStylesAtom).has(createVertexType("Airport")),
+    ).toBe(false);
   });
 
   test("surfaces an envelope-level error for the wrong file kind", async () => {

--- a/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/utils/fileData", () => ({
 
 function renderButton(seed?: (state: DbState) => void) {
   const state = new DbState();
-  // Start with no user styles so seeded ones are the only conflicts.
+  // Start with no user styles so seeded ones are the only existing styles.
   state.vertexStyles.clear();
   state.edgeStyles.clear();
   seed?.(state);
@@ -195,7 +195,7 @@ describe("LoadStylesButton", () => {
   test("labels a card that replaces an existing style 'Current' and a new one 'Default'", async () => {
     const user = userEvent.setup();
     renderButton(state => {
-      // Airport already has a user style, so loading a different one conflicts.
+      // Airport already has a user style, so loading a different one replaces it.
       state.addVertexStyle(createVertexType("Airport"), { color: "#abc" });
     });
 
@@ -207,8 +207,8 @@ describe("LoadStylesButton", () => {
       }),
     );
 
-    // The conflicting Airport card tags its before side "Current"; the brand-new
-    // Country card tags its before side "Default".
+    // The existing-style Airport card tags its before side "Current"; the
+    // brand-new Country card tags its before side "Default".
     expect(await screen.findByText("Current")).toBeInTheDocument();
     expect(screen.getByText("Default")).toBeInTheDocument();
   });

--- a/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
@@ -125,7 +125,7 @@ export function StyleImportModal({
 
   return (
     <DialogContent className="h-[52rem] w-[min(64rem,calc(100vw-2rem))] max-w-none">
-      <DialogHeader>
+      <DialogHeader className="pb-6">
         <DialogMedia className="bg-primary-subtle text-primary-foreground">
           <UploadIcon />
         </DialogMedia>
@@ -137,10 +137,25 @@ export function StyleImportModal({
           ones you want to import. This cannot be undone.
         </DialogDescription>
       </DialogHeader>
-      <div className="flex flex-col gap-3 border-t px-6 pt-6">
+      <div className="flex flex-col gap-3 border-t px-6 py-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <label
+            htmlFor="style-import-select-all"
+            className="flex w-fit shrink-0 cursor-pointer items-center gap-2 text-sm"
+          >
+            <Checkbox
+              id="style-import-select-all"
+              checked={selectAllCheckedState[selectAll]}
+              disabled={visibleItems.length === 0}
+              onCheckedChange={checked => toggleVisible(checked === true)}
+            />
+            Select all
+          </label>
           <ToggleGroup
             type="single"
+            variant="outline"
+            spacing={0}
+            className="sm:ml-auto"
             value={filter}
             onValueChange={value => {
               if (value in filterLabels) {
@@ -158,23 +173,11 @@ export function StyleImportModal({
             search={search}
             onSearch={setSearch}
             searchPlaceholder="Search by type name"
-            className="sm:ml-auto sm:max-w-xs"
+            className="sm:max-w-xs"
           />
         </div>
-        <label
-          htmlFor="style-import-select-all"
-          className="flex w-fit cursor-pointer items-center gap-2 text-sm"
-        >
-          <Checkbox
-            id="style-import-select-all"
-            checked={selectAllCheckedState[selectAll]}
-            disabled={visibleItems.length === 0}
-            onCheckedChange={checked => toggleVisible(checked === true)}
-          />
-          Select all
-        </label>
       </div>
-      <DialogBody className="@container gap-8 pt-3">
+      <DialogBody className="@container gap-8 border-t pt-3">
         {visibleItems.length === 0 ? (
           <EmptyState>
             <EmptyStateIcon variant="subtle">
@@ -183,8 +186,7 @@ export function StyleImportModal({
             <EmptyStateContent>
               <EmptyStateTitle>No matching types</EmptyStateTitle>
               <EmptyStateDescription>
-                No types match the current filter and search. Clear the search
-                or switch tabs to see more.
+                Your filters matched 0 items. Try removing some filters.
               </EmptyStateDescription>
             </EmptyStateContent>
           </EmptyState>
@@ -296,7 +298,7 @@ function FooterSummary({
         <span>{`${nodeCount} ${nodeCount === 1 ? "node" : "nodes"}, ${edgeCount} ${edgeCount === 1 ? "edge" : "edges"}`}</span>
       </p>
       {skippedCount > 0 ? (
-        <p className="text-sm">{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already match and were skipped`}</p>
+        <p className="text-sm">{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already matched and ${skippedCount === 1 ? "was" : "were"} skipped`}</p>
       ) : null}
     </div>
   );

--- a/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { UploadIcon } from "lucide-react";
 import { useState } from "react";
 
-import { Button } from "@/components";
+import { Button, Checkbox, ToggleGroup, ToggleGroupItem } from "@/components";
 import {
   DialogBody,
   DialogContent,
@@ -13,10 +13,17 @@ import {
   DialogMedia,
   DialogTitle,
 } from "@/components/Dialog";
+import SearchBar from "@/components/SearchBar";
 
 import type { StyleImportItem, StyleImportPlan } from "./styleImportPlan";
+import type { StyleImportFilter } from "./styleImportView";
 
 import { EdgeStyleImportCard } from "./EdgeStyleImportCard";
+import {
+  filterCounts,
+  selectAllState,
+  selectVisibleItems,
+} from "./styleImportView";
 import { VertexStyleImportCard } from "./VertexStyleImportCard";
 
 /**
@@ -28,10 +35,19 @@ function itemKey(item: StyleImportItem): string {
   return `${item.kind}:${item.type}`;
 }
 
+const filterLabels: Record<StyleImportFilter, string> = {
+  all: "All",
+  nodes: "Nodes",
+  edges: "Edges",
+  conflicts: "Conflicts",
+};
+
 /**
  * The selective style load modal: every actionable style from the file as a
- * before→after card, all selected by default. Loading writes the checked
- * styles to the user styles layer via `onLoad` and dismisses.
+ * before→after card, all selected by default. A filter tab, search box, and
+ * Select-All narrow what is shown; selection stays the source of truth, so the
+ * footer and Load button count every checked item regardless of the view.
+ * Loading writes the checked styles to the user styles layer via `onLoad`.
  */
 export function StyleImportModal({
   fileName,
@@ -47,10 +63,14 @@ export function StyleImportModal({
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(
     () => new Set(plan.items.map(itemKey)),
   );
+  const [filter, setFilter] = useState<StyleImportFilter>("all");
+  const [search, setSearch] = useState("");
 
-  const selectedItems = plan.items.filter(item =>
-    selectedKeys.has(itemKey(item)),
-  );
+  const isSelected = (item: StyleImportItem) => selectedKeys.has(itemKey(item));
+
+  const selectedItems = plan.items.filter(isSelected);
+  const visibleItems = selectVisibleItems(plan.items, filter, search);
+  const counts = filterCounts(plan.items, search);
 
   function toggle(item: StyleImportItem) {
     setSelectedKeys(prev => {
@@ -65,8 +85,25 @@ export function StyleImportModal({
     });
   }
 
-  const vertexItems = plan.items.filter(item => item.kind === "vertex");
-  const edgeItems = plan.items.filter(item => item.kind === "edge");
+  function toggleVisible(select: boolean) {
+    setSelectedKeys(prev => {
+      const next = new Set(prev);
+      for (const item of visibleItems) {
+        if (select) {
+          next.add(itemKey(item));
+        } else {
+          next.delete(itemKey(item));
+        }
+      }
+      return next;
+    });
+  }
+
+  const visibleVertexItems = visibleItems.filter(
+    item => item.kind === "vertex",
+  );
+  const visibleEdgeItems = visibleItems.filter(item => item.kind === "edge");
+  const selectAll = selectAllState(visibleItems, isSelected);
 
   return (
     <DialogContent className="w-[min(64rem,calc(100vw-2rem))] max-w-none">
@@ -82,23 +119,62 @@ export function StyleImportModal({
           ones you want to import. This cannot be undone.
         </DialogDescription>
       </DialogHeader>
-      <DialogBody className="@container gap-8 border-t">
-        <StyleGroupGrid heading="Node styles" count={vertexItems.length}>
-          {vertexItems.map(item => (
+      <div className="flex flex-col gap-3 border-t pt-6 sm:flex-row sm:items-center">
+        <ToggleGroup
+          type="single"
+          value={filter}
+          onValueChange={value =>
+            value && setFilter(value as StyleImportFilter)
+          }
+          spacing={0}
+          variant="outline"
+        >
+          {(Object.keys(filterLabels) as StyleImportFilter[]).map(key => (
+            <ToggleGroupItem key={key} value={key}>
+              {`${filterLabels[key]} ${counts[key]}`}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+        <SearchBar
+          search={search}
+          onSearch={setSearch}
+          searchPlaceholder="Search by type name"
+          className="sm:ml-auto sm:max-w-xs"
+        />
+      </div>
+      <label
+        htmlFor="style-import-select-all"
+        className="flex w-fit cursor-pointer items-center gap-2 text-sm"
+      >
+        <Checkbox
+          id="style-import-select-all"
+          checked={
+            selectAll === "indeterminate"
+              ? "indeterminate"
+              : selectAll === "checked"
+          }
+          disabled={visibleItems.length === 0}
+          onCheckedChange={checked => toggleVisible(checked === true)}
+        />
+        Select all
+      </label>
+      <DialogBody className="@container gap-8">
+        <StyleGroupGrid heading="Node types" count={visibleVertexItems.length}>
+          {visibleVertexItems.map(item => (
             <VertexStyleImportCard
               key={itemKey(item)}
               item={item}
-              selected={selectedKeys.has(itemKey(item))}
+              selected={isSelected(item)}
               onToggle={() => toggle(item)}
             />
           ))}
         </StyleGroupGrid>
-        <StyleGroupGrid heading="Edge styles" count={edgeItems.length}>
-          {edgeItems.map(item => (
+        <StyleGroupGrid heading="Edge types" count={visibleEdgeItems.length}>
+          {visibleEdgeItems.map(item => (
             <EdgeStyleImportCard
               key={itemKey(item)}
               item={item}
-              selected={selectedKeys.has(itemKey(item))}
+              selected={isSelected(item)}
               onToggle={() => toggle(item)}
             />
           ))}
@@ -129,8 +205,8 @@ export function StyleImportModal({
 
 /**
  * A titled, responsive grid of cards for one entity kind. Renders nothing when
- * the kind has no items so an all-nodes or all-edges file shows just the one
- * section.
+ * the kind has no visible items, so a group disappears under a filter or search
+ * that excludes it.
  */
 function StyleGroupGrid({
   heading,

--- a/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
@@ -16,7 +16,7 @@ import {
 import SearchBar from "@/components/SearchBar";
 
 import type { StyleImportItem, StyleImportPlan } from "./styleImportPlan";
-import type { StyleImportFilter } from "./styleImportView";
+import type { SelectAllState, StyleImportFilter } from "./styleImportView";
 
 import { EdgeStyleImportCard } from "./EdgeStyleImportCard";
 import {
@@ -41,6 +41,14 @@ const filterLabels: Record<StyleImportFilter, string> = {
   edges: "Edges",
   conflicts: "Conflicts",
 };
+
+/** Maps the three-state Select-All to Radix's `checked` value. */
+const selectAllCheckedState: Record<SelectAllState, boolean | "indeterminate"> =
+  {
+    checked: true,
+    unchecked: false,
+    indeterminate: "indeterminate",
+  };
 
 /**
  * The selective style load modal: every actionable style from the file as a
@@ -123,9 +131,11 @@ export function StyleImportModal({
         <ToggleGroup
           type="single"
           value={filter}
-          onValueChange={value =>
-            value && setFilter(value as StyleImportFilter)
-          }
+          onValueChange={value => {
+            if (value in filterLabels) {
+              setFilter(value as StyleImportFilter);
+            }
+          }}
           spacing={0}
           variant="outline"
         >
@@ -148,11 +158,7 @@ export function StyleImportModal({
       >
         <Checkbox
           id="style-import-select-all"
-          checked={
-            selectAll === "indeterminate"
-              ? "indeterminate"
-              : selectAll === "checked"
-          }
+          checked={selectAllCheckedState[selectAll]}
           disabled={visibleItems.length === 0}
           onCheckedChange={checked => toggleVisible(checked === true)}
         />
@@ -246,12 +252,12 @@ function FooterSummary({
   const edgeCount = selectedItems.length - nodeCount;
 
   return (
-    <div className="text-muted-foreground text-sm">
+    <div className="text-muted-foreground text-base">
       <p>
         {`${selectedItems.length} of ${totalCount} selected · ${nodeCount} ${nodeCount === 1 ? "node" : "nodes"}, ${edgeCount} ${edgeCount === 1 ? "edge" : "edges"}`}
       </p>
       {skippedCount > 0 ? (
-        <p>{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already match and were skipped`}</p>
+        <p className="text-xs">{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already match and were skipped`}</p>
       ) : null}
     </div>
   );

--- a/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
@@ -1,9 +1,19 @@
 import type { ReactNode } from "react";
 
-import { UploadIcon } from "lucide-react";
+import { SearchXIcon, UploadIcon } from "lucide-react";
 import { useState } from "react";
 
-import { Button, Checkbox, ToggleGroup, ToggleGroupItem } from "@/components";
+import {
+  Button,
+  Checkbox,
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateIcon,
+  EmptyStateTitle,
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components";
 import {
   DialogBody,
   DialogContent,
@@ -114,7 +124,7 @@ export function StyleImportModal({
   const selectAll = selectAllState(visibleItems, isSelected);
 
   return (
-    <DialogContent className="w-[min(64rem,calc(100vw-2rem))] max-w-none">
+    <DialogContent className="h-[52rem] w-[min(64rem,calc(100vw-2rem))] max-w-none">
       <DialogHeader>
         <DialogMedia className="bg-primary-subtle text-primary-foreground">
           <UploadIcon />
@@ -127,64 +137,87 @@ export function StyleImportModal({
           ones you want to import. This cannot be undone.
         </DialogDescription>
       </DialogHeader>
-      <div className="flex flex-col gap-3 border-t pt-6 sm:flex-row sm:items-center">
-        <ToggleGroup
-          type="single"
-          value={filter}
-          onValueChange={value => {
-            if (value in filterLabels) {
-              setFilter(value as StyleImportFilter);
-            }
-          }}
-          spacing={0}
-          variant="outline"
+      <div className="flex flex-col gap-3 border-t px-6 pt-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <ToggleGroup
+            type="single"
+            value={filter}
+            onValueChange={value => {
+              if (value in filterLabels) {
+                setFilter(value as StyleImportFilter);
+              }
+            }}
+          >
+            {(Object.keys(filterLabels) as StyleImportFilter[]).map(key => (
+              <ToggleGroupItem key={key} value={key}>
+                {`${filterLabels[key]} ${counts[key]}`}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <SearchBar
+            search={search}
+            onSearch={setSearch}
+            searchPlaceholder="Search by type name"
+            className="sm:ml-auto sm:max-w-xs"
+          />
+        </div>
+        <label
+          htmlFor="style-import-select-all"
+          className="flex w-fit cursor-pointer items-center gap-2 text-sm"
         >
-          {(Object.keys(filterLabels) as StyleImportFilter[]).map(key => (
-            <ToggleGroupItem key={key} value={key}>
-              {`${filterLabels[key]} ${counts[key]}`}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
-        <SearchBar
-          search={search}
-          onSearch={setSearch}
-          searchPlaceholder="Search by type name"
-          className="sm:ml-auto sm:max-w-xs"
-        />
+          <Checkbox
+            id="style-import-select-all"
+            checked={selectAllCheckedState[selectAll]}
+            disabled={visibleItems.length === 0}
+            onCheckedChange={checked => toggleVisible(checked === true)}
+          />
+          Select all
+        </label>
       </div>
-      <label
-        htmlFor="style-import-select-all"
-        className="flex w-fit cursor-pointer items-center gap-2 text-sm"
-      >
-        <Checkbox
-          id="style-import-select-all"
-          checked={selectAllCheckedState[selectAll]}
-          disabled={visibleItems.length === 0}
-          onCheckedChange={checked => toggleVisible(checked === true)}
-        />
-        Select all
-      </label>
-      <DialogBody className="@container gap-8">
-        <StyleGroupGrid heading="Node types" count={visibleVertexItems.length}>
-          {visibleVertexItems.map(item => (
-            <VertexStyleImportCard
-              key={itemKey(item)}
-              item={item}
-              selected={isSelected(item)}
-              onToggle={() => toggle(item)}
-            />
-          ))}
-        </StyleGroupGrid>
-        <StyleGroupGrid heading="Edge types" count={visibleEdgeItems.length}>
-          {visibleEdgeItems.map(item => (
-            <EdgeStyleImportCard
-              key={itemKey(item)}
-              item={item}
-              selected={isSelected(item)}
-              onToggle={() => toggle(item)}
-            />
-          ))}
-        </StyleGroupGrid>
+      <DialogBody className="@container gap-8 pt-3">
+        {visibleItems.length === 0 ? (
+          <EmptyState>
+            <EmptyStateIcon variant="subtle">
+              <SearchXIcon />
+            </EmptyStateIcon>
+            <EmptyStateContent>
+              <EmptyStateTitle>No matching types</EmptyStateTitle>
+              <EmptyStateDescription>
+                No types match the current filter and search. Clear the search
+                or switch tabs to see more.
+              </EmptyStateDescription>
+            </EmptyStateContent>
+          </EmptyState>
+        ) : (
+          <>
+            <StyleGroupGrid
+              heading="Node types"
+              count={visibleVertexItems.length}
+            >
+              {visibleVertexItems.map(item => (
+                <VertexStyleImportCard
+                  key={itemKey(item)}
+                  item={item}
+                  selected={isSelected(item)}
+                  onToggle={() => toggle(item)}
+                />
+              ))}
+            </StyleGroupGrid>
+            <StyleGroupGrid
+              heading="Edge types"
+              count={visibleEdgeItems.length}
+            >
+              {visibleEdgeItems.map(item => (
+                <EdgeStyleImportCard
+                  key={itemKey(item)}
+                  item={item}
+                  selected={isSelected(item)}
+                  onToggle={() => toggle(item)}
+                />
+              ))}
+            </StyleGroupGrid>
+          </>
+        )}
       </DialogBody>
       <DialogFooter className="items-center sm:justify-between">
         <FooterSummary
@@ -252,12 +285,18 @@ function FooterSummary({
   const edgeCount = selectedItems.length - nodeCount;
 
   return (
-    <div className="text-muted-foreground text-base">
+    <div className="text-muted-foreground space-y-0.5 text-base">
       <p>
-        {`${selectedItems.length} of ${totalCount} selected · ${nodeCount} ${nodeCount === 1 ? "node" : "nodes"}, ${edgeCount} ${edgeCount === 1 ? "edge" : "edges"}`}
+        <span className="text-foreground font-medium">
+          {selectedItems.length}
+        </span>
+        <span> of </span>
+        <span className="text-foreground font-medium">{totalCount}</span>
+        <span> selected · </span>
+        <span>{`${nodeCount} ${nodeCount === 1 ? "node" : "nodes"}, ${edgeCount} ${edgeCount === 1 ? "edge" : "edges"}`}</span>
       </p>
       {skippedCount > 0 ? (
-        <p className="text-xs">{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already match and were skipped`}</p>
+        <p className="text-sm">{`${skippedCount} ${skippedCount === 1 ? "style" : "styles"} already match and were skipped`}</p>
       ) : null}
     </div>
   );

--- a/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/StyleImportModal.tsx
@@ -49,7 +49,8 @@ const filterLabels: Record<StyleImportFilter, string> = {
   all: "All",
   nodes: "Nodes",
   edges: "Edges",
-  conflicts: "Conflicts",
+  new: "New",
+  existing: "Existing",
 };
 
 /** Maps the three-state Select-All to Radix's `checked` value. */

--- a/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
@@ -21,7 +21,7 @@ export function VertexStyleImportCard({
     <ImportCard label={item.type} checked={selected} onCheckedChange={onToggle}>
       <ImportCardSurface className="grid grid-cols-[1fr_auto_1fr] items-center justify-items-center gap-(--card-spacing)">
         <PreviewLabel className="opacity-60">
-          {item.status === "conflict" ? "Current" : "Default"}
+          {item.status === "existing" ? "Current" : "Default"}
         </PreviewLabel>
         <PreviewLabel className="col-start-3">Incoming</PreviewLabel>
         <VertexSymbol

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportPlan.test.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportPlan.test.ts
@@ -45,7 +45,7 @@ describe("buildStyleImportPlan", () => {
     expect(plan.skippedCount).toBe(0);
   });
 
-  test("classifies a type that already has a user style as a conflict", () => {
+  test("classifies a type that already has a user style as existing", () => {
     const type = createVertexType("Airport");
     const current: VertexStyleStorage = { type, color: "#111" };
     const incoming: VertexStyleStorage = { type, color: "#abc" };
@@ -60,7 +60,7 @@ describe("buildStyleImportPlan", () => {
       {
         kind: "vertex",
         type,
-        status: "conflict",
+        status: "existing",
         incoming,
         incomingStyle: resolveVertexStyle(type, incoming),
         currentStyle: resolveVertexStyle(type, current),

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportPlan.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportPlan.ts
@@ -15,10 +15,11 @@ import {
 } from "@/core/StateProvider/graphStyles";
 
 /**
- * Whether the type already has a style the load would replace (`conflict`) or is
- * brand new (`new`). Drives the "Current" vs. "Default" before-label on a card.
+ * Whether the type already has a user style the load would replace (`existing`)
+ * or is brand new (`new`). Drives the "Current" vs. "Default" before-label on a
+ * card and the New / Existing filter tabs.
  */
-export type StyleImportStatus = "new" | "conflict";
+export type StyleImportStatus = "new" | "existing";
 
 /**
  * One loadable style, ready to render as a before→after card. `incoming` is the
@@ -61,7 +62,7 @@ export type StyleImportPlan = {
  * Turns a parsed styling file into the load plan: for each type, resolve the
  * incoming and current styles, drop the ones that resolve identically (a no-op
  * the user shouldn't have to decide about), and classify the rest as new or
- * conflict. Comparison is at the resolved level so a file that merely sets a
+ * existing. Comparison is at the resolved level so a file that merely sets a
  * field to its existing effective value is skipped, regardless of how the two
  * storage partials happen to differ.
  */
@@ -84,7 +85,7 @@ export function buildStyleImportPlan(
     items.push({
       kind: "vertex",
       type,
-      status: current ? "conflict" : "new",
+      status: current ? "existing" : "new",
       incoming,
       incomingStyle,
       currentStyle,
@@ -102,7 +103,7 @@ export function buildStyleImportPlan(
     items.push({
       kind: "edge",
       type,
-      status: current ? "conflict" : "new",
+      status: current ? "existing" : "new",
       incoming,
       incomingStyle,
       currentStyle,

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportView.test.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportView.test.ts
@@ -1,0 +1,174 @@
+import { createEdgeType, createVertexType } from "@/core/entities";
+import {
+  resolveEdgeStyle,
+  resolveVertexStyle,
+} from "@/core/StateProvider/graphStyles";
+
+import type {
+  EdgeStyleImportItem,
+  StyleImportItem,
+  StyleImportStatus,
+  VertexStyleImportItem,
+} from "./styleImportPlan";
+
+import {
+  filterCounts,
+  selectAllState,
+  selectVisibleItems,
+} from "./styleImportView";
+
+function vertexItem(
+  name: string,
+  status: StyleImportStatus = "new",
+): VertexStyleImportItem {
+  const type = createVertexType(name);
+  const incoming = { type };
+  return {
+    kind: "vertex",
+    type,
+    status,
+    incoming,
+    incomingStyle: resolveVertexStyle(type, incoming),
+    currentStyle: resolveVertexStyle(type),
+  };
+}
+
+function edgeItem(
+  name: string,
+  status: StyleImportStatus = "new",
+): EdgeStyleImportItem {
+  const type = createEdgeType(name);
+  const incoming = { type };
+  return {
+    kind: "edge",
+    type,
+    status,
+    incoming,
+    incomingStyle: resolveEdgeStyle(type, incoming),
+    currentStyle: resolveEdgeStyle(type),
+  };
+}
+
+describe("selectVisibleItems", () => {
+  test("returns everything for the all filter with no search", () => {
+    const items = [vertexItem("Airport"), edgeItem("route")];
+
+    expect(selectVisibleItems(items, "all", "")).toStrictEqual(items);
+  });
+
+  test("keeps only vertices for the nodes filter", () => {
+    const airport = vertexItem("Airport");
+    const items = [airport, edgeItem("route")];
+
+    expect(selectVisibleItems(items, "nodes", "")).toStrictEqual([airport]);
+  });
+
+  test("keeps only edges for the edges filter", () => {
+    const route = edgeItem("route");
+    const items = [vertexItem("Airport"), route];
+
+    expect(selectVisibleItems(items, "edges", "")).toStrictEqual([route]);
+  });
+
+  test("keeps only conflicts across both kinds for the conflicts filter", () => {
+    const conflictVertex = vertexItem("Airport", "conflict");
+    const conflictEdge = edgeItem("route", "conflict");
+    const items = [
+      conflictVertex,
+      vertexItem("Country", "new"),
+      conflictEdge,
+      edgeItem("contains", "new"),
+    ];
+
+    expect(selectVisibleItems(items, "conflicts", "")).toStrictEqual([
+      conflictVertex,
+      conflictEdge,
+    ]);
+  });
+
+  test("narrows by case-insensitive substring on the type name", () => {
+    const airport = vertexItem("Airport");
+    const items = [airport, vertexItem("Country")];
+
+    expect(selectVisibleItems(items, "all", "port")).toStrictEqual([airport]);
+    expect(selectVisibleItems(items, "all", "AIR")).toStrictEqual([airport]);
+  });
+
+  test("composes the active filter with the search term", () => {
+    const airRoute = edgeItem("airRoute");
+    const items = [vertexItem("Airport"), airRoute, edgeItem("contains")];
+
+    expect(selectVisibleItems(items, "edges", "air")).toStrictEqual([airRoute]);
+  });
+});
+
+describe("filterCounts", () => {
+  test("counts each tab independently with no search", () => {
+    const items = [
+      vertexItem("Airport", "conflict"),
+      vertexItem("Country", "new"),
+      edgeItem("route", "conflict"),
+    ];
+
+    expect(filterCounts(items, "")).toStrictEqual({
+      all: 3,
+      nodes: 2,
+      edges: 1,
+      conflicts: 2,
+    });
+  });
+
+  test("reflects the active search in every tab count", () => {
+    const items = [
+      vertexItem("Airport", "conflict"),
+      vertexItem("Country", "new"),
+      edgeItem("route", "conflict"),
+    ];
+
+    // Only "Airport" matches, and it is both a node and a conflict.
+    expect(filterCounts(items, "air")).toStrictEqual({
+      all: 1,
+      nodes: 1,
+      edges: 0,
+      conflicts: 1,
+    });
+  });
+});
+
+describe("selectAllState", () => {
+  const airport = vertexItem("Airport");
+  const country = vertexItem("Country");
+  const route = edgeItem("route");
+
+  function selectedSet(...items: StyleImportItem[]) {
+    const selected = new Set(items);
+    return (item: StyleImportItem) => selected.has(item);
+  }
+
+  test("is unchecked when no visible item is selected", () => {
+    expect(selectAllState([airport, country], selectedSet())).toBe("unchecked");
+  });
+
+  test("is checked when every visible item is selected", () => {
+    expect(
+      selectAllState([airport, country], selectedSet(airport, country)),
+    ).toBe("checked");
+  });
+
+  test("is indeterminate when some but not all visible items are selected", () => {
+    expect(selectAllState([airport, country], selectedSet(airport))).toBe(
+      "indeterminate",
+    );
+  });
+
+  test("ignores selection outside the visible subset", () => {
+    // route is selected but not visible, so the visible nodes read as unchecked.
+    expect(selectAllState([airport, country], selectedSet(route))).toBe(
+      "unchecked",
+    );
+  });
+
+  test("is unchecked when there are no visible items", () => {
+    expect(selectAllState([], selectedSet(airport))).toBe("unchecked");
+  });
+});

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportView.test.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportView.test.ts
@@ -70,19 +70,35 @@ describe("selectVisibleItems", () => {
     expect(selectVisibleItems(items, "edges", "")).toStrictEqual([route]);
   });
 
-  test("keeps only conflicts across both kinds for the conflicts filter", () => {
-    const conflictVertex = vertexItem("Airport", "conflict");
-    const conflictEdge = edgeItem("route", "conflict");
+  test("keeps only existing-style types across both kinds for the existing filter", () => {
+    const existingVertex = vertexItem("Airport", "existing");
+    const existingEdge = edgeItem("route", "existing");
     const items = [
-      conflictVertex,
+      existingVertex,
       vertexItem("Country", "new"),
-      conflictEdge,
+      existingEdge,
       edgeItem("contains", "new"),
     ];
 
-    expect(selectVisibleItems(items, "conflicts", "")).toStrictEqual([
-      conflictVertex,
-      conflictEdge,
+    expect(selectVisibleItems(items, "existing", "")).toStrictEqual([
+      existingVertex,
+      existingEdge,
+    ]);
+  });
+
+  test("keeps only brand-new types across both kinds for the new filter", () => {
+    const newVertex = vertexItem("Country", "new");
+    const newEdge = edgeItem("contains", "new");
+    const items = [
+      vertexItem("Airport", "existing"),
+      newVertex,
+      edgeItem("route", "existing"),
+      newEdge,
+    ];
+
+    expect(selectVisibleItems(items, "new", "")).toStrictEqual([
+      newVertex,
+      newEdge,
     ]);
   });
 
@@ -105,32 +121,34 @@ describe("selectVisibleItems", () => {
 describe("filterCounts", () => {
   test("counts each tab independently with no search", () => {
     const items = [
-      vertexItem("Airport", "conflict"),
+      vertexItem("Airport", "existing"),
       vertexItem("Country", "new"),
-      edgeItem("route", "conflict"),
+      edgeItem("route", "existing"),
     ];
 
     expect(filterCounts(items, "")).toStrictEqual({
       all: 3,
       nodes: 2,
       edges: 1,
-      conflicts: 2,
+      new: 1,
+      existing: 2,
     });
   });
 
   test("reflects the active search in every tab count", () => {
     const items = [
-      vertexItem("Airport", "conflict"),
+      vertexItem("Airport", "existing"),
       vertexItem("Country", "new"),
-      edgeItem("route", "conflict"),
+      edgeItem("route", "existing"),
     ];
 
-    // Only "Airport" matches, and it is both a node and a conflict.
+    // Only "Airport" matches, and it is both a node with an existing style.
     expect(filterCounts(items, "air")).toStrictEqual({
       all: 1,
       nodes: 1,
       edges: 0,
-      conflicts: 1,
+      new: 0,
+      existing: 1,
     });
   });
 });

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
@@ -1,0 +1,95 @@
+import type { StyleImportItem } from "./styleImportPlan";
+
+/**
+ * Which subset of the import list a filter tab shows. `all` is every item;
+ * `nodes`/`edges` narrow by kind; `conflicts` keeps only types that already
+ * have a user-layer style the load would replace.
+ */
+export type StyleImportFilter = "all" | "nodes" | "edges" | "conflicts";
+
+/** The per-tab counts, reflecting the active search. */
+export type StyleImportFilterCounts = Record<StyleImportFilter, number>;
+
+/** Whether a Select-All control over the visible items is on, off, or mixed. */
+export type SelectAllState = "checked" | "unchecked" | "indeterminate";
+
+function matchesFilter(item: StyleImportItem, filter: StyleImportFilter) {
+  switch (filter) {
+    case "all":
+      return true;
+    case "nodes":
+      return item.kind === "vertex";
+    case "edges":
+      return item.kind === "edge";
+    case "conflicts":
+      return item.status === "conflict";
+  }
+}
+
+function matchesSearch(item: StyleImportItem, search: string) {
+  return item.type.toLowerCase().includes(search.toLowerCase());
+}
+
+/**
+ * The items shown under the current filter tab and search term — the grid's
+ * source of truth. Selection is tracked separately so a filtered-out item stays
+ * selected; this only decides what is on screen.
+ */
+export function selectVisibleItems(
+  items: StyleImportItem[],
+  filter: StyleImportFilter,
+  search: string,
+): StyleImportItem[] {
+  return items.filter(
+    item => matchesFilter(item, filter) && matchesSearch(item, search),
+  );
+}
+
+/**
+ * The count each filter tab shows, narrowed by the active search so the tab
+ * label and the grid it reveals always agree.
+ */
+export function filterCounts(
+  items: StyleImportItem[],
+  search: string,
+): StyleImportFilterCounts {
+  const counts: StyleImportFilterCounts = {
+    all: 0,
+    nodes: 0,
+    edges: 0,
+    conflicts: 0,
+  };
+  for (const item of items) {
+    if (!matchesSearch(item, search)) {
+      continue;
+    }
+    counts.all++;
+    if (item.kind === "vertex") {
+      counts.nodes++;
+    } else {
+      counts.edges++;
+    }
+    if (item.status === "conflict") {
+      counts.conflicts++;
+    }
+  }
+  return counts;
+}
+
+/**
+ * The Select-All state for the currently-visible items only. An empty view or
+ * no selection reads unchecked; a partial visible selection reads indeterminate.
+ */
+export function selectAllState(
+  visibleItems: StyleImportItem[],
+  isSelected: (item: StyleImportItem) => boolean,
+): SelectAllState {
+  if (visibleItems.length === 0) {
+    return "unchecked";
+  }
+  const selectedCount = visibleItems.filter(isSelected).length;
+  if (selectedCount === 0) {
+    return "unchecked";
+  }
+  return selectedCount === visibleItems.length ? "checked" : "indeterminate";
+}

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
@@ -26,8 +26,8 @@ function matchesFilter(item: StyleImportItem, filter: StyleImportFilter) {
   }
 }
 
-function matchesSearch(item: StyleImportItem, search: string) {
-  return item.type.toLowerCase().includes(search.toLowerCase());
+function matchesSearch(item: StyleImportItem, normalizedSearch: string) {
+  return item.type.toLowerCase().includes(normalizedSearch);
 }
 
 /**
@@ -40,8 +40,10 @@ export function selectVisibleItems(
   filter: StyleImportFilter,
   search: string,
 ): StyleImportItem[] {
+  const normalizedSearch = search.toLowerCase();
   return items.filter(
-    item => matchesFilter(item, filter) && matchesSearch(item, search),
+    item =>
+      matchesFilter(item, filter) && matchesSearch(item, normalizedSearch),
   );
 }
 
@@ -59,8 +61,9 @@ export function filterCounts(
     edges: 0,
     conflicts: 0,
   };
+  const normalizedSearch = search.toLowerCase();
   for (const item of items) {
-    if (!matchesSearch(item, search)) {
+    if (!matchesSearch(item, normalizedSearch)) {
       continue;
     }
     counts.all++;

--- a/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
+++ b/packages/graph-explorer/src/modules/StyleImport/styleImportView.ts
@@ -2,10 +2,11 @@ import type { StyleImportItem } from "./styleImportPlan";
 
 /**
  * Which subset of the import list a filter tab shows. `all` is every item;
- * `nodes`/`edges` narrow by kind; `conflicts` keeps only types that already
- * have a user-layer style the load would replace.
+ * `nodes`/`edges` narrow by kind; `new` keeps types the user has not styled yet;
+ * `existing` keeps types that already have a user-layer style the load would
+ * replace.
  */
-export type StyleImportFilter = "all" | "nodes" | "edges" | "conflicts";
+export type StyleImportFilter = "all" | "nodes" | "edges" | "new" | "existing";
 
 /** The per-tab counts, reflecting the active search. */
 export type StyleImportFilterCounts = Record<StyleImportFilter, number>;
@@ -21,8 +22,10 @@ function matchesFilter(item: StyleImportItem, filter: StyleImportFilter) {
       return item.kind === "vertex";
     case "edges":
       return item.kind === "edge";
-    case "conflicts":
-      return item.status === "conflict";
+    case "new":
+      return item.status === "new";
+    case "existing":
+      return item.status === "existing";
   }
 }
 
@@ -59,7 +62,8 @@ export function filterCounts(
     all: 0,
     nodes: 0,
     edges: 0,
-    conflicts: 0,
+    new: 0,
+    existing: 0,
   };
   const normalizedSearch = search.toLowerCase();
   for (const item of items) {
@@ -72,8 +76,10 @@ export function filterCounts(
     } else {
       counts.edges++;
     }
-    if (item.status === "conflict") {
-      counts.conflicts++;
+    if (item.status === "existing") {
+      counts.existing++;
+    } else {
+      counts.new++;
     }
   }
   return counts;


### PR DESCRIPTION
## Why

Third and final slice of the selective style import modal (#1970). The modal shipped in #1984 was usable but flat: every incoming style listed at once, no way to narrow a large file. This adds the polish layer — filter tabs, type-name search, and bulk selection — so a user loading a big styling file can zero in on just the types they care about.

## What

- **New shared `Toggle` / `ToggleGroup`** primitives (faithful shadcn import, adapted to our `cva`/token stack), barrel-exported.
- **Filter tabs** — All / Nodes / Edges / New / Existing, each with a live count that reflects the active search. All tabs stay enabled at zero count.
- **Type-name search** — case-insensitive substring, composes with the active tab (filter ∩ search).
- **Grouped subheaders** that show/hide based on matches; an **empty state** when nothing matches.
- **Select all** that toggles only the currently-visible items and shows indeterminate on a partial visible selection. Selection stays the source of truth — the footer and Load button always count every checked item, across all tabs.
- Renamed the import status `conflict` → **`existing`** and added the paired **New** tab, so the vocabulary is "New vs Existing" rather than the overloaded "conflict".
- Stable modal height while filtering (still shrinks with the viewport).

The filter/search/select-all logic lives in a pure module (`styleImportView.ts`) so it's unit-tested directly; the modal wiring is exercised through an integration test.

## How to read
1. [styleImportView.ts](https://github.com/aws/graph-explorer/pull/1989/files#diff-0a002104fbe389d3df4ef8baab7c530f84231ce292c1a8aaaa0dd2f68bb9b969) — pure view logic: filter ∩ search, per-tab counts, Select-All state
2. [StyleImportModal.tsx](https://github.com/aws/graph-explorer/pull/1989/files#diff-27693f094e68208e6adfce5171e68f4b01c825bd2e83b8043a1555e2374c46f7) — how the modal wires the logic into tabs, search, Select-all, and the empty state
3. [Toggle.tsx](https://github.com/aws/graph-explorer/pull/1989/files#diff-99ebf89d3a72f115ea6335cf7486aae695874dfa2a6bf100d640aa8d49701d7a) / [ToggleGroup.tsx](https://github.com/aws/graph-explorer/pull/1989/files#diff-a128b7592af21809b9be8a6b98baf6bdfa4810a7aece28f03421856333f71f9f) — the shared primitive
4. [styleImportPlan.ts](https://github.com/aws/graph-explorer/pull/1989/files#diff-2b6668e401b5dfb7b3467eef002f02c3069e1f0645163c9a484e709c9603214d) — the `conflict` → `existing` status rename

## Testing

`styleImportView.test.ts` covers filtering, search composition, and Select-All over filtered subsets; the modal integration test proves filter + search + Select-All compose. All checks (types/lint/format) and tests pass.

- Closes #1973
- Related to #1970
