### PR TITLE
Clean up release-review nits: logging seam and doc drift

### DIFF
--- a/docs/agents/product.md
+++ b/docs/agents/product.md
@@ -17,9 +17,9 @@ Graph Explorer is a React-based web application that enables users to visualize 
 ## Key Features
 
 - **Connections Management**: Create and manage database connections
-- **Graph Visualization**: Interactive graph view with search, custom queries, and styling
+- **Graph Visualization**: Interactive graph view with search, custom queries, and styles
 - **Tabular View**: Show/hide nodes and edges, export to CSV/JSON
-- **Data Explorer**: List all nodes and properties for a specific node type and send to graph view
+- **Data Table View**: List all nodes and properties for a specific node type and send to graph view
 - **Schema View**: View node types and their relationships as a graph
 - **Authentication**: AWS IAM authentication via SigV4 signing protocol
 
@@ -41,7 +41,7 @@ Graph Explorer is a React-based web application that enables users to visualize 
 
 ## Data Storage & Persistence
 
-- Client-side only — all user data and preferences are stored client-side; the backend proxy server stores nothing
+- Client-side only — all user data and styles are stored client-side; the backend proxy server stores nothing
 - IndexedDB via localforage is the primary storage mechanism
-- Persisted: user preferences and settings, connection configurations, query history, visualization settings, layout preferences
+- Persisted: user styles and settings, connection configurations, query history, visualization settings, layout preferences
 - Graph data is queried directly from the connected databases and is not owned or persisted by Graph Explorer

--- a/docs/features/graph-view.md
+++ b/docs/features/graph-view.md
@@ -74,14 +74,14 @@ Provides the ability to filter nodes or edges from the visualization by label (o
 
 ### Styles Panel
 
-The Styles panel holds node and edge styling behind two tabs: **Nodes** and **Edges**.
+The Styles panel holds node and edge styling behind two tabs: **Nodes** and **Edges**. As you edit a node or edge type, a live preview shows it exactly as it will appear on the canvas.
 
 On the **Nodes** tab, each node type can be customized in a variety of ways.
 
 - **Display label** allows you to change how the node label (or rdf:type) is represented
 - **Display name attribute** allows you to choose the attribute on the node that is used to uniquely label the node in the graph visualization and search
 - **Display description attribute** allows you to choose the attribute on the node that is used to describe the node in search
-- **Icon** can be picked from the built-in Lucide library via the **Browse** button, or uploaded as a custom SVG/raster image.
+- **Icon** can be searched or paged through in the built-in Lucide library via the **Browse** button, or uploaded as a custom SVG/raster image.
 - **Colors and borders** can be customized to visually distinguish from other node types
 
 On the **Edges** tab, each edge type can be customized in a variety of ways.

--- a/packages/graph-explorer/src/core/StateProvider/migrateUserStyling.ts
+++ b/packages/graph-explorer/src/core/StateProvider/migrateUserStyling.ts
@@ -103,8 +103,8 @@ function toTypeKeyedMap<T extends { type: VertexType | EdgeType }>(
   const map = new Map<T["type"], T>();
   for (const item of items) {
     if (map.has(item.type)) {
-      console.warn(
-        `[graph-explorer] Duplicate ${label} type "${item.type}" found in legacy user-styling data; keeping the last entry.`,
+      logger.warn(
+        `[user-styling-migration] Duplicate ${label} type "${item.type}" found in legacy user-styling data; keeping the last entry.`,
       );
     }
     map.set(item.type, item);


### PR DESCRIPTION
## Description

Cleanup nits surfaced by the post-v3.1.0 release review. No behavior change:

- **Logging seam** — route the user-styling migration's duplicate-type warning through `logger.warn` instead of a raw `console.warn`, matching the rest of the codebase.
- **Docs** — document the live style preview and the searchable/paged icon picker in `graph-view.md`; replace glossary-retired terms in `docs/agents/product.md` ("Data Explorer" → "Data Table View", "preferences/styling" → "styles").

## Validation

`pnpm checks` and the affected tests (`migrateUserStyling`, `saveConfigurationToFile`) pass. Changes are a one-line logging swap and doc wording — nothing runtime-visible to exercise.

## Related Issues

<!-- None; originated from the release review. -->

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
