### PR TITLE
Escape Gremlin string literals completely and consistently

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -1,26 +1,135 @@
 import { createEdgeId, createVertexId } from "@/core";
 
-import { fragment } from "./fragments";
+import { ESCAPABLE_PATTERN, fragment, SHORT_ESCAPES } from "./fragments";
+
+/**
+ * Decodes a Gremlin double-quoted string literal back to its value, reversing
+ * the seven escape sequences the escaper emits.
+ */
+function parseGremlinLiteral(literal: string): string {
+  return literal.slice(1, -1).replace(/\\(.)/g, (_, escaped: string) => {
+    switch (escaped) {
+      case "b":
+        return "\b";
+      case "t":
+        return "\t";
+      case "n":
+        return "\n";
+      case "f":
+        return "\f";
+      case "r":
+        return "\r";
+      default:
+        return escaped;
+    }
+  });
+}
+
+/**
+ * A literal whose body contains no bare delimiter and no escape outside the set
+ * the escaper emits. Asserted alongside each round trip because the decoder
+ * alone is tolerant: it maps an unescaped `\"` and a lone trailing `\\` back to
+ * themselves, so decoding would still succeed if the escaper stopped escaping.
+ */
+const WELL_FORMED_LITERAL = /^"(?:[^"\\]|\\[btnfr\\"])*"$/;
+
+/**
+ * Asserts the literal is well formed and decodes back to the original value.
+ */
+function expectRoundTrip(literal: string, value: string) {
+  expect(literal).toMatch(WELL_FORMED_LITERAL);
+  expect(parseGremlinLiteral(literal)).toBe(value);
+}
+
+/**
+ * Inputs every constructor is round-tripped over: embedded delimiters,
+ * backslashes, control characters, unicode, and strings resembling query syntax
+ * — the cases the curated exact-literal table does not enumerate.
+ */
+const awkwardStrings = [
+  "",
+  " leading and trailing ",
+  'has a " double quote',
+  "has a ' single quote",
+  "has a \\ backslash",
+  "has a ` backtick",
+  "has <angle> brackets",
+  "has a newline\nin it",
+  "has a tab\tin it",
+  "has a carriage\rreturn",
+  `has a ${String.fromCharCode(0x08)} backspace`,
+  `has a ${String.fromCharCode(0x0c)} form feed`,
+  `has a ${String.fromCharCode(0x01)} control character`,
+  `has a ${String.fromCharCode(0x0b)} vertical tab`,
+  'backslash before a double quote a\\"b',
+  'two backslashes before a quote a\\\\"b',
+  "trailing backslash\\",
+  "\\",
+  "café — naïve — 日本語",
+  "emoji 😀 here",
+  `line ${String.fromCharCode(0x2028)} separator`,
+  `delete ${String.fromCharCode(0x7f)} character`,
+  `nbsp ${String.fromCharCode(0x00a0)} character`,
+  "\ud800",
+  "cost is $total",
+] as const;
+
+describe("the escape table and its match pattern", () => {
+  it("should hold a single UTF-16 code unit per key, which is all the pattern can express", () => {
+    expect(
+      Object.keys(SHORT_ESCAPES).filter(char => char.length !== 1),
+    ).toEqual([]);
+  });
+
+  it("should match every character the table escapes, and no others", () => {
+    // `matchAll` rather than `test`, which advances `lastIndex` on a global regex.
+    const matched: string[] = [];
+    for (let code = 0; code < 0x110000; code++) {
+      const char = String.fromCodePoint(code);
+      if ([...char.matchAll(ESCAPABLE_PATTERN)].length > 0) {
+        matched.push(char);
+      }
+    }
+    expect(matched.toSorted()).toEqual(Object.keys(SHORT_ESCAPES).toSorted());
+  });
+});
 
 describe("fragment.string", () => {
-  it("should wrap the value in double quotes", () => {
-    expect(fragment.string("test")).toEqual('"test"');
+  // Double-quoted: `"` and `\` are escaped and control characters take their
+  // short escapes, so `'` and `$` are the characters left bare.
+  const cases: [input: string, literal: string][] = [
+    ["test", '"test"'],
+    [" te st ", '" te st "'],
+    ["", '""'],
+    ["te\\st", '"te\\\\st"'],
+    ['te"st', '"te\\"st"'],
+    ["te'st", `"te'st"`],
+    ["a\bb", '"a\\bb"'],
+    ["a\tb", '"a\\tb"'],
+    ["a\nb", '"a\\nb"'],
+    ["a\fb", '"a\\fb"'],
+    ["a\rb", '"a\\rb"'],
+  ];
+
+  it.each(cases)("encodes %j", (value, literal) => {
+    expect(fragment.string(value)).toBe(literal);
   });
 
-  it("should preserve surrounding whitespace", () => {
-    expect(fragment.string(" te st ")).toEqual('" te st "');
+  it("should leave a dollar sign alone, since escaping it breaks the query on Neptune", () => {
+    expect(fragment.string("cost is $total")).toBe('"cost is $total"');
   });
 
-  it("should produce an empty literal for an empty string", () => {
-    expect(fragment.string("")).toEqual('""');
+  it("should emit a control character without a short escape raw, never as \\uXXXX", () => {
+    expect(fragment.string(`a${String.fromCharCode(0x01)}b`)).toBe(
+      `"a${String.fromCharCode(0x01)}b"`,
+    );
+    expect(fragment.string(`a${String.fromCharCode(0x0b)}b`)).toBe(
+      `"a${String.fromCharCode(0x0b)}b"`,
+    );
   });
 
-  it("should escape a double quote", () => {
-    expect(fragment.string('te"st')).toEqual('"te\\"st"');
-  });
-
-  it("should leave a single quote alone, since it needs no escaping", () => {
-    expect(fragment.string("t'est")).toEqual('"t\'est"');
+  it.each(awkwardStrings)("round-trips %j", value => {
+    expectRoundTrip(fragment.string(value), value);
   });
 });
 
@@ -36,6 +145,18 @@ describe("fragment.identifier", () => {
   it("should escape a double quote", () => {
     expect(fragment.identifier('ci"ty')).toEqual('"ci\\"ty"');
   });
+
+  it("should escape a backslash", () => {
+    expect(fragment.identifier("ci\\ty")).toEqual('"ci\\\\ty"');
+  });
+
+  it("should leave a dollar sign alone", () => {
+    expect(fragment.identifier("wei$rd")).toEqual('"wei$rd"');
+  });
+
+  it.each(awkwardStrings)("round-trips a name %j", value => {
+    expectRoundTrip(fragment.identifier(value), value);
+  });
 });
 
 describe("fragment.id", () => {
@@ -49,5 +170,17 @@ describe("fragment.id", () => {
 
   it("should add the long suffix to a numeric ID", () => {
     expect(fragment.id(createVertexId(124))).toEqual("124L");
+  });
+
+  it("should escape a double quote in a string ID", () => {
+    expect(fragment.id(createVertexId('1"2'))).toEqual('"1\\"2"');
+  });
+
+  it("should escape a backslash in a string ID", () => {
+    expect(fragment.id(createVertexId("1\\2"))).toEqual('"1\\\\2"');
+  });
+
+  it.each(awkwardStrings)("round-trips a string ID %j", value => {
+    expectRoundTrip(fragment.id(createVertexId(value)), value);
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -17,14 +17,65 @@ import { type QueryFragment, toQueryFragment } from "../queryFragment";
  * its own.
  */
 
-function escape(value: string): string {
-  return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
+/**
+ * Escapes a value for a double-quoted Gremlin string literal, returning the
+ * body without the surrounding quotes.
+ *
+ * The escape vocabulary is deliberately minimal — backslash, the double-quote
+ * delimiter, and the five whitespace controls with a short form — because it is
+ * the intersection of what every supported engine accepts. Two engines parse
+ * the query text differently: Neptune uses an ANTLR grammar, while open-source
+ * Apache TinkerPop Gremlin Server and JanusGraph parse it as Groovy. Notably:
+ *
+ * - `\uXXXX` is not used: Groovy 2.5 (TinkerPop 3.6.2) resolves unicode escapes
+ *   at the source level before lexing, so a `\` at a literal's edge would
+ *   decode to a backslash and break out of the string. C0 control characters
+ *   without a short form are emitted raw instead, which every engine accepts.
+ * - A raw newline or carriage return is rejected by the Groovy lexer, so both
+ *   take their short escape rather than passing through.
+ * - `$` is left unescaped, since a `\$` escape is a parse error on Neptune.
+ *   Keeping it verbatim on every engine depends on the delimiter rather than on
+ *   an escape.
+ *
+ * Verified live against Neptune 1.2.1.0/1.4.7.0 and Gremlin Server 3.6.2/3.8.
+ */
+/**
+ * Each key is one character, and its value is that character's escape sequence.
+ * `ESCAPABLE_PATTERN` is derived from the keys, so the two cannot disagree about
+ * which characters get escaped. Both properties are asserted in the tests: a key
+ * spanning more than one UTF-16 code unit would contribute only its first unit
+ * to the pattern, matching characters it was never meant to.
+ */
+export const SHORT_ESCAPES = {
+  "\\": "\\\\",
+  '"': '\\"',
+  "\b": "\\b",
+  "\t": "\\t",
+  "\n": "\\n",
+  "\f": "\\f",
+  "\r": "\\r",
+} as const;
+
+type EscapableCharacter = keyof typeof SHORT_ESCAPES;
+
+export const ESCAPABLE_PATTERN = new RegExp(
+  `[${Object.keys(SHORT_ESCAPES)
+    .map(char => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`)
+    .join("")}]`,
+  "g",
+);
+
+function escapeStringLiteralBody(value: string): string {
+  return value.replaceAll(
+    ESCAPABLE_PATTERN,
+    char => SHORT_ESCAPES[char as EscapableCharacter],
+  );
 }
 
 export const fragment = {
   /** A Gremlin string literal, including the surrounding double quotes. */
   string(value: string): QueryFragment {
-    return toQueryFragment(`"${escape(value)}"`);
+    return toQueryFragment(`"${escapeStringLiteralBody(value)}"`);
   },
 
   /**
@@ -32,17 +83,19 @@ export const fragment = {
    * use the same delimiters and escaping as any other literal.
    */
   identifier(name: string): QueryFragment {
-    return toQueryFragment(`"${escape(name)}"`);
+    return toQueryFragment(`"${escapeStringLiteralBody(name)}"`);
   },
 
   /**
    * An entity ID. A numeric ID takes the Gremlin long suffix and therefore
-   * needs no delimiters.
+   * needs no delimiters; a string ID is a string literal like any other.
    */
   id(entityId: VertexId | EdgeId): QueryFragment {
     const rawId = getRawId(entityId);
     return toQueryFragment(
-      typeof rawId === "number" ? `${rawId}L` : `"${rawId}"`,
+      typeof rawId === "number"
+        ? `${rawId}L`
+        : `"${escapeStringLiteralBody(rawId)}"`,
     );
   },
 };


### PR DESCRIPTION
## Description

Every Gremlin string literal Graph Explorer sends comes from the `fragment` constructors in `connector/gremlin/fragments.ts`. The escaper there only did any escaping when the value already contained a double quote:

```ts
return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
```

Three consequences, all reachable with ordinary property values:

- **`fragment.id` never escaped at all.** Its string branch interpolated the raw ID, so an ID containing a double quote emitted `"te"st"` — an unbalanced literal, and a query the database rejects.
- **Backslashes passed through bare.** `te\st` emitted `"te\st"`, where the backslash begins an escape sequence the value never intended.
- **Control characters passed through raw.** An embedded newline stayed a literal newline inside the query text, so it also reached the `query` template tag's whitespace normalization and could alter the value before it was sent.

This routes `string`, `identifier`, and the string branch of `id` through one escaper covering backslash, the double-quote delimiter, and the five whitespace control characters that have a short escape form. The set is deliberately narrow: it is the intersection of what every supported engine accepts, so it holds for both Neptune and open-source Apache TinkerPop Gremlin Server / JanusGraph, which parse query text differently. The reasoning for each inclusion and exclusion is recorded on the escaper itself.

String delimiting is unchanged.

## How to read

1. [`connector/gremlin/fragments.ts`](https://github.com/aws/graph-explorer/pull/2043/files#diff-1d089533c25397d7fa71d381aa6345baad8801c33bca2ac12c8e9121e2256124) — the escaper and the reasoning for each escape form it does and does not emit
2. [`connector/gremlin/fragments.test.ts`](https://github.com/aws/graph-explorer/pull/2043/files#diff-feeb6e3e5ffa1d953fa3162ce34c3f6d5cf6a03a963c1e10ffa4d4b0d5336f52) — the exact-literal tables and the shared round-trip suite

## Validation

Verified against live databases while deriving the escape set — Neptune 1.2.1.0 and 1.4.7.0, and Gremlin Server 3.6.2 and 3.8 — covering each escape form, raw control characters, unicode, and quote/backslash combinations. Engine behaviour was identical across both Neptune versions.

In the test suite, each constructor has an exact-literal table plus a shared round-trip suite asserting two things per input: that the emitted literal is well formed, and that decoding it returns the original value. The well-formedness check matters because a decoder alone is too permissive to fail — it maps an unescaped quote back to itself, so a round-trip assertion would still pass if the escaper stopped escaping.

Confirmed the suite catches regressions by reverting the escaper under it: escaping nothing fails 29 tests, and restoring the previous conditional escaper fails 17.

The match pattern is derived from the escape table rather than written out separately. Two tests hold that derivation honest — one sweeps every code point to assert the pattern matches exactly the table's keys and nothing else, the other that each key is a single code unit, since a longer key would contribute only its first unit to the pattern and match characters it was never meant to. Both were verified to fail when the table and pattern are deliberately put out of step.

## Related Issues

- Related to #2020
- Related to #2039

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
