### PR TITLE
Derive style-preview labels from the resolved style

### DIFF
--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.test.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.test.tsx
@@ -8,23 +8,47 @@ import { EdgePreview } from "./EdgePreview";
 function edgeStyle(overrides?: Partial<EdgeStyle>): EdgeStyle {
   return {
     ...appDefaultEdgeStyle,
-    type: createEdgeType("KNOWS"),
+    type: createEdgeType("route"),
     ...overrides,
   };
 }
 
 describe("EdgePreview", () => {
-  it("renders the provided label rather than deriving one from the edge type", () => {
+  it("labels the edge with its resolved type by default", () => {
+    render(<EdgePreview edgeStyle={edgeStyle({ displayLabel: "Flight" })} />);
+
+    expect(screen.getByText("Flight")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Flight edge preview" }),
+    ).toBeInTheDocument();
+  });
+
+  it("labels a data-attribute name as a placeholder", () => {
+    render(
+      <EdgePreview edgeStyle={edgeStyle({ displayNameAttribute: "dist" })} />,
+    );
+
+    expect(screen.getByText("<dist>")).toBeInTheDocument();
+  });
+
+  it("leaves the type untransformed by default", () => {
     render(
       <EdgePreview
-        edgeStyle={edgeStyle({ type: createEdgeType("http://x/knows") })}
-        label="skos:broadMatch"
+        edgeStyle={edgeStyle({ type: createEdgeType("http://x/route") })}
       />,
     );
 
-    expect(screen.getByText("skos:broadMatch")).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: "skos:broadMatch edge preview" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("http://x/route")).toBeInTheDocument();
+  });
+
+  it("applies a provided transform to the label", () => {
+    render(
+      <EdgePreview
+        edgeStyle={edgeStyle({ type: createEdgeType("http://x/route") })}
+        transform={text => text.replace("http://x/", "x:")}
+      />,
+    );
+
+    expect(screen.getByText("x:route")).toBeInTheDocument();
   });
 });

--- a/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
+++ b/packages/graph-explorer/src/components/EdgePreview/EdgePreview.tsx
@@ -2,9 +2,11 @@ import type { ComponentPropsWithoutRef } from "react";
 
 import type { EdgeStyle } from "@/core";
 
+import { identityTransform, type TextTransformer } from "@/hooks";
 import { cn } from "@/utils";
 
 import { LabelPreview } from "../LabelPreview";
+import { edgePreviewLabel } from "../previewLabels";
 import {
   type ArrowGeometry,
   type ArrowPrimitive,
@@ -38,7 +40,13 @@ function VertexPlaceholder({
 
 interface EdgePreviewProps {
   edgeStyle: EdgeStyle;
-  label: string;
+  /**
+   * Transform applied to type/attribute names in the label — pass the
+   * connection's `useTextTransform()` to match the canvas (e.g. SPARQL prefix
+   * folding). Defaults to identity so a preview of a style from another source
+   * (an import file) is not reinterpreted through the active connection.
+   */
+  transform?: TextTransformer;
   className?: string;
 }
 
@@ -46,7 +54,12 @@ interface EdgePreviewProps {
  * Two placeholder nodes connected by the styled edge. Geometry is ported
  * verbatim from cytoscape so the preview matches the canvas.
  */
-export function EdgePreview({ edgeStyle, label, className }: EdgePreviewProps) {
+export function EdgePreview({
+  edgeStyle,
+  transform = identityTransform,
+  className,
+}: EdgePreviewProps) {
+  const label = edgePreviewLabel(edgeStyle, transform);
   const lineWidthPx = edgeStyle.lineThickness * DEFAULT_ZOOM;
   const arrowUnit = getArrowWidth(edgeStyle.lineThickness) * DEFAULT_ZOOM;
 

--- a/packages/graph-explorer/src/components/LabelPreview.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.tsx
@@ -15,8 +15,8 @@ const PADDING = 2;
 const BORDER_RADIUS = 2;
 
 interface LabelPreviewProps {
-  /** The label text to display. */
-  children: string;
+  /** The label content to display. */
+  children: React.ReactNode;
   /** The label visual style (colors, border, opacity). */
   labelStyle: LabelVisualStyle;
   /**

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.test.tsx
@@ -2,6 +2,8 @@
 import { QueryClient } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 
+import type { TextTransformer } from "@/hooks";
+
 import {
   appDefaultVertexStyle,
   createVertexType,
@@ -20,23 +22,55 @@ function vertexStyle(overrides?: Partial<VertexStyle>): VertexStyle {
   };
 }
 
+function renderPreview(style: VertexStyle, transform?: TextTransformer) {
+  render(
+    <TestProvider store={getAppStore()} client={new QueryClient()}>
+      <VertexPreview vertexStyle={style} transform={transform} />
+    </TestProvider>,
+  );
+}
+
 describe("VertexPreview", () => {
-  it("renders the provided label rather than deriving one from the vertex type", () => {
-    render(
-      <TestProvider store={getAppStore()} client={new QueryClient()}>
-        <VertexPreview
-          vertexStyle={vertexStyle({
-            type: createVertexType("http://x/Person"),
-          })}
-          label="foaf:Person"
-        />
-      </TestProvider>,
+  it("labels the type and a placeholder for the id-derived name", () => {
+    renderPreview(vertexStyle({ displayNameAttribute: "~id" }));
+
+    expect(screen.getByText("Person")).toBeInTheDocument();
+    expect(screen.getByText("<id>")).toBeInTheDocument();
+  });
+
+  it("uses the display type override and names a data attribute as a placeholder", () => {
+    renderPreview(
+      vertexStyle({
+        type: createVertexType("http://x/Person"),
+        displayLabel: "Human",
+        displayNameAttribute: "name",
+      }),
     );
 
-    expect(screen.getByText("foaf:Person")).toBeInTheDocument();
+    expect(screen.getByText("Human")).toBeInTheDocument();
+    expect(screen.getByText("<name>")).toBeInTheDocument();
     // The symbol renders its own accessible name from the vertex style.
     expect(
-      screen.getByRole("img", { name: "http://x/Person symbol" }),
+      screen.getByRole("img", { name: "Human symbol" }),
     ).toBeInTheDocument();
+  });
+
+  it("leaves the type untransformed by default", () => {
+    renderPreview(vertexStyle({ type: createVertexType("http://x/Person") }));
+
+    expect(screen.getByText("http://x/Person")).toBeInTheDocument();
+  });
+
+  it("applies a provided transform to the type and placeholder", () => {
+    renderPreview(
+      vertexStyle({
+        type: createVertexType("http://x/Person"),
+        displayNameAttribute: "http://x/name",
+      }),
+      text => text.replace("http://x/", "x:"),
+    );
+
+    expect(screen.getByText("x:Person")).toBeInTheDocument();
+    expect(screen.getByText("<x:name>")).toBeInTheDocument();
   });
 });

--- a/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
+++ b/packages/graph-explorer/src/components/VertexSymbol/VertexPreview.tsx
@@ -1,25 +1,37 @@
 import { appDefaultNodeLabelStyle, type VertexStyle } from "@/core";
+import { identityTransform, type TextTransformer } from "@/hooks";
 import { cn } from "@/utils";
 
 import { LabelPreview } from "../LabelPreview";
+import { vertexPreviewLabel } from "../previewLabels";
 import { PREVIEW_SCALE, VertexSymbol } from "./VertexSymbol";
 
 interface VertexPreviewProps {
   vertexStyle: VertexStyle;
-  label: string;
+  /**
+   * Transform applied to type/attribute names in the label — pass the
+   * connection's `useTextTransform()` to match the canvas (e.g. SPARQL prefix
+   * folding). Defaults to identity so a preview of a style from another source
+   * (an import file) is not reinterpreted through the active connection.
+   */
+  transform?: TextTransformer;
   className?: string;
 }
 
 /**
- * A vertex shape preview with a label badge beneath it, matching the canvas
- * appearance. The label uses the same model→viewBox scale the symbol renders
- * at, so node and label stay proportional as the caller CSS-zooms the preview.
+ * A vertex shape preview with a two-line label badge beneath it, matching the
+ * canvas node badge: a bold type line above the display-name line. Both derive
+ * from the resolved style, and the badge uses the same model→viewBox scale the
+ * symbol renders at, so node and label stay proportional as the caller
+ * CSS-zooms the preview.
  */
 export function VertexPreview({
   vertexStyle,
-  label,
+  transform = identityTransform,
   className,
 }: VertexPreviewProps) {
+  const { type, name } = vertexPreviewLabel(vertexStyle, transform);
+
   return (
     <div className={cn("w-full min-w-0", className)}>
       {/* min-w-0 lets the column shrink so a long label truncates instead of overflowing */}
@@ -28,9 +40,10 @@ export function VertexPreview({
         <LabelPreview
           labelStyle={appDefaultNodeLabelStyle}
           scale={PREVIEW_SCALE}
-          className="-mt-3"
+          className="-mt-3 flex flex-col"
         >
-          {label}
+          <span className="truncate text-[0.7em] font-bold">{type}</span>
+          <span className="truncate">{name}</span>
         </LabelPreview>
       </div>
     </div>

--- a/packages/graph-explorer/src/components/previewLabels.test.ts
+++ b/packages/graph-explorer/src/components/previewLabels.test.ts
@@ -1,0 +1,135 @@
+import {
+  appDefaultEdgeStyle,
+  appDefaultVertexStyle,
+  createEdgeType,
+  createVertexType,
+  type EdgeStyle,
+  type VertexStyle,
+} from "@/core";
+import { identityTransform, type TextTransformer } from "@/hooks";
+import { LABELS } from "@/utils";
+
+import { edgePreviewLabel, vertexPreviewLabel } from "./previewLabels";
+
+/** Stands in for the SPARQL prefix transform: strips a namespace prefix. */
+const prefixing: TextTransformer = text => text.replace("http://x/", "x:");
+
+function edgeStyle(overrides?: Partial<EdgeStyle>): EdgeStyle {
+  return {
+    ...appDefaultEdgeStyle,
+    type: createEdgeType("route"),
+    ...overrides,
+  };
+}
+
+function vertexStyle(overrides?: Partial<VertexStyle>): VertexStyle {
+  return {
+    ...appDefaultVertexStyle,
+    type: createVertexType("Airport"),
+    ...overrides,
+  };
+}
+
+describe("edgePreviewLabel", () => {
+  it("resolves the reserved types attribute to the type name", () => {
+    expect(
+      edgePreviewLabel(
+        edgeStyle({ displayNameAttribute: "types" }),
+        identityTransform,
+      ),
+    ).toBe("route");
+  });
+
+  it("resolves the reserved types attribute to the display type override", () => {
+    expect(
+      edgePreviewLabel(
+        edgeStyle({ displayNameAttribute: "types", displayLabel: "Flight" }),
+        identityTransform,
+      ),
+    ).toBe("Flight");
+  });
+
+  it("renders the id as a placeholder", () => {
+    expect(
+      edgePreviewLabel(
+        edgeStyle({ displayNameAttribute: "~id" }),
+        identityTransform,
+      ),
+    ).toBe("<id>");
+  });
+
+  it("names a data attribute as a placeholder", () => {
+    expect(
+      edgePreviewLabel(
+        edgeStyle({ displayNameAttribute: "dist" }),
+        identityTransform,
+      ),
+    ).toBe("<dist>");
+  });
+
+  it("transforms an attribute-name placeholder and the type", () => {
+    expect(
+      edgePreviewLabel(
+        edgeStyle({
+          type: createEdgeType("http://x/route"),
+          displayNameAttribute: "http://x/dist",
+        }),
+        prefixing,
+      ),
+    ).toBe("<x:dist>");
+  });
+});
+
+describe("vertexPreviewLabel", () => {
+  it("uses the type name for both lines when the name derives from the id", () => {
+    expect(
+      vertexPreviewLabel(
+        vertexStyle({ displayNameAttribute: "~id" }),
+        identityTransform,
+      ),
+    ).toStrictEqual({ type: "Airport", name: "<id>" });
+  });
+
+  it("uses the display type override for the type line", () => {
+    expect(
+      vertexPreviewLabel(
+        vertexStyle({ displayNameAttribute: "code", displayLabel: "Airfield" }),
+        identityTransform,
+      ),
+    ).toStrictEqual({ type: "Airfield", name: "<code>" });
+  });
+
+  it("resolves the reserved types attribute to the type name", () => {
+    expect(
+      vertexPreviewLabel(
+        vertexStyle({ displayNameAttribute: "types" }),
+        identityTransform,
+      ),
+    ).toStrictEqual({ type: "Airport", name: "Airport" });
+  });
+
+  it("prefixes the type and attribute placeholder via the transform", () => {
+    expect(
+      vertexPreviewLabel(
+        vertexStyle({
+          type: createVertexType("http://x/Airport"),
+          displayNameAttribute: "http://x/code",
+        }),
+        prefixing,
+      ),
+    ).toStrictEqual({ type: "x:Airport", name: "<x:code>" });
+  });
+
+  it("falls back to the missing-type label for an empty display label and type", () => {
+    expect(
+      vertexPreviewLabel(
+        vertexStyle({
+          type: createVertexType(""),
+          displayLabel: "",
+          displayNameAttribute: "~id",
+        }),
+        identityTransform,
+      ),
+    ).toStrictEqual({ type: LABELS.MISSING_TYPE, name: "<id>" });
+  });
+});

--- a/packages/graph-explorer/src/components/previewLabels.ts
+++ b/packages/graph-explorer/src/components/previewLabels.ts
@@ -1,0 +1,54 @@
+import type { EdgeStyle, VertexStyle } from "@/core";
+import type { TextTransformer } from "@/hooks";
+
+import { LABELS, RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
+
+/**
+ * The type-line text for a style preview: the display-type override, or the
+ * transformed type (SPARQL IRIs become prefixed), falling back to the
+ * missing-type label. Matches the canvas derivation in `displayTypeConfigs.ts`
+ * so a preview reads the same as the node badge / edge label it stands in for.
+ */
+function typeText(
+  style: VertexStyle | EdgeStyle,
+  transform: TextTransformer,
+): string {
+  return style.displayLabel || transform(style.type) || LABELS.MISSING_TYPE;
+}
+
+/**
+ * The single label an edge preview draws — also the node preview's name line.
+ * A preview has no entity instance, so an attribute-derived name can't show a
+ * real value; it shows the attribute name as a `<placeholder>` instead. The
+ * reserved `types` attribute resolves to the type text since that needs no
+ * instance data.
+ */
+export function edgePreviewLabel(
+  style: VertexStyle | EdgeStyle,
+  transform: TextTransformer,
+): string {
+  if (style.displayNameAttribute === RESERVED_TYPES_PROPERTY) {
+    return typeText(style, transform);
+  }
+  if (style.displayNameAttribute === RESERVED_ID_PROPERTY) {
+    return "<id>";
+  }
+  return `<${transform(style.displayNameAttribute)}>`;
+}
+
+/**
+ * The two lines a node preview draws — a type line above the name line — to
+ * match the canvas node badge, derived from the resolved style.
+ */
+export function vertexPreviewLabel(
+  style: VertexStyle,
+  transform: TextTransformer,
+): {
+  type: string;
+  name: string;
+} {
+  return {
+    type: typeText(style, transform),
+    name: edgePreviewLabel(style, transform),
+  };
+}

--- a/packages/graph-explorer/src/hooks/useTextTransform.ts
+++ b/packages/graph-explorer/src/hooks/useTextTransform.ts
@@ -6,6 +6,9 @@ import { replacePrefixes } from "@/utils/rdf";
 
 export type TextTransformer = (text: string) => string;
 
+/** A no-op transform: text passes through unchanged. */
+export const identityTransform: TextTransformer = text => text;
+
 export const textTransformSelector = atom(get => {
   const queryEngine = get(queryEngineSelector);
   const prefixes = get(prefixesAtom);

--- a/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/EdgesStyling/EdgeStyleDialog.tsx
@@ -37,6 +37,7 @@ import {
   type LineStyle,
   useEdgeStyling,
 } from "@/core/StateProvider/graphStyles";
+import { useTextTransform } from "@/hooks";
 import useTranslations from "@/hooks/useTranslations";
 import { RESERVED_TYPES_PROPERTY } from "@/utils";
 
@@ -75,6 +76,7 @@ export function EdgeStyleDialog() {
 function Content({ edgeType }: { edgeType: EdgeType }) {
   const displayConfig = useDisplayEdgeTypeConfig(edgeType);
   const t = useTranslations();
+  const textTransform = useTextTransform();
   const queryEngine = useQueryEngine();
 
   const { edgeStyle, setEdgeStyle, resetEdgeStyle } = useEdgeStyling(edgeType);
@@ -111,7 +113,7 @@ function Content({ edgeType }: { edgeType: EdgeType }) {
               <PreviewSurface>
                 <EdgePreview
                   edgeStyle={edgeStyle}
-                  label={displayConfig.displayLabel}
+                  transform={textTransform}
                   className="zoom-90 px-4 py-3"
                 />
               </PreviewSurface>

--- a/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
+++ b/packages/graph-explorer/src/modules/NodesStyling/NodeStyleDialog.tsx
@@ -37,6 +37,7 @@ import {
   useVertexStyling,
 } from "@/core/StateProvider/graphStyles";
 import { isAllowedIconValue } from "@/core/styling";
+import { useTextTransform } from "@/hooks";
 import useTranslations from "@/hooks/useTranslations";
 import {
   RESERVED_ID_PROPERTY,
@@ -88,6 +89,7 @@ export function NodeStyleDialog() {
 
 function Content({ vertexType }: { vertexType: VertexType }) {
   const t = useTranslations();
+  const textTransform = useTextTransform();
 
   const { vertexStyle, setVertexStyle, resetVertexStyle } =
     useVertexStyling(vertexType);
@@ -244,7 +246,7 @@ function Content({ vertexType }: { vertexType: VertexType }) {
                 <PreviewSurface className="flex-1">
                   <VertexPreview
                     vertexStyle={vertexStyle}
-                    label={displayConfig.displayLabel}
+                    transform={textTransform}
                     className="zoom-50"
                   />
                 </PreviewSurface>

--- a/packages/graph-explorer/src/modules/StyleImport/EdgeStyleImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/EdgeStyleImportCard.tsx
@@ -28,19 +28,11 @@ export function EdgeStyleImportCard({
       <ImportCardSurface className="space-y-9">
         <div className="flex flex-col items-center gap-3">
           <PreviewLabel>Before</PreviewLabel>
-          <EdgePreview
-            edgeStyle={item.currentStyle}
-            label={item.currentStyle.displayLabel || item.type}
-            className="zoom-75"
-          />
+          <EdgePreview edgeStyle={item.currentStyle} className="zoom-75" />
         </div>
         <div className="flex flex-col items-center gap-3">
           <PreviewLabel>After</PreviewLabel>
-          <EdgePreview
-            edgeStyle={item.incomingStyle}
-            label={item.incomingStyle.displayLabel || item.type}
-            className="zoom-75"
-          />
+          <EdgePreview edgeStyle={item.incomingStyle} className="zoom-75" />
         </div>
       </ImportCardSurface>
       <ImportCardTitle>{item.type}</ImportCardTitle>

--- a/packages/graph-explorer/src/modules/StyleImport/ImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/ImportCard.tsx
@@ -86,7 +86,7 @@ export function ImportCardTitle({
 }
 
 /**
- * The incoming style's non-visual properties; unset values show as "Not set".
+ * The incoming style's non-visual properties; unset values show as "Not present".
  */
 export function ImportCardProperties({
   properties,
@@ -104,7 +104,9 @@ export function ImportCardProperties({
             <dt className="text-muted-foreground">{label}</dt>
             <dd>
               {value === undefined ? (
-                <span className="text-muted-foreground italic">Not set</span>
+                <span className="text-muted-foreground italic">
+                  Not present
+                </span>
               ) : (
                 <span className="gx-wrap-break-word font-mono text-sm">
                   {value}

--- a/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
@@ -232,7 +232,7 @@ describe("LoadStylesButton", () => {
     expect(screen.getByText("city")).toBeInTheDocument();
   });
 
-  test("labels an unset incoming non-visual property 'Not set'", async () => {
+  test("labels an unset incoming non-visual property 'Not present'", async () => {
     const user = userEvent.setup();
     renderButton();
 
@@ -246,7 +246,7 @@ describe("LoadStylesButton", () => {
     );
 
     await screen.findByRole("checkbox", { name: "Load Airport style" });
-    expect(screen.getAllByText("Not set")).toHaveLength(3);
+    expect(screen.getAllByText("Not present")).toHaveLength(3);
   });
 
   test("shows the incoming non-visual properties an edge style sets", async () => {

--- a/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/LoadStylesButton.test.tsx
@@ -125,9 +125,9 @@ describe("LoadStylesButton", () => {
       stylingFile({ vertices: { Airport: { color: "#abc" } }, edges: {} }),
     );
 
-    // Click the type name in the card body — the wrapping label forwards to the
-    // checkbox, so the whole card is one control.
-    await user.click(await screen.findByText("Airport"));
+    // Click a preview label in the card body — the wrapping label forwards to
+    // the checkbox, so the whole card is one control.
+    await user.click(await screen.findByText("Before"));
 
     expect(
       screen.getByRole("checkbox", { name: "Load Airport style" }),
@@ -227,7 +227,8 @@ describe("LoadStylesButton", () => {
     );
 
     await screen.findByRole("checkbox", { name: "Load Airport style" });
-    expect(screen.getByText("Airfield")).toBeInTheDocument();
+    // "Airfield" labels the Display type row and the after-preview type line.
+    expect(screen.getAllByText("Airfield")).toHaveLength(2);
     expect(screen.getByText("code")).toBeInTheDocument();
     expect(screen.getByText("city")).toBeInTheDocument();
   });
@@ -264,9 +265,10 @@ describe("LoadStylesButton", () => {
     );
 
     await screen.findByRole("checkbox", { name: "Load route style" });
-    // "Flight" labels the after preview and the Display type row; the before
-    // preview falls back to "route", so it appears exactly twice.
-    expect(screen.getAllByText("Flight")).toHaveLength(2);
+    // "Flight" labels the Display type row; the after preview shows
+    // the placeholder "<dist>" for the display name attribute.
+    expect(screen.getByText("Flight")).toBeInTheDocument();
+    expect(screen.getByText("<dist>")).toBeInTheDocument();
     expect(screen.getByText("dist")).toBeInTheDocument();
     // Edges have no description attribute, so that row never appears.
     expect(screen.queryByText("Display description")).not.toBeInTheDocument();

--- a/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
@@ -1,6 +1,6 @@
 import { ArrowRightIcon } from "lucide-react";
 
-import { VertexSymbol } from "@/components";
+import { VertexPreview } from "@/components";
 
 import type { VertexStyleImportItem } from "./styleImportPlan";
 
@@ -27,9 +27,9 @@ export function VertexStyleImportCard({
       <ImportCardSurface className="grid grid-cols-[1fr_auto_1fr] items-center justify-items-center gap-(--card-spacing)">
         <PreviewLabel>Before</PreviewLabel>
         <PreviewLabel className="col-start-3">After</PreviewLabel>
-        <VertexSymbol vertexStyle={item.currentStyle} className="size-12" />
+        <VertexPreview vertexStyle={item.currentStyle} className="zoom-50" />
         <ArrowRightIcon className="text-primary-foreground/50 size-4 shrink-0" />
-        <VertexSymbol vertexStyle={item.incomingStyle} className="size-12" />
+        <VertexPreview vertexStyle={item.incomingStyle} className="zoom-50" />
       </ImportCardSurface>
       <ImportCardTitle>{item.type}</ImportCardTitle>
       <ImportCardProperties

--- a/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
+++ b/packages/graph-explorer/src/modules/StyleImport/VertexStyleImportCard.tsx
@@ -26,9 +26,9 @@ export function VertexStyleImportCard({
     <ImportCard label={item.type} checked={selected} onCheckedChange={onToggle}>
       <ImportCardSurface className="grid grid-cols-[1fr_auto_1fr] items-center justify-items-center gap-(--card-spacing)">
         <PreviewLabel>Before</PreviewLabel>
-        <PreviewLabel className="col-start-3">After</PreviewLabel>
+        <ArrowRightIcon className="text-primary-foreground/50 row-span-2 size-4 shrink-0" />
+        <PreviewLabel>After</PreviewLabel>
         <VertexPreview vertexStyle={item.currentStyle} className="zoom-50" />
-        <ArrowRightIcon className="text-primary-foreground/50 size-4 shrink-0" />
         <VertexPreview vertexStyle={item.incomingStyle} className="zoom-50" />
       </ImportCardSurface>
       <ImportCardTitle>{item.type}</ImportCardTitle>


### PR DESCRIPTION
## Description

Style previews used to be handed a `label` string by each caller, so an import card labelled itself with the display-*type* override while the canvas labels a node/edge by its *display-name* attribute. The two drifted, and a preview could contradict what the graph actually renders.

This makes the previews derive their own label from the resolved style — the single source both the preview and the canvas already share — and removes the `label` prop entirely.

**Core change:** a pure helper (`previewLabels.ts`) resolves a style to its label the way the canvas does:
- The reserved `types` attribute → the type text (`displayLabel ?? type`).
- The reserved `~id` → `<id>`; any data attribute → `<attr>`. A preview has no entity instance, so an attribute-derived name is shown as a `<placeholder>` naming the attribute rather than a fabricated value.
- Node previews render the two-line canvas badge (bold type line above the name line); edge previews render the single name line.

**Connection-awareness is opt-in.** The helper takes a `TextTransformer`; the previews default it to identity. The **style dialogs** pass the active connection's `useTextTransform()` so SPARQL IRIs render prefixed (`foaf:Person`), matching the canvas. The **style-import cards** omit it — a style loaded from a file must not be reinterpreted through whichever connection happens to be active.

Also: the import card's unset non-visual property label changed from "Not set" to "Not present".

## Validation

- `pnpm checks` passes (types, lint, format).
- `pnpm test` passes (2265 tests); new `previewLabels.test.ts` covers reserved/attribute/transform/missing-type cases, and the preview components have identity-default and opt-in-transform tests.

### Screenshots

**Selective style import — property graph (Gremlin).** Before/after cards with `<code>`/`<dist>` placeholders, "Not present" for unset properties, and the arrow centered across each node card.

<img width="900" alt="Selective style import modal on a Gremlin connection" src="https://github.com/user-attachments/assets/6a462b0c-50de-41a2-8a34-e1797cf1c5a6" />

**Selective style import — RDF (SPARQL).** Type names render as the file's raw IRIs, not folded through the active connection's prefixes — the import preview is connection-independent.

<img width="900" alt="Selective style import modal on a SPARQL connection showing raw IRIs" src="https://github.com/user-attachments/assets/dbb6e902-ec1c-4fe7-98cc-3ae4bbaf8694" />

**Node style dialog.** The preview shows the two-line badge — `airport` over the `<code>` display-name placeholder.

<img width="900" alt="Node style dialog preview with two-line type and placeholder label" src="https://github.com/user-attachments/assets/5d118b0d-eae2-4286-9fc1-65986fd4ea42" />

**Edge style dialog.** The preview labels the edge with the `<dist>` display-name placeholder.

<img width="900" alt="Edge style dialog preview with display-name placeholder" src="https://github.com/user-attachments/assets/cc8f8783-2b4e-4c91-a0cf-735b6f76b7d6" />

## How to read
1. [previewLabels.ts](https://github.com/aws/graph-explorer/pull/1993/files#diff-1828645503d92c2df7d523c4c89e79811e2e3f48f0bfa9fed95ccd7ff87d9afd) — start here; the label-derivation rules
2. [VertexPreview.tsx](https://github.com/aws/graph-explorer/pull/1993/files#diff-6cda72cfbe6e1c601d03d093fa81f6f74159512993cd2bde2a33da30413179f7) — two-line node badge + the optional `transform` prop
3. [EdgePreview.tsx](https://github.com/aws/graph-explorer/pull/1993/files#diff-824b802627e2e57149321c9df2de09e59d7da15590069bb8c1a55e88beb6a3b3) — edge label derives the same way
4. [ImportCard.tsx](https://github.com/aws/graph-explorer/pull/1993/files#diff-e9908e768292ffeead9f6f09c1acf431f6cb1a02ec3dc0ab5fcb713e27603dba) — "Not present" label

Call-site changes (the two style dialogs opt into the transform; the import cards drop the manual `label`) follow from the above.

## Related Issues

- Related to #1970
- Related to #1946

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
