### PR TITLE
Seed default connection only when the store is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ plans/
 
 # Local-only files (settings, overrides, secrets)
 *.local.*
+
+# Local dev default-connection fixture, generated per-environment at runtime
+**/defaultConnection.json

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,10 @@ _Avoid_: Active configuration (legacy code term `activeConfigurationAtom`)
 
 **Last Active Connection**:
 A persisted, shared breadcrumb recording the most recently activated Connection across all tabs. Last-writer-wins; used only as the cold-start seed for a fresh tab's Active Connection, never read live by the app.
-_Avoid_: Default connection (that is a separate new-user/notebook injection path)
+
+**Default Connection**:
+A Connection injected automatically into an empty store from environment-provided config — a `defaultConnection.json` file (local/self-hosted) or the SageMaker proxy endpoint (notebook). Seeded only when no Connections exist, and re-seeded if the last Connection is deleted. When the config names no Query Language, one Default Connection is produced per Query Language. Distinct from the Last Active Connection, which is a persisted breadcrumb rather than a connection.
+_Avoid_: Seed connection
 
 **Query Language**:
 The graph query protocol a Connection uses — one of Gremlin, openCypher, or SPARQL. Determines which Explorer is instantiated and implies the graph type (Gremlin/openCypher → property graph, SPARQL → RDF).

--- a/packages/graph-explorer/src/core/AppStatusLoader.test.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from "jotai";
 import { vi } from "vitest";
 
 import { type AppStore, getAppStore } from "@/core";
+import { logger } from "@/utils";
 import { createRandomRawConfiguration } from "@/utils/testing";
 
 import type { RawConfiguration } from "./ConfigurationProvider";
