### PR TITLE
Refresh Amazon Linux base image snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Pinned to a dated ECR Public snapshot for reproducible builds; bump to move forward.
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023.12.20260720.0 AS base
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.12.20260803.3 AS base
 ENV NODE_VERSION=24.16.0
 
 # Install Node.js and openssl, then remove everything not needed at runtime


### PR DESCRIPTION
## Description

Refresh the Amazon Linux 2023 base image pin to the current upstream snapshot (`2023.12.20260720.0` → `2023.12.20260803.3`) to stay current with the routine base image cadence. No application code changes.

## Validation

- `pnpm checks` passes with no errors.
- `pnpm test` passes with no failures.
- Docker image builds successfully from the refreshed base.

## Related Issues

<!-- none -->

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.