### PR TITLE
Escape openCypher string literals for the full character set

### DIFF
--- a/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
@@ -1,6 +1,11 @@
+import fc from "fast-check";
+
 import { createEdgeId, createVertexId } from "@/core";
 
-import { UnsupportedValueTypeError } from "../queryValueError";
+import {
+  UnrepresentableStringError,
+  UnsupportedValueTypeError,
+} from "../queryValueError";
 import { fragment } from "./fragments";
 
 describe("fragment.string", () => {
@@ -22,6 +27,23 @@ describe("fragment.string", () => {
 
   it("should leave a single quote alone, since it needs no escaping", () => {
     expect(fragment.string("t'est")).toEqual('"t\'est"');
+  });
+
+  it("should escape a backslash", () => {
+    expect(fragment.string("te\\st")).toEqual('"te\\\\st"');
+  });
+
+  it("should escape a control character", () => {
+    expect(fragment.string("a\nb")).toEqual('"a\\nb"');
+  });
+
+  it("should round-trip arbitrary strings through the literal", () => {
+    fc.assert(
+      fc.property(fc.string(), value => {
+        fc.pre(value.isWellFormed() && !value.includes("\0"));
+        expect(JSON.parse(fragment.string(value))).toBe(value);
+      }),
+    );
   });
 });
 
@@ -47,6 +69,20 @@ describe("fragment.id", () => {
   it("should throw for a numeric ID, which openCypher does not support", () => {
     expect(() => fragment.id(createVertexId(124))).toThrow(
       UnsupportedValueTypeError,
+    );
+  });
+
+  it("should escape a double quote in a string ID", () => {
+    expect(fragment.id(createVertexId('1"2'))).toEqual('"1\\"2"');
+  });
+
+  it("should escape a backslash in a string ID", () => {
+    expect(fragment.id(createVertexId("1\\2"))).toEqual('"1\\\\2"');
+  });
+
+  it("should reject an unrepresentable string ID via the string guard", () => {
+    expect(() => fragment.id(createVertexId("a\0b"))).toThrow(
+      UnrepresentableStringError,
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fragments.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.ts
@@ -21,15 +21,16 @@ import {
  * its own.
  */
 
-function escape(value: string): string {
-  return value.includes('"') ? JSON.stringify(value).slice(1, -1) : value;
-}
-
 export const fragment = {
-  /** An openCypher string literal, including the surrounding double quotes. */
+  /**
+   * An openCypher string literal, including the surrounding double quotes.
+   * `JSON.stringify` produces a double-quoted literal whose escapes — `\"`,
+   * `\\`, the shorthand control escapes (`\n`, `\t`, `\r`, `\b`, `\f`), and
+   * `\uXXXX` for any other control character — are all valid Cypher escapes.
+   */
   string(value: string): QueryFragment {
     assertRepresentable(value);
-    return toQueryFragment(`"${escape(value)}"`);
+    return toQueryFragment(JSON.stringify(value));
   },
 
   /** A property key or label, delimited by backticks. */
@@ -44,7 +45,6 @@ export const fragment = {
     if (typeof rawId !== "string") {
       throw new UnsupportedValueTypeError("openCypher", "id", rawId);
     }
-    assertRepresentable(rawId);
-    return toQueryFragment(`"${rawId}"`);
+    return fragment.string(rawId);
   },
 };


### PR DESCRIPTION
## Description

Replaces the openCypher `string()` literal constructor's hand-rolled `escape()` with `JSON.stringify`. The old `escape()` only rewrote a value that already contained a double quote, so a backslash or control character in any other value passed through raw and could break the resulting literal — a correctness bug. `JSON.stringify` produces a complete, correctly-escaped double-quoted literal, and every escape it emits (`\"`, `\\`, the shorthand control escapes, and `\uXXXX`) is valid openCypher — a strict subset of what the engine accepts.

`id()` now routes through `string()` because an openCypher entity ID is itself a string literal; this also fixes a string ID that contains a quote or backslash. The representability guard (`assertRepresentable`) added in the prior PR is preserved as the first statement of `string()`.

Suggested reading order: `openCypher/fragments.ts`, then `openCypher/fragments.test.ts`.

## Validation

`pnpm checks` and `pnpm test` both pass. The openCypher fragment tests were extended to cover backslashes, control characters, and string IDs containing quotes/backslashes.

## Related Issues

- Part of #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
