### PR TITLE
Normalize connection URLs on the read path

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.test.ts
@@ -1,3 +1,5 @@
+import type { ConnectionConfig } from "@shared/types";
+
 import { createRandomName } from "@shared/utils/testing";
 import { createStore } from "jotai";
 
@@ -435,6 +437,28 @@ describe("normalizeConnection", () => {
     expect(result.graphDbUrl).toBe(
       "http://blazegraph:9999/blazegraph/namespace/kb",
     );
+  });
+
+  test("should yield an empty url when the url key is missing", () => {
+    // Persisted configs are not schema-validated on read, so a stored
+    // connection can lack `url` despite the compile-time required type.
+    const result = normalizeConnection({} as ConnectionConfig);
+    expect(result.url).toBe("");
+  });
+
+  test("should strip newlines and surrounding whitespace from url", () => {
+    const result = normalizeConnection({
+      url: "  https://example.com/\r\ngraph  ",
+    });
+    expect(result.url).toBe("https://example.com/graph");
+  });
+
+  test("should strip newlines and surrounding whitespace from graphDbUrl", () => {
+    const result = normalizeConnection({
+      url: "https://proxy.com",
+      graphDbUrl: "  https://db.com/\r\ngraph  ",
+    });
+    expect(result.graphDbUrl).toBe("https://db.com/graph");
   });
 });
 

--- a/packages/graph-explorer/src/core/StateProvider/configuration.ts
+++ b/packages/graph-explorer/src/core/StateProvider/configuration.ts
@@ -100,13 +100,27 @@ export function mergeConfiguration(
   };
 }
 
