### PR TITLE
Delimit Gremlin string literals with single quotes

### DIFF
--- a/docs/adr/20260804-single-quoted-gremlin-literals.md
+++ b/docs/adr/20260804-single-quoted-gremlin-literals.md
@@ -1,0 +1,23 @@
+# ADR — Single-quoted Gremlin string literals
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Related:** `connector/gremlin/fragments.ts` (`SHORT_ESCAPES`, the one place this is implemented); `docs/agents/connectors.md`. Issue #2020.
+
+## Context
+
+Graph Explorer sends Gremlin as script text, and the two front ends it supports do not parse that text the same way. Neptune uses the ANTLR `gremlin-language` grammar. Open-source Apache TinkerPop Gremlin Server and JanusGraph compile it with `GremlinGroovyScriptEngine`, so Groovy's rules apply.
+
+That split leaves no way to carry a `$` through a **double-quoted** literal. A double-quoted Groovy string is a GString, where `$` introduces an expression to evaluate rather than a character to keep. The obvious remedy — escaping it as `\$` — is a hard parse error on Neptune. So one engine needs the escape and the other rejects it, and `$` is ordinary data: a price column, a template string, an attribute name someone chose.
+
+## Decision
+
+Delimit every Gremlin string literal with **single quotes**, and escape the single quote rather than the double quote.
+
+A single-quoted Groovy string is a plain string with no interpolation, so `$` needs no escape on either engine — rather than detecting which front end a connection talks to, which the template layer does not know and which would mean maintaining two escaping rules. The escape set becomes backslash, the single-quote delimiter, and the five whitespace control characters that have a short form.
+
+Tested directly against Neptune 1.2.1.0 and 1.4.7.0 and Gremlin Server 3.6.2 and 3.8 — the oldest and newest of each, which differ in Groovy version and in how they resolve unicode escapes: that both delimiters are accepted, that `$` survives verbatim in a single-quoted literal, that `\$` fails on Neptune, that `${...}` is evaluated in a double-quoted literal on the Groovy engines, and that each of the seven escapes decodes as intended. That single quotes are accepted _wherever_ double quotes are is read off the `gremlin-language` grammar, not exhaustively tested.
+
+## Consequences
+
+Escaping now runs opposite to intuition: inside a Gremlin literal a **double quote needs no escape** and a **single quote does**. A test that feeds a double quote therefore cannot tell a value that went through a fragment constructor from one a template wrapped in quotes by hand — both produce identical text. The discriminating character is the single quote, and the tests that prove routing feed one.

--- a/docs/agents/connectors.md
+++ b/docs/agents/connectors.md
@@ -20,3 +20,4 @@
 - Interpolate values into a query only as Query Fragments, from that language's `fragments.ts`. A fragment brings its own delimiters, so the template must not add quotes, backticks, or angle brackets around it.
 - Each `fragments.ts` exports one `fragment` object: import it as `import { fragment } from "./fragments"` and call `fragment.string(...)`, `fragment.identifier(...)`, `fragment.id(...)` (Gremlin/openCypher) or `fragment.iri(...)` (SPARQL). Keep the `fragment.` qualifier at call sites — don't destructure — so the self-delimiting invariant stays visible.
 - Fragments are per language and not interchangeable, even where two languages look alike
