### PR TITLE
Add Query Fragment modules for each query language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,6 +35,10 @@ _Avoid_: Seed connection
 The graph query protocol a Connection uses — one of Gremlin, openCypher, or SPARQL. Determines which Explorer is instantiated and implies the graph type (Gremlin/openCypher → property graph, SPARQL → RDF).
 _Avoid_: Query engine (internal code name `queryEngine`, but UI says "Query Language")
 
+**Query Fragment**:
+A piece of query text that carries its own delimiters, so a template interpolating it never writes quotes around it. Every value reaching a query — a string literal, an identifier such as a Property key or type label, or an IRI — becomes a Query Fragment first. Each Query Language has its own fragments; one language's fragment is not valid in another.
+_Avoid_: Query Parameter Value (implies parameterization, which no supported backend offers for identifiers), Query Literal (an identifier is not a literal), Fragment (unqualified — the connector code already calls a Vertex or Edge returned without its attributes a "fragment", which is a result rather than query text)
+
 **Vertex Type**:
 A classification of vertices. The schema, styling, filtering, and exploration all operate at the type level. UI label varies by query language: "Node Label" (Gremlin/openCypher), "Class" (SPARQL).
 

--- a/docs/agents/connectors.md
+++ b/docs/agents/connectors.md
@@ -16,5 +16,8 @@
 
 ## Database Queries
 
-- Use the `query` template tag from `@/utils` for all query strings (Gremlin, openCypher, SPARQL) to ensure consistent formatting
-- For Gremlin queries, use `escapeString()` from `@/utils` to escape special characters in string literals
+- Use the `query` template tag from `@/utils` for all query strings (Gremlin, openCypher, SPARQL) to ensure consistent formatting. Note the tag only formats — it does not escape anything.
+- Interpolate values into a query only as Query Fragments, from that language's `fragments.ts`. A fragment brings its own delimiters, so the template must not add quotes, backticks, or angle brackets around it.
+- Each `fragments.ts` exports one `fragment` object: import it as `import { fragment } from "./fragments"` and call `fragment.string(...)`, `fragment.identifier(...)`, `fragment.id(...)` (Gremlin/openCypher) or `fragment.iri(...)` (SPARQL). Keep the `fragment.` qualifier at call sites — don't destructure — so the self-delimiting invariant stays visible.
+- Fragments are per language and not interchangeable, even where two languages look alike
+- `escapeString()` is the predecessor to the fragment modules and is on its way out; do not add callers