+/**
+ * Cleans a URL for storage and request use: strips newlines and surrounding
+ * whitespace (pasted from docs/chat), then the trailing slash. Tolerates a
+ * missing value because persisted configs are not schema-validated on read, so
+ * a stored connection can lack `url` despite the compile-time required type.
+ */
+export function normalizeUrl(url: string | undefined): string {
+  return (
+    url
+      ?.replace(/[\r\n]/g, "")
+      .trim()
+      .replace(/\/$/, "") ?? ""
+  );
+}
+
 export function normalizeConnection(connection: ConnectionConfig) {
   return {
     ...connection,
-    // Remove trailing slash
-    url: connection.url.replace(/\/$/, "") || "",
+    url: normalizeUrl(connection.url),
     queryEngine: connection.queryEngine || "gremlin",
-    graphDbUrl: connection.graphDbUrl?.replace(/\/$/, "") || "",
+    graphDbUrl: normalizeUrl(connection.graphDbUrl),
     proxyConnection:
       connection.proxyConnection ?? connection.graphDbUrl != null,
     awsAuthEnabled: connection.awsAuthEnabled ?? false,

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.test.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/components";
+
+import ConnectionDeleteButton from "./ConnectionDeleteButton";
+
+function renderButton(saveCopy: () => boolean) {
+  const deleteActiveConfig = vi.fn();
+  render(
+    <TooltipProvider>
+      <ConnectionDeleteButton
+        connectionName="Test Connection"
+        isSync={false}
+        deleteActiveConfig={deleteActiveConfig}
+        saveCopy={saveCopy}
+      />
+    </TooltipProvider>,
+  );
+  return deleteActiveConfig;
+}
+
+describe("ConnectionDeleteButton", () => {
+  it("deletes after saving a copy when the export succeeds", async () => {
+    const user = userEvent.setup();
+    const deleteActiveConfig = renderButton(() => true);
+
+    await user.click(screen.getByRole("button", { name: "Delete connection" }));
+    await user.click(
+      screen.getByRole("button", { name: "Save a Copy & Delete" }),
+    );
+
+    expect(deleteActiveConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not delete when the copy export is refused", async () => {
+    const user = userEvent.setup();
+    const deleteActiveConfig = renderButton(() => false);
+
+    await user.click(screen.getByRole("button", { name: "Delete connection" }));
+    await user.click(
+      screen.getByRole("button", { name: "Save a Copy & Delete" }),
+    );
+
+    expect(deleteActiveConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDeleteButton.tsx
@@ -23,13 +23,17 @@ export default function ConnectionDeleteButton({
   connectionName: string;
   isSync: boolean;
   deleteActiveConfig: () => void;
-  saveCopy: () => void;
+  saveCopy: () => boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
   const saveAndDelete = () => {
-    saveCopy();
-    deleteActiveConfig();
+    // Only delete once the backup copy is actually written; a refused export
+    // (e.g. a connection with no URL) already surfaced its own error, and
+    // deleting anyway would destroy the connection the copy was meant to save.
+    if (saveCopy()) {
+      deleteActiveConfig();
+    }
   };
 
   return (

--- a/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/ConnectionDetail.tsx
@@ -59,10 +59,10 @@ import { useCancelSchemaSync, useSchemaSync } from "@/hooks/useSchemaSync";
 import useTranslations from "@/hooks/useTranslations";
 import CreateConnection from "@/modules/CreateConnection";
 import { formatDate, formatRelativeDate, LABELS, logger } from "@/utils";
-import saveConfigurationToFile from "@/utils/saveConfigurationToFile";
 
 import ConnectionData from "./ConnectionData";
 import ConnectionDeleteButton from "./ConnectionDeleteButton";
+import { exportConnectionWithFeedback } from "./exportConnection";
 import {
   InfoBar,
   InfoItem,
@@ -82,7 +82,7 @@ function ConnectionDetail({ config }: ConnectionDetailProps) {
 
   const { isFetching } = useSchemaSync();
 
-  const onConfigExport = () => saveConfigurationToFile(config);
+  const onConfigExport = () => exportConnectionWithFeedback(config);
 
   const deleteActiveConfig = useDeleteActiveConfiguration();
 

--- a/packages/graph-explorer/src/modules/ConnectionDetail/exportConnection.test.ts
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/exportConnection.test.ts
@@ -1,0 +1,59 @@
+import * as fileSaver from "file-saver";
+import { toast } from "sonner";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ConfigurationContextProps } from "@/core";
+
+import { createRandomRawConfiguration } from "@/utils/testing/randomData";
+
+import { exportConnectionWithFeedback } from "./exportConnection";
+
+vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+
+const saveAsMock = vi.mocked(fileSaver.saveAs);
+const toastErrorMock = vi.mocked(toast.error);
+
+function makeConfig(
+  connection: ConfigurationContextProps["connection"],
+): ConfigurationContextProps {
+  return {
+    ...createRandomRawConfiguration(),
+    connection,
+    schema: { vertices: [], edges: [] },
+    totalVertices: 0,
+    vertexTypes: [],
+    totalEdges: 0,
+    edgeTypes: [],
+  };
+}
+
+describe("exportConnectionWithFeedback", () => {
+  it("exports a connection that has a url and reports success", () => {
+    const exported = exportConnectionWithFeedback(
+      makeConfig({ url: "https://example.com", queryEngine: "gremlin" }),
+    );
+
+    expect(exported).toBe(true);
+    expect(saveAsMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("reports failure and does not export when the url is only whitespace", () => {
+    const exported = exportConnectionWithFeedback(
+      makeConfig({ url: "  \r\n  ", queryEngine: "gremlin" }),
+    );
+
+    expect(exported).toBe(false);
+    expect(saveAsMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports failure and does not export when there is no connection", () => {
+    const exported = exportConnectionWithFeedback(makeConfig(undefined));
+
+    expect(exported).toBe(false);
+    expect(saveAsMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/graph-explorer/src/modules/ConnectionDetail/exportConnection.ts
+++ b/packages/graph-explorer/src/modules/ConnectionDetail/exportConnection.ts
@@ -1,0 +1,26 @@
+import { toast } from "sonner";
+
+import { type ConfigurationContextProps, normalizeUrl } from "@/core";
+import saveConfigurationToFile from "@/utils/saveConfigurationToFile";
+
+/**
+ * Exports a connection to a file, surfacing a toast when the connection has no
+ * usable URL. A URL-less config produces a file that fails its own import
+ * validation, so the export is refused with feedback rather than silently
+ * writing a broken file. Returns whether the file was written, so callers that
+ * chain a destructive action (e.g. save-a-copy-then-delete) can skip it when
+ * the copy was refused.
+ */
+export function exportConnectionWithFeedback(
+  config: ConfigurationContextProps,
+): boolean {
+  if (!normalizeUrl(config.connection?.url)) {
+    toast.error("Cannot Export Connection", {
+      description: "This connection has no URL to export",
+    });
+    return false;
+  }
+
+  saveConfigurationToFile(config);
+  return true;
+}

--- a/packages/graph-explorer/src/utils/saveConfigurationToFile.test.ts
+++ b/packages/graph-explorer/src/utils/saveConfigurationToFile.test.ts
@@ -240,6 +240,71 @@ describe("saveConfigurationToFile", () => {
     expect(parseConnectionFile(parsed)).toBeNull();
   });
 
+  it("should strip whitespace and newlines from the exported url", async () => {
+    const config = makeConfig({
+      connection: {
+        url: "  https://neptune.example.com:8182/\r\n  ",
+        queryEngine: "gremlin",
+      },
+    });
+
+    saveConfigurationToFile(config);
+
+    const [blob] = saveAsMock.mock.calls[0];
+    const parsed = JSON.parse(await (blob as Blob).text());
+
+    expect(parsed.connection.url).toBe("https://neptune.example.com:8182");
+    // The cleaned file must survive its own import validation.
+    expect(parseConnectionFile(parsed)?.connection.url).toBe(
+      "https://neptune.example.com:8182",
+    );
+  });
+
+  it("should not add a graphDbUrl to a non-proxy exported connection", async () => {
+    // Production configs reach the writer already normalized, where a non-proxy
+    // connection carries graphDbUrl: "" (never undefined). The writer must not
+    // re-emit that empty string.
+    const config = makeConfig({
+      connection: {
+        url: "https://example.com",
+        queryEngine: "gremlin",
+        graphDbUrl: "",
+      },
+    });
+
+    saveConfigurationToFile(config);
+
+    const [blob] = saveAsMock.mock.calls[0];
+    const parsed = JSON.parse(await (blob as Blob).text());
+
+    // An empty-string graphDbUrl would fail import validation (z.url), so a
+    // connection without one must omit the key rather than emit "".
+    expect(parsed.connection.graphDbUrl).toBeUndefined();
+    expect(parseConnectionFile(parsed)).not.toBeNull();
+  });
+
+  it("should keep and clean a proxy graphDbUrl", async () => {
+    const config = makeConfig({
+      connection: {
+        url: "https://proxy.example.com",
+        queryEngine: "gremlin",
+        graphDbUrl: "  https://neptune.example.com:8182/\r\n  ",
+      },
+    });
+
+    saveConfigurationToFile(config);
+
+    const [blob] = saveAsMock.mock.calls[0];
+    const parsed = JSON.parse(await (blob as Blob).text());
+
+    expect(parsed.connection.graphDbUrl).toBe(
+      "https://neptune.example.com:8182",
+    );
+    expect(parseConnectionFile(parsed)?.connection.graphDbUrl).toBe(
+      "https://neptune.example.com:8182",
+    );
+  });
+
   it("should only export necessary fields", async () => {
     const config = makeConfig({
       totalVertices: 100,

--- a/packages/graph-explorer/src/utils/saveConfigurationToFile.ts
+++ b/packages/graph-explorer/src/utils/saveConfigurationToFile.ts
@@ -1,19 +1,24 @@
 import { saveAs } from "file-saver";
 
-import type { ConfigurationContextProps } from "@/core";
+import { type ConfigurationContextProps, normalizeUrl } from "@/core";
 
 import type { ExportedConnectionFile } from "./parseConnectionFile";
 
 import { toJsonFileData } from "./fileData";
 
 const saveConfigurationToFile = (config: ConfigurationContextProps) => {
+  const { graphDbUrl, ...connection } = config.connection ?? {};
+  const normalizedGraphDbUrl = normalizeUrl(graphDbUrl);
   const exportableConfig: ExportedConnectionFile = {
     id: config.id,
     displayLabel: config.displayLabel || config.id,
     connection: {
-      ...config.connection,
-      url: config.connection?.url ?? "",
+      ...connection,
+      url: normalizeUrl(config.connection?.url),
       queryEngine: config.connection?.queryEngine || "gremlin",
+      // Omit an empty graphDbUrl entirely; a present "" fails import validation.
+      // Normalized non-proxy configs carry "", so guard on the cleaned value.
+      ...(normalizedGraphDbUrl && { graphDbUrl: normalizedGraphDbUrl }),
     },
     schema: {
       vertices: config.schema.vertices,


### PR DESCRIPTION
## Description

Follow-up to #1982, which trimmed URL whitespace only on connection-form submit — that never repairs connections already persisted with bad data. This normalizes at the **read path** instead, so existing connections work without being re-saved.

- `normalizeConnection` now strips newlines and surrounding whitespace (in addition to the existing trailing-slash) from `url` and `graphDbUrl`. Because it feeds every request and the `graph-db-connection-url` proxy header, existing bad data is repaired on read.
- `normalizeConnection` also tolerates a missing `url` key. Persisted configs are not schema-validated on read, so a stored connection can lack `url` despite the compile-time required type; previously this crashed the connection view app-wide via `undefined.replace`.
- Exported connection files clean the `url` too and omit an empty `graphDbUrl`, so a non-proxy export survives its own import validation.
- Export is refused with a toast when a connection has no usable URL, and "Save a Copy & Delete" now deletes only when the backup copy was actually written (previously it deleted regardless, losing the connection with no copy).

Out of scope, by design: the connection form (`CreateConnection.tsx`, being reworked separately), any IndexedDB migration, and Zod-on-read for stored configs.

## Validation

- `pnpm checks` and full `pnpm test` pass (all suites green).
- New tests cover: whitespace/newline stripping and missing-`url` tolerance in `normalizeConnection`; clean re-importable export for both non-proxy (`graphDbUrl` omitted) and proxy connections; export-refused toast; and delete-skipped-when-refused in the save-a-copy flow.

## How to read
1. [configuration.ts](https://github.com/aws/graph-explorer/pull/1998/files#diff-27c64af06537bc612ce14025383d6b010cb5d6b875c47d905e25b0ca0f408e33) — the core change: new `normalizeUrl` helper and its use in `normalizeConnection`
2. [saveConfigurationToFile.ts](https://github.com/aws/graph-explorer/pull/1998/files#diff-7397b9f9f987a506209fe7c9b6076fa47da67be8ce180b47c6596ac3b24590c8) — export cleaning + empty-`graphDbUrl` omission
3. [exportConnection.ts](https://github.com/aws/graph-explorer/pull/1998/files#diff-ae9e53ebf70224fe9327596ce79ca6e2e67b572fc6608600100749421c086528) — new guarded export helper returning success
4. [ConnectionDeleteButton.tsx](https://github.com/aws/graph-explorer/pull/1998/files#diff-a3bacc8896aab78b44ea35379dab89176d932e1f715e3856e7919bee5e4be3f4) — gate the delete on a successful copy

## Related Issues

- Closes #1978
- Related to #1982

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
