### PR TITLE
Add UnescapableValueError for values a query position cannot represent

### DIFF
--- a/packages/graph-explorer/src/connector/queryValueError.test.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.test.ts
@@ -1,5 +1,6 @@
 import {
   QueryValueError,
+  UnescapableValueError,
   UnrepresentableNumberError,
   UnrepresentableValueError,
   UnsupportedValueTypeError,
@@ -91,6 +92,86 @@ describe("UnrepresentableNumberError", () => {
     expect(new UnrepresentableNumberError(1e21).details).toStrictEqual({
       value: 1e21,
       valueText: "1e+21",
+    });
+  });
+});
+
+describe("UnescapableValueError", () => {
+  it("carries the language, position, value, and unescapable characters", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b>c", [
+      " ",
+      ">",
+    ]);
+
+    expect(error.language).toBe("sparql");
+    expect(error.position).toBe("IRI");
+    expect(error.value).toBe("a b>c");
+    expect(error.unescapableCharacters).toStrictEqual([" ", ">"]);
+  });
+
+  it("is an Error and a QueryValueError, but not an UnrepresentableValueError", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b", [" "]);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(QueryValueError);
+    expect(error).not.toBeInstanceOf(UnrepresentableValueError);
+  });
+
+  it("names itself after the subclass", () => {
+    expect(new UnescapableValueError("sparql", "IRI", "a b", [" "]).name).toBe(
+      "UnescapableValueError",
+    );
+  });
+
+  it("derives a message that names the language and position", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b", [" "]);
+
+    expect(error.message).toContain("sparql");
+    expect(error.message).toContain("IRI");
+    expect(error.message).toContain("characters that cannot be represented");
+  });
+
+  it("exposes the unescapable characters as sorted codepoint labels in details", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b>c", [
+      " ",
+      ">",
+    ]);
+
+    expect(error.details).toStrictEqual({
+      language: "sparql",
+      position: "IRI",
+      value: "a b>c",
+      unescapableCharacters: ["U+0020", "U+003E"],
+    });
+  });
+
+  it("dedupes and sorts the unescapable characters by codepoint", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b>c", [
+      ">",
+      " ",
+      ">",
+    ]);
+
+    expect(error.details).toStrictEqual({
+      language: "sparql",
+      position: "IRI",
+      value: "a b>c",
+      unescapableCharacters: ["U+0020", "U+003E"],
+    });
+  });
+
+  it("preserves the full value verbatim in details, including control characters", () => {
+    const value = "line\u0001\nend";
+    const error = new UnescapableValueError("sparql", "IRI", value, [
+      "\u0001",
+      "\n",
+    ]);
+
+    expect(error.details).toStrictEqual({
+      language: "sparql",
+      position: "IRI",
+      value,
+      unescapableCharacters: ["U+0001", "U+000A"],
     });
   });
 });

--- a/packages/graph-explorer/src/connector/queryValueError.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.ts
@@ -87,3 +87,53 @@ export class UnsupportedValueTypeError extends QueryValueError {
     };
   }
 }
+
+/**
+ * The value cannot be escaped for this position — the position's grammar offers
+ * no escape mechanism for the characters it carries, so there is no faithful
+ * query text to emit. Position-specific rather than an `UnrepresentableValueError`,
+ * because the same character can be legal elsewhere: a space or `>` has no escape
+ * inside a SPARQL IRI, yet a space is fine in a SPARQL string literal.
+ *
+ * The caller detects the offending characters, since only it knows the
+ * position's grammar; this class only reports them.
+ */
+export class UnescapableValueError extends QueryValueError {
+  readonly language: QueryEngine;
+  readonly position: FragmentPosition;
+  readonly value: string;
+  readonly unescapableCharacters: readonly string[];
+
+  constructor(
+    language: QueryEngine,
+    position: FragmentPosition,
+    value: string,
+    unescapableCharacters: readonly string[],
+  ) {
+    super(
+      "UnescapableValueError",
+      `The ${language} ${position} value contains characters that cannot be represented in a query.`,
+    );
+    this.language = language;
+    this.position = position;
+    this.value = value;
+    this.unescapableCharacters = unescapableCharacters;
+  }
+
+  get details() {
+    // Each entry is a single character the caller detected; codePointAt(0) is always defined.
+    const codepoints = [...new Set(this.unescapableCharacters)]
+      .map(char => char.codePointAt(0)!)
+      .sort((a, b) => a - b);
+    return {
+      language: this.language,
+      position: this.position,
+      value: this.value,
+      unescapableCharacters: codepoints.map(toCodepointLabel),
+    };
+  }
+}
+
+function toCodepointLabel(codepoint: number): string {
+  return `U+${codepoint.toString(16).toUpperCase().padStart(4, "0")}`;
+}

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   QueryValueError,
+  UnescapableValueError,
   UnsupportedValueTypeError,
 } from "@/connector/queryValueError";
 import { FileEnvelopeError } from "@/core/fileEnvelope";