+- Gremlin literals are single-quoted, so inside one a double quote needs no escaping and a single quote does — see `docs/adr/20260804-single-quoted-gremlin-literals.md`. A test proving a value went through a fragment constructor has to feed a single quote; a double quote passes through either way and proves nothing.

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -9,7 +9,7 @@ describe("Gremlin > edgeConnectionsTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.E().hasLabel("route").limit(10000)
+        g.E().hasLabel('route').limit(10000)
           .project('sourceType', 'targetType')
           .by(outV().label())
           .by(inV().label())

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.test.ts
@@ -17,10 +17,10 @@ describe("Gremlin > fetchEdgeConnections", () => {
 
     expect(gremlinFetch).toHaveBeenCalledTimes(2);
     expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining('hasLabel("route")'),
+      expect.stringContaining("hasLabel('route')"),
     );
     expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining('hasLabel("contains")'),
+      expect.stringContaining("hasLabel('contains')"),
     );
     expect(result).toStrictEqual({
       edgeConnections: [
@@ -112,11 +112,11 @@ describe("Gremlin > fetchEdgeConnections", () => {
     const gremlinFetch = vi.fn().mockResolvedValue(emptyResponse);
 
     await fetchEdgeConnections(gremlinFetch, {
-      edgeTypes: [createEdgeType('edge"with"quotes')],
+      edgeTypes: [createEdgeType("edge'with'quotes")],
     });
 
     expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining('hasLabel("edge\\"with\\"quotes")'),
+      expect.stringContaining("hasLabel('edge\\'with\\'quotes')"),
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -22,18 +22,18 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toEqual(
       normalize(`
-        g.V("124").as("start")
+        g.V('124').as('start')
           .both()
-          .hasLabel("airport").and(has("city",containing("Sea")), has("country",containing("ES")))
-          .filter(__.not(__.hasId("256")))
+          .hasLabel('airport').and(has('city',containing('Sea')), has('country',containing('ES')))
+          .filter(__.not(__.hasId('256')))
           .dedup()
           .range(0, 10)
-          .as("neighbor")
-          .project("vertex", "edges")
+          .as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -47,13 +47,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
-          .both().dedup().as("neighbor")
-          .project("vertex", "edges")
+        g.V('12').as('start')
+          .both().dedup().as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -68,15 +68,15 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
+        g.V('12').as('start')
           .both()
-          .filter(__.not(__.hasId("256", "512")))
-          .dedup().as("neighbor")
-          .project("vertex", "edges")
+          .filter(__.not(__.hasId('256', '512')))
+          .dedup().as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -90,13 +90,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V(12L).as("start")
-          .both().dedup().as("neighbor")
-          .project("vertex", "edges")
+        g.V(12L).as('start')
+          .both().dedup().as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -111,13 +111,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
-          .both().dedup().range(0, 5).as("neighbor")
-          .project("vertex", "edges")
+        g.V('12').as('start')
+          .both().dedup().range(0, 5).as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -139,13 +139,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
-          .both().hasLabel("country").dedup().range(0, 10).as("neighbor")
-          .project("vertex", "edges")
+        g.V('12').as('start')
+          .both().hasLabel('country').dedup().range(0, 10).as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -161,13 +161,13 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
-          .both().hasLabel("country", "airport", "continent").dedup().range(0, 10).as("neighbor")
-          .project("vertex", "edges")
+        g.V('12').as('start')
+          .both().hasLabel('country', 'airport', 'continent').dedup().range(0, 10).as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -187,15 +187,15 @@ describe("Gremlin > oneHopTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.V("12").as("start")
-          .both().hasLabel("country")
-            .and(has("city",containing("Sea")),has("country",containing("ES")))
-            .dedup().range(0, 10).as("neighbor")
-          .project("vertex", "edges")
+        g.V('12').as('start')
+          .both().hasLabel('country')
+            .and(has('city',containing('Sea')),has('country',containing('ES')))
+            .dedup().range(0, 10).as('neighbor')
+          .project('vertex', 'edges')
             .by()
             .by(
-              __.select("start").bothE()
-                .where(otherV().where(eq("neighbor")))
+              __.select('start').bothE()
+                .where(otherV().where(eq('neighbor')))
                 .dedup().fold()
             )
       `),
@@ -209,18 +209,18 @@ describe("Gremlin > oneHopTemplate", () => {
     });
 
     expect(normalize(template)).toContain(
-      normalize('.both().hasLabel("country", "capital").dedup()'),
+      normalize(".both().hasLabel('country', 'capital').dedup()"),
     );
   });
 
   it("should escape a vertex type containing the delimiter", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
-      filterByVertexTypes: ['coun"try'],
+      filterByVertexTypes: ["coun'try"],
     });
 
     expect(normalize(template)).toContain(
-      normalize('.both().hasLabel("coun\\"try").dedup()'),
+      normalize(".both().hasLabel('coun\\'try').dedup()"),
     );
   });
 
@@ -236,7 +236,7 @@ describe("Gremlin > oneHopTemplate", () => {
 
     it("matches an attribute containing the value", () => {
       expect(fragmentFor([{ name: "country", value: "ES" }])).toContain(
-        normalize('and(has("country",containing("ES")))'),
+        normalize("and(has('country',containing('ES')))"),
       );
     });
 
@@ -248,35 +248,35 @@ describe("Gremlin > oneHopTemplate", () => {
         ]),
       ).toContain(
         normalize(
-          'and(has("city",containing("Sea")), has("country",containing("US")))',
+          "and(has('city',containing('Sea')), has('country',containing('US')))",
         ),
       );
     });
 
     it("escapes an attribute name containing the delimiter", () => {
-      expect(fragmentFor([{ name: 'ci"ty', value: "Sea" }])).toContain(
-        normalize('and(has("ci\\"ty",containing("Sea")))'),
+      expect(fragmentFor([{ name: "ci'ty", value: "Sea" }])).toContain(
+        normalize("and(has('ci\\'ty',containing('Sea')))"),
       );
     });
 
     it("escapes a filter value containing the delimiter", () => {
-      expect(fragmentFor([{ name: "city", value: 'Se"a' }])).toContain(
-        normalize('and(has("city",containing("Se\\"a")))'),
+      expect(fragmentFor([{ name: "city", value: "Se'a" }])).toContain(
+        normalize("and(has('city',containing('Se\\'a')))"),
       );
     });
 
     it("omits the filter step when there are no filters", () => {
       expect(fragmentFor([])).toBe(
         normalize(`
-          g.V("12").as("start")
+          g.V('12').as('start')
             .both()
             .dedup()
-            .as("neighbor")
-            .project("vertex", "edges")
+            .as('neighbor')
+            .project('vertex', 'edges')
               .by()
               .by(
-                __.select("start").bothE()
-                  .where(otherV().where(eq("neighbor")))
+                __.select('start').bothE()
+                  .where(otherV().where(eq('neighbor')))
                   .dedup().fold()
               )
         `),

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -22,18 +22,18 @@ function attributeFilterTemplate({ name, value }: AttributeFilter): string {
  * excludedVertices = new Set(["256"])
  * limit = 10
  *
- * g.V("124").as("start")
+ * g.V('124').as('start')
  *   .both()
- *   .hasLabel("airport").and(has("city",containing("Sea")), has("country",containing("ES")))
- *   .filter(__.not(__.hasId("256")))
+ *   .hasLabel('airport').and(has('city',containing('Sea')), has('country',containing('ES')))
+ *   .filter(__.not(__.hasId('256')))
  *   .dedup()
  *   .range(0, 10)
- *   .as("neighbor")
- *   .project("vertex", "edges")
+ *   .as('neighbor')
+ *   .project('vertex', 'edges')
  *     .by()
  *     .by(
- *       __.select("start").bothE()
- *         .where(otherV().where(eq("neighbor")))
+ *       __.select('start').bothE()
+ *         .where(otherV().where(eq('neighbor')))
  *         .dedup().fold()
  *     )
  */
@@ -75,18 +75,18 @@ export default function oneHopTemplate({
     : ``;
 
   return query`
-    g.V(${idTemplate}).as("start")
+    g.V(${idTemplate}).as('start')
       .both()
       ${nodeFiltersTemplate}
       ${excludedTemplate}
       .dedup()
       ${range}
-      .as("neighbor")
-      .project("vertex", "edges")
+      .as('neighbor')
+      .project('vertex', 'edges')
         .by()
         .by(
-          __.select("start").bothE()
-            .where(otherV().where(eq("neighbor")))
+          __.select('start').bothE()
+            .where(otherV().where(eq('neighbor')))
             .dedup().fold()
         )
   `;

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.test.ts
@@ -10,11 +10,11 @@ describe("Gremlin > edgesSchemaTemplate", () => {
       normalize(`
         g.V().limit(1)
           .project(
-            "route",
-            "contain"
+            'route',
+            'contain'
           )
-          .by(V().bothE("route").limit(1))
-          .by(V().bothE("contain").limit(1))
+          .by(V().bothE('route').limit(1))
+          .by(V().bothE('contain').limit(1))
       `),
     );
   });
@@ -26,27 +26,27 @@ describe("Gremlin > edgesSchemaTemplate", () => {
       normalize(`
         g.V().limit(1)
           .project(
-            "a",
-            "b",
-            "c"
+            'a',
+            'b',
+            'c'
           )
-          .by(V().bothE("a").limit(1))
-          .by(V().bothE("b").limit(1))
-          .by(V().bothE("c").limit(1))
+          .by(V().bothE('a').limit(1))
+          .by(V().bothE('b').limit(1))
+          .by(V().bothE('c').limit(1))
       `),
     );
   });
 
   it("Should escape a label containing the delimiter", () => {
-    const template = edgesSchemaTemplate({ types: ['ro"ute'] });
+    const template = edgesSchemaTemplate({ types: ["ro'ute"] });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V().limit(1)
           .project(
-            "ro\\"ute"
+            'ro\\'ute'
           )
-          .by(V().bothE("ro\\"ute").limit(1))
+          .by(V().bothE('ro\\'ute').limit(1))
       `),
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
@@ -17,11 +17,11 @@ import { fragment } from "../fragments";
  * // Returns:
  * // g.V().limit(1)
  * //   .project(
- * //     "route",
- * //     "contain"
+ * //     'route',
+ * //     'contain'
  * //   )
- * //   .by(V().bothE("route").limit(1))
- * //   .by(V().bothE("contain").limit(1))
+ * //   .by(V().bothE('route').limit(1))
+ * //   .by(V().bothE('contain').limit(1))
  */
 export default function edgesSchemaTemplate({ types }: { types: string[] }) {
   const labels = uniq(types.flatMap(type => type.split("::"))).map(

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.test.ts
@@ -10,11 +10,11 @@ describe("Gremlin > verticesSchemaTemplate", () => {
       normalize(`
         g.V().limit(1)
           .project(
-            "airport",
-            "country"
+            'airport',
+            'country'
           )
-          .by(V().hasLabel("airport").limit(1))
-          .by(V().hasLabel("country").limit(1))
+          .by(V().hasLabel('airport').limit(1))
+          .by(V().hasLabel('country').limit(1))
       `),
     );
   });
@@ -26,27 +26,27 @@ describe("Gremlin > verticesSchemaTemplate", () => {
       normalize(`
         g.V().limit(1)
           .project(
-            "a",
-            "b",
-            "c"
+            'a',
+            'b',
+            'c'
           )
-          .by(V().hasLabel("a").limit(1))
-          .by(V().hasLabel("b").limit(1))
-          .by(V().hasLabel("c").limit(1))
+          .by(V().hasLabel('a').limit(1))
+          .by(V().hasLabel('b').limit(1))
+          .by(V().hasLabel('c').limit(1))
       `),
     );
   });
 
   it("Should escape a label containing the delimiter", () => {
-    const template = verticesSchemaTemplate({ types: ['air"port'] });
+    const template = verticesSchemaTemplate({ types: ["air'port"] });
 
     expect(normalize(template)).toBe(
       normalize(`
         g.V().limit(1)
           .project(
-            "air\\"port"
+            'air\\'port'
           )
-          .by(V().hasLabel("air\\"port").limit(1))
+          .by(V().hasLabel('air\\'port').limit(1))
       `),
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
@@ -17,11 +17,11 @@ import { fragment } from "../fragments";
  * // Returns:
  * // g.V().limit(1)
  * //   .project(
- * //     "airport",
- * //     "country"
+ * //     'airport',
+ * //     'country'
  * //   )
- * //   .by(V().hasLabel("airport").limit(1))
- * //   .by(V().hasLabel("country").limit(1))
+ * //   .by(V().hasLabel('airport').limit(1))
+ * //   .by(V().hasLabel('country').limit(1))
  */
 export default function verticesSchemaTemplate({ types }: { types: string[] }) {
   const labels = uniq(types.flatMap(type => type.split("::"))).map(

--- a/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchVertexTypeCounts/vertexTypeCountTemplate.test.ts
@@ -4,12 +4,12 @@ describe("Gremlin > vertexTypeCountTemplate", () => {
   it("should count the vertices with the given label", () => {
     const template = vertexTypeCountTemplate("airport");
 
-    expect(template).toBe('g.V().hasLabel("airport").count()');
+    expect(template).toBe("g.V().hasLabel('airport').count()");
   });
 
   it("should escape a label containing the delimiter", () => {
-    const template = vertexTypeCountTemplate('air"port');
+    const template = vertexTypeCountTemplate("air'port");
 
-    expect(template).toBe('g.V().hasLabel("air\\"port").count()');
+    expect(template).toBe("g.V().hasLabel('air\\'port').count()");
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -4,7 +4,7 @@ import { UnrepresentableNumberError } from "../queryValueError";
 import { ESCAPABLE_PATTERN, fragment, SHORT_ESCAPES } from "./fragments";
 
 /**
- * Decodes a Gremlin double-quoted string literal back to its value, reversing
+ * Decodes a Gremlin single-quoted string literal back to its value, reversing
  * the seven escape sequences the escaper emits.
  */
 function parseGremlinLiteral(literal: string): string {
@@ -29,10 +29,10 @@ function parseGremlinLiteral(literal: string): string {
 /**
  * A literal whose body contains no bare delimiter and no escape outside the set
  * the escaper emits. Asserted alongside each round trip because the decoder
- * alone is tolerant: it maps an unescaped `\"` and a lone trailing `\\` back to
+ * alone is tolerant: it maps an unescaped `\'` and a lone trailing `\\` back to
  * themselves, so decoding would still succeed if the escaper stopped escaping.
  */
-const WELL_FORMED_LITERAL = /^"(?:[^"\\]|\\[btnfr\\"])*"$/;
+const WELL_FORMED_LITERAL = /^'(?:[^'\\]|\\[btnfr\\'])*'$/;
 
 /**
  * Asserts the literal is well formed and decodes back to the original value.
@@ -62,8 +62,8 @@ const awkwardStrings = [
   `has a ${String.fromCharCode(0x0c)} form feed`,
   `has a ${String.fromCharCode(0x01)} control character`,
   `has a ${String.fromCharCode(0x0b)} vertical tab`,
-  'backslash before a double quote a\\"b',
-  'two backslashes before a quote a\\\\"b',
+  "backslash before a single quote a\\'b",
+  "two backslashes before a quote a\\\\'b",
   "trailing backslash\\",
   "\\",
   "café — naïve — 日本語",
@@ -96,20 +96,20 @@ describe("the escape table and its match pattern", () => {
 });
 
 describe("fragment.string", () => {
-  // Double-quoted: `"` and `\` are escaped and control characters take their
-  // short escapes, so `'` and `$` are the characters left bare.
+  // Single-quoted: `'` and `\` are escaped and control characters take their
+  // short escapes, so `"` and `$` are the characters left bare.
   const cases: [input: string, literal: string][] = [
-    ["test", '"test"'],
-    [" te st ", '" te st "'],
-    ["", '""'],
-    ["te\\st", '"te\\\\st"'],
-    ['te"st', '"te\\"st"'],
-    ["te'st", `"te'st"`],
-    ["a\bb", '"a\\bb"'],
-    ["a\tb", '"a\\tb"'],
-    ["a\nb", '"a\\nb"'],
-    ["a\fb", '"a\\fb"'],
-    ["a\rb", '"a\\rb"'],
+    ["test", "'test'"],
+    [" te st ", "' te st '"],
+    ["", "''"],
+    ["te\\st", "'te\\\\st'"],
+    ["te'st", "'te\\'st'"],
+    ['te"st', `'te"st'`],
+    ["a\bb", "'a\\bb'"],
+    ["a\tb", "'a\\tb'"],
+    ["a\nb", "'a\\nb'"],
+    ["a\fb", "'a\\fb'"],
+    ["a\rb", "'a\\rb'"],
   ];
 
   it.each(cases)("encodes %j", (value, literal) => {
@@ -117,15 +117,15 @@ describe("fragment.string", () => {
   });
 
   it("should leave a dollar sign alone, since escaping it breaks the query on Neptune", () => {
-    expect(fragment.string("cost is $total")).toBe('"cost is $total"');
+    expect(fragment.string("cost is $total")).toBe("'cost is $total'");
   });
 
   it("should emit a control character without a short escape raw, never as \\uXXXX", () => {
     expect(fragment.string(`a${String.fromCharCode(0x01)}b`)).toBe(
-      `"a${String.fromCharCode(0x01)}b"`,
+      `'a${String.fromCharCode(0x01)}b'`,
     );
     expect(fragment.string(`a${String.fromCharCode(0x0b)}b`)).toBe(
-      `"a${String.fromCharCode(0x0b)}b"`,
+      `'a${String.fromCharCode(0x0b)}b'`,
     );
   });
 
@@ -135,24 +135,24 @@ describe("fragment.string", () => {
 });
 
 describe("fragment.identifier", () => {
-  it("should wrap the name in double quotes", () => {
-    expect(fragment.identifier("city")).toEqual('"city"');
+  it("should wrap the name in single quotes", () => {
+    expect(fragment.identifier("city")).toEqual("'city'");
   });
 
   it("should preserve spaces in the name", () => {
-    expect(fragment.identifier("home city")).toEqual('"home city"');
+    expect(fragment.identifier("home city")).toEqual("'home city'");
   });
 
-  it("should escape a double quote", () => {
-    expect(fragment.identifier('ci"ty')).toEqual('"ci\\"ty"');
+  it("should escape a single quote", () => {
+    expect(fragment.identifier("ci'ty")).toEqual("'ci\\'ty'");
   });
 
   it("should escape a backslash", () => {
-    expect(fragment.identifier("ci\\ty")).toEqual('"ci\\\\ty"');
+    expect(fragment.identifier("ci\\ty")).toEqual("'ci\\\\ty'");
   });
 
   it("should leave a dollar sign alone", () => {
-    expect(fragment.identifier("wei$rd")).toEqual('"wei$rd"');
+    expect(fragment.identifier("wei$rd")).toEqual("'wei$rd'");
   });
 
   it.each(awkwardStrings)("round-trips a name %j", value => {
@@ -199,24 +199,24 @@ describe("fragment.number", () => {
 });
 
 describe("fragment.id", () => {
-  it("should wrap a string ID in double quotes", () => {
-    expect(fragment.id(createVertexId("124"))).toEqual('"124"');
+  it("should wrap a string ID in single quotes", () => {
+    expect(fragment.id(createVertexId("124"))).toEqual("'124'");
   });
 
   it("should accept an edge ID", () => {
-    expect(fragment.id(createEdgeId("e1"))).toEqual('"e1"');
+    expect(fragment.id(createEdgeId("e1"))).toEqual("'e1'");
   });
 
   it("should add the long suffix to a numeric ID", () => {
     expect(fragment.id(createVertexId(124))).toEqual("124L");
   });
 
-  it("should escape a double quote in a string ID", () => {
-    expect(fragment.id(createVertexId('1"2'))).toEqual('"1\\"2"');
+  it("should escape a single quote in a string ID", () => {
+    expect(fragment.id(createVertexId("1'2"))).toEqual("'1\\'2'");
   });
 
   it("should escape a backslash in a string ID", () => {
-    expect(fragment.id(createVertexId("1\\2"))).toEqual('"1\\\\2"');
+    expect(fragment.id(createVertexId("1\\2"))).toEqual("'1\\\\2'");
   });
 
   it.each(awkwardStrings)("round-trips a string ID %j", value => {

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -19,14 +19,20 @@ import { UnrepresentableNumberError } from "../queryValueError";
  */
 
 /**
- * Escapes a value for a double-quoted Gremlin string literal, returning the
- * body without the surrounding quotes.
+ * The escape sequence for each character a Gremlin string literal cannot carry
+ * verbatim: the backslash, the single-quote delimiter, and the five whitespace
+ * controls that have a short form.
  *
- * The escape vocabulary is deliberately minimal — backslash, the double-quote
- * delimiter, and the five whitespace controls with a short form — because it is
- * the intersection of what every supported engine accepts. Two engines parse
- * the query text differently: Neptune uses an ANTLR grammar, while open-source
- * Apache TinkerPop Gremlin Server and JanusGraph parse it as Groovy. Notably:
+ * Each key is one character. `ESCAPABLE_PATTERN` is derived from the keys, so
+ * the two cannot disagree about which characters get escaped. Both properties
+ * are asserted in the tests: a key spanning more than one UTF-16 code unit would
+ * contribute only its first unit to the pattern, matching characters it was
+ * never meant to.
+ *
+ * The set is the intersection of what every supported engine accepts, and it is
+ * deliberately no larger — two engines parse the query text differently, Neptune
+ * with an ANTLR grammar and open-source Apache TinkerPop Gremlin Server and
+ * JanusGraph as Groovy. Notably:
  *
  * - `\uXXXX` is not used: Groovy 2.5 (TinkerPop 3.6.2) resolves unicode escapes
  *   at the source level before lexing, so a `\` at a literal's edge would
@@ -34,22 +40,15 @@ import { UnrepresentableNumberError } from "../queryValueError";
  *   without a short form are emitted raw instead, which every engine accepts.
  * - A raw newline or carriage return is rejected by the Groovy lexer, so both
  *   take their short escape rather than passing through.
- * - `$` is left unescaped, since a `\$` escape is a parse error on Neptune.
- *   Keeping it verbatim on every engine depends on the delimiter rather than on
- *   an escape.
+ * - A double quote needs no escape inside a single-quoted literal, and `$` is
+ *   left alone because a `\$` escape is a parse error on Neptune. Keeping `$`
+ *   verbatim is what the delimiter choice buys — see the ADR.
  *
  * Verified live against Neptune 1.2.1.0/1.4.7.0 and Gremlin Server 3.6.2/3.8.
  */
-/**
- * Each key is one character, and its value is that character's escape sequence.
- * `ESCAPABLE_PATTERN` is derived from the keys, so the two cannot disagree about
- * which characters get escaped. Both properties are asserted in the tests: a key
- * spanning more than one UTF-16 code unit would contribute only its first unit
- * to the pattern, matching characters it was never meant to.
- */
 export const SHORT_ESCAPES = {
   "\\": "\\\\",
-  '"': '\\"',
+  "'": "\\'",
   "\b": "\\b",
   "\t": "\\t",
   "\n": "\\n",
@@ -77,9 +76,9 @@ function escapeStringLiteralBody(value: string): string {
 }
 
 export const fragment = {
-  /** A Gremlin string literal, including the surrounding double quotes. */
+  /** A Gremlin string literal, including the surrounding single quotes. */
   string(value: string): QueryFragment {
-    return toQueryFragment(`"${escapeStringLiteralBody(value)}"`);
+    return toQueryFragment(`'${escapeStringLiteralBody(value)}'`);
   },
 
   /**
@@ -87,7 +86,7 @@ export const fragment = {
    * use the same delimiters and escaping as any other literal.
    */
   identifier(name: string): QueryFragment {
-    return toQueryFragment(`"${escapeStringLiteralBody(name)}"`);
+    return toQueryFragment(`'${escapeStringLiteralBody(name)}'`);
   },
 
   /**
@@ -115,7 +114,7 @@ export const fragment = {
     return toQueryFragment(
       typeof rawId === "number"
         ? `${rawId}L`
-        : `"${escapeStringLiteralBody(rawId)}"`,
+        : `'${escapeStringLiteralBody(rawId)}'`,
     );
   },
 };

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -16,7 +16,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
       vertexTypes: ["airport"],
     });
 
-    expect(normalize(template)).toBe(normalize('g.V().hasLabel("airport")'));
+    expect(normalize(template)).toBe(normalize("g.V().hasLabel('airport')"));
   });
 
   it("Should return a template for multiple vertex types", () => {
@@ -25,7 +25,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport","country")'),
+      normalize("g.V().hasLabel('airport','country')"),
     );
   });
 
@@ -35,7 +35,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("country","capital")'),
+      normalize("g.V().hasLabel('country','capital')"),
     );
   });
 
@@ -47,7 +47,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(
-        'g.V().or(has("city",containing("JFK")),has("code",containing("JFK")))',
+        "g.V().or(has('city',containing('JFK')),has('code',containing('JFK')))",
       ),
     );
   });
@@ -60,50 +60,50 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("city","JFK"),has("code","JFK"))'),
+      normalize("g.V().or(has('city','JFK'),has('code','JFK'))"),
     );
   });
 
   it("Should escape the search term", () => {
     const template = keywordSearchTemplate({
-      searchTerm: '"JFK"',
+      searchTerm: "'JFK'",
       searchByAttributes: ["code"],
       exactMatch: true,
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("code","\\"JFK\\""))'),
+      normalize("g.V().or(has('code','\\'JFK\\''))"),
     );
   });
 
   it("Should escape a vertex type containing the delimiter", () => {
     const template = keywordSearchTemplate({
-      vertexTypes: ['air"port'],
+      vertexTypes: ["air'port"],
     });
 
-    expect(normalize(template)).toBe(normalize('g.V().hasLabel("air\\"port")'));
+    expect(normalize(template)).toBe(normalize("g.V().hasLabel('air\\'port')"));
   });
 
   it("Should escape an attribute name containing the delimiter", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
-      searchByAttributes: ['ci"ty'],
+      searchByAttributes: ["ci'ty"],
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("ci\\"ty",containing("JFK")))'),
+      normalize("g.V().or(has('ci\\'ty',containing('JFK')))"),
     );
   });
 
   it("Should escape an attribute name when matching exactly", () => {
     const template = keywordSearchTemplate({
       searchTerm: "JFK",
-      searchByAttributes: ['ci"ty'],
+      searchByAttributes: ["ci'ty"],
       exactMatch: true,
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("ci\\"ty","JFK"))'),
+      normalize("g.V().or(has('ci\\'ty','JFK'))"),
     );
   });
 
@@ -116,7 +116,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport").or(has(id,"JFK"))'),
+      normalize("g.V().hasLabel('airport').or(has(id,'JFK'))"),
     );
   });
 
@@ -129,7 +129,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport").or(has(id,containing("JFK")))'),
+      normalize("g.V().hasLabel('airport').or(has(id,containing('JFK')))"),
     );
   });
 
@@ -143,9 +143,9 @@ describe("Gremlin > keywordSearchTemplate", () => {
       normalize(`
         g.V()
           .or(
-            has(id, containing("JFK")), 
-            has("city", containing("JFK")), 
-            has("code", containing("JFK"))
+            has(id, containing('JFK')), 
+            has('city', containing('JFK')), 
+            has('code', containing('JFK'))
           )
       `),
     );
@@ -159,7 +159,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().hasLabel("airport").range(25,50)'),
+      normalize("g.V().hasLabel('airport').range(25,50)"),
     );
   });
 
@@ -172,7 +172,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("code",containing("JFK"))).range(2,12)'),
+      normalize("g.V().or(has('code',containing('JFK'))).range(2,12)"),
     );
   });
 
@@ -184,7 +184,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("code",containing("JFK"))).range(0,10)'),
+      normalize("g.V().or(has('code',containing('JFK'))).range(0,10)"),
     );
   });
 
@@ -196,7 +196,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
     });
 
     expect(normalize(template)).toBe(
-      normalize('g.V().or(has("code",containing("JFK")))'),
+      normalize("g.V().or(has('code',containing('JFK')))"),
     );
   });
 
@@ -221,7 +221,7 @@ describe("Gremlin > keywordSearchTemplate", () => {
 
     expect(normalize(template)).toBe(
       normalize(
-        'g.V().hasLabel("airport").or(has("code",containing("JFK"))).range(1,26)',
+        "g.V().hasLabel('airport').or(has('code',containing('JFK'))).range(1,26)",
       ),
     );
   });

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
@@ -16,10 +16,10 @@ import { fragment } from "../fragments";
  * exactMatch = false
  *
  * g.V()
- *  .hasLabel("airport")
+ *  .hasLabel('airport')
  *  .or(
- *    has("city",containing("JFK")),
- *    has("code",containing("JFK"))
+ *    has('city',containing('JFK')),
+ *    has('code',containing('JFK'))
  *  )
  *  .range(0,100)
  */

--- a/packages/graph-explorer/src/connector/gremlin/neighborCounts.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/neighborCounts.test.ts
@@ -102,7 +102,7 @@ describe("neighborCounts", () => {
     }).catch(() => null);
 
     expect(mockFetch).toHaveBeenCalledWith(query`
-      g.V("12")
+      g.V('12')
        .group()
        .by(id)
        .by(


### PR DESCRIPTION
## Description

> Stacked on #2046 — review that first. This PR's diff is against its branch.

Graph Explorer sends Gremlin as script text, and the two front ends it supports do not parse that text alike. Neptune uses the ANTLR `gremlin-language` grammar; open-source Apache TinkerPop Gremlin Server and JanusGraph compile it with `GremlinGroovyScriptEngine`.

That split leaves no way to carry a `$` through a **double-quoted** literal. A double-quoted Groovy string is a GString, where `$` introduces an expression to resolve rather than a character to keep. The obvious remedy — escaping it as `\$` — is a hard parse error on Neptune. One engine needs the escape and the other rejects it, and `$` is ordinary data: a price column, a template string, an attribute name someone chose.

Single quotes sidestep the question. A single-quoted Groovy string is a plain string with no interpolation, and the grammar accepts single quotes, so one form of text is correct on every engine with no per-engine branching. The escape table swaps its delimiter entry to match, which is what makes this safe: the delimiter and its escape have to move together or a value ending in the delimiter would close the literal early.

The whole Gremlin surface moves, not just fragment output — the hardcoded step labels (`.as('start')`, `.project('vertex', 'edges')`) and the `@example` blocks are single-quoted too, so nothing in the codebase models the old form.

## How to read

1. [`connector/gremlin/fragments.ts`](https://github.com/aws/graph-explorer/pull/2047/files#diff-1d089533c25397d7fa71d381aa6345baad8801c33bca2ac12c8e9121e2256124) — the delimiter and its escape-table entry, moving in lockstep
2. [`docs/adr/20260804-single-quoted-gremlin-literals.md`](https://github.com/aws/graph-explorer/pull/2047/files#diff-d88f1b88fd416655e98c0c8ecf1a7e2210f1276acb63c9635f19a1980ef79092) — the decision, what was tested directly, and what was read off the grammar
3. [`connector/gremlin/fetchNeighbors/oneHopTemplate.ts`](https://github.com/aws/graph-explorer/pull/2047/files#diff-88dac7bd19897e26fd2e354ba783714a944af45efe03374def286129634f7140) — the only template carrying hardcoded step labels

The rest is exact-text assertions in nine test files following the same conversion.

## Validation

**The consequence worth reviewing carefully:** escaping now runs opposite to intuition. Inside a Gremlin literal a double quote needs **no** escape and a single quote does. So a test that feeds a double quote can no longer distinguish a value built by a fragment constructor from one a template wrapped in quotes by hand — both emit identical text.

Every test named "escapes … containing the delimiter" therefore had to switch from feeding `air"port` to feeding `air'port`. Two were missed on the first pass and caught in review; both are fixed here. Each is now confirmed to fail if its call site reverts to hand-wrapping: reverting all four value-routing sites at once fails six tests, the schema template fails one on its own, and the edge-type and search-term paths fail three and one respectively. The ADR records this trap so the next person converting a test does not reintroduce it, and `docs/agents/connectors.md` carries the rule where someone writing a Gremlin test will meet it.

Grepping for double-quoted Gremlin steps across the connector — source, tests, and comments — returns nothing.

`pnpm checks` clean; `pnpm test` 2480 passing.

## Related Issues

- Related to #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
