### PR TITLE
Add initiative, kickoff, and wayfinder planning vocabulary

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -50,7 +50,7 @@ An _optional_ placeholder child issue under an Initiative, used when there's no 
 _Avoid_: Spark, prospect, stub, discovery
 
 **Wayfinder**:
-`/wayfinder` — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Run against an Initiative — either directly, or later off a Kickoff placeholder — it creates a `wayfinder:map` issue as a sibling child under the Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
+The exercise (invoked with `/wayfinder`) that plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Run against an Initiative — either directly, or later off a Kickoff placeholder — it creates a `wayfinder:map` issue as a sibling child under the Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
 
 ## Pull requests
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -46,11 +46,11 @@ A body of work too big for one release, expressing a vision (e.g. overhauling th
 _Avoid_: Roadmap item (higher-level), theme
 
 **Kickoff**:
-The first child issue under an Initiative — the trackable spike whose job is to scope the still-vague initiative. Always typed **Spike**, parented to its Initiative, and labelled `wayfinder:kickoff`. It _contains_ a [Wayfinder](#wayfinder) session: running Wayfinder charts the map on this same issue, so it also carries `wayfinder:map`, and the kickoff is done once the Wayfinder route is clear. Its deliverable is the scoping; completing it turns a vague Initiative into planned work (features and epics as further children, siblings to the kickoff).
+The first child issue under an Initiative — the placeholder that flags the initiative has been picked up for scoping. Always typed **Spike**, parented to its Initiative, and labelled `wayfinder:kickoff`. A thin trigger: it closes once a [Wayfinder](#wayfinder) session spins up the map, handing the scoping lifecycle off to that map. It does not own the scoping itself.
 _Avoid_: Spark, prospect, stub, discovery
 
 **Wayfinder**:
-The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Runs inside a Kickoff; the Kickoff issue _is_ the `wayfinder:map`.
+The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Started from a Kickoff; it creates a `wayfinder:map` issue as a sibling child under the same Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
 
 ## Pull requests
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -37,6 +37,21 @@ When a skill says "publish to the issue tracker", create a GitHub issue. When it
 
 To change these on an existing issue, use `gh issue edit <number>` — note the flag names differ from create: `--parent <n>` / `--remove-parent`, `--add-blocked-by <n>` / `--remove-blocked-by <n>`, `--add-blocking <n>` / `--remove-blocking <n>`, and `--add-sub-issue <n>` / `--remove-sub-issue <n>`.
 
+## Planning vocabulary
+
+Terms for the pre-build planning hierarchy on the project board. All map onto the native GitHub issue types above.
+
+**Initiative**:
+A body of work too big for one release, expressing a vision (e.g. overhauling the style system). Always typed **Epic**. It is a never-tracked container — the board tracks its children, not the initiative itself — and it parents the features and epics that eventually deliver the vision. Sits below a Roadmap Item in scope and _may_ be flagged as one, but never requires it.
+_Avoid_: Roadmap item (higher-level), theme
+
+**Kickoff**:
+The first child issue under an Initiative — the trackable spike whose job is to scope the still-vague initiative. Always typed **Spike**, parented to its Initiative, and labelled `wayfinder:kickoff`. It _contains_ a [Wayfinder](#wayfinder) session: running Wayfinder charts the map on this same issue, so it also carries `wayfinder:map`, and the kickoff is done once the Wayfinder route is clear. Its deliverable is the scoping; completing it turns a vague Initiative into planned work (features and epics as further children, siblings to the kickoff).
+_Avoid_: Spark, prospect, stub, discovery
+
+**Wayfinder**:
+The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Runs inside a Kickoff; the Kickoff issue _is_ the `wayfinder:map`.
+
 ## Pull requests
 
 - Always publish as a draft, and set up remote tracking when publishing a branch

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -46,11 +46,11 @@ A body of work too big for one release, expressing a vision (e.g. overhauling th
 _Avoid_: Roadmap item (higher-level), theme
 
 **Kickoff**:
-The first child issue under an Initiative — the placeholder that flags the initiative has been picked up for scoping. Always typed **Spike**, parented to its Initiative, and labelled `wayfinder:kickoff`. A thin trigger: it closes once a [Wayfinder](#wayfinder) session spins up the map, handing the scoping lifecycle off to that map. It does not own the scoping itself.
+An _optional_ placeholder child issue under an Initiative, used when there's no time to run the [Wayfinder](#wayfinder) exercise immediately — it flags that the initiative is awaiting scoping. Always typed **Spike**, parented to its Initiative, and labelled `wayfinder:kickoff`. A thin trigger: it closes once a Wayfinder session spins up the map, handing the scoping lifecycle off to that map. It does not own the scoping itself, and is skipped entirely when Wayfinder is run straight away.
 _Avoid_: Spark, prospect, stub, discovery
 
 **Wayfinder**:
-The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Started from a Kickoff; it creates a `wayfinder:map` issue as a sibling child under the same Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
+The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Run against an Initiative — either directly, or later off a Kickoff placeholder — it creates a `wayfinder:map` issue as a sibling child under the Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
 
 ## Pull requests
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -50,7 +50,7 @@ An _optional_ placeholder child issue under an Initiative, used when there's no 
 _Avoid_: Spark, prospect, stub, discovery
 
 **Wayfinder**:
-The `/wayfinder` skill (`~/.claude/skills/wayfinder`) — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Run against an Initiative — either directly, or later off a Kickoff placeholder — it creates a `wayfinder:map` issue as a sibling child under the Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
+`/wayfinder` — plans a chunk of work too big for one agent session as a shared map of investigation tickets on the issue tracker, resolved one at a time until the route to the destination is clear. Run against an Initiative — either directly, or later off a Kickoff placeholder — it creates a `wayfinder:map` issue as a sibling child under the Initiative, which then owns the scoping route until features and epics can be landed under the Initiative.
 
 ## Pull requests
 


### PR DESCRIPTION
## Description

Adds three planning terms to `docs/agents/issue-tracker.md` so agents share a vocabulary for pre-build scoping work on the project board:

- **Initiative** — a vision-scale body of work, always typed **Epic**; a never-tracked container that parents the features and epics that deliver it. Below a roadmap item in scope, optionally flagged as one.
- **Kickoff** — an _optional_ placeholder child (**Spike**, `wayfinder:kickoff`) flagging an initiative is awaiting scoping; a thin trigger that closes once a Wayfinder map is created. Skipped when Wayfinder runs immediately.
- **Wayfinder** — the `/wayfinder` exercise that charts the scoping map; run against an initiative it creates a `wayfinder:map` sibling that owns the scoping route.

Also creates the `wayfinder:kickoff` GitHub label.

The entries follow the `CONTEXT.md` glossary style (term / definition / _Avoid_) and are grounded in the native GitHub issue types already documented in this file (Epic, Spike).

## Validation

Docs-only change. `pnpm check:format` passes.

## Related Issues

- Related to #2003

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
