### PR TITLE
Refuse query values no database can carry

### DIFF
--- a/docs/adr/20260805-refuse-unrepresentable-query-values.md
+++ b/docs/adr/20260805-refuse-unrepresentable-query-values.md
@@ -1,0 +1,30 @@
+# ADR — Refuse query values no database can carry
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Related:** #2020 (query-construction failure types). Builds on the `QueryValueError` hierarchy in `connector/queryValueError.ts`. Affects the fragment constructors in `connector/{openCypher,gremlin,sparql}/fragments.ts`.
+
+## Context
+
+A fragment constructor turns a raw value — a search term, a property key, an entity ID — into query text. Two classes of value cannot be transmitted faithfully to any database, in any of the three query languages, at any position:
+
+- **Unpaired surrogate (U+D800–U+DFFF).** Half a UTF-16 code unit, with no Unicode scalar value and therefore no valid UTF-8 encoding. Every connector UTF-8 encodes its query text. On the openCypher/Gremlin path Neptune receives the JSON-escaped `\ud800`, returns HTTP 200, and silently substitutes `?` — the wrong data with no error. On the SPARQL path `encodeURIComponent` throws a raw `URIError` from deep inside the explorer.
+- **NUL (U+0000).** Not representable in graph data. XSD 1.1 Part 2 §3.3.1.1 defines `xsd:string`'s value space via XML's `Char` production, which excludes U+0000. Neptune's openCypher and SPARQL endpoints reject it; Neptune's Gremlin endpoint rejects it in every graph-term position Graph Explorer generates.
+
+`String.prototype.isWellFormed()` (ES2024) is false exactly for the surrogate case; `value.includes("\0")` covers the NUL.
+
+## Decision
+
+The fragment constructors **refuse** such a value rather than emit it. A single guard, `assertRepresentable(value)`, throws `UnrepresentableStringError` (a `QueryValueError`), and is called as the first statement of each of the eight string-accepting constructors across the three languages. The rule is language- and position-independent, so it is applied uniformly rather than per language.
+
+## Considered Options
+
+- **Refuse via a runtime guard (chosen).** A guard, not a boolean predicate, so a call site cannot forget to act on its result. A reflective conformance sweep (one test that enumerates every constructor via `Object.entries`) asserts that an unrepresentable value throws `QueryValueError`, so a ninth constructor added later is covered automatically. The sweep asserts the base class, not the concrete subclass, so it survives a future change that rejects a position for its own reason.
+- **A branded `RepresentableString` type**, making a missing guard a _compile_ error. A stronger guarantee, but it pushes validation up into the template layer and collides with the existing ID branding (`VertexId`/`EdgeId`) — a value would need to be both a `VertexId` and a `RepresentableString`. Rejected in favour of the runtime guard plus the conformance sweep.
+- **Emit and let the database decide.** Rejected: acceptance without faithful semantics is worse than a clean refusal — see below.
+
+## Consequences
+
+- This is **deliberately stricter than SPARQL 1.1**, which makes NUL legal. Three non-Neptune SPARQL engines accept a NUL-bearing literal and then silently match the _wrong term_ (Blazegraph) or truncate it (Virtuoso). A value that is accepted but matches something other than what was written is worse than one that is cleanly refused, so we refuse it everywhere.
+- **The check cannot be centralised.** By `toQueryFragment` or the transport boundary, escaping has already run: `JSON.stringify` has turned a NUL into the six characters `\u0000` and a lone surrogate into `\ud800`. There is nothing left to detect — a centralised check would inspect escaped text and always pass. The guard must see raw input, which forces it into the constructors. This is the non-obvious constraint a future reader would try to "clean up."
+- **The error carries only `value`**, not language or position, because neither affects the outcome — no query of any kind can carry the value. If a debugger needs "which operation failed," that belongs at the catch boundary, where the calling hook already knows the operation (expand-node, keyword-search); it is not threaded down through the fragment layer. This is also why a `"number"`-style position axis would have been the wrong shape for the error's diagnostic context.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vitest/coverage-v8": "4.1.9",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-hooks": "7.1.1",
+    "fast-check": "^4.9.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
     "oxfmt": "^0.55.0",

