### PR TITLE
Add query template characterization tests

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -1,0 +1,20 @@
+import { createEdgeType } from "@/core";
+import { normalizeWithNoSpace as normalize } from "@/utils/testing";
+
+import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
+
+describe("Gremlin > edgeConnectionsTemplate", () => {
+  it("should sample edges of the type and project the endpoint labels", () => {
+    const template = edgeConnectionsTemplate(createEdgeType("route"));
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.E().hasLabel("route").limit(10000)
+          .project('sourceType', 'targetType')
+          .by(outV().label())
+          .by(inV().label())
+          .dedup()
+      `),
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -193,14 +193,14 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
-  it("should split a namespaced vertex type on the '::' separator", () => {
+  it("should expand a Neptune multi-label type into separate labels on '::'", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      filterByVertexTypes: ["namespace::country"],
+      filterByVertexTypes: ["country::capital"],
     });
 
     expect(normalize(template)).toContain(
-      normalize('.both().hasLabel("namespace", "country").dedup()'),
+      normalize('.both().hasLabel("country", "capital").dedup()'),
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -192,4 +192,90 @@ describe("Gremlin > oneHopTemplate", () => {
       `),
     );
   });
+
+  it("should split a namespaced vertex type on the '::' separator", () => {
+    const template = oneHopTemplate({
+      vertexId: createVertexId("12"),
+      filterByVertexTypes: ["namespace::country"],
+    });
+
+    expect(normalize(template)).toContain(
+      normalize('.both().hasLabel("namespace", "country").dedup()'),
+    );
+  });
+
+  // Each criterion dataType and operator produces a distinct predicate fragment.
+  describe("filter criteria", () => {
+    function fragmentFor(criterion: {
+      name: string;
+      value: string | number;
+      operator: string;
+      dataType?: "Number" | "String" | "Date";
+    }) {
+      return normalize(
+        oneHopTemplate({
+          vertexId: createVertexId("12"),
+          filterCriteria: [criterion],
+        }),
+      );
+    }
+
+    it.each([
+      ["eq", 'has("longest",eq(10000))'],
+      ["==", 'has("longest",eq(10000))'],
+      ["gt", 'has("longest",gt(10000))'],
+      ["gte", 'has("longest",gte(10000))'],
+      ["lt", 'has("longest",lt(10000))'],
+      ["lte", 'has("longest",lte(10000))'],
+      ["neq", 'has("longest",neq(10000))'],
+    ])("renders a Number criterion with the %s operator", (operator, frag) => {
+      expect(
+        fragmentFor({
+          name: "longest",
+          value: 10000,
+          operator,
+          dataType: "Number",
+        }),
+      ).toContain(normalize(`and(${frag})`));
+    });
+
+    it.each([
+      ["eq", 'has("country","ES")'],
+      ["neq", 'has("country",neq("ES"))'],
+      ["like", 'has("country",containing("ES"))'],
+    ])("renders a String criterion with the %s operator", (operator, frag) => {
+      expect(
+        fragmentFor({
+          name: "country",
+          value: "ES",
+          operator,
+          dataType: "String",
+        }),
+      ).toContain(normalize(`and(${frag})`));
+    });
+
+    it("treats a criterion without a dataType as a String", () => {
+      expect(
+        fragmentFor({ name: "country", value: "ES", operator: "eq" }),
+      ).toContain(normalize('and(has("country","ES"))'));
+    });
+
+    it.each([
+      ["eq", 'has("created",eq(datetime(2020)))'],
+      ["gt", 'has("created",gt(datetime(2020)))'],
+      ["gte", 'has("created",gte(datetime(2020)))'],
+      ["lt", 'has("created",lt(datetime(2020)))'],
+      ["lte", 'has("created",lte(datetime(2020)))'],
+      ["neq", 'has("created",neq(datetime(2020)))'],
+    ])("renders a Date criterion with the %s operator", (operator, frag) => {
+      expect(
+        fragmentFor({
+          name: "created",
+          value: 2020,
+          operator,
+          dataType: "Date",
+        }),
+      ).toContain(normalize(`and(${frag})`));
+    });
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
@@ -1,0 +1,9 @@
+import vertexTypeCountTemplate from "./vertexTypeCountTemplate";
+
+describe("Gremlin > vertexTypeCountTemplate", () => {
+  it("should count the vertices with the given label", () => {
+    const template = vertexTypeCountTemplate("airport");
+
+    expect(template).toBe('g.V().hasLabel("airport").count()');
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -18,6 +18,26 @@ describe("Gremlin > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(normalize('g.V().hasLabel("airport")'));
   });
 
+  it("Should return a template for multiple vertex types", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["airport", "country"],
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().hasLabel("airport","country")'),
+    );
+  });
+
+  it("Should split a namespaced vertex type on the '::' separator", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ["namespace::airport"],
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().hasLabel("namespace","airport")'),
+    );
+  });
+
   it("Should return a template for searched attributes containing the search term", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -28,13 +28,13 @@ describe("Gremlin > keywordSearchTemplate", () => {
     );
   });
 
-  it("Should split a namespaced vertex type on the '::' separator", () => {
+  it("Should expand a Neptune multi-label type into separate labels on '::'", () => {
     const template = keywordSearchTemplate({
-      vertexTypes: ["namespace::airport"],
+      vertexTypes: ["country::capital"],
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("namespace","airport")'),
+      normalize('g.V().hasLabel("country","capital")'),
     );
   });
 

--- a/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -1,0 +1,17 @@
+import { createEdgeType } from "@/core";
+import { query } from "@/utils";
+
+import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
+
+describe("OpenCypher > edgeConnectionsTemplate", () => {
+  it("should sample edges of the type and return distinct endpoint labels", () => {
+    const template = edgeConnectionsTemplate(createEdgeType("route"));
+
+    expect(template).toBe(query`
+      MATCH (s)-[e:\`route\`]->(t)
+      WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
+      LIMIT 10000
+      RETURN DISTINCT sourceLabels, targetLabels
+    `);
+  });
+});

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -145,13 +145,13 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
-  it("should split namespaced vertex types on the '::' separator", () => {
+  it("should expand Neptune multi-label types into separate labels on '::'", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      filterByVertexTypes: ["ns::country", "ns::airport"],
+      filterByVertexTypes: ["country::capital", "city::town"],
     });
 
-    expect(template).toContain("(v:ns OR v:country OR v:ns OR v:airport)");
+    expect(template).toContain("(v:country OR v:capital OR v:city OR v:town)");
   });
 
   // Each criterion dataType and operator produces a distinct WHERE fragment.

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -132,16 +132,98 @@ describe("OpenCypher > oneHopTemplate", () => {
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e]-(tgt:airport) 
+        MATCH (v)-[e]-(tgt:airport)
         WHERE ID(v) = "124"
-        WITH DISTINCT v, tgt 
-        ORDER BY toInteger(ID(tgt)) 
+        WITH DISTINCT v, tgt
+        ORDER BY toInteger(ID(tgt))
         LIMIT 10
         MATCH (v)-[e]-(tgt)
-        RETURN 
-          collect(DISTINCT tgt) AS vObjects, 
-          collect(e) AS eObjects 
+        RETURN
+          collect(DISTINCT tgt) AS vObjects,
+          collect(e) AS eObjects
       `,
     );
+  });
+
+  it("should split namespaced vertex types on the '::' separator", () => {
+    const template = oneHopTemplate({
+      vertexId: createVertexId("12"),
+      filterByVertexTypes: ["ns::country", "ns::airport"],
+    });
+
+    expect(template).toContain("(v:ns OR v:country OR v:ns OR v:airport)");
+  });
+
+  // Each criterion dataType and operator produces a distinct WHERE fragment.
+  describe("filter criteria", () => {
+    function templateFor(criterion: {
+      name: string;
+      value: string | number;
+      operator: string;
+      dataType?: "Number" | "String" | "Date";
+    }) {
+      return oneHopTemplate({
+        vertexId: createVertexId("12"),
+        filterCriteria: [criterion],
+      });
+    }
+
+    it.each([
+      ["eq", "tgt.longest = 10000"],
+      ["==", "tgt.longest = 10000"],
+      ["gt", "tgt.longest > 10000"],
+      ["gte", "tgt.longest >= 10000"],
+      ["lt", "tgt.longest < 10000"],
+      ["lte", "tgt.longest <= 10000"],
+      ["neq", "tgt.longest <> 10000"],
+    ])("renders a Number criterion with the %s operator", (operator, frag) => {
+      expect(
+        templateFor({
+          name: "longest",
+          value: 10000,
+          operator,
+          dataType: "Number",
+        }),
+      ).toContain(frag);
+    });
+
+    it.each([
+      ["eq", 'tgt.country = "ES"'],
+      ["neq", 'tgt.country <> "ES"'],
+      ["like", 'tgt.country CONTAINS "ES"'],
+    ])("renders a String criterion with the %s operator", (operator, frag) => {
+      expect(
+        templateFor({
+          name: "country",
+          value: "ES",
+          operator,
+          dataType: "String",
+        }),
+      ).toContain(frag);
+    });
+
+    it("treats a criterion without a dataType as a String", () => {
+      expect(
+        templateFor({ name: "country", value: "ES", operator: "eq" }),
+      ).toContain('tgt.country = "ES"');
+    });
+
+    it.each([
+      ["eq", 'tgt.created = DateTime("2020")'],
+      ["gt", 'tgt.created > DateTime("2020")'],
+      ["gte", 'tgt.created >= DateTime("2020")'],
+      ["lt", 'tgt.created < DateTime("2020")'],
+      ["lte", 'tgt.created <= DateTime("2020")'],
+      ["neq", 'tgt.created <> DateTime("2020")'],
+    ])("renders a Date criterion with the %s operator", (operator, frag) => {
+      expect(
+        templateFor({
+          name: "created",
+          value: "2020",
+          operator,
+          dataType: "Date",
+        }),
+      ).toContain(frag);
+    });
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
@@ -1,0 +1,9 @@
+import vertexTypeCountTemplate from "./vertexTypeCountTemplate";
+
+describe("OpenCypher > vertexTypeCountTemplate", () => {
+  it("should count the vertices with the given label", () => {
+    const template = vertexTypeCountTemplate("airport");
+
+    expect(template).toBe("MATCH (v:`airport`) RETURN count(v) AS count");
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.test.ts
@@ -1,0 +1,29 @@
+import { createVertexId } from "@/core";
+import { normalizeWithNewlines as normalize } from "@/utils/testing";
+
+import oneHopNeighborsBlankNodesIdsTemplate from "./oneHopNeighborsBlankNodesIdsTemplate";
+
+describe("oneHopNeighborsBlankNodesIdsTemplate", () => {
+  it("should wrap the neighbor sub-query and select only blank nodes", () => {
+    const template = oneHopNeighborsBlankNodesIdsTemplate({
+      resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
+      limit: 10,
+    });
+
+    expect(normalize(template)).toContain(
+      normalize("SELECT DISTINCT (?neighbor AS ?bNode)"),
+    );
+    expect(normalize(template)).toContain(
+      normalize("SELECT DISTINCT ?neighbor"),
+    );
+    expect(normalize(template)).toContain(
+      normalize(
+        "BIND(<http://www.example.com/soccer/resource#EPL> AS ?resource)",
+      ),
+    );
+    expect(normalize(template)).toContain(normalize("LIMIT 10"));
+    expect(normalize(template)).toContain(
+      normalize("FILTER(isBlank(?neighbor))"),
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsBlankNodesIdsTemplate.test.ts
@@ -1,4 +1,5 @@
 import { createVertexId } from "@/core";
+import { query } from "@/utils";
 import { normalizeWithNewlines as normalize } from "@/utils/testing";
 
 import oneHopNeighborsBlankNodesIdsTemplate from "./oneHopNeighborsBlankNodesIdsTemplate";
@@ -10,20 +11,30 @@ describe("oneHopNeighborsBlankNodesIdsTemplate", () => {
       limit: 10,
     });
 
-    expect(normalize(template)).toContain(
-      normalize("SELECT DISTINCT (?neighbor AS ?bNode)"),
-    );
-    expect(normalize(template)).toContain(
-      normalize("SELECT DISTINCT ?neighbor"),
-    );
-    expect(normalize(template)).toContain(
-      normalize(
-        "BIND(<http://www.example.com/soccer/resource#EPL> AS ?resource)",
-      ),
-    );
-    expect(normalize(template)).toContain(normalize("LIMIT 10"));
-    expect(normalize(template)).toContain(
-      normalize("FILTER(isBlank(?neighbor))"),
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT (?neighbor AS ?bNode) {
+          {
+            SELECT DISTINCT ?neighbor
+            WHERE {
+              BIND(<http://www.example.com/soccer/resource#EPL> AS ?resource)
+              {
+                ?neighbor ?predicate ?resource .
+                OPTIONAL { ?neighbor a ?class } .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              }
+              UNION
+              {
+                ?resource ?predicate ?neighbor .
+                OPTIONAL { ?neighbor a ?class } .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+              }
+            }
+            LIMIT 10
+          }
+          FILTER(isBlank(?neighbor))
+        }
+      `),
     );
   });
 });

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -1,10 +1,22 @@
 import { createVertexId } from "@/core";
