### PR TITLE
Use Tailwind IntelliSense for CSS files in Zed

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -16,5 +16,13 @@
         "classFunctions": ["cva", "cn"]
       }
     }
+  },
+  "languages": {
+    "CSS": {
+      "language_servers": [
+        "tailwindcss-intellisense-css",
+        "!vscode-css-language-server"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Description

Configures Zed to use the Tailwind IntelliSense language server for CSS files (and disables the default VS Code CSS language server for them). Without this, Zed's CSS server flags Tailwind v4 at-rules (`@theme`, `@utility`, `@custom-variant`) in `index.css` as unknown. Editor-only config; no runtime or build impact.

## Validation

- Tailwind v4 at-rules in `packages/graph-explorer/src/index.css` no longer report as errors in Zed; class completions work in CSS.

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