--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -71,7 +71,6 @@ const awkwardStrings = [
   `line ${String.fromCharCode(0x2028)} separator`,
   `delete ${String.fromCharCode(0x7f)} character`,
   `nbsp ${String.fromCharCode(0x00a0)} character`,
-  "\ud800",
   "cost is $total",
 ] as const;
 

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -1,7 +1,10 @@
 import { type EdgeId, getRawId, type VertexId } from "@/core";
 
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
-import { UnrepresentableNumberError } from "../queryValueError";
+import {
+  assertRepresentable,
+  UnrepresentableNumberError,
+} from "../queryValueError";
 
 /*
  * Constructs Query Fragments for Gremlin. A fragment is safe to interpolate
@@ -78,6 +81,7 @@ function escapeStringLiteralBody(value: string): string {
 export const fragment = {
   /** A Gremlin string literal, including the surrounding single quotes. */
   string(value: string): QueryFragment {
+    assertRepresentable(value);
     return toQueryFragment(`'${escapeStringLiteralBody(value)}'`);
   },
 
@@ -86,6 +90,7 @@ export const fragment = {
    * use the same delimiters and escaping as any other literal.
    */
   identifier(name: string): QueryFragment {
+    assertRepresentable(name);
     return toQueryFragment(`'${escapeStringLiteralBody(name)}'`);
   },
 
@@ -111,10 +116,10 @@ export const fragment = {
    */
   id(entityId: VertexId | EdgeId): QueryFragment {
     const rawId = getRawId(entityId);
-    return toQueryFragment(
-      typeof rawId === "number"
-        ? `${rawId}L`
-        : `'${escapeStringLiteralBody(rawId)}'`,
-    );
+    if (typeof rawId === "number") {
+      return toQueryFragment(`${rawId}L`);
+    }
+    assertRepresentable(rawId);
+    return toQueryFragment(`'${escapeStringLiteralBody(rawId)}'`);
   },
 };

--- a/packages/graph-explorer/src/connector/openCypher/fragments.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.ts
@@ -1,7 +1,10 @@
 import { type EdgeId, getRawId, type VertexId } from "@/core";
 
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
-import { UnsupportedValueTypeError } from "../queryValueError";
+import {
+  assertRepresentable,
+  UnsupportedValueTypeError,
+} from "../queryValueError";
 
 /*
  * Constructs Query Fragments for openCypher. A fragment is safe to interpolate
@@ -25,11 +28,13 @@ function escape(value: string): string {
 export const fragment = {
   /** An openCypher string literal, including the surrounding double quotes. */
   string(value: string): QueryFragment {
+    assertRepresentable(value);
     return toQueryFragment(`"${escape(value)}"`);
   },
 
   /** A property key or label, delimited by backticks. */
   identifier(name: string): QueryFragment {
+    assertRepresentable(name);
     return toQueryFragment(`\`${name}\``);
   },
 
@@ -39,6 +44,7 @@ export const fragment = {
     if (typeof rawId !== "string") {
       throw new UnsupportedValueTypeError("openCypher", "id", rawId);
     }
+    assertRepresentable(rawId);
     return toQueryFragment(`"${rawId}"`);
   },
 };

--- a/packages/graph-explorer/src/connector/queryValueError.test.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.test.ts
@@ -1,7 +1,9 @@
 import {
+  assertRepresentable,
   QueryValueError,
   UnescapableValueError,
   UnrepresentableNumberError,
+  UnrepresentableStringError,
   UnrepresentableValueError,
   UnsupportedValueTypeError,
 } from "./queryValueError";
@@ -173,5 +175,35 @@ describe("UnescapableValueError", () => {
       value,
       unescapableCharacters: ["U+0001", "U+000A"],
     });
+  });
+});
+
+describe("assertRepresentable", () => {
+  it.each([
+    ["a lone high surrogate", "a\uD800b"],
+    ["a lone low surrogate", "a\uDC00b"],
+    ["a NUL mid-string", "a\0b"],
+    ["a NUL alone", "\0"],
+  ])("throws UnrepresentableStringError for %s", (_, value) => {
+    expect(() => assertRepresentable(value)).toThrow(
+      UnrepresentableStringError,
+    );
+  });
+
+  it.each([
+    ["a valid surrogate pair", "a😀b"],
+    ["a plain control character", "a\u0001b"],
+    ["an empty string", ""],
+    ["ordinary text", "hello"],
+  ])("does not throw for %s", (_, value) => {
+    expect(() => assertRepresentable(value)).not.toThrow();
+  });
+
+  it("carries the offending value on the error", () => {
+    const value = "a\0b";
+    const error = new UnrepresentableStringError(value);
+
+    expect(error.value).toBe(value);
+    expect(error.details).toStrictEqual({ value });
   });
 });

