### PR TITLE
Preserve interpolated values when normalizing query whitespace

### DIFF
--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -30,7 +30,6 @@
     "cytoscape-fcose": "^2.2.0",
     "cytoscape-klay": "^3.1.4",
     "date-fns": "^4.4.0",
-    "dedent": "^1.7.2",
     "dompurify": "^3.4.12",
     "file-saver": "^2.0.5",
     "flat": "^6.0.1",

--- a/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.test.ts
+++ b/packages/graph-explorer/src/components/Tabular/controls/ExportControl/transformToCsv.test.ts
@@ -1,5 +1,4 @@
-import dedent from "dedent";
-
+import { stripCommonIndent } from "@/utils";
 import { LABELS } from "@/utils/constants";
 
 import type { TabularColumnInstance } from "../../helpers/tableInstanceToTabularInstance";
@@ -477,7 +476,7 @@ function createColumnWithAccessor<T extends object>(
 
 /** Removes leading space evenly across all lines, removes empty lines, and normalizes line endings. */
 function csv(value: string) {
-  return dedent(value)
+  return stripCommonIndent(value)
     .replace(/^\s*\n/gm, "")
     .replace(/\r\n|\r|\n/g, "\n");
 }

--- a/packages/graph-explorer/src/connector/sparql/filterHelpers.ts
+++ b/packages/graph-explorer/src/connector/sparql/filterHelpers.ts
@@ -68,7 +68,7 @@ export function getNeighborsFilter(excludedVertices?: Set<VertexId>) {
           !isLiteral(?neighbor) &&
           ?predicate != ${fragment.iri(rdfTypeUri)} &&
           ?neighbor NOT IN (
-            ${excludedVerticesTemplates.join(", \n")}
+            ${excludedVerticesTemplates.join(",\n")}
           )
         )
       `

--- a/packages/graph-explorer/src/utils/sanitizeQuery.test.ts
+++ b/packages/graph-explorer/src/utils/sanitizeQuery.test.ts
@@ -1,4 +1,4 @@
-import { query } from "./sanitizeQuery";
+import { query, stripCommonIndent } from "./sanitizeQuery";
 
 describe("sanitizeQuery", () => {
   it("should remove leading space evenly across all lines and remove empty lines", () => {
@@ -46,5 +46,89 @@ describe("sanitizeQuery", () => {
         `LIMIT 10\n` +
         `OFFSET 10`,
     );
+  });
+
+  it("preserves a value's trailing space while still trimming scaffolding trailing space", () => {
+    const value = query`
+      PREFIX a: ${"trailing-space "}
+      END
+    `;
+
+    expect(value).toEqual(`PREFIX a: trailing-space \nEND`);
+  });
+
+  it("preserves a blank line inside a value while still dropping blank scaffolding lines", () => {
+    const value = query`
+      START
+
+      ${"line1\n\nline3"}
+      END
+    `;
+
+    expect(value).toEqual(`START\nline1\n\nline3\nEND`);
+  });
+
+  it("preserves an all-whitespace value instead of collapsing its line", () => {
+    const value = query`
+      START
+      ${"   "}
+      END
+    `;
+
+    expect(value).toEqual(`START\n   \nEND`);
+  });
+
+  it("preserves a value that is only a newline", () => {
+    const value = query`
+      START
+      ${"\n"}
+      END
+    `;
+
+    expect(value).toEqual(`START\n\n\nEND`);
+  });
+
+  it("leaves a flush-left scaffold line intact when other lines are indented", () => {
+    const value = query`
+      SELECT x
+zeroindent
+      END
+    `;
+
+    expect(value).toEqual(`SELECT x\nzeroindent\nEND`);
+  });
+
+  it("re-indents a multi-line value's continuation lines to the interpolation column", () => {
+    const value = query`
+      WHERE {
+        ${"a\nb\nc"}
+      }
+    `;
+
+    expect(value).toEqual(`WHERE {\n  a\n  b\n  c\n}`);
+  });
+});
+
+describe("stripCommonIndent", () => {
+  it("computes the minimum indent over non-blank lines only", () => {
+    const value = stripCommonIndent("\n    a\n\n      b\n    c\n");
+    expect(value).toEqual("a\n\n  b\nc");
+  });
+
+  it("uses a shallower value line as the common indent when it is the minimum", () => {
+    const value = stripCommonIndent(
+      "\n        deep line one\n  shallow\n        deep line two\n",
+    );
+    expect(value).toEqual("deep line one\nshallow\n      deep line two");
+  });
+
+  it("counts tabs and spaces per character", () => {
+    const value = stripCommonIndent("\n\t\ta\n\t\t\tb\n");
+    expect(value).toEqual("a\n\tb");
+  });
+
+  it("trims the leading and trailing newline", () => {
+    const value = stripCommonIndent("\n  only\n");
+    expect(value).toEqual("only");
   });
 });

--- a/packages/graph-explorer/src/utils/sanitizeQuery.ts
+++ b/packages/graph-explorer/src/utils/sanitizeQuery.ts
@@ -1,50 +1,145 @@
-import dedent from "dedent";
-
-/** Removes leading space evenly across all lines and removes empty lines. */
+/**
+ * Assembles a query string, normalizing the whitespace of the literal template
+ * scaffolding while preserving each interpolated value verbatim.
+ *
+ * The whitespace normalization — strip common indent, drop blank lines, trim
+ * trailing whitespace — runs over the literal parts only. Values are held aside
+ * as structural tokens and never spliced into a string the transforms inspect,
+ * so a value with leading/trailing spaces, an embedded blank line, or one that
+ * is entirely whitespace survives intact. A multi-line value's continuation
+ * lines are still re-indented to the column where the value lands.
+ */
 export function query(
   literals: TemplateStringsArray,
   ...placeholders: unknown[]
-) {
-  // Ensure any parameters are properly indented
-  const indented = indentTemplate(literals, ...placeholders);
-  return (
-    // Remove leading space
-    dedent(indented)
-      // Remove empty lines
-      .replace(/^\s*\n/gm, "")
-      // Remove trailing whitespace
-      .replace(/\s+$/gm, "")
+): string {
+  const values = placeholders.map(String);
+  const lines = splitIntoLines(literals, values);
+  const min = minCommonIndent(lines);
+  return lines
+    .filter(hasContent)
+    .map(line => renderLine(line, values, min))
+    .join("\n");
+}
+
+/**
+ * Strips the smallest indentation shared by every non-blank line, then trims
+ * surrounding whitespace. Replaces the `dedent` dependency, reproducing its
+ * indentation behavior byte-for-byte. The minimum is computed over non-blank
+ * lines only, so a blank line never forces the common indent to zero.
+ */
+export function stripCommonIndent(text: string): string {
+  const lines = text.split("\n");
+  let min: number | null = null;
+  for (const line of lines) {
+    const match = line.match(/^([ \t]+)\S/);
+    if (match) {
+      min = min === null ? match[1].length : Math.min(min, match[1].length);
+    }
+  }
+  if (min === null) {
+    return text.trim();
+  }
+  const width = min;
+  return lines
+    .map(line => (isIndented(line) ? line.slice(width) : line))
+    .join("\n")
+    .trim();
+}
+
+/** A part of a line: literal text, or a slot referencing a non-empty value. */
+type LinePart = { text: string } | { valueIndex: number };
+type Line = LinePart[];
+
+/**
+ * Interleaves literals and value slots into lines. A value slot is a structural
+ * token, not text, so the whitespace normalization never touches a value's
+ * bytes. An empty value contributes no token, so its line collapses exactly as
+ * an empty scaffold line would.
+ */
+function splitIntoLines(
+  literals: TemplateStringsArray,
+  values: string[],
+): Line[] {
+  const lines: Line[] = [[]];
+  function push(part: LinePart) {
+    lines[lines.length - 1].push(part);
+  }
+
+  literals.forEach((literal, i) => {
+    literal.split("\n").forEach((segment, segmentIndex) => {
+      if (segmentIndex > 0) {
+        lines.push([]);
+      }
+      if (segment !== "") {
+        push({ text: segment });
+      }
+    });
+    if (i < values.length && values[i] !== "") {
+      push({ valueIndex: i });
+    }
+  });
+
+  return lines;
+}
+
+/** Smallest leading-whitespace width across content lines, matching `stripCommonIndent`. */
+function minCommonIndent(lines: Line[]): number {
+  let min: number | null = null;
+  for (const line of lines) {
+    if (!hasContent(line)) {
+      continue;
+    }
+    const width = leadingWhitespace(line).length;
+    if (width > 0) {
+      min = min === null ? width : Math.min(min, width);
+    }
+  }
+  return min ?? 0;
+}
+
+function renderLine(line: Line, values: string[], min: number): string {
+  let rendered = "";
+  line.forEach((part, i) => {
+    if ("valueIndex" in part) {
+      rendered += indentContinuationLines(values[part.valueIndex], rendered);
+      return;
+    }
+    const text =
+      i === 0 && isIndented(part.text) ? part.text.slice(min) : part.text;
+    rendered += i === line.length - 1 ? text.replace(/\s+$/, "") : text;
+  });
+  return rendered;
+}
+
+/** Re-indents every line after the first to the column reached on the current line. */
+function indentContinuationLines(value: string, renderedSoFar: string): string {
+  const valueLines = value.split("\n");
+  if (valueLines.length === 1) {
+    return value;
+  }
+  const column = renderedSoFar.length - (renderedSoFar.lastIndexOf("\n") + 1);
+  const indent = " ".repeat(column);
+  const [first, ...rest] = valueLines;
+  return [first, ...rest.map(line => indent + line)].join("\n");
+}
+
+/** A line has content if it holds a value slot or any non-whitespace literal text. */
+function hasContent(line: Line): boolean {
+  return line.some(part =>
+    "valueIndex" in part ? true : /\S/.test(part.text),
   );
 }
 
-/** Ensures that all multi-line template values match the indentation of the line where they are used. */
-function indentTemplate(
-  strings: TemplateStringsArray,
-  ...values: unknown[]
-): string {
-  return strings.reduce((result, str, i) => {
-    // Coerce the current value to a string
-    const value = i < values.length ? String(values[i]) : "";
+/** Leading whitespace of a line — the spaces/tabs of its first literal part, if any. */
+function leadingWhitespace(line: Line): string {
+  const first = line[0];
+  if (first === undefined || !("text" in first)) {
+    return "";
+  }
+  return first.text.match(/^[ \t]*/)?.[0] ?? "";
+}
 
-    // Get the amount of indentation to add
-    const lines = str.split("\n");
-    const lastLine = lines[lines.length - 1];
-    const match = lastLine.match(/^( *)/); // capture leading spaces
-    const indent = match?.[1] ?? "";
-
-    // Add indentation to any lines after the first
-    const valueLines = value.split("\n");
-    const indentedValue =
-      valueLines.length > 1
-        ? valueLines[0] +
-          "\n" +
-          valueLines
-            .slice(1)
-            .map(line => indent + line)
-            .join("\n")
-        : value;
-
-    // Concatenate the result with the indented string
-    return result + str + indentedValue;
-  }, "");
+function isIndented(line: string): boolean {
+  return line[0] === " " || line[0] === "\t";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,9 +321,6 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
-      dedent:
-        specifier: ^1.7.2
-        version: 1.7.2(babel-plugin-macros@3.1.0)
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
@@ -3183,9 +3180,6 @@ packages:
   '@types/papaparse@5.5.2':
     resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
 
-  '@types/parse-json@4.0.2':
-    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
-
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -3391,10 +3385,6 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  babel-plugin-macros@3.1.0:
-    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
-    engines: {node: '>=10', npm: '>=6'}
-
   babel-plugin-polyfill-corejs2@0.4.15:
     resolution: {integrity: sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==}
     peerDependencies:
@@ -3459,10 +3449,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
@@ -3569,10 +3555,6 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  cosmiconfig@7.1.0:
-    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
-    engines: {node: '>=10'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3671,14 +3653,6 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
-  dedent@1.7.2:
-    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
-    peerDependencies:
-      babel-plugin-macros: ^3.1.0
-    peerDependenciesMeta:
-      babel-plugin-macros:
-        optional: true
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3755,9 +3729,6 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
-
-  error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -4069,10 +4040,6 @@ packages:
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -4087,9 +4054,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -4182,9 +4146,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4360,9 +4321,6 @@ packages:
   lightningcss@1.33.0:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   lint-staged@17.0.7:
     resolution: {integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==}
@@ -4618,14 +4576,6 @@ packages:
   papaparse@5.5.3:
     resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
-  parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
-
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -4654,10 +4604,6 @@ packages:
 
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
-
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4900,10 +4846,6 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -8121,9 +8063,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@types/parse-json@4.0.2':
-    optional: true
-
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -8356,13 +8295,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  babel-plugin-macros@3.1.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
-      cosmiconfig: 7.1.0
-      resolve: 1.22.12
-    optional: true
-
   babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -8445,9 +8377,6 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-
-  callsites@3.1.0:
-    optional: true
 
   caniuse-lite@1.0.30001806: {}
 
@@ -8541,15 +8470,6 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig@7.1.0:
-    dependencies:
-      '@types/parse-json': 4.0.2
-      import-fresh: 3.3.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      yaml: 2.9.0
-    optional: true
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -8631,10 +8551,6 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
-  dedent@1.7.2(babel-plugin-macros@3.1.0):
-    optionalDependencies:
-      babel-plugin-macros: 3.1.0
-
   deep-is@0.1.4: {}
 
   delayed-stream@1.0.0: {}
@@ -8695,11 +8611,6 @@ snapshots:
   entities@8.0.0: {}
 
   environment@1.1.0: {}
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
-    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -9082,12 +8993,6 @@ snapshots:
 
   immediate@3.0.6: {}
 
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-    optional: true
-
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -9095,9 +9000,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
-
-  is-arrayish@0.2.1:
-    optional: true
 
   is-core-module@2.16.2:
     dependencies:
@@ -9180,9 +9082,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
-
-  json-parse-even-better-errors@2.3.1:
-    optional: true
 
   json-schema-traverse@0.4.1: {}
 
@@ -9304,9 +9203,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.33.0
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
-
-  lines-and-columns@1.2.4:
-    optional: true
 
   lint-staged@17.0.7:
     dependencies:
@@ -9553,19 +9449,6 @@ snapshots:
 
   papaparse@5.5.3: {}
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-    optional: true
-
-  parse-json@5.2.0:
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
-    optional: true
-
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -9586,9 +9469,6 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@8.4.0: {}
-
-  path-type@4.0.0:
-    optional: true
 
   pathe@2.0.3: {}
 
@@ -9906,9 +9786,6 @@ snapshots:
       jsesc: 3.1.0
 
   require-from-string@2.0.2: {}
-
-  resolve-from@4.0.0:
-    optional: true
 
   resolve-pkg-maps@1.0.0:
     optional: true


### PR DESCRIPTION
## Description

`sanitizeQuery`'s `query` tag used to concatenate the literal parts and the interpolated values into one string and then run three whitespace transforms over the whole thing — strip common indentation, drop blank lines, and trim trailing whitespace per line. Because the transforms ran on the merged string, they could not tell scaffolding apart from an interpolated value, so a value with leading/trailing spaces, an embedded blank line, or one that was entirely whitespace was silently rewritten.

This change normalizes only the literal scaffolding and splices the values in verbatim. Values are held aside as structural tokens (an index-based splice — no marker character is ever injected into the skeleton), so a value's bytes never pass through the whitespace regexes. A multi-line value's continuation lines are still re-indented to the column where the value lands, so sub-clauses keep lining up.

It also drops the `dedent` dependency in favor of a small local `stripCommonIndent` helper, so the whitespace policy is fully owned in one place. `stripCommonIndent` reproduces `dedent`'s indentation behavior byte-for-byte (minimum indent computed over non-blank lines only).

There is no change to the output of any existing query: the previous behavior on whitespace-clean scaffolding is preserved, and the one call site that relied on the old whole-string trim (a `", \n"` separator in the SPARQL neighbors filter) drops the now-unnecessary trailing space so its output stays byte-identical.

## Validation

- `pnpm checks` clean; `pnpm test` green (full suite).
- Existing `sanitizeQuery` cases and all connector characterization tests are unchanged.
- New tests cover the now-preserved value shapes (trailing space, embedded blank line, all-whitespace value, newline-only value, multi-line re-indent, flush-left scaffold line) plus a `stripCommonIndent` unit test.

## Related Issues

- Part of #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
