### PR TITLE
Build every Gremlin literal through the fragment constructors

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -3,6 +3,7 @@ import type { AttributeFilter } from "@/connector/useGEFetchTypes";
 import { createVertexId } from "@/core";
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 
+import { UnrepresentableNumberError } from "../../queryValueError";
 import oneHopTemplate from "./oneHopTemplate";
 
 describe("Gremlin > oneHopTemplate", () => {
@@ -123,6 +124,12 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
+  it("Should reject a limit with no plain decimal form", () => {
+    expect(() =>
+      oneHopTemplate({ vertexId: createVertexId("12"), limit: Infinity }),
+    ).toThrow(new UnrepresentableNumberError(Infinity));
+  });
+
   it("Should return a template for specific vertex type", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
@@ -206,6 +213,17 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
+  it("should escape a vertex type containing the delimiter", () => {
+    const template = oneHopTemplate({
+      vertexId: createVertexId("12"),
+      filterByVertexTypes: ['coun"try'],
+    });
+
+    expect(normalize(template)).toContain(
+      normalize('.both().hasLabel("coun\\"try").dedup()'),
+    );
+  });
+
   describe("attribute filters", () => {
     function fragmentFor(attributeFilters: AttributeFilter[]) {
       return normalize(
@@ -232,6 +250,18 @@ describe("Gremlin > oneHopTemplate", () => {
         normalize(
           'and(has("city",containing("Sea")), has("country",containing("US")))',
         ),
+      );
+    });
+
+    it("escapes an attribute name containing the delimiter", () => {
+      expect(fragmentFor([{ name: 'ci"ty', value: "Sea" }])).toContain(
+        normalize('and(has("ci\\"ty",containing("Sea")))'),
+      );
+    });
+
+    it("escapes a filter value containing the delimiter", () => {
+      expect(fragmentFor([{ name: "city", value: 'Se"a' }])).toContain(
+        normalize('and(has("city",containing("Se\\"a")))'),
       );
     });
 

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -8,7 +8,7 @@ import { query } from "@/utils";
 import { fragment } from "../fragments";
 
 function attributeFilterTemplate({ name, value }: AttributeFilter): string {
-  return `has("${name}",containing("${value}"))`;
+  return `has(${fragment.identifier(name)},containing(${fragment.string(value)}))`;
 }
 
 /**
@@ -45,12 +45,12 @@ export default function oneHopTemplate({
   limit = 0,
 }: Omit<NeighborsRequest, "vertexTypes">): string {
   const idTemplate = fragment.id(vertexId);
-  const range = limit > 0 ? `.range(0, ${limit})` : "";
+  const range = limit > 0 ? `.range(0, ${fragment.number(limit)})` : "";
 
   const vertexTypes = filterByVertexTypes.flatMap(type => type.split("::"));
   const vertexTypesTemplate =
     vertexTypes.length > 0
-      ? `hasLabel(${vertexTypes.map(type => `"${type}"`).join(", ")})`
+      ? `hasLabel(${vertexTypes.map(fragment.identifier).join(", ")})`
       : ``;
 
   const attributeFiltersTemplate =

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
@@ -36,4 +36,18 @@ describe("Gremlin > edgesSchemaTemplate", () => {
       `),
     );
   });
+
+  it("Should escape a label containing the delimiter", () => {
+    const template = edgesSchemaTemplate({ types: ['ro"ute'] });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.V().limit(1)
+          .project(
+            "ro\\"ute"
+          )
+          .by(V().bothE("ro\\"ute").limit(1))
+      `),
+    );
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
@@ -2,6 +2,8 @@ import { uniq } from "lodash";
 
 import { query } from "@/utils";
 
+import { fragment } from "../fragments";
+
 /**
  * Given a set of edge types, it returns a Gremlin template that contains
  * one sample of each edge type.
@@ -23,7 +25,7 @@ import { query } from "@/utils";
  */
 export default function edgesSchemaTemplate({ types }: { types: string[] }) {
   const labels = uniq(types.flatMap(type => type.split("::"))).map(
-    label => `"${label}"`,
+    fragment.identifier,
   );
 
   return query`

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
@@ -36,4 +36,18 @@ describe("Gremlin > verticesSchemaTemplate", () => {
       `),
     );
   });
+
+  it("Should escape a label containing the delimiter", () => {
+    const template = verticesSchemaTemplate({ types: ['air"port'] });
+
+    expect(normalize(template)).toBe(
+      normalize(`
+        g.V().limit(1)
+          .project(
+            "air\\"port"
+          )
+          .by(V().hasLabel("air\\"port").limit(1))
+      `),
+    );
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
@@ -2,6 +2,8 @@ import { uniq } from "lodash";
 
 import { query } from "@/utils";
 
+import { fragment } from "../fragments";
+
 /**
  * Given a set of nodes labels, it returns a Gremlin template that contains
  * one sample of each node label.
@@ -23,7 +25,7 @@ import { query } from "@/utils";
  */
 export default function verticesSchemaTemplate({ types }: { types: string[] }) {
   const labels = uniq(types.flatMap(type => type.split("::"))).map(
-    label => `"${label}"`,
+    fragment.identifier,
   );
 
   return query`

--- a/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
@@ -6,4 +6,10 @@ describe("Gremlin > vertexTypeCountTemplate", () => {
 
     expect(template).toBe('g.V().hasLabel("airport").count()');
   });
+
+  it("should escape a label containing the delimiter", () => {
+    const template = vertexTypeCountTemplate('air"port');
+
+    expect(template).toBe('g.V().hasLabel("air\\"port").count()');
+  });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.ts
@@ -1,6 +1,8 @@
+import { fragment } from "../fragments";
+
 /**
  * It returns a Gremlin template to number of vertices of a particular label
  */
 export default function vertexTypeCountTemplate(label: string) {
-  return `g.V().hasLabel("${label}").count()`;
+  return `g.V().hasLabel(${fragment.identifier(label)}).count()`;
 }

--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -1,5 +1,6 @@
 import { createEdgeId, createVertexId } from "@/core";
 
+import { UnrepresentableNumberError } from "../queryValueError";
 import { ESCAPABLE_PATTERN, fragment, SHORT_ESCAPES } from "./fragments";
 
 /**
@@ -157,6 +158,44 @@ describe("fragment.identifier", () => {
   it.each(awkwardStrings)("round-trips a name %j", value => {
     expectRoundTrip(fragment.identifier(value), value);
   });
+
+  // Gremlin takes a property key or label as an ordinary string literal, so
+  // `identifier` and `string` coincide. Nothing in a generated query reveals
+  // which one a call site chose; if the two ever diverge, every call site's
+  // choice has to be re-checked rather than assumed.
+  it.each(awkwardStrings)(
+    "should render %j identically to a string literal",
+    value => {
+      expect(fragment.identifier(value)).toBe(fragment.string(value));
+    },
+  );
+});
+
+describe("fragment.number", () => {
+  // `%s` rather than `%j`, which renders NaN and the infinities as `null`.
+  it.each([
+    [0, "0"],
+    [100, "100"],
+    [-5, "-5"],
+    [1.5, "1.5"],
+    [-1.5, "-1.5"],
+    [0.000001, "0.000001"],
+    [Number.MAX_SAFE_INTEGER, "9007199254740991"],
+    // Large enough to lose precision, but still written out in full, so the
+    // parser reads it as a number.
+    [1e20, "100000000000000000000"],
+  ])("should emit %s without delimiters", (value, text) => {
+    expect(fragment.number(value)).toBe(text);
+  });
+
+  it.each([NaN, Infinity, -Infinity, 1e21, -1e21, 1e-7, Number.MIN_VALUE])(
+    "should reject %s, which has no plain decimal form",
+    value => {
+      expect(() => fragment.number(value)).toThrow(
+        new UnrepresentableNumberError(value),
+      );
+    },
+  );
 });
 
 describe("fragment.id", () => {

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -1,6 +1,7 @@
 import { type EdgeId, getRawId, type VertexId } from "@/core";
 
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
+import { UnrepresentableNumberError } from "../queryValueError";
 
 /*
  * Constructs Query Fragments for Gremlin. A fragment is safe to interpolate
@@ -65,6 +66,9 @@ export const ESCAPABLE_PATTERN = new RegExp(
   "g",
 );
 
+/** A number written out in full, rather than as a word or in exponential form. */
+const BARE_DECIMAL = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/;
+
 function escapeStringLiteralBody(value: string): string {
   return value.replaceAll(
     ESCAPABLE_PATTERN,
@@ -84,6 +88,22 @@ export const fragment = {
    */
   identifier(name: string): QueryFragment {
     return toQueryFragment(`"${escapeStringLiteralBody(name)}"`);
+  },
+
+  /**
+   * A numeric operand, emitted without delimiters so the database reads it as a
+   * number rather than as text.
+   *
+   * The check is on the emitted text, not the value, because it is that text the
+   * database parses: a value is representable only if `String` renders it as a
+   * plain decimal.
+   */
+  number(value: number): QueryFragment {
+    const text = String(value);
+    if (!BARE_DECIMAL.test(text)) {
+      throw new UnrepresentableNumberError(value);
+    }
+    return toQueryFragment(text);
   },
 
   /**

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -1,6 +1,7 @@
 import { SEARCH_TOKENS } from "@/utils";
 import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 
+import { UnrepresentableNumberError } from "../../queryValueError";
 import keywordSearchTemplate from "./keywordSearchTemplate";
 
 describe("Gremlin > keywordSearchTemplate", () => {
@@ -72,6 +73,37 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize('g.V().or(has("code","\\"JFK\\""))'),
+    );
+  });
+
+  it("Should escape a vertex type containing the delimiter", () => {
+    const template = keywordSearchTemplate({
+      vertexTypes: ['air"port'],
+    });
+
+    expect(normalize(template)).toBe(normalize('g.V().hasLabel("air\\"port")'));
+  });
+
+  it("Should escape an attribute name containing the delimiter", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchByAttributes: ['ci"ty'],
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().or(has("ci\\"ty",containing("JFK")))'),
+    );
+  });
+
+  it("Should escape an attribute name when matching exactly", () => {
+    const template = keywordSearchTemplate({
+      searchTerm: "JFK",
+      searchByAttributes: ['ci"ty'],
+      exactMatch: true,
+    });
+
+    expect(normalize(template)).toBe(
+      normalize('g.V().or(has("ci\\"ty","JFK"))'),
     );
   });
 
@@ -166,6 +198,16 @@ describe("Gremlin > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize('g.V().or(has("code",containing("JFK")))'),
     );
+  });
+
+  it("Should reject a limit with no plain decimal form", () => {
+    expect(() =>
+      keywordSearchTemplate({
+        searchTerm: "JFK",
+        searchByAttributes: ["code"],
+        limit: Infinity,
+      }),
+    ).toThrow(new UnrepresentableNumberError(Infinity));
   });
 
   it("Should return a template for a specific vertex type", () => {

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
@@ -18,10 +18,10 @@ import { fragment } from "../fragments";
  * g.V()
  *  .hasLabel("airport")
  *  .or(
- *    has("city", containing("JFK"),
- *    has("code", containing("JFK")
+ *    has("city",containing("JFK")),
+ *    has("code",containing("JFK"))
  *  )
- *  .range(0, 100)
+ *  .range(0,100)
  */
 export default function keywordSearchTemplate({
   searchTerm,
@@ -36,7 +36,7 @@ export default function keywordSearchTemplate({
   if (vertexTypes.length !== 0) {
     const hasLabelContent = vertexTypes
       .flatMap(type => type.split("::"))
-      .map(type => `"${type}"`)
+      .map(fragment.identifier)
       .join(",");
     template += `.hasLabel(${hasLabelContent})`;
   }
@@ -52,10 +52,11 @@ export default function keywordSearchTemplate({
           }
           return `has(id,containing(${searchLiteral}))`;
         }
+        const key = fragment.identifier(attr);
         if (exactMatch === true) {
-          return `has("${attr}",${searchLiteral})`;
+          return `has(${key},${searchLiteral})`;
         }
-        return `has("${attr}",containing(${searchLiteral}))`;
+        return `has(${key},containing(${searchLiteral}))`;
       })
       .join(",");
 
@@ -63,7 +64,7 @@ export default function keywordSearchTemplate({
   }
 
   if (limit) {
-    template += `.range(${offset},${offset + limit})`;
+    template += `.range(${fragment.number(offset)},${fragment.number(offset + limit)})`;
   }
   return template;
 }

--- a/packages/graph-explorer/src/connector/queryValueError.test.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.test.ts
@@ -1,4 +1,9 @@
-import { QueryValueError, UnsupportedValueTypeError } from "./queryValueError";
+import {
+  QueryValueError,
+  UnrepresentableNumberError,
+  UnrepresentableValueError,
+  UnsupportedValueTypeError,
+} from "./queryValueError";
 
 describe("UnsupportedValueTypeError", () => {
   it("carries the language, position, and original value", () => {
@@ -44,6 +49,48 @@ describe("UnsupportedValueTypeError", () => {
       position: "IRI",
       valueType: "number",
       value: 124,
+    });
+  });
+});
+
+describe("UnrepresentableNumberError", () => {
+  it("is an Error, a QueryValueError, and an UnrepresentableValueError", () => {
+    const error = new UnrepresentableNumberError(NaN);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(QueryValueError);
+    expect(error).toBeInstanceOf(UnrepresentableValueError);
+  });
+
+  it("names itself after the subclass", () => {
+    expect(new UnrepresentableNumberError(NaN).name).toBe(
+      "UnrepresentableNumberError",
+    );
+  });
+
+  it("preserves the original numeric value", () => {
+    const error = new UnrepresentableNumberError(1e21);
+
+    expect(error.value).toBe(1e21);
+    expect(typeof error.value).toBe("number");
+  });
+
+  // NaN loses its identity through JSON, so it goes through its own assertion.
+  it("preserves NaN", () => {
+    expect(new UnrepresentableNumberError(NaN).value).toBeNaN();
+  });
+
+  it("derives a message that names the offending value's text form", () => {
+    expect(new UnrepresentableNumberError(1e21).message).toContain("1e+21");
+    expect(new UnrepresentableNumberError(Infinity).message).toContain(
+      "Infinity",
+    );
+  });
+
+  it("exposes the value and its text form as details", () => {
+    expect(new UnrepresentableNumberError(1e21).details).toStrictEqual({
+      value: 1e21,
+      valueText: "1e+21",
     });
   });
 });

--- a/packages/graph-explorer/src/connector/queryValueError.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.ts
@@ -31,6 +31,28 @@ export abstract class QueryValueError extends Error {
 export abstract class UnrepresentableValueError extends QueryValueError {}
 
 /**
+ * A number with no plain-decimal text form: `NaN` and the infinities render as
+ * bare words, and magnitudes outside roughly 1e-7 to 1e21 switch to exponential
+ * notation (`1e+21`, `5e-7`). None of these are a numeric literal in any query
+ * language, so the failure is a property of the value rather than the position.
+ */
+export class UnrepresentableNumberError extends UnrepresentableValueError {
+  readonly value: number;
+
+  constructor(value: number) {
+    super(
+      "UnrepresentableNumberError",
+      `The value ${String(value)} has no plain-decimal form and cannot be used in a query.`,
+    );
+    this.value = value;
+  }
+
+  get details() {
+    return { value: this.value, valueText: String(this.value) };
+  }
+}
+
+/**
  * The position accepts a value, but not one of this type — a numeric ID where a
  * language only supports string IDs, or a non-string where an IRI is required.
  *


### PR DESCRIPTION
## Description

#2043 made the Gremlin escaper in `connector/gremlin/fragments.ts` complete, but seven interpolation sites never called it — they wrote their own quotes around the value instead:

```ts
`has("${name}",containing("${value}"))`   // attribute filter: name and value
`"${type}"`                              // vertex type labels
`"${label}"`                             // schema sampling, vertex type counts
`has("${attr}",…)`                       // keyword search attribute names
```

So an attribute name, type label, or filter value containing a double quote or a backslash still produced query text the database rejects — an unbalanced literal, surfacing as an opaque error or as no results.

The `range` step had the same shape of gap in a numeric position — `.range(0, ${limit})` and `.range(${offset},${offset + limit})` interpolated their bounds directly. The node expansion limit is a connection option validated only as a number with no upper bound, so a large enough value reached the query in exponential form (`1e+21`), which the engine reads as a decimal rather than a whole number and refuses to bind to the step.

This routes all of them through the fragment constructors: `fragment.identifier` for a property key, label, or type, `fragment.string` for a user-supplied value, and a new `fragment.number` for the range bounds, which reports anything but a non-negative safe integer rather than emitting it. Holding that rule in the constructor rather than at each call site also makes it uniform — the two templates' own guards differ (`limit > 0` versus `if (limit)`), so a negative passed one and not the other. No Gremlin template writes a delimiter or an unchecked operand of its own now.

The schema-sampling conversion is worth calling out as more than cosmetic: a label containing a double quote previously produced a malformed `.project(...)`, which broke schema discovery for that label — and every search that included the affected attribute.

Two things deliberately left alone, both belonging to the follow-up that changes the delimiter: hardcoded step labels (`.as("start")`, `.project("vertex", "edges")`), which are language constants rather than values, and the `@example` blocks that illustrate them.

## How to read

1. [`fetchNeighbors/oneHopTemplate.ts`](https://github.com/aws/graph-explorer/pull/2046/files#diff-88dac7bd19897e26fd2e354ba783714a944af45efe03374def286129634f7140) — the attribute filter, the only site where both a key and a value needed routing
2. [`keywordSearch/keywordSearchTemplate.ts`](https://github.com/aws/graph-explorer/pull/2046/files#diff-a85e651228422134a4c7adf427e738d121f37a02aa7dfcdb479c4d1c18be5142) — attribute names in both the exact and partial branches; also corrects an `@example` whose parentheses never balanced
3. [`fragments.test.ts`](https://github.com/aws/graph-explorer/pull/2046/files#diff-feeb6e3e5ffa1d953fa3162ce34c3f6d5cf6a03a963c1e10ffa4d4b0d5336f52) — the one test not tied to a call site, explained under Validation

The three remaining template conversions are the same one-line substitution.

## Validation

Every converted site has a test that feeds a value containing the delimiter and asserts the escaped form. That specific input matters: a test using an ordinary value passes whether the text came from a fragment constructor or from hand-written quotes, so it would prove nothing about routing. Confirmed by reverting the five source files with the new tests in place — exactly the nine new tests fail, and the 217 pre-existing ones still pass, so the conversions are what the tests are measuring.

`fragments.test.ts` gains one test of a different kind. In Gremlin a property key and a plain value render identically, so choosing the wrong constructor at a call site is invisible in the emitted query and no per-site test can catch it. That test pins the equivalence as deliberate: if the two ever stop agreeing, it fails and the call sites get re-examined rather than assumed.

`fragment.number`'s range is pinned from both sides: the largest safe integer is accepted, while a non-integer, a negative, `NaN`, either infinity, `1e21`, and `MAX_SAFE_INTEGER + 1` are each rejected. Weakening the predicate to `Number.isInteger` fails three of those cases, so the boundary is held by tests rather than by the comment.

`pnpm checks` clean; `pnpm test` 2480 passing.

## Note for release notes

Not a change requested here, but worth recording before it is forgotten. Values are now matched literally, which is a behaviour change for anyone who had adapted to the old pass-through — typing `C:\\logs` to find `C:\logs` now searches for two backslashes and returns nothing, which is indistinguishable from "no such data". Worth one line in the notes when this work lands, alongside the fix itself. The improvement is best described in terms of the data rather than the mechanism: search, filtering, and neighbor expansion now work on graphs whose attribute names or type labels contain a double quote or backslash.

## Related Issues

- Related to #2020
- Related to #2039

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