--- a/packages/graph-explorer/src/connector/queryValueError.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.ts
@@ -53,6 +53,42 @@ export class UnrepresentableNumberError extends UnrepresentableValueError {
 }
 
 /**
+ * The value cannot be transmitted to any database: an unpaired surrogate has no
+ * UTF-8 encoding, and graph data cannot hold a NUL (XSD `xsd:string` is defined
+ * over XML's `Char` production, which excludes U+0000). Independent of language
+ * and position — no query in any language can carry it — so it carries neither.
+ */
+export class UnrepresentableStringError extends UnrepresentableValueError {
+  readonly value: string;
+
+  constructor(value: string) {
+    super(
+      "UnrepresentableStringError",
+      "This value contains characters that cannot be sent to a database.",
+    );
+    this.value = value;
+  }
+
+  get details() {
+    return { value: this.value };
+  }
+}
+
+/**
+ * Throws if a value cannot be transmitted to any database. A guard rather than a
+ * boolean predicate so a call site cannot forget to act on the result. The check
+ * must run on the raw value: escaping (`JSON.stringify`) turns a NUL into the
+ * six characters `\u0000` and a lone surrogate into `\ud800`, so a check after
+ * escaping — in `toQueryFragment` or at the transport boundary — would inspect
+ * escaped text and always pass.
+ */
+export function assertRepresentable(value: string): void {
+  if (!value.isWellFormed() || value.includes("\0")) {
+    throw new UnrepresentableStringError(value);
+  }
+}
+
+/**
  * The position accepts a value, but not one of this type — a numeric ID where a
  * language only supports string IDs, or a non-string where an IRI is required.
  *

--- a/packages/graph-explorer/src/connector/representabilityGuard.test.ts
+++ b/packages/graph-explorer/src/connector/representabilityGuard.test.ts
@@ -12,11 +12,13 @@ const modules = { openCypher, gremlin, sparql };
 describe.each(Object.entries(modules))(
   "%s constructors reject unrepresentable values",
   (_, fragment) => {
-    // Branded IDs are strings at runtime, so every constructor accepts a string.
-    const constructors = Object.entries(fragment) as [
-      string,
-      (value: string) => QueryFragment,
-    ][];
+    // Every string-accepting constructor takes a string (branded IDs are
+    // strings at runtime). Gremlin's `number` is the one non-string
+    // constructor; the guard is a string check, so it is not part of this
+    // sweep — including it would pass for an unrelated reason and mask a gap.
+    const constructors = (
+      Object.entries(fragment) as [string, (value: string) => QueryFragment][]
+    ).filter(([name]) => name !== "number");
 
     it.each(constructors)("%s throws QueryValueError", (_, construct) => {
       for (const value of ["a\uD800b", "a\0b"]) {

--- a/packages/graph-explorer/src/connector/representabilityGuard.test.ts
+++ b/packages/graph-explorer/src/connector/representabilityGuard.test.ts
@@ -1,0 +1,41 @@
+import fc from "fast-check";
+
+import type { QueryFragment } from "./queryFragment";
+
+import { fragment as gremlin } from "./gremlin/fragments";
+import { fragment as openCypher } from "./openCypher/fragments";
+import { QueryValueError } from "./queryValueError";
+import { fragment as sparql } from "./sparql/fragments";
+
+const modules = { openCypher, gremlin, sparql };
+
+describe.each(Object.entries(modules))(
+  "%s constructors reject unrepresentable values",
+  (_, fragment) => {
+    // Branded IDs are strings at runtime, so every constructor accepts a string.
+    const constructors = Object.entries(fragment) as [
+      string,
+      (value: string) => QueryFragment,
+    ][];
+
+    it.each(constructors)("%s throws QueryValueError", (_, construct) => {
+      for (const value of ["a\uD800b", "a\0b"]) {
+        expect(() => construct(value)).toThrow(QueryValueError);
+      }
+    });
+  },
+);
+
+it("refuses any string carrying a NUL or lone surrogate", () => {
+  fc.assert(
+    fc.property(
+      fc.string(),
+      fc.constantFrom("\0", "\uD800", "\uDC00"),
+      (s, bad) => {
+        expect(() =>
+          openCypher.string(s.slice(0, 1) + bad + s.slice(1)),
+        ).toThrow(QueryValueError);
+      },
+    ),
+  );
+});

--- a/packages/graph-explorer/src/connector/sparql/fragments.ts
+++ b/packages/graph-explorer/src/connector/sparql/fragments.ts
@@ -1,7 +1,10 @@
 import type { EdgeId, VertexId } from "@/core";
 
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
-import { UnsupportedValueTypeError } from "../queryValueError";
+import {
+  assertRepresentable,
+  UnsupportedValueTypeError,
+} from "../queryValueError";
 
 /*
  * Constructs Query Fragments for SPARQL. A fragment is safe to interpolate
@@ -28,6 +31,7 @@ function escape(value: string): string {
 export const fragment = {
   /** A SPARQL string literal, including the surrounding double quotes. */
   string(value: string): QueryFragment {
+    assertRepresentable(value);
     return toQueryFragment(`"${escape(value)}"`);
   },
 