--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -1,0 +1,53 @@
+import { createEdgeId, createVertexId } from "@/core";
+
+import { fragment } from "./fragments";
+
+describe("fragment.string", () => {
+  it("should wrap the value in double quotes", () => {
+    expect(fragment.string("test")).toEqual('"test"');
+  });
+
+  it("should preserve surrounding whitespace", () => {
+    expect(fragment.string(" te st ")).toEqual('" te st "');
+  });
+
+  it("should produce an empty literal for an empty string", () => {
+    expect(fragment.string("")).toEqual('""');
+  });
+
+  it("should escape a double quote", () => {
+    expect(fragment.string('te"st')).toEqual('"te\\"st"');
+  });
+
+  it("should leave a single quote alone, since it needs no escaping", () => {
+    expect(fragment.string("t'est")).toEqual('"t\'est"');
+  });
+});
+
+describe("fragment.identifier", () => {
+  it("should wrap the name in double quotes", () => {
+    expect(fragment.identifier("city")).toEqual('"city"');
+  });
+
+  it("should preserve spaces in the name", () => {
+    expect(fragment.identifier("home city")).toEqual('"home city"');
+  });
+
+  it("should escape a double quote", () => {
+    expect(fragment.identifier('ci"ty')).toEqual('"ci\\"ty"');
+  });
+});
+
+describe("fragment.id", () => {
+  it("should wrap a string ID in double quotes", () => {
+    expect(fragment.id(createVertexId("124"))).toEqual('"124"');
+  });
+
+  it("should accept an edge ID", () => {
+    expect(fragment.id(createEdgeId("e1"))).toEqual('"e1"');
+  });
+
+  it("should add the long suffix to a numeric ID", () => {
+    expect(fragment.id(createVertexId(124))).toEqual("124L");
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -1,0 +1,51 @@
+import { type EdgeId, getRawId, type VertexId } from "@/core";
+
+import { type QueryFragment, toQueryFragment } from "../queryFragment";
+
+/*
+ * Constructs Query Fragments for Gremlin. A fragment is safe to interpolate
+ * without the template adding delimiters of its own.
+ *
+ * These constructors are intentionally per-language rather than shared, even
+ * where two languages currently coincide: the delimiters, escaping, and ID
+ * rules diverge (openCypher delimits identifiers with backticks, SPARQL has
+ * IRIs and no identifiers, Gremlin suffixes numeric IDs with L).
+ *
+ * Exported as a single object so call sites always read `fragment.string(…)`,
+ * `fragment.identifier(…)`, etc. The qualifier keeps the invariant visible: the
+ * returned text already carries its delimiters, so the template must not add
+ * its own.
+ */
+
+function escape(value: string): string {
+  return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
+}
+
+export const fragment = {
+  /** A Gremlin string literal, including the surrounding double quotes. */
+  string(value: string): QueryFragment {
+    return toQueryFragment(`"${escape(value)}"`);
+  },
+
+  /**
+   * A property key or label. Gremlin takes these as string literals, so they
+   * use the same delimiters and escaping as any other literal.
+   *
+   * Of the two behaviors present in the templates this replaces, this adopts
+   * the escaping one used by the edge connections template.
+   */
+  identifier(name: string): QueryFragment {
+    return toQueryFragment(`"${escape(name)}"`);
+  },
+
+  /**
+   * An entity ID. A numeric ID takes the Gremlin long suffix and therefore
+   * needs no delimiters.
+   */
+  id(entityId: VertexId | EdgeId): QueryFragment {
+    const rawId = getRawId(entityId);
+    return toQueryFragment(
+      typeof rawId === "number" ? `${rawId}L` : `"${rawId}"`,
+    );
+  },
+};

--- a/packages/graph-explorer/src/connector/gremlin/idParam.ts
+++ b/packages/graph-explorer/src/connector/gremlin/idParam.ts
@@ -1,6 +1,10 @@
 import { type EdgeId, getRawId, type VertexId } from "@/core";
 
-/** Formats the ID parameter for a gremlin query based on the ID type. */
+/**
+ * Formats the ID parameter for a gremlin query based on the ID type.
+ *
+ * @deprecated Use the fragment constructors in `./fragments` instead.
+ */
 export function idParam(entityId: VertexId | EdgeId) {
   const rawId = getRawId(entityId);
   return typeof rawId === "number" ? `${rawId}L` : `"${rawId}"`;

--- a/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
@@ -1,0 +1,51 @@
+import { createEdgeId, createVertexId } from "@/core";
+
+import { fragment } from "./fragments";
+
+describe("fragment.string", () => {
+  it("should wrap the value in double quotes", () => {
+    expect(fragment.string("test")).toEqual('"test"');
+  });
+
+  it("should preserve surrounding whitespace", () => {
+    expect(fragment.string(" te st ")).toEqual('" te st "');
+  });
+
+  it("should produce an empty literal for an empty string", () => {
+    expect(fragment.string("")).toEqual('""');
+  });
+
+  it("should escape a double quote", () => {
+    expect(fragment.string('te"st')).toEqual('"te\\"st"');
+  });
+
+  it("should leave a single quote alone, since it needs no escaping", () => {
+    expect(fragment.string("t'est")).toEqual('"t\'est"');
+  });
+});
+
+describe("fragment.identifier", () => {
+  it("should wrap the name in backticks", () => {
+    expect(fragment.identifier("airport")).toEqual("`airport`");
+  });
+
+  it("should preserve spaces in the name", () => {
+    expect(fragment.identifier("home airport")).toEqual("`home airport`");
+  });
+});
+
+describe("fragment.id", () => {
+  it("should wrap a string ID in double quotes", () => {
+    expect(fragment.id(createVertexId("124"))).toEqual('"124"');
+  });
+
+  it("should accept an edge ID", () => {
+    expect(fragment.id(createEdgeId("e1"))).toEqual('"e1"');
+  });
+
+  it("should throw for a numeric ID, which openCypher does not support", () => {
+    expect(() => fragment.id(createVertexId(124))).toThrow(
+      "Invalid ID type: number",
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/openCypher/fragments.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.ts
@@ -1,0 +1,50 @@
+import { type EdgeId, getRawId, type VertexId } from "@/core";
+
+import { type QueryFragment, toQueryFragment } from "../queryFragment";
+
+/*
+ * Constructs Query Fragments for openCypher. A fragment is safe to interpolate
+ * without the template adding delimiters of its own.
+ *
+ * These constructors are intentionally per-language rather than shared, even
+ * where two languages currently coincide: the delimiters, escaping, and ID
+ * rules diverge (openCypher delimits identifiers with backticks, SPARQL has
+ * IRIs and no identifiers, Gremlin suffixes numeric IDs with L).
+ *
+ * Exported as a single object so call sites always read `fragment.string(…)`,
+ * `fragment.identifier(…)`, etc. The qualifier keeps the invariant visible: the
+ * returned text already carries its delimiters, so the template must not add
+ * its own.
+ */
+
+function escape(value: string): string {
+  return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
+}
+
+export const fragment = {
+  /** An openCypher string literal, including the surrounding double quotes. */
+  string(value: string): QueryFragment {
+    return toQueryFragment(`"${escape(value)}"`);
+  },
+
+  /**
+   * A property key or label, delimited by backticks.
+   *
+   * Note this cannot yet replace the property accesses that interpolate a name
+   * with no delimiters at all (`v.${attr}`, `tgt.${name}`): adding backticks
+   * there changes the query text for every name, so those sites move with the
+   * rule corrections rather than with the migration.
+   */
+  identifier(name: string): QueryFragment {
+    return toQueryFragment(`\`${name}\``);
+  },
+
+  /** An entity ID. openCypher only supports string IDs. */
+  id(entityId: VertexId | EdgeId): QueryFragment {
+    const rawId = getRawId(entityId);
+    if (typeof rawId !== "string") {
+      throw new Error(`Invalid ID type: ${typeof rawId} (${String(rawId)})`);
+    }
+    return toQueryFragment(`"${rawId}"`);
+  },
+};

--- a/packages/graph-explorer/src/connector/openCypher/idParam.ts
+++ b/packages/graph-explorer/src/connector/openCypher/idParam.ts
@@ -1,6 +1,10 @@
 import { type EdgeId, getRawId, type VertexId } from "@/core";
 
-/** Formats the ID parameter for an openCypher query based on the ID type. */
+/**
+ * Formats the ID parameter for an openCypher query based on the ID type.
+ *
+ * @deprecated Use the fragment constructors in `./fragments` instead.
+ */
 export function idParam(id: VertexId | EdgeId) {
   const rawId = getRawId(id);
   if (typeof rawId !== "string") {

--- a/packages/graph-explorer/src/connector/queryFragment.ts
+++ b/packages/graph-explorer/src/connector/queryFragment.ts
@@ -1,0 +1,20 @@
+import type { Branded } from "@/utils";
+
+/**
+ * A piece of query text that a template can interpolate without adding
+ * delimiters of its own, because the fragment already carries whatever
+ * delimiters its position requires.
+ *
+ * Produced by the per-query-language fragment modules — see
+ * `src/connector/<query-language>/fragments.ts`. One language's fragment is not
+ * valid in another.
+ */
+export type QueryFragment = Branded<string, "QueryFragment">;
+
+/**
+ * Marks text as a Query Fragment. The single place a fragment is minted, so
+ * every construction path is auditable through the fragment modules.
+ */
+export function toQueryFragment(text: string): QueryFragment {
+  return text as QueryFragment;
+}

--- a/packages/graph-explorer/src/connector/sparql/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fragments.test.ts
@@ -1,0 +1,51 @@
+import { createEdgeId, createVertexId } from "@/core";
+
+import { fragment } from "./fragments";
+
+describe("fragment.string", () => {
+  it("should wrap the value in double quotes", () => {
+    expect(fragment.string("test")).toEqual('"test"');
+  });
+
+  it("should preserve surrounding whitespace", () => {
+    expect(fragment.string(" te st ")).toEqual('" te st "');
+  });
+
+  it("should produce an empty literal for an empty string", () => {
+    expect(fragment.string("")).toEqual('""');
+  });
+
+  it("should escape a double quote", () => {
+    expect(fragment.string('te"st')).toEqual('"te\\"st"');
+  });
+
+  it("should leave a single quote alone, since it needs no escaping", () => {
+    expect(fragment.string("t'est")).toEqual('"t\'est"');
+  });
+});
+
+describe("fragment.iri", () => {
+  it("should wrap the value in angle brackets", () => {
+    expect(fragment.iri("http://example.com/thing")).toEqual(
+      "<http://example.com/thing>",
+    );
+  });
+
+  it("should accept a vertex ID", () => {
+    expect(fragment.iri(createVertexId("http://example.com/thing"))).toEqual(
+      "<http://example.com/thing>",
+    );
+  });
+
+  it("should accept an edge ID", () => {
+    expect(fragment.iri(createEdgeId("http://example.com/e1"))).toEqual(
+      "<http://example.com/e1>",
+    );
+  });
+
+  it("should throw when the value is not a string, since an IRI is text", () => {
+    expect(() => fragment.iri(createVertexId(124))).toThrow(
+      "Invalid ID type: number",
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fragments.ts
+++ b/packages/graph-explorer/src/connector/sparql/fragments.ts
@@ -1,0 +1,42 @@
+import type { EdgeId, VertexId } from "@/core";
+
+import { type QueryFragment, toQueryFragment } from "../queryFragment";
+
+/*
+ * Constructs Query Fragments for SPARQL. A fragment is safe to interpolate
+ * without the template adding delimiters of its own.
+ *
+ * These constructors are intentionally per-language rather than shared, even
+ * where two languages currently coincide: the delimiters, escaping, and ID
+ * rules diverge (openCypher delimits identifiers with backticks, SPARQL has
+ * IRIs and no identifiers, Gremlin suffixes numeric IDs with L).
+ *
+ * SPARQL has no `identifier` constructor: RDF has no bare identifiers, so a
+ * predicate or class is an IRI. It has no `id` constructor either, because an
+ * entity ID is itself an IRI.
+ *
+ * Exported as a single object so call sites always read `fragment.string(…)`,
+ * `fragment.iri(…)`. The qualifier keeps the invariant visible: the returned
+ * text already carries its delimiters, so the template must not add its own.
+ */
+
+function escape(value: string): string {
+  return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
+}
+
+export const fragment = {
+  /** A SPARQL string literal, including the surrounding double quotes. */
+  string(value: string): QueryFragment {
+    return toQueryFragment(`"${escape(value)}"`);
+  },
+
+  /** An IRI reference, delimited by angle brackets. */
+  iri(value: VertexId | EdgeId | string): QueryFragment {
+    if (typeof value !== "string") {
+      throw new Error(
+        `Invalid ID type: ${typeof value} (${String(value)}), must be a URI`,
+      );
+    }
+    return toQueryFragment(`<${value}>`);
+  },
+};

--- a/packages/graph-explorer/src/connector/sparql/idParam.ts
+++ b/packages/graph-explorer/src/connector/sparql/idParam.ts
@@ -1,6 +1,10 @@
 import type { EdgeId, VertexId } from "@/core";
 
-/** Formats the ID parameter for a sparql query based on the ID type. */
+/**
+ * Formats the ID parameter for a sparql query based on the ID type.
+ *
+ * @deprecated Use the fragment constructors in `./fragments` instead.
+ */
 export function idParam(id: VertexId | EdgeId | string) {
   if (typeof id !== "string") {
     throw new Error("ID must be a URI");


### PR DESCRIPTION
## Description

Introduces a Query Fragment module for each query language (`gremlin`, `openCypher`, `sparql`) that constructs pieces of query text carrying their own delimiters, so templates will not need to write quotes, backticks, or angle brackets around interpolated values.

This is a purely additive first step — the modules exist and are fully tested, but nothing calls them yet. It relocates the delimiter-and-escaping responsibility that today lives scattered across ~20 templates (via `escapeString` and the three per-connector `idParam` helpers) into one place per language. Behavior is preserved exactly; migrating the templates onto these modules is separate follow-up work.

Each module exposes only the positions its language supports: Gremlin and openCypher get `stringLiteral`, `identifier`, and `id`; SPARQL gets `stringLiteral` and `iri` (RDF has no bare identifiers, and an entity ID is itself an IRI). Fragments are minted in one place, `connector/queryFragment.ts`, so every construction path is auditable. The old `escapeString` and `idParam` helpers are marked deprecated and will be removed as the templates migrate.

## How to read

1. [connector/queryFragment.ts](https://github.com/aws/graph-explorer/pull/2027/files#diff-b3c44237a969c9dd5b5165eaa53360161d312b9db8214308248da44db7c8567b) — the `QueryFragment` type and the single mint point
2. [connector/gremlin/fragments.ts](https://github.com/aws/graph-explorer/pull/2027/files#diff-1d089533c25397d7fa71d381aa6345baad8801c33bca2ac12c8e9121e2256124) — representative module; openCypher mirrors it
3. [connector/sparql/fragments.ts](https://github.com/aws/graph-explorer/pull/2027/files#diff-f0b80fabd10e05efa4dc35727ef0ffcde7228d9f789996d857a295b97dde3edb) — differs: `iri` instead of `identifier`/`id`
4. [docs/agents/connectors.md](https://github.com/aws/graph-explorer/pull/2027/files#diff-aa67cd30579825aed72a294739be26b064de612e061e5875d25d40fd5290cb1f) — guidance pointing new query code at the modules

## Validation

- `pnpm checks` passes (types, lint, format)
- `pnpm test` passes — 30 new tests across the three fragment modules, assertions chosen to remain stable as the escaping rules are refined later
- No existing template or test was modified; no production code path reaches the new modules yet

## Related Issues

- Related to #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