@@ -103,9 +104,12 @@ test("renders the app when no default connection is configured", async () => {
   const { findByText } = renderAppStatusLoader(store);
 
   // With no default to seed, the app falls through to its children rather
-  // than stalling on a loading state.
+  // than stalling on a loading state, and logs that none were found.
   await findByText("ready");
   expect(store.get(configurationAtom).size).toBe(0);
+  expect(vi.mocked(logger.debug)).toHaveBeenCalledWith(
+    "No default connections found",
+  );
 
   // Emptying the store keeps the app rendered rather than showing a spinner.
   act(() => {

--- a/packages/graph-explorer/src/core/AppStatusLoader.test.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+import { queryEngineOptions } from "@shared/types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render } from "@testing-library/react";
+import { Provider } from "jotai";
+import { vi } from "vitest";
+
+import { type AppStore, getAppStore } from "@/core";
+import { createRandomRawConfiguration } from "@/utils/testing";
+
+import type { RawConfiguration } from "./ConfigurationProvider";
+
+import AppStatusLoader from "./AppStatusLoader";
+import * as defaultConnection from "./defaultConnection";
+import { configurationAtom } from "./StateProvider";
+
+function mockDefaultConnection(configs: RawConfiguration[]) {
+  vi.spyOn(defaultConnection, "fetchDefaultConnection").mockResolvedValue(
+    configs,
+  );
+}
+
+function renderAppStatusLoader(store: AppStore) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <Provider store={store}>
+        <AppStatusLoader>
+          <div>ready</div>
+        </AppStatusLoader>
+      </Provider>
+    </QueryClientProvider>,
+  );
+}
+
+test("adding the default connection settles instead of looping", async () => {
+  mockDefaultConnection([createRandomRawConfiguration()]);
+
+  const store = getAppStore();
+  const writeCounts = vi.fn();
+  const unsub = store.sub(configurationAtom, () => {
+    writeCounts(store.get(configurationAtom).size);
+  });
+
+  const { findByText } = renderAppStatusLoader(store);
+
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(1);
+
+  unsub();
+
+  // The default connection is written exactly once; a looping effect would
+  // keep replacing the map with a fresh reference and pile up writes.
+  expect(writeCounts.mock.calls.length).toBe(1);
+});
+
+test("seeds one connection per query engine with a single write", async () => {
+  const configs = queryEngineOptions.map(() => createRandomRawConfiguration());
+  mockDefaultConnection(configs);
+
+  const store = getAppStore();
+  const writeCounts = vi.fn();
+  const unsub = store.sub(configurationAtom, () => {
+    writeCounts(store.get(configurationAtom).size);
+  });
+
+  const { findByText } = renderAppStatusLoader(store);
+
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(configs.length);
+
+  unsub();
+
+  // All engines are seeded in one write, and the effect settles afterwards.
+  expect(writeCounts.mock.calls.length).toBe(1);
+});
+
+test("re-adds the default connection after the last connection is deleted", async () => {
+  mockDefaultConnection([createRandomRawConfiguration()]);
+
+  const store = getAppStore();
+  const { findByText } = renderAppStatusLoader(store);
+
+  // Initial load adds the default connection.
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(1);
+
+  // Deleting the last connection empties the store.
+  act(() => {
+    store.set(configurationAtom, new Map());
+  });
+
+  // The default connection is re-added and the app becomes ready again
+  // instead of stalling on the "Reading configuration..." boundary.
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(1);
+});
+
+test("renders the app when no default connection is configured", async () => {
+  mockDefaultConnection([]);
+
+  const store = getAppStore();
+  const { findByText } = renderAppStatusLoader(store);
+
+  // With no default to seed, the app falls through to its children rather
+  // than stalling on a loading state.
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(0);
+
+  // Emptying the store keeps the app rendered rather than showing a spinner.
+  act(() => {
+    store.set(configurationAtom, new Map());
+  });
+
+  await findByText("ready");
+  expect(store.get(configurationAtom).size).toBe(0);
+});

--- a/packages/graph-explorer/src/core/AppStatusLoader.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.tsx
@@ -25,17 +25,29 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
   const setActiveConfig = useSetAtom(activeConfigurationAtom);
   const [configuration, setConfiguration] = useAtom(configurationAtom);
 
+  // An empty store is what drives the whole default-connection flow: the query
+  // fetches, the effect seeds, and the loading states show only while it holds.
+  // Emptying the store (e.g. deleting the last connection) re-arms all three.
+  const storeIsEmpty = configuration.size === 0;
+
   const defaultConfigQuery = useQuery({
     queryKey: ["default-connection"],
     queryFn: fetchDefaultConnection,
     staleTime: Infinity,
-    // Run the query only if the store is loaded and there are no configs
-    enabled: configuration.size === 0,
+    enabled: storeIsEmpty,
   });
 
   const defaultConnectionConfigs = defaultConfigQuery.data;
+  const hasDefaultConnection = Boolean(defaultConnectionConfigs?.length);
 
   useEffect(() => {
+    // Seed the default connection only into an empty store. The size guard lets
+    // the effect settle after the write yet re-fire to re-add the default when
+    // the last connection is deleted, instead of looping.
+    if (!storeIsEmpty) {
+      return;
+    }
+
     if (!defaultConnectionConfigs) {
       // Query hasn't run yet
       return;
@@ -43,13 +55,6 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
 
     if (!defaultConnectionConfigs.length) {
       logger.debug("No default connections found");
-      return;
-    }
-
-    // Only seed the default connection into an empty store. Guarding on size
-    // lets the effect re-fire and re-add the default when the last connection
-    // is deleted, while settling after the write instead of looping.
-    if (configuration.size > 0) {
       return;
     }
 
@@ -65,13 +70,13 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
       setActiveConfig(defaultConnectionConfigs[0].id);
     });
   }, [
-    configuration.size,
+    storeIsEmpty,
     setActiveConfig,
     setConfiguration,
     defaultConnectionConfigs,
   ]);
 
-  if (configuration.size === 0 && defaultConfigQuery.isLoading) {
+  if (storeIsEmpty && defaultConfigQuery.isLoading) {
     return (
       <PanelEmptyState
         title="Loading default connection..."
@@ -81,12 +86,7 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
     );
   }
 
-  // Loading from config file if exists
-  if (
-    configuration.size === 0 &&
-    defaultConnectionConfigs &&
-    defaultConnectionConfigs.length > 0
-  ) {
+  if (storeIsEmpty && hasDefaultConnection) {
     return (
       <PanelEmptyState
         title="Reading configuration..."

--- a/packages/graph-explorer/src/core/AppStatusLoader.tsx
+++ b/packages/graph-explorer/src/core/AppStatusLoader.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import {
   type PropsWithChildren,
   startTransition,
@@ -22,7 +22,7 @@ function AppStatusLoader({ children }: PropsWithChildren) {
 }
 
 function LoadDefaultConfig({ children }: PropsWithChildren) {
-  const [activeConfig, setActiveConfig] = useAtom(activeConfigurationAtom);
+  const setActiveConfig = useSetAtom(activeConfigurationAtom);
   const [configuration, setConfiguration] = useAtom(configurationAtom);
 
   const defaultConfigQuery = useQuery({
@@ -46,6 +46,13 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
       return;
     }
 
+    // Only seed the default connection into an empty store. Guarding on size
+    // lets the effect re-fire and re-add the default when the last connection
+    // is deleted, while settling after the write instead of looping.
+    if (configuration.size > 0) {
+      return;
+    }
+
     startTransition(() => {
       logger.debug("Adding default connections", defaultConnectionConfigs);
       setConfiguration(prev => {
@@ -58,8 +65,7 @@ function LoadDefaultConfig({ children }: PropsWithChildren) {
       setActiveConfig(defaultConnectionConfigs[0].id);
     });
   }, [
-    activeConfig,
-    configuration,
+    configuration.size,
     setActiveConfig,
     setConfiguration,
     defaultConnectionConfigs,

--- a/packages/graph-explorer/src/core/defaultConnection.test.ts
+++ b/packages/graph-explorer/src/core/defaultConnection.test.ts
@@ -1,3 +1,4 @@
+import { queryEngineOptions } from "@shared/types";
 import {
   createRandomBoolean,
   createRandomInteger,
@@ -13,6 +14,7 @@ import {
 
 import {
   DefaultConnectionDataSchema,
+  fetchDefaultConnection,
   mapToConnection,
 } from "./defaultConnection";
 
@@ -107,6 +109,51 @@ describe("DefaultConnectionDataSchema", () => {
     );
   });
 });
+
+describe("fetchDefaultConnection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("location", { origin: "https://example.com" });
+  });
+
+  test("expands into one connection per query language when no query engine is provided", async () => {
+    const data = createRandomDefaultConnectionData();
+    delete (data as { GRAPH_EXP_GRAPH_TYPE?: string }).GRAPH_EXP_GRAPH_TYPE;
+    stubDefaultConnectionResponse(data);
+
+    const configs = await fetchDefaultConnection();
+
+    expect(configs.map(config => config.connection?.queryEngine)).toEqual([
+      ...queryEngineOptions,
+    ]);
+    expect(configs.map(config => config.id)).toEqual(
+      queryEngineOptions.map(engine => `Default Connection-${engine}`),
+    );
+  });
+
+  test("returns a single connection when a query engine is provided", async () => {
+    const data = createRandomDefaultConnectionData();
+    data.GRAPH_EXP_GRAPH_TYPE = "gremlin";
+    stubDefaultConnectionResponse(data);
+
+    const configs = await fetchDefaultConnection();
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].connection?.queryEngine).toBe("gremlin");
+    expect(configs[0].id).toBe("Default Connection");
+  });
+});
+
+function stubDefaultConnectionResponse(data: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+}
 
 function createRandomDefaultConnectionData() {
   return {


### PR DESCRIPTION
## Description

Fixes an infinite loop in the default-connection seeding logic. The effect in `AppStatusLoader` listed `configuration` in its deps but wrote a fresh `Map` on every run with no size guard, so each write re-triggered it — a loop that only surfaced once a default connection was actually served (on `main` the fetch returned `[]` and the effect early-returned).

- **Seed only into an empty store, keyed on size** — the effect now settles after seeding yet still re-fires to re-add the default connection when the last connection is deleted, instead of looping or stalling forever on the "Reading configuration..." state.
- **Consolidate the empty-store checks** — the "store is empty" condition drove the query, the seed effect, and both loading states through four separate size comparisons; it's now derived once as `storeIsEmpty`.
- **Ignore the local `defaultConnection.json` dev fixture** — a per-environment runtime artifact that would otherwise override real default-connection config if committed.
- **Tests** — cover the loop-settles and re-add-after-delete behavior, the per-query-language fan-out, and the no-default case; plus a domain glossary entry for **Default Connection**.

## How to read

1. [packages/graph-explorer/src/core/AppStatusLoader.tsx](https://github.com/aws/graph-explorer/pull/1991/files#diff-ab9e0731aef7679ecf60987aebce5097faed0590b2735f4dcf958a9dfa094f55) — the fix: `storeIsEmpty` guard and consolidated checks
2. [packages/graph-explorer/src/core/AppStatusLoader.test.tsx](https://github.com/aws/graph-explorer/pull/1991/files#diff-1825622904a514085ab76c11da891956750c874adba6f4219a5e413b93f4c508) — behavior tests: settles, re-adds after delete, no-default case
3. [packages/graph-explorer/src/core/defaultConnection.test.ts](https://github.com/aws/graph-explorer/pull/1991/files#diff-5a6040668895d71e96a5f5b3cc90b53cb31054dad8a827a993dd4d2cdd749b8c) — fan-out tests for `fetchDefaultConnection`
4. [CONTEXT.md](https://github.com/aws/graph-explorer/pull/1991/files#diff-86fee53c33308768d49a4ac0ff5720fd7f5411a8c8bd62ab9b80bbffa2977a14) — glossary entry for Default Connection

## Validation

- `pnpm check:types` and `pnpm check:format` pass.
- `pnpm test` passes (526 tests).

## Related Issues

<!-- No existing issue tracks this defect. -->

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