@@ -35,6 +36,15 @@ describe("createDisplayError", () => {
 
   it("Should fall back to generic wording for an unrecognized query value failure", () => {
     const result = createDisplayError(new UnrecognizedQueryValueError());
+    expect(result).toStrictEqual({
+      title: "This value cannot be used",
+      message: "This value cannot be used in a query against this database.",
+    });
+  });
+
+  it("Should fall back to generic wording for an unescapable value failure", () => {
+    const error = new UnescapableValueError("sparql", "IRI", "a b", [" "]);
+    const result = createDisplayError(error);
     expect(result).toStrictEqual({
       title: "This value cannot be used",
       message: "This value cannot be used in a query against this database.",

--- a/packages/graph-explorer/src/utils/createErrorDetails.test.ts
+++ b/packages/graph-explorer/src/utils/createErrorDetails.test.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import {
   QueryValueError,
+  UnescapableValueError,
   UnsupportedValueTypeError,
 } from "@/connector/queryValueError";
 
@@ -309,6 +310,15 @@ describe("createErrorDetails", () => {
         name: "DetailedQueryValueError",
         message: "cannot be used",
         data: JSON.stringify({ someContext: "value" }, null, 2),
+      });
+    });
+
+    it("serializes an UnescapableValueError through its own details", () => {
+      const error = new UnescapableValueError("sparql", "IRI", "a b", [" "]);
+      expect(createErrorDetails(error)).toStrictEqual({
+        name: "UnescapableValueError",
+        message: error.message,
+        data: JSON.stringify(error.details, null, 2),
       });
     });
   });


### PR DESCRIPTION
## Description

Adds `UnescapableValueError`, a shared `QueryValueError` subclass a query fragment module throws when a value carries characters a given query position cannot represent — for example a space or `>` inside a SPARQL IRI, which has no escape mechanism (whereas a space is perfectly fine inside a SPARQL string literal). The error is position-specific and language-agnostic: it carries the query `language`, the `position`, the full `value`, and the offending characters, so both the SPARQL and openCypher fragment modules can reuse it.

This is foundation-only. No fragment or template constructs it yet — a follow-up SPARQL PR stacks on this branch and wires it into `iri()` and full-charset literal escaping.

The caller detects the offending characters, because only it knows the grammar of its position; the error just reports them. The `details` getter renders them as sorted, de-duplicated `U+XXXX` codepoint labels, which is what makes an otherwise invisible offender (a raw space, control character, or newline) legible in the error-details dialog. The user-facing message stays deliberately generic and does not interpolate the raw value.

It rides the **existing** `QueryValueError` fallback in `createDisplayError`/`createErrorDetails` — those source files are unchanged; the new tests confirm a subclass renders and serializes correctly through that fallback.

## How to read

1. [packages/graph-explorer/src/connector/queryValueError.ts](https://github.com/aws/graph-explorer/pull/2051/files#diff-9b35d78dbdcdd2187afcd580799799d3a3d37af3af11ea05f67e7c1d34fdeaf6) — the new class; mirrors the sibling `UnsupportedValueTypeError`
2. [packages/graph-explorer/src/connector/queryValueError.test.ts](https://github.com/aws/graph-explorer/pull/2051/files#diff-6145b085e9c5829705c67b54a6b4ffcf0b8f927ad861f28d807238a9a2b53c09) — fields, message, and the codepoint-label `details` shape
3. [packages/graph-explorer/src/utils/createDisplayError.test.ts](https://github.com/aws/graph-explorer/pull/2051/files#diff-3197d28596777d783aaa05ed01886f77e5253ea49281fdef6439f8c5e0e9fc9e) and [createErrorDetails.test.ts](https://github.com/aws/graph-explorer/pull/2051/files#diff-da6a4971206e825de665a9611afc20f3cbdd8be9bc77cf9e0589ab70a19531c3) — prove the existing base-class fallback already handles it

## Validation

- `pnpm checks` clean (types + lint + format).
- `pnpm test` green — 210 files / 2504 tests.

## Related Issues

- Related to #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
