### PR TITLE
Clear unavailable sessions after restore

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { useAtomValue } from "jotai";
+import { act } from "react";
+
+import {
+  createRandomVertex,
+  DbState,
+  FakeExplorer,
+  renderHookWithState,
+} from "@/utils/testing";
+
+import {
+  activeGraphSessionAtom,
+  type GraphSessionStorageModel,
+} from "./storage";
+import { useAvailablePreviousSession } from "./useAvailablePreviousSession";
+import { useRestoreGraphSession } from "./useRestoreGraphSession";
+
+test("clears a previous session when none of its entities still exist", async () => {
+  const missingVertex = createRandomVertex();
+  const previousSession: GraphSessionStorageModel = {
+    vertices: new Set([missingVertex.id]),
+    edges: new Set(),
+  };
+  const state = new DbState(new FakeExplorer()).withGraphSession(
+    previousSession,
+  );
+
+  const { result } = renderHookWithState(() => {
+    const restore = useRestoreGraphSession();
+    const availablePreviousSession = useAvailablePreviousSession();
+    const activeGraphSession = useAtomValue(activeGraphSessionAtom);
+
+    return { restore, availablePreviousSession, activeGraphSession };
+  }, state);
+
+  expect(result.current.availablePreviousSession).toStrictEqual(
+    previousSession,
+  );
+
+  await act(() => result.current.restore.mutateAsync(previousSession));
+
+  expect(result.current.restore.isSuccess).toBe(true);
+  expect(result.current.availablePreviousSession).toBeNull();
+  expect(result.current.activeGraphSession).toStrictEqual({
+    vertices: new Set(),
+    edges: new Set(),
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphSession/useRestoreGraphSession.ts
@@ -9,6 +9,8 @@ import { createDisplayError } from "@/utils/createDisplayError";
 
 import type { GraphSessionStorageModel } from "./storage";
 
+import { useUpdateGraphSession } from "./useUpdateGraphSession";
+
 /**
  * Provides a mutation that restores the graph session from storage.
  */
@@ -16,6 +18,7 @@ export function useRestoreGraphSession() {
   const queryClient = useQueryClient();
   const addToGraph = useAddToGraph();
   const formatEntityCounts = useEntityCountFormatterCallback();
+  const updateGraphSession = useUpdateGraphSession();
 
   const mutation = useMutation({
     mutationFn: async (graph: GraphSessionStorageModel) => {
@@ -36,6 +39,12 @@ export function useRestoreGraphSession() {
 
         // Update Graph Explorer state
         await addToGraph(result.entities);
+        if (
+          result.entities.vertices.length === 0 &&
+          result.entities.edges.length === 0
+        ) {
+          updateGraphSession();
+        }
 
         return result;
       })();

--- a/packages/graph-explorer/src/utils/testing/DbState.ts
+++ b/packages/graph-explorer/src/utils/testing/DbState.ts
@@ -14,6 +14,7 @@ import {
   edgesTypesFilteredAtom,
   type EdgeType,
   explorerForTestingAtom,
+  type GraphSessionStorageModel,
   type GraphViewLayout,
   graphViewLayoutAtom,
   mapEdgeToTypeConfig,
@@ -54,6 +55,7 @@ import {
  */
 export class DbState {
   #activeSchema: SchemaStorageModel | null;
+  #graphSession: GraphSessionStorageModel | undefined;
   activeConfig: RawConfiguration;
   vertexStyles: Map<VertexType, VertexStyleStorage>;
   edgeStyles: Map<EdgeType, EdgeStyleStorage>;
@@ -107,6 +109,12 @@ export class DbState {
   /** Removes the active schema from the state. */
   withNoActiveSchema() {
     this.#activeSchema = null;
+    return this;
+  }
+
+  /** Sets the persisted graph session independently from the current graph. */
+  withGraphSession(graphSession: GraphSessionStorageModel) {
+    this.#graphSession = graphSession;
     return this;
   }
 
@@ -256,7 +264,7 @@ export class DbState {
       new Map([
         [
           this.activeConfig.id,
-          {
+          this.#graphSession ?? {
             vertices: new Set(this.vertices.map(v => v.id)),
             edges: new Set(this.edges.map(e => e.id)),
           },


### PR DESCRIPTION
## Description

- Persist a successful empty restoration through the existing graph-session update boundary so a stale previous session is replaced by the current empty graph and the restore action disappears.
- Keep failed restorations retryable and leave non-empty restorations on the existing add-and-persist path.
- Add a hook regression test and a `DbState` session fixture that reproduce a persisted session whose entities no longer exist in the graph database.

## Validation

- `pnpm test useRestoreGraphSession`
- `pnpm checks`
- `pnpm test` — 219 test files and 2,668 tests passed

## Related Issues

- Fixes #959

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
