### PR TITLE
Delete the unused attribute filter operator matrix

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,10 @@ A classification of edges. UI label varies by query language: "Edge Label" (Grem
 Vertices directly connected to a given vertex (one hop away). Users "expand neighbors" to progressively discover the graph. Neighbor counts track total vs. unfetched to indicate how much remains unexplored.
 _Avoid_: Connections (ambiguous with Connection)
 
+**Attribute Filter**:
+A named property paired with a value that a neighbor's property must contain for that neighbor to be expanded. Only string properties are filterable, and every filter must match. Users add these when expanding neighbors to narrow the results.
+_Avoid_: Criterion (implies a configurable operator, which the product does not offer), filter criteria
+
 **Session**:
 The set of vertices and edges a user has loaded through exploration for a given Connection. Persisted to IndexedDB so users can close the browser and restore where they left off.
 _Avoid_: State, workspace

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/index.test.ts
@@ -183,7 +183,7 @@ describe("Gremlin > fetchNeighbors", () => {
     const response = await fetchNeighbors(mockGremlinFetch(), {
       vertexId: createVertexId("2018"),
       filterByVertexTypes: ["airport"],
-      filterCriteria: [{ name: "code", value: "TF", operator: "LIKE" }],
+      attributeFilters: [{ name: "code", value: "TF" }],
     });
 
     expect(response).toStrictEqual({

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -1,3 +1,5 @@
+import type { AttributeFilter } from "@/connector/useGEFetchTypes";
+
 import { createVertexId } from "@/core";
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 
@@ -5,13 +7,13 @@ import oneHopTemplate from "./oneHopTemplate";
 
 describe("Gremlin > oneHopTemplate", () => {
   it("should produce documentation example", () => {
-    // This represents the filter criteria used in the example documentation
+    // This represents the attribute filters used in the example documentation
     const template = oneHopTemplate({
       vertexId: createVertexId("124"),
       filterByVertexTypes: ["airport"],
-      filterCriteria: [
-        { name: "longest", dataType: "Number", operator: "gt", value: 10000 },
-        { name: "country", dataType: "String", operator: "like", value: "ES" },
+      attributeFilters: [
+        { name: "city", value: "Sea" },
+        { name: "country", value: "ES" },
       ],
       excludedVertices: new Set([createVertexId("256")]),
       limit: 10,
@@ -21,7 +23,7 @@ describe("Gremlin > oneHopTemplate", () => {
       normalize(`
         g.V("124").as("start")
           .both()
-          .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
+          .hasLabel("airport").and(has("city",containing("Sea")), has("country",containing("ES")))
           .filter(__.not(__.hasId("256")))
           .dedup()
           .range(0, 10)
@@ -165,13 +167,13 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
-  it("Should return a template with specific filter criteria", () => {
+  it("Should return a template with specific attribute filters", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country"],
-      filterCriteria: [
-        { name: "longest", value: 10000, operator: "gte", dataType: "Number" },
-        { name: "country", value: "ES", operator: "like" },
+      attributeFilters: [
+        { name: "city", value: "Sea" },
+        { name: "country", value: "ES" },
       ],
       limit: 10,
     });
@@ -180,7 +182,7 @@ describe("Gremlin > oneHopTemplate", () => {
       normalize(`
         g.V("12").as("start")
           .both().hasLabel("country")
-            .and(has("longest",gte(10000)),has("country",containing("ES")))
+            .and(has("city",containing("Sea")),has("country",containing("ES")))
             .dedup().range(0, 10).as("neighbor")
           .project("vertex", "edges")
             .by()
@@ -204,78 +206,51 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
-  // Each criterion dataType and operator produces a distinct predicate fragment.
-  describe("filter criteria", () => {
-    function fragmentFor(criterion: {
-      name: string;
-      value: string | number;
-      operator: string;
-      dataType?: "Number" | "String" | "Date";
-    }) {
+  describe("attribute filters", () => {
+    function fragmentFor(attributeFilters: AttributeFilter[]) {
       return normalize(
         oneHopTemplate({
           vertexId: createVertexId("12"),
-          filterCriteria: [criterion],
+          attributeFilters,
         }),
       );
     }
 
-    it.each([
-      ["eq", 'has("longest",eq(10000))'],
-      ["==", 'has("longest",eq(10000))'],
-      ["gt", 'has("longest",gt(10000))'],
-      ["gte", 'has("longest",gte(10000))'],
-      ["lt", 'has("longest",lt(10000))'],
-      ["lte", 'has("longest",lte(10000))'],
-      ["neq", 'has("longest",neq(10000))'],
-    ])("renders a Number criterion with the %s operator", (operator, frag) => {
-      expect(
-        fragmentFor({
-          name: "longest",
-          value: 10000,
-          operator,
-          dataType: "Number",
-        }),
-      ).toContain(normalize(`and(${frag})`));
+    it("matches an attribute containing the value", () => {
+      expect(fragmentFor([{ name: "country", value: "ES" }])).toContain(
+        normalize('and(has("country",containing("ES")))'),
+      );
     });
 
-    it.each([
-      ["eq", 'has("country","ES")'],
-      ["neq", 'has("country",neq("ES"))'],
-      ["like", 'has("country",containing("ES"))'],
-    ])("renders a String criterion with the %s operator", (operator, frag) => {
+    it("requires every filter to match", () => {
       expect(
-        fragmentFor({
-          name: "country",
-          value: "ES",
-          operator,
-          dataType: "String",
-        }),
-      ).toContain(normalize(`and(${frag})`));
+        fragmentFor([
+          { name: "city", value: "Sea" },
+          { name: "country", value: "US" },
+        ]),
+      ).toContain(
+        normalize(
+          'and(has("city",containing("Sea")), has("country",containing("US")))',
+        ),
+      );
     });
 
-    it("treats a criterion without a dataType as a String", () => {
-      expect(
-        fragmentFor({ name: "country", value: "ES", operator: "eq" }),
-      ).toContain(normalize('and(has("country","ES"))'));
-    });
-
-    it.each([
-      ["eq", 'has("created",eq(datetime(2020)))'],
-      ["gt", 'has("created",gt(datetime(2020)))'],
-      ["gte", 'has("created",gte(datetime(2020)))'],
-      ["lt", 'has("created",lt(datetime(2020)))'],
-      ["lte", 'has("created",lte(datetime(2020)))'],
-      ["neq", 'has("created",neq(datetime(2020)))'],
-    ])("renders a Date criterion with the %s operator", (operator, frag) => {
-      expect(
-        fragmentFor({
-          name: "created",
-          value: 2020,
-          operator,
-          dataType: "Date",
-        }),
-      ).toContain(normalize(`and(${frag})`));
+    it("omits the filter step when there are no filters", () => {
+      expect(fragmentFor([])).toBe(
+        normalize(`
+          g.V("12").as("start")
+            .both()
+            .dedup()
+            .as("neighbor")
+            .project("vertex", "edges")
+              .by()
+              .by(
+                __.select("start").bothE()
+                  .where(otherV().where(eq("neighbor")))
+                  .dedup().fold()
+              )
+        `),
+      );
     });
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -1,110 +1,30 @@
-import type { Criterion, NeighborsRequest } from "@/connector/useGEFetchTypes";
+import type {
+  AttributeFilter,
+  NeighborsRequest,
+} from "@/connector/useGEFetchTypes";
 
 import { query } from "@/utils";
 
 import { fragment } from "../fragments";
 
-function criterionNumberTemplate({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `has("${name}",eq(${value}))`;
-    case "gt":
-    case ">":
-      return `has("${name}",gt(${value}))`;
-    case "gte":
-    case ">=":
-      return `has("${name}",gte(${value}))`;
-    case "lt":
-    case "<":
-      return `has("${name}",lt(${value}))`;
-    case "lte":
-    case "<=":
-      return `has("${name}",lte(${value}))`;
-    case "neq":
-    case "!=":
-      return `has("${name}",neq(${value}))`;
-  }
-}
-
-function criterionStringTemplate({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `has("${name}","${value}")`;
-    case "neq":
-    case "!=":
-      return `has("${name}",neq("${value}"))`;
-    case "like":
-      return `has("${name}",containing("${value}"))`;
-  }
-}
-
-function criterionDateTemplate({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `has("${name}",eq(datetime(${value})))`;
-    case "gt":
-    case ">":
-      return `has("${name}",gt(datetime(${value})))`;
-    case "gte":
-    case ">=":
-      return `has("${name}",gte(datetime(${value})))`;
-    case "lt":
-    case "<":
-      return `has("${name}",lt(datetime(${value})))`;
-    case "lte":
-    case "<=":
-      return `has("${name}",lte(datetime(${value})))`;
-    case "neq":
-    case "!=":
-      return `has("${name}",neq(datetime(${value})))`;
-  }
-}
-
-function criterionTemplate(criterion: Criterion): string {
-  switch (criterion.dataType) {
-    case "Number":
-      return criterionNumberTemplate(criterion);
-    case "Date":
-      return criterionDateTemplate(criterion);
-    case "String":
-    case undefined:
-    default:
-      return criterionStringTemplate(criterion);
-  }
+function attributeFilterTemplate({ name, value }: AttributeFilter): string {
+  return `has("${name}",containing("${value}"))`;
 }
 
 /**
  * @example
  * sourceId = "124"
  * vertexTypes = ["airport"]
- * filterCriteria = [
- *   { name: "longest", dataType: "Int", operator: "gt", value: 10000 },
- *   { name: "country", dataType: "String", operator: "like", value: "ES" }
+ * attributeFilters = [
+ *   { name: "city", value: "Sea" },
+ *   { name: "country", value: "ES" }
  * ]
  * excludedVertices = new Set(["256"])
  * limit = 10
  *
  * g.V("124").as("start")
  *   .both()
- *   .hasLabel("airport").and(has("longest",gt(10000)), has("country",containing("ES")))
+ *   .hasLabel("airport").and(has("city",containing("Sea")), has("country",containing("ES")))
  *   .filter(__.not(__.hasId("256")))
  *   .dedup()
  *   .range(0, 10)
@@ -121,7 +41,7 @@ export default function oneHopTemplate({
   vertexId,
   excludedVertices = new Set(),
   filterByVertexTypes = [],
-  filterCriteria = [],
+  attributeFilters = [],
   limit = 0,
 }: Omit<NeighborsRequest, "vertexTypes">): string {
   const idTemplate = fragment.id(vertexId);
@@ -133,12 +53,12 @@ export default function oneHopTemplate({
       ? `hasLabel(${vertexTypes.map(type => `"${type}"`).join(", ")})`
       : ``;
 
-  const filterCriteriaTemplate =
-    filterCriteria.length > 0
-      ? `and(${filterCriteria.map(criterionTemplate).join(", ")})`
+  const attributeFiltersTemplate =
+    attributeFilters.length > 0
+      ? `and(${attributeFilters.map(attributeFilterTemplate).join(", ")})`
       : ``;
 
-  const nodeFilters = [vertexTypesTemplate, filterCriteriaTemplate].filter(
+  const nodeFilters = [vertexTypesTemplate, attributeFiltersTemplate].filter(
     Boolean,
   );
 

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -104,7 +104,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
   it("Should return a template for searched attributes matching with the search terms, and the ID token attribute", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
-      searchByAttributes: ["city", "code", SEARCH_TOKENS.ALL_ATTRIBUTES],
+      searchByAttributes: [SEARCH_TOKENS.NODE_ID, "city", "code"],
     });
 
     expect(normalize(template)).toBe(

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
@@ -44,12 +44,7 @@ export default function keywordSearchTemplate({
   if (searchTerm) {
     const searchLiteral = fragment.string(searchTerm);
 
-    const orContent = uniq(
-      searchByAttributes.includes(SEARCH_TOKENS.ALL_ATTRIBUTES)
-        ? [SEARCH_TOKENS.NODE_ID, ...searchByAttributes]
-        : searchByAttributes,
-    )
-      .filter(attr => attr !== SEARCH_TOKENS.ALL_ATTRIBUTES)
+    const orContent = uniq(searchByAttributes)
       .map(attr => {
         if (attr === SEARCH_TOKENS.NODE_ID) {
           if (exactMatch === true) {

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -1,3 +1,5 @@
+import type { AttributeFilter } from "@/connector/useGEFetchTypes";
+
 import { createVertexId } from "@/core";
 import { query } from "@/utils";
 
@@ -97,22 +99,22 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
-  it("Should return a template with specific filter criteria", () => {
+  it("Should return a template with specific attribute filters", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country"],
-      filterCriteria: [
-        { name: "longest", value: 10000, operator: "gte", dataType: "Number" },
-        { name: "country", value: "ES", operator: "like" },
+      attributeFilters: [
+        { name: "city", value: "Sea" },
+        { name: "country", value: "ES" },
       ],
       limit: 10,
     });
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e]-(tgt:country) 
-        WHERE ID(v) = "12" AND tgt.longest >= 10000 AND tgt.country CONTAINS "ES" 
-        WITH DISTINCT v, tgt 
+        MATCH (v)-[e]-(tgt:country)
+        WHERE ID(v) = "12" AND tgt.city CONTAINS "Sea" AND tgt.country CONTAINS "ES"
+        WITH DISTINCT v, tgt
         ORDER BY toInteger(ID(tgt)) 
         LIMIT 10
         MATCH (v)-[e]-(tgt)
@@ -154,87 +156,39 @@ describe("OpenCypher > oneHopTemplate", () => {
     expect(template).toContain("(v:country OR v:capital OR v:city OR v:town)");
   });
 
-  // Each criterion dataType and operator produces a distinct WHERE fragment.
-  describe("filter criteria", () => {
-    function templateFor(criterion: {
-      name: string;
-      value: string | number;
-      operator: string;
-      dataType?: "Number" | "String" | "Date";
-    }) {
+  describe("attribute filters", () => {
+    function templateFor(attributeFilters: AttributeFilter[]) {
       return oneHopTemplate({
         vertexId: createVertexId("12"),
-        filterCriteria: [criterion],
+        attributeFilters,
       });
     }
 
-    it.each([
-      ["eq", "tgt.longest = 10000"],
-      ["==", "tgt.longest = 10000"],
-      ["gt", "tgt.longest > 10000"],
-      ["gte", "tgt.longest >= 10000"],
-      ["lt", "tgt.longest < 10000"],
-      ["lte", "tgt.longest <= 10000"],
-      ["neq", "tgt.longest <> 10000"],
-    ])("renders a Number criterion with the %s operator", (operator, frag) => {
-      expect(
-        templateFor({
-          name: "longest",
-          value: 10000,
-          operator,
-          dataType: "Number",
-        }),
-      ).toContain(frag);
+    it("matches an attribute containing the value", () => {
+      expect(templateFor([{ name: "country", value: "ES" }])).toContain(
+        'tgt.country CONTAINS "ES"',
+      );
     });
 
-    it.each([
-      ["eq", 'tgt.country = "ES"'],
-      ["neq", 'tgt.country <> "ES"'],
-      ["like", 'tgt.country CONTAINS "ES"'],
-    ])("renders a String criterion with the %s operator", (operator, frag) => {
+    it("requires every filter to match", () => {
       expect(
-        templateFor({
-          name: "country",
-          value: "ES",
-          operator,
-          dataType: "String",
-        }),
-      ).toContain(frag);
+        templateFor([
+          { name: "city", value: "Sea" },
+          { name: "country", value: "US" },
+        ]),
+      ).toContain('tgt.city CONTAINS "Sea" AND tgt.country CONTAINS "US"');
     });
 
-    it("treats a criterion without a dataType as a String", () => {
-      expect(
-        templateFor({ name: "country", value: "ES", operator: "eq" }),
-      ).toContain('tgt.country = "ES"');
-    });
-
-    it.each([
-      ["eq", 'tgt.created = DateTime("2020")'],
-      ["gt", 'tgt.created > DateTime("2020")'],
-      ["gte", 'tgt.created >= DateTime("2020")'],
-      ["lt", 'tgt.created < DateTime("2020")'],
-      ["lte", 'tgt.created <= DateTime("2020")'],
-      ["neq", 'tgt.created <> DateTime("2020")'],
-    ])("renders a Date criterion with the %s operator", (operator, frag) => {
-      expect(
-        templateFor({
-          name: "created",
-          value: "2020",
-          operator,
-          dataType: "Date",
-        }),
-      ).toContain(frag);
-    });
-
-    it("coerces a non-string String criterion value to text", () => {
-      expect(
-        templateFor({
-          name: "longest",
-          value: 10000,
-          operator: "eq",
-          dataType: "String",
-        }),
-      ).toContain('tgt.longest = "10000"');
+    it("omits the filter condition when there are no filters", () => {
+      expect(templateFor([])).toBe(
+        query`
+          MATCH (v)-[e]-(tgt)
+          WHERE ID(v) = "12"
+          RETURN
+            collect(DISTINCT tgt) AS vObjects,
+            collect(e) AS eObjects
+        `,
+      );
     });
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
@@ -1,95 +1,14 @@
-import type { Criterion, NeighborsRequest } from "@/connector/useGEFetchTypes";
+import type {
+  AttributeFilter,
+  NeighborsRequest,
+} from "@/connector/useGEFetchTypes";
 
 import { query } from "@/utils";
 
 import { fragment } from "../fragments";
 
-const criterionNumberTemplate = ({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string => {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `tgt.${name} = ${value}`;
-    case "gt":
-    case ">":
-      return `tgt.${name} > ${value}`;
-    case "gte":
-    case ">=":
-      return `tgt.${name} >= ${value}`;
-    case "lt":
-    case "<":
-      return `tgt.${name} < ${value}`;
-    case "lte":
-    case "<=":
-      return `tgt.${name} <= ${value}`;
-    case "neq":
-    case "!=":
-      return `tgt.${name} <> ${value}`;
-  }
-};
-
-const criterionStringTemplate = ({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string => {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `tgt.${name} = "${value}"`;
-    case "neq":
-    case "!=":
-      return `tgt.${name} <> "${value}"`;
-    case "like":
-      return `tgt.${name} CONTAINS "${value}"`;
-  }
-};
-
-const criterionDateTemplate = ({
-  name,
-  operator,
-  value,
-}: Omit<Criterion, "dataType">): string => {
-  switch (operator.toLowerCase()) {
-    case "eq":
-    case "==":
-    default:
-      return `tgt.${name} = DateTime("${value}")`;
-    case "gt":
-    case ">":
-      return `tgt.${name} > DateTime("${value}")`;
-    case "gte":
-    case ">=":
-      return `tgt.${name} >= DateTime("${value}")`;
-    case "lt":
-    case "<":
-      return `tgt.${name} < DateTime("${value}")`;
-    case "lte":
-    case "<=":
-      return `tgt.${name} <= DateTime("${value}")`;
-    case "neq":
-    case "!=":
-      return `tgt.${name} <> DateTime("${value}")`;
-  }
-};
-
-const criterionTemplate = (criterion: Criterion): string => {
-  switch (criterion.dataType) {
-    case "Number":
-      return criterionNumberTemplate(criterion);
-    case "Date":
-      return criterionDateTemplate(criterion);
-    case "String":
-    case undefined:
-    default:
-      return criterionStringTemplate(criterion);
-  }
-};
+const attributeFilterTemplate = ({ name, value }: AttributeFilter): string =>
+  `tgt.${name} CONTAINS "${value}"`;
 
 /**
  * @example
@@ -110,7 +29,7 @@ const criterionTemplate = (criterion: Criterion): string => {
 const oneHopTemplate = ({
   vertexId,
   filterByVertexTypes = [],
-  filterCriteria = [],
+  attributeFilters = [],
   excludedVertices = new Set(),
   limit = 0,
 }: Omit<NeighborsRequest, "vertexTypes">): string => {
@@ -137,7 +56,7 @@ const oneHopTemplate = ({
     `ID(v) = ${fragment.id(vertexId)}`,
     formattedExcludedVertices,
     formattedVertexTypes,
-    ...(filterCriteria?.map(criterionTemplate) ?? []),
+    ...attributeFilters.map(attributeFilterTemplate),
   ]
     .filter(Boolean)
     .join(" AND ");

--- a/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.test.ts
@@ -177,7 +177,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["airport"],
       searchTerm: "JFK",
-      searchByAttributes: ["city", "code", SEARCH_TOKENS.ALL_ATTRIBUTES],
+      searchByAttributes: [SEARCH_TOKENS.NODE_ID, "city", "code"],
     });
 
     expect(normalize(template)).toBe(
@@ -194,7 +194,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
       vertexTypes: ["airport", "country"],
       searchTerm: "JFK",
       exactMatch: false,
-      searchByAttributes: ["city", "code", SEARCH_TOKENS.ALL_ATTRIBUTES],
+      searchByAttributes: [SEARCH_TOKENS.NODE_ID, "city", "code"],
       limit: 50,
       offset: 25,
     });

--- a/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.ts
@@ -51,12 +51,7 @@ const keywordSearchTemplate = ({
   const searchLiteral = searchTerm ? fragment.string(searchTerm) : undefined;
   const searchTermWhereClause =
     searchLiteral !== undefined &&
-    uniq(
-      searchByAttributes.includes(SEARCH_TOKENS.ALL_ATTRIBUTES)
-        ? [SEARCH_TOKENS.NODE_ID, ...searchByAttributes]
-        : searchByAttributes,
-    )
-      .filter(attr => attr !== SEARCH_TOKENS.ALL_ATTRIBUTES)
+    uniq(searchByAttributes)
       .map(attr => {
         // ID is a special case
         if (attr === SEARCH_TOKENS.NODE_ID) {

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/index.test.ts
@@ -222,9 +222,7 @@ describe("fetchNeighbors", () => {
     const request: SPARQLNeighborsRequest = {
       resourceURI: createRandomUrlString() as any,
       subjectClasses: [createRandomUrlString()],
-      filterCriteria: [
-        { predicate: "http://example.com/name", object: "test" },
-      ],
+      attributeFilters: [{ name: "http://example.com/name", value: "test" }],
       excludedVertices: new Set([createRandomUrlString() as any]),
       limit: 10,
     };

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.test.ts
@@ -41,18 +41,18 @@ describe("oneHopNeighborsTemplate", () => {
   });
 
   it("should produce documentation example", () => {
-    // This represents the filter criteria used in the example documentation
+    // This represents the attribute filters used in the example documentation
     const template = oneHopNeighborsTemplate({
       resourceURI: createVertexId("http://www.example.com/soccer/resource#EPL"),
       subjectClasses: ["http://www.example.com/soccer/ontology/Team"],
-      filterCriteria: [
+      attributeFilters: [
         {
-          predicate: "http://www.example.com/soccer/ontology/teamName",
-          object: "Arsenal",
+          name: "http://www.example.com/soccer/ontology/teamName",
+          value: "Arsenal",
         },
         {
-          predicate: "http://www.example.com/soccer/ontology/nickname",
-          object: "Gunners",
+          name: "http://www.example.com/soccer/ontology/nickname",
+          value: "Gunners",
         },
       ],
       limit: 2,

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/oneHopNeighborsTemplate.ts
@@ -1,3 +1,5 @@
+import type { AttributeFilter } from "@/connector/useGEFetchTypes";
+
 import { query } from "@/utils";
 
 import {
@@ -6,11 +8,7 @@ import {
   getSubjectClasses,
 } from "../filterHelpers";
 import { fragment } from "../fragments";
-import {
-  rdfTypeUri,
-  type SPARQLCriterion,
-  type SPARQLNeighborsRequest,
-} from "../types";
+import { rdfTypeUri, type SPARQLNeighborsRequest } from "../types";
 
 /**
  * Creates a SPARQL query that will find all neighbors for the given resource URI and search filters.
@@ -27,9 +25,9 @@ import {
  * subjectClasses = [
  *   "http://www.example.com/soccer/ontology/Team",
  * ]
- * filterCriteria = [
- *   { predicate: "http://www.example.com/soccer/ontology/teamName", object: "Arsenal" },
- *   { predicate: "http://www.example.com/soccer/ontology/nickname", object: "Gunners" },
+ * attributeFilters = [
+ *   { name: "http://www.example.com/soccer/ontology/teamName", value: "Arsenal" },
+ *   { name: "http://www.example.com/soccer/ontology/nickname", value: "Gunners" },
  * ]
  * limit = 2
  *
@@ -172,7 +170,7 @@ export function oneHopNeighborsTemplate(
 export function findNeighborsUsingFilters({
   resourceURI,
   subjectClasses = [],
-  filterCriteria = [],
+  attributeFilters = [],
   excludedVertices = new Set(),
   limit = 0,
 }: SPARQLNeighborsRequest): string {
@@ -198,29 +196,29 @@ export function findNeighborsUsingFilters({
         ${getNeighborsFilter(excludedVertices)}
         ${getSubjectClasses(subjectClasses)}
       }
-      ${getFilterTemplate(filterCriteria)}
+      ${getFilterTemplate(attributeFilters)}
     }
     ${getLimit(limit)}
   `;
 }
 
 /**
- * Creates a filter template for the given filter criteria.
+ * Creates a filter template for the given attribute filters.
  *
- * The ?pValue must equal the given criteria predicate and the ?object must match the given criteria object with a partial match.
+ * The ?pValue must equal the filter's attribute name and the ?object must contain the filter's value.
  */
-function getFilterTemplate(filterCriteria: SPARQLCriterion[]) {
-  const hasFilters = filterCriteria.length > 0;
+function getFilterTemplate(attributeFilters: AttributeFilter[]) {
+  const hasFilters = attributeFilters.length > 0;
 
-  const createFilterTemplate = (c: SPARQLCriterion) =>
-    `(?pValue=${fragment.iri(c.predicate)} && regex(str(?object), "${c.object}", "i"))`;
+  const createFilterTemplate = (filter: AttributeFilter) =>
+    `(?pValue=${fragment.iri(filter.name)} && regex(str(?object), "${filter.value}", "i"))`;
 
   return hasFilters
     ? query`
         ?neighbor ?pValue ?object .
         FILTER(
           isLiteral(?object) && (
-            ${filterCriteria.map(createFilterTemplate).join(" ||\n")}
+            ${attributeFilters.map(createFilterTemplate).join(" ||\n")}
           )
         )
       `

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.test.ts
@@ -1,0 +1,162 @@
+import { createVertexId, type Vertex } from "@/core";
+import { createTestableVertex } from "@/utils/testing";
+
+import type { BlankNodeItem, BlankNodesMap } from "../types";
+
+import { storedBlankNodeNeighborsRequest } from "./storedBlankNodeNeighborsRequest";
+
+const blankNodeId = createVertexId("_:b0");
+
+function blankNodesWithNeighbors(vertices: Vertex[]): BlankNodesMap {
+  const item = {
+    id: blankNodeId,
+    subQueryTemplate: "",
+    vertex: createTestableVertex().withRdfValues().asVertex(),
+    neighborCounts: { totalCount: vertices.length, counts: new Map() },
+    neighbors: { vertices, edges: [] },
+  } satisfies BlankNodeItem;
+
+  return new Map([[blankNodeId, item]]);
+}
+
+function airportWith(attributes: Record<string, string>) {
+  return createTestableVertex()
+    .withRdfValues()
+    .with({ types: ["airport"], attributes })
+    .asVertex();
+}
+
+describe("SPARQL > storedBlankNodeNeighborsRequest", () => {
+  it("should return nothing when the blank node has no stored neighbors", async () => {
+    const response = await storedBlankNodeNeighborsRequest(new Map(), {
+      resourceURI: blankNodeId,
+    });
+
+    expect(response).toStrictEqual({ vertices: [], edges: [] });
+  });
+
+  it("should return every stored neighbor when no filters are given", async () => {
+    const seattle = airportWith({ city: "Seattle" });
+    const portland = airportWith({ city: "Portland" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattle, portland]),
+      { resourceURI: blankNodeId },
+    );
+
+    expect(response.vertices).toStrictEqual([seattle, portland]);
+  });
+
+  it("should keep only neighbors whose attribute contains the filter value", async () => {
+    const seattle = airportWith({ city: "Seattle" });
+    const portland = airportWith({ city: "Portland" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattle, portland]),
+      {
+        resourceURI: blankNodeId,
+        subjectClasses: ["airport"],
+        attributeFilters: [{ name: "city", value: "Seat" }],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([seattle]);
+  });
+
+  it("should require every filter to match", async () => {
+    const seattleWa = airportWith({ city: "Seattle", state: "WA" });
+    const seattleOr = airportWith({ city: "Seattle", state: "OR" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattleWa, seattleOr]),
+      {
+        resourceURI: blankNodeId,
+        subjectClasses: ["airport"],
+        attributeFilters: [
+          { name: "city", value: "Seattle" },
+          { name: "state", value: "WA" },
+        ],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([seattleWa]);
+  });
+
+  it("should exclude neighbors missing the filtered attribute", async () => {
+    const withCity = airportWith({ city: "Seattle" });
+    const withoutCity = airportWith({ state: "WA" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([withCity, withoutCity]),
+      {
+        resourceURI: blankNodeId,
+        subjectClasses: ["airport"],
+        attributeFilters: [{ name: "city", value: "Seattle" }],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([withCity]);
+  });
+
+  it("should exclude neighbors whose type is not requested", async () => {
+    const airport = airportWith({ city: "Seattle" });
+    const country = createTestableVertex()
+      .withRdfValues()
+      .with({ types: ["country"], attributes: { city: "Seattle" } })
+      .asVertex();
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([airport, country]),
+      {
+        resourceURI: blankNodeId,
+        subjectClasses: ["airport"],
+        attributeFilters: [{ name: "city", value: "Seattle" }],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([airport]);
+  });
+
+  it("should apply filters when no subject classes are requested", async () => {
+    const seattle = airportWith({ city: "Seattle" });
+    const portland = airportWith({ city: "Portland" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattle, portland]),
+      {
+        resourceURI: blankNodeId,
+        attributeFilters: [{ name: "city", value: "Seat" }],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([seattle]);
+  });
+
+  it("should treat an empty subject class list as no type constraint", async () => {
+    const seattle = airportWith({ city: "Seattle" });
+    const portland = airportWith({ city: "Portland" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattle, portland]),
+      {
+        resourceURI: blankNodeId,
+        subjectClasses: [],
+        attributeFilters: [{ name: "city", value: "Seat" }],
+      },
+    );
+
+    expect(response.vertices).toStrictEqual([seattle]);
+  });
+
+  it("should limit the number of neighbors returned", async () => {
+    const seattle = airportWith({ city: "Seattle" });
+    const portland = airportWith({ city: "Portland" });
+
+    const response = await storedBlankNodeNeighborsRequest(
+      blankNodesWithNeighbors([seattle, portland]),
+      { resourceURI: blankNodeId, limit: 1 },
+    );
+
+    expect(response.vertices).toStrictEqual([seattle]);
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts
@@ -18,24 +18,19 @@ export const storedBlankNodeNeighborsRequest = (
     }
 
     const filteredVertices = bNode.neighbors.vertices.filter(vertex => {
-      if (!req.subjectClasses && !req.filterCriteria?.length) {
-        return true;
-      }
-
-      if (!req.subjectClasses?.includes(vertex.type)) {
+      if (
+        req.subjectClasses?.length &&
+        !req.subjectClasses.includes(vertex.type)
+      ) {
         return false;
       }
 
-      if (!req.filterCriteria?.length) {
-        return true;
-      }
-
-      for (const criterion of req.filterCriteria) {
-        const attrVal = vertex.attributes[criterion.predicate];
+      for (const filter of req.attributeFilters ?? []) {
+        const attrVal = vertex.attributes[filter.name];
         if (attrVal == null) {
           return false;
         }
-        if (!String(attrVal).match(new RegExp(criterion.object, "gi"))) {
+        if (!String(attrVal).match(new RegExp(filter.value, "gi"))) {
           return false;
         }
       }

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.test.ts
@@ -1,4 +1,4 @@
-import { LABELS, SEARCH_TOKENS } from "@/utils";
+import { LABELS } from "@/utils";
 import { normalize } from "@/utils/testing";
 
 import keywordSearchTemplate from "./keywordSearchTemplate";
@@ -235,39 +235,6 @@ describe("SPARQL > keywordSearchTemplate", () => {
       subjectClasses: ["air:airport"],
       searchTerm: "JFK",
       predicates: ["air:city", "air:code"],
-      exactMatch: true,
-    });
-
-    expect(normalize(template)).toBe(
-      normalize(`
-        SELECT DISTINCT ?subject ?predicate ?object
-        WHERE {
-          {
-            # This sub-query will find any matching instances to the given filters and limit the results
-            SELECT DISTINCT ?subject
-            WHERE {
-              ?subject ?pValue ?value .
-              OPTIONAL { ?subject a ?class } .
-              FILTER (?pValue IN (<air:city>, <air:code>))
-              FILTER (?class IN (<air:airport>))
-              FILTER (?value = "JFK")
-            }
-          }
-          {
-            # Values and types
-            ?subject ?predicate ?object
-            FILTER(isLiteral(?object) || ?predicate = <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
-          }
-        }
-      `),
-    );
-  });
-
-  it("Should return a template for searched attributes without the all attributes token predicate", () => {
-    const template = keywordSearchTemplate({
-      subjectClasses: ["air:airport"],
-      searchTerm: "JFK",
-      predicates: ["air:city", "air:code", SEARCH_TOKENS.ALL_ATTRIBUTES],
       exactMatch: true,
     });
 

--- a/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/keywordSearch/keywordSearchTemplate.ts
@@ -1,4 +1,4 @@
-import { query, SEARCH_TOKENS } from "@/utils";
+import { query } from "@/utils";
 
 import { getLimit, getSubjectClasses } from "../filterHelpers";
 import { fragment } from "../fragments";
@@ -116,13 +116,11 @@ export function findSubjectsMatchingFilters(
 }
 
 function getFilterPredicates(predicates?: string[]) {
-  const filteredPredicates =
-    predicates?.filter(p => p !== SEARCH_TOKENS.ALL_ATTRIBUTES) || [];
-  if (!filteredPredicates.length) {
+  if (!predicates?.length) {
     return "";
   }
 
-  return `FILTER (?pValue IN (${filteredPredicates.map(fragment.iri).join(", ")}))`;
+  return `FILTER (?pValue IN (${predicates.map(fragment.iri).join(", ")}))`;
 }
 
 function getFilterObject(exactMatch?: boolean, searchTerm?: string) {

--- a/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
+++ b/packages/graph-explorer/src/connector/sparql/sparqlExplorer.ts
@@ -5,11 +5,7 @@ import type { FeatureFlags, NormalizedConnection } from "@/core";
 import { createLoggerFromConnection } from "@/core/connector";
 import { env, logger } from "@/utils";
 
-import type {
-  Criterion,
-  Explorer,
-  ExplorerRequestOptions,
-} from "../useGEFetchTypes";
+import type { Explorer, ExplorerRequestOptions } from "../useGEFetchTypes";
 import type {
   BlankNodesMap,
   GraphSummary,
@@ -118,10 +114,7 @@ export function createSparqlExplorer(
       const request: SPARQLNeighborsRequest = {
         resourceURI: req.vertexId,
         subjectClasses: req.filterByVertexTypes,
-        filterCriteria: req.filterCriteria?.map((c: Criterion) => ({
-          predicate: c.name,
-          object: c.value,
-        })),
+        attributeFilters: req.attributeFilters,
         excludedVertices: req.excludedVertices,
         limit: req.limit,
       };

--- a/packages/graph-explorer/src/connector/sparql/types.ts
+++ b/packages/graph-explorer/src/connector/sparql/types.ts
@@ -2,22 +2,11 @@ import { z } from "zod";
 
 import type { Edge, Vertex, VertexId, VertexType } from "@/core";
 
-import type { NeighborCount } from "../useGEFetchTypes";
+import type { AttributeFilter, NeighborCount } from "../useGEFetchTypes";
 
 export type SparqlFetch = <TResult = any>(
   queryTemplate: string,
 ) => Promise<TResult>;
-
-export type SPARQLCriterion = {
-  /**
-   * Predicate URI.
-   */
-  predicate: string;
-  /**
-   * Object value.
-   */
-  object: string;
-};
 
 export type SPARQLNeighborsRequest = {
   /**
@@ -29,9 +18,9 @@ export type SPARQLNeighborsRequest = {
    */
   subjectClasses?: Array<string>;
   /**
-   * Filter by predicates and objects matching values.
+   * Filter by predicates whose values contain the given values.
    */
-  filterCriteria?: Array<SPARQLCriterion>;
+  attributeFilters?: Array<AttributeFilter>;
   /**
    * Exclude vertices from the results.
    */

--- a/packages/graph-explorer/src/connector/useGEFetchTypes.ts
+++ b/packages/graph-explorer/src/connector/useGEFetchTypes.ts
@@ -61,24 +61,16 @@ export type SchemaResponse = {
   edgeConnections?: EdgeConnection[];
 };
 
-export type Criterion = {
-  /**
-   * Attribute name.
-   */
+/**
+ * Narrows neighbors to those whose attribute contains the given value.
+ *
+ * Only string attributes are filterable, so the value needs no type of its own.
+ */
+export type AttributeFilter = {
+  /** Attribute name. */
   name: string;
-  /**
-   * Operator value =, >=, LIKE, ...
-   */
-  operator: string;
-  /**
-   * Filter value.
-   */
-  value: any;
-  /**
-   * Attribute data type.
-   * By default, String.
-   */
-  dataType?: "String" | "Number" | "Date";
+  /** Value the attribute must contain. */
+  value: string;
 };
 
 /**
@@ -105,7 +97,7 @@ export type NeighborsRequest = {
   /**
    * Filter by vertex attributes.
    */
-  filterCriteria?: Array<Criterion>;
+  attributeFilters?: Array<AttributeFilter>;
   /**
    * Limit the number of results.
    * 0 = No limit.

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -133,9 +133,8 @@ function ExpansionOptions({
           vertexId={vertexId}
           filters={{
             filterByVertexTypes: [selectedType],
-            filterCriteria: filters.map(filter => ({
+            attributeFilters: filters.map(filter => ({
               name: filter.name,
-              operator: "LIKE",
               value: filter.value,
             })),
             limit: limitEnabled && limit ? limit : undefined,

--- a/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
+++ b/packages/graph-explorer/src/modules/SearchSidebar/useKeywordSearch.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import type { QueryEngine } from "@shared/types";
 
+import { act } from "@testing-library/react";
 import { vi } from "vitest";
 
 import {
@@ -17,6 +18,7 @@ import {
 } from "@/utils/testing";
 
 import useKeywordSearch from "./useKeywordSearch";
+import { useKeywordSearchQuery } from "./useKeywordSearchQuery";
 
 vi.mock("./useKeywordSearchQuery", () => ({
   useKeywordSearchQuery: vi.fn().mockReturnValue({
@@ -232,6 +234,76 @@ describe("useKeywordSearch", () => {
           label: "All string datatype properties",
         },
       ]);
+    });
+  });
+
+  /*
+   * The all-attributes token is expanded here and never reaches a query
+   * template, so these tests pin the only place the fan-out happens.
+   */
+  describe("all attributes token expansion", () => {
+    function initializeConfigWithStringAttributes(queryEngine: QueryEngine) {
+      return (store: AppStore) => {
+        const config = createRandomRawConfiguration();
+        const schema = createRandomSchema();
+        config.connection!.queryEngine = queryEngine;
+        schema.vertices[0].attributes = [
+          { name: "city", dataType: "String" },
+          { name: "code", dataType: "String" },
+          { name: "elevation", dataType: "Number" },
+        ];
+
+        store.set(configurationAtom, new Map([[config.id, config]]));
+        store.set(schemaAtom, new Map([[config.id, schema]]));
+        store.set(activeConfigurationAtom, config.id);
+      };
+    }
+
+    it("Should search the ID and every string attribute when all attributes is selected", () => {
+      const { result } = renderHookWithJotai(
+        () => useKeywordSearch(),
+        initializeConfigWithStringAttributes("gremlin"),
+      );
+
+      act(() =>
+        result.current.onAttributeOptionChange(SEARCH_TOKENS.ALL_ATTRIBUTES),
+      );
+
+      expect(vi.mocked(useKeywordSearchQuery)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          searchByAttributes: [SEARCH_TOKENS.NODE_ID, "city", "code"],
+        }),
+      );
+    });
+
+    it("Should omit the ID for SPARQL, which cannot search by it", () => {
+      const { result } = renderHookWithJotai(
+        () => useKeywordSearch(),
+        initializeConfigWithStringAttributes("sparql"),
+      );
+
+      act(() =>
+        result.current.onAttributeOptionChange(SEARCH_TOKENS.ALL_ATTRIBUTES),
+      );
+
+      expect(vi.mocked(useKeywordSearchQuery)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          searchByAttributes: ["city", "code"],
+        }),
+      );
+    });
+
+    it("Should send just the chosen attribute when one is selected", () => {
+      const { result } = renderHookWithJotai(
+        () => useKeywordSearch(),
+        initializeConfigWithStringAttributes("gremlin"),
+      );
+
+      act(() => result.current.onAttributeOptionChange("city"));
+
+      expect(vi.mocked(useKeywordSearchQuery)).toHaveBeenLastCalledWith(
+        expect.objectContaining({ searchByAttributes: ["city"] }),
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

`Criterion` carried an untyped `value` alongside `operator` and `dataType` fields, and the Gremlin and openCypher neighbor-expansion templates each implemented roughly twelve operators across three data types. None of it was reachable.

The investigation behind this is written up in [a comment on #2031](https://github.com/aws/graph-explorer/issues/2031#issuecomment-5173717833). In short:

- The only producer hardcodes `operator: "LIKE"` and never sets `dataType`, so every request took the String branch.
- There is no operator or data type picker in the UI, and filterable attributes are gated on `dataType === "String"`, so a per-type operator matrix has nothing to act on.
- SPARQL never implemented the matrix, discarding both fields when mapping to its own request type.
- The matrix is present in the original October 2022 port in its current form, next to a producer that already hardcoded `"LIKE"`. Nothing has ever set a `dataType`.
- No filter state is persisted, so there was nothing to migrate.

So the untyped value was a symptom. `Criterion` becomes `AttributeFilter` — a name and the string value the attribute must contain — and the type now states what the product actually does. Folding `SPARQLCriterion` into it also removes the field-renaming map in the SPARQL explorer, collapsing three names for one concept into one.

Two latent defects disappear with the dead branches: a substring match combined with a `Number` data type silently became an equality test, and the untyped value required string coercion at each template. A third is fixed directly — the in-memory blank node filter dropped attribute filters entirely unless a subject class was also supplied.

Supporting cleanup, tangential to the above: the three keyword search templates each re-implemented the all-attributes token expansion, which is unreachable because `useKeywordSearch` expands the token into concrete attribute names before a request is built. The three copies had drifted apart.

### On numeric and temporal filtering

#1787 asks for range filtering on numeric and temporal properties, which is roughly what this matrix would have served. It is not a step backwards: what is deleted is template-layer text generation with no UI, no producer, and a branch that silently produced the wrong query. Building #1787 needs a filter UI, typed values, and an operator model designed against real requirements — none of which this code provided.

## How to read

1. [useGEFetchTypes.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-0c7354cf3dc8c5d7aaf003faa70bd2c4cbd1590207b9554b394bbe45989d2f8e) — the new `AttributeFilter` type; start here
2. [gremlin/fetchNeighbors/oneHopTemplate.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-88dac7bd19897e26fd2e354ba783714a944af45efe03374def286129634f7140) — the matrix, replaced by one substring predicate
3. [openCypher/fetchNeighbors/oneHopTemplate.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-f55e0587cefda3bbf0073f367663da2ea9371212dcd4f2b6c956ce8896905f36) — the same collapse, for comparison
4. [sparql/types.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-bd5c92261edafcc61e62bdba679001951347f4b53e79f84dc055f99c95be2701) — `SPARQLCriterion` deleted
5. [sparql/sparqlExplorer.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-0e95d16c601b6a5bb5c6f1fde6935393e53f383b4e42da296c492472cedcba67) — the field-renaming map it existed for, now gone
6. [sparql/fetchNeighbors/storedBlankNodeNeighborsRequest.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-f325cf892af2403cc3c3211c4c4ce04f7583bb56c8a21fb91a6ea3a1eab6efbb) — the guard fix; three chained returns become one check
7. [modules/NodeExpand/NodeExpandContent.tsx](https://github.com/aws/graph-explorer/pull/2042/files#diff-c6746be85d08783865c2dfeaa65c59623bef47f4745fe7208796d9d44d0b9211) — the sole producer, now two fields
8. [gremlin/keywordSearch/keywordSearchTemplate.ts](https://github.com/aws/graph-explorer/pull/2042/files#diff-a85e651228422134a4c7adf427e738d121f37a02aa7dfcdb479c4d1c18be5142) — the tangential keyword search cleanup

## Validation

`pnpm checks` and `pnpm test` both pass (2344 tests).

No user-visible change is intended. For the one shape the filter UI can produce, all three query languages emit byte-identical query text before and after.

Suggested focus for review:

- Each deletion was proved dead before removal. The three keyword search template tests were rewritten to pass the post-expansion attribute list with **unchanged** expected queries — if the deleted branches had done anything, those assertions would have moved.
- The roughly thirty-five operator and data type test cases were deleted because they covered removed behaviour. Escaping tests were kept.
- New coverage: seven tests for the in-memory blank node filter, which had none, and three pinning the all-attributes expansion at the one place it now happens.

One known wording problem, deliberately left: the `AttributeFilter` doc comment and the new `CONTEXT.md` glossary entry say filters are conjoined, which is true for Gremlin and openCypher but not for SPARQL, which joins them with `||`. Whether that divergence is intentional is being investigated separately, and the wording will follow that answer rather than pre-empt it.

## Related Issues

- Closes #2031
- Related to #2020
- Related to #2038
- Related to #2039
- Related to #2040
- Related to #2041
- Related to #1787

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