@@ -36,6 +40,7 @@ export const fragment = {
     if (typeof value !== "string") {
       throw new UnsupportedValueTypeError("sparql", "IRI", value);
     }
+    assertRepresentable(value);
     return toQueryFragment(`<${value}>`);
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 7.1.1
         version: 7.1.1(eslint@10.2.1(jiti@2.7.0))
+      fast-check:
+        specifier: ^4.9.0
+        version: 4.9.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -3861,6 +3864,10 @@ packages:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
 
+  fast-check@4.9.0:
+    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
+    engines: {node: '>=12.17.0'}
+
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
@@ -4704,6 +4711,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@8.4.2:
+    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -8866,6 +8876,10 @@ snapshots:
 
   fake-indexeddb@6.2.5: {}
 
+  fast-check@4.9.0:
+    dependencies:
+      pure-rand: 8.4.2
+
   fast-copy@4.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -9651,6 +9665,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@8.4.2: {}
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
## Description

Some string values cannot be transmitted to any graph database, in any query language, at any position — yet the fragment constructors would happily emit them and produce silent data corruption:

- **Unpaired UTF-16 surrogate (U+D800–U+DFFF)** — half a code unit with no Unicode scalar value and therefore no valid UTF-8 encoding. On the openCypher/Gremlin path Neptune receives the escaped surrogate, returns HTTP 200, and silently substitutes `?` (the wrong data, no error); on the SPARQL path `encodeURIComponent` throws a raw `URIError` from deep inside the app.
- **NUL (U+0000)** — not representable in graph data. XSD `xsd:string` is defined over XML's `Char` production, which excludes U+0000.

This PR makes the fragment constructors refuse such a value rather than emit it. A single guard, `assertRepresentable(value)`, throws a new `UnrepresentableStringError` (a `QueryValueError`) and runs as the first statement of every string-accepting constructor across all three query languages (gremlin / openCypher / sparql). The rule is language- and position-independent, so it is applied uniformly.

The guard cannot be centralised — see the ADR. By `toQueryFragment` or the transport boundary, escaping has already run, turning a NUL and a lone surrogate into their escaped text forms, so a downstream check would inspect escaped text and always pass. The guard must see the raw input, which forces it into the constructors.

A reflective conformance sweep enumerates every string-accepting constructor via `Object.entries` and asserts that an unrepresentable value throws `QueryValueError`, so a future constructor is covered automatically. A `fast-check` negative property fuzzes surrogate/NUL insertion into random strings.

An ADR (`docs/adr/20260805-refuse-unrepresentable-query-values.md`) records the decision, the rejected alternatives (a branded `RepresentableString` type; emit-and-let-the-database-decide), and why the guard is deliberately stricter than SPARQL 1.1 (which makes NUL legal — but engines then silently match the wrong term or truncate).

Suggested reading order: `connector/queryValueError.ts` → the three `connector/{openCypher,gremlin,sparql}/fragments.ts` → `connector/representabilityGuard.test.ts` → the ADR.

## Validation

- `pnpm checks` passes with no errors.
- `pnpm test` passes (2509 tests).
- New unit tests: `queryValueError.test.ts` (the guard's accept/reject cases) and `representabilityGuard.test.ts` (the reflective sweep + fast-check property).

## Related Issues

- Part of #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