-import { query } from "@/utils";
+import { LABELS, query } from "@/utils";
 import { normalizeWithNewlines as normalize } from "@/utils/testing";
 
 import { oneHopNeighborsTemplate } from "./oneHopNeighborsTemplate";
 
 describe("oneHopNeighborsTemplate", () => {
+  it("should filter to subjects with no type when the missing-type class is requested", () => {
+    const template = oneHopNeighborsTemplate({
+      resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
+      subjectClasses: [LABELS.MISSING_TYPE],
+    });
+
+    expect(normalize(template)).toContain(
+      normalize("FILTER NOT EXISTS { ?subject a ?class }"),
+    );
+    expect(normalize(template)).not.toContain(normalize("FILTER (?class IN ("));
+  });
+
   it("should produce documentation example", () => {
     // This represents the filter criteria used in the example documentation
     const template = oneHopNeighborsTemplate({

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -11,10 +11,33 @@ describe("oneHopNeighborsTemplate", () => {
       subjectClasses: [LABELS.MISSING_TYPE],
     });
 
-    expect(normalize(template)).toContain(
-      normalize("FILTER NOT EXISTS { ?subject a ?class }"),
+    expect(normalize(template)).toEqual(
+      normalize(query`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            SELECT DISTINCT ?neighbor
+            WHERE {
+              BIND(<http://www.example.com/soccer/resource#EPL> AS ?resource)
+              {
+                ?neighbor ?predicate ?resource .
+                OPTIONAL { ?neighbor a ?class } .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+                FILTER NOT EXISTS { ?subject a ?class }
+              }
+              UNION
+              {
+                ?resource ?predicate ?neighbor .
+                OPTIONAL { ?neighbor a ?class } .
+                FILTER(!isLiteral(?neighbor) && ?predicate != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+                FILTER NOT EXISTS { ?subject a ?class }
+              }
+            }
+          }
+          ${commonPartOfQuery("http://www.example.com/soccer/resource#EPL")}
+        }
+      `),
     );
-    expect(normalize(template)).not.toContain(normalize("FILTER (?class IN ("));
   });
 
   it("should produce documentation example", () => {

--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.test.ts
@@ -1,0 +1,29 @@
+import { createVertexType } from "@/core";
+import { query } from "@/utils";
+
+import predicatesByClassTemplate from "./predicatesByClassTemplate";
+
+describe("SPARQL > predicatesByClassTemplate", () => {
+  it("should select literal predicates for a sample subject of the class", () => {
+    const template = predicatesByClassTemplate({
+      class: createVertexType("http://example.org/Airport"),
+    });
+
+    expect(template).toBe(query`
+      # Return all predicates which are connected from the given class
+      SELECT ?pred (SAMPLE(?object) as ?sample)
+      WHERE {
+        {
+          SELECT ?subject
+          WHERE {
+            ?subject a <http://example.org/Airport>.
+          }
+          LIMIT 1
+        }
+        ?subject ?pred ?object.
+        FILTER(!isBlank(?object) && isLiteral(?object))
+      }
+      GROUP BY ?pred
+    `);
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchVertexCountsByType/classWithCountsTemplates.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchVertexCountsByType/classWithCountsTemplates.test.ts
@@ -1,0 +1,16 @@
+import { query } from "@/utils";
+
+import classWithCountsTemplates from "./classWithCountsTemplates";
+
+describe("SPARQL > classWithCountsTemplates", () => {
+  it("should count the instances of the given class", () => {
+    const template = classWithCountsTemplates("http://example.org/Airport");
+
+    expect(template).toBe(query`
+      # Fetch the number of instances of the given class
+      SELECT (COUNT(?start) AS ?instancesCount) {
+        ?start a <http://example.org/Airport>
+      }
+    `);
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.test.ts
@@ -1,0 +1,34 @@
+import { normalize } from "@/utils/testing";
+
+import keywordSearchBlankNodesIdsTemplate from "./keywordSearchBlankNodesIdsTemplate";
+
+describe("SPARQL > keywordSearchBlankNodesIdsTemplate", () => {
+  it("should wrap the subject sub-query and select only blank nodes", () => {
+    const template = keywordSearchBlankNodesIdsTemplate({
+      subjectClasses: ["air:airport"],
+      searchTerm: "JFK",
+      predicates: ["air:city"],
+      limit: 10,
+    });
+
+    expect(normalize(template)).toContain(
+      normalize("SELECT DISTINCT (?subject as ?bNode)"),
+    );
+    expect(normalize(template)).toContain(
+      normalize("SELECT DISTINCT ?subject"),
+    );
+    expect(normalize(template)).toContain(
+      normalize("FILTER (?pValue IN (<air:city>))"),
+    );
+    expect(normalize(template)).toContain(
+      normalize("FILTER (?class IN (<air:airport>))"),
+    );
+    expect(normalize(template)).toContain(
+      normalize('FILTER (regex(str(?value), "JFK", "i"))'),
+    );
+    expect(normalize(template)).toContain(normalize("LIMIT 10"));
+    expect(normalize(template)).toContain(
+      normalize("FILTER(isBlank(?subject))"),
+    );
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchBlankNodesIdsTemplate.test.ts
@@ -11,24 +11,25 @@ describe("SPARQL > keywordSearchBlankNodesIdsTemplate", () => {
       limit: 10,
     });
 
-    expect(normalize(template)).toContain(
-      normalize("SELECT DISTINCT (?subject as ?bNode)"),
-    );
-    expect(normalize(template)).toContain(
-      normalize("SELECT DISTINCT ?subject"),
-    );
-    expect(normalize(template)).toContain(
-      normalize("FILTER (?pValue IN (<air:city>))"),
-    );
-    expect(normalize(template)).toContain(
-      normalize("FILTER (?class IN (<air:airport>))"),
-    );
-    expect(normalize(template)).toContain(
-      normalize('FILTER (regex(str(?value), "JFK", "i"))'),
-    );
-    expect(normalize(template)).toContain(normalize("LIMIT 10"));
-    expect(normalize(template)).toContain(
-      normalize("FILTER(isBlank(?subject))"),
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT DISTINCT (?subject as ?bNode)
+        WHERE {
+          {
+            # This sub-query will find any matching instances to the given filters and limit the results
+            SELECT DISTINCT ?subject
+            WHERE {
+              ?subject ?pValue ?value .
+              OPTIONAL { ?subject a ?class } .
+              FILTER (?pValue IN (<air:city>))
+              FILTER (?class IN (<air:airport>))
+              FILTER (regex(str(?value), "JFK", "i"))
+            }
+            LIMIT 10
+          }
+          FILTER(isBlank(?subject))
+        }
+      `),
     );
   });
 });

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
@@ -1,9 +1,29 @@
-import { SEARCH_TOKENS } from "@/utils";
+import { LABELS, SEARCH_TOKENS } from "@/utils";
 import { normalize } from "@/utils/testing";
 
 import keywordSearchTemplate from "./keywordSearchTemplate";
 
 describe("SPARQL > keywordSearchTemplate", () => {
+  it("Should filter to subjects with no type when the missing-type class is requested", () => {
+    const template = keywordSearchTemplate({
+      subjectClasses: [LABELS.MISSING_TYPE],
+    });
+
+    expect(normalize(template)).toContain(
+      normalize("FILTER NOT EXISTS { ?subject a ?class }"),
+    );
+    expect(normalize(template)).not.toContain(normalize("FILTER (?class IN ("));
+  });
+
+  it("Should return a template with an offset but no limit", () => {
+    const template = keywordSearchTemplate({
+      offset: 20,
+    });
+
+    expect(normalize(template)).toContain(normalize("OFFSET 20"));
+    expect(normalize(template)).not.toContain(normalize("LIMIT"));
+  });
+
   it("Should return a template for an empty request", () => {
     const template = keywordSearchTemplate({});
 

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
@@ -9,10 +9,27 @@ describe("SPARQL > keywordSearchTemplate", () => {
       subjectClasses: [LABELS.MISSING_TYPE],
     });
 
-    expect(normalize(template)).toContain(
-      normalize("FILTER NOT EXISTS { ?subject a ?class }"),
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            # This sub-query will find any matching instances to the given filters and limit the results
+            SELECT DISTINCT ?subject
+            WHERE {
+              ?subject ?pValue ?value .
+              OPTIONAL { ?subject a ?class } .
+              FILTER NOT EXISTS { ?subject a ?class }
+            }
+          }
+          {
+            # Values and types
+            ?subject ?predicate ?object
+            FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+          }
+        }
+      `),
     );
-    expect(normalize(template)).not.toContain(normalize("FILTER (?class IN ("));
   });
 
   it("Should return a template with an offset but no limit", () => {
@@ -20,8 +37,27 @@ describe("SPARQL > keywordSearchTemplate", () => {
       offset: 20,
     });
 
-    expect(normalize(template)).toContain(normalize("OFFSET 20"));
-    expect(normalize(template)).not.toContain(normalize("LIMIT"));
+    expect(normalize(template)).toBe(
+      normalize(`
+        SELECT DISTINCT ?subject ?predicate ?object
+        WHERE {
+          {
+            # This sub-query will find any matching instances to the given filters and limit the results
+            SELECT DISTINCT ?subject
+            WHERE {
+              ?subject ?pValue ?value .
+              OPTIONAL { ?subject a ?class } .
+            }
+            OFFSET 20
+          }
+          {
+            # Values and types
+            ?subject ?predicate ?object
+            FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+          }
+        }
+      `),
+    );
   });
 
   it("Should return a template for an empty request", () => {


### PR DESCRIPTION
## Description

Adds characterization tests for query templates that previously had thin or no coverage, establishing a net before an upcoming batch of per-language template changes. No template source is modified — every test asserts the query text produced today.

Two logical parts:

- **New tests for six untested templates** — the edge-connection and vertex-type-count templates for Gremlin and openCypher, plus two SPARQL schema/count templates. Each was single-shape and had no test at all.
- **Branch coverage for existing template tests** — fills gaps where a template had a test but left whole branches unexercised:
  - Gremlin & openCypher `oneHopTemplate`: the `Date` criterion type, the full comparison-operator matrix, the no-dataType→String default, and the Neptune `::` multi-label expansion
  - Gremlin `keywordSearch`: multiple vertex types and the `::` multi-label expansion
  - SPARQL `oneHopNeighborsTemplate` & `keywordSearch`: the missing-type subject-class branch (`FILTER NOT EXISTS`), plus offset-only pagination
  - SPARQL blank-node id wrappers (`oneHopNeighborsBlankNodesIdsTemplate`, `keywordSearchBlankNodesIdsTemplate`): first tests for two files with no coverage

## How to read

1. [New-template tests (Gremlin edge connections)](https://github.com/aws/graph-explorer/pull/2028/files#diff-c8bf8a11c409637643d2339e3f3857e4b9c709a7086edd5c8f162687cfd173b8) — representative of the six brand-new characterization tests; a single-shape template with one asserted query
2. [Gremlin `oneHopTemplate` tests](https://github.com/aws/graph-explorer/pull/2028/files#diff-4bf7513e93b2e2f572ea6e3960892ec8e25f5d22dce28ac1858da986741c04d7) — the largest gap fill: Date type, full operator matrix, and the `::` multi-label expansion
3. [openCypher `oneHopTemplate` tests](https://github.com/aws/graph-explorer/pull/2028/files#diff-21706649552155a6aa6408ba18de35c4462545709ff4ee77946bdb37741960df) — same matrix for openCypher; note the `::` multi-label expansion is emitted per-label
4. [SPARQL blank-node id wrapper tests](https://github.com/aws/graph-explorer/pull/2028/files#diff-1fccf59e80b8c5b3dd9c82454fa9ede9f20e1f049adcc38c2f6d701397f52630) — first coverage for a previously untested wrapper (the sibling keyword-search wrapper follows the same shape)

## Validation

`pnpm checks` passes (lint, format, types) and `pnpm test` passes (206 files, 2327 tests). Tests were written against current output; one openCypher case pins current behaviour — a Neptune multi-label type (`a::b`) is expanded into its individual labels, and each is emitted independently (so repeated labels across types are not de-duplicated).

## Related Issues

- Related to #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.

