### PR TITLE
Require full-instance assertions for thrown errors

### DIFF
--- a/docs/adr/20260805-refuse-unrepresentable-query-values.md
+++ b/docs/adr/20260805-refuse-unrepresentable-query-values.md
@@ -19,7 +19,7 @@ The fragment constructors **refuse** such a value rather than emit it. A single 
 
 ## Considered Options
 
-- **Refuse via a runtime guard (chosen).** A guard, not a boolean predicate, so a call site cannot forget to act on its result. A reflective conformance sweep (one test that enumerates every constructor via `Object.entries`) asserts that an unrepresentable value throws `QueryValueError`, so a ninth constructor added later is covered automatically. The sweep asserts the base class, not the concrete subclass, so it survives a future change that rejects a position for its own reason.
+- **Refuse via a runtime guard (chosen).** A guard, not a boolean predicate, so a call site cannot forget to act on its result. A reflective conformance sweep (one test that enumerates every constructor via `Object.entries`) asserts that an unrepresentable value throws `UnrepresentableStringError`, so a ninth constructor added later is covered automatically. The sweep pins the concrete subclass rather than the base class: representability is refused uniformly regardless of language or position, so a constructor that reclassified an unrepresentable value as some other `QueryValueError` subclass would be a regression the sweep should catch.
 - **A branded `RepresentableString` type**, making a missing guard a _compile_ error. A stronger guarantee, but it pushes validation up into the template layer and collides with the existing ID branding (`VertexId`/`EdgeId`) — a value would need to be both a `VertexId` and a `RepresentableString`. Rejected in favour of the runtime guard plus the conformance sweep.
 - **Emit and let the database decide.** Rejected: acceptance without faithful semantics is worse than a clean refusal — see below.
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -67,7 +67,7 @@ Commands are in AGENTS.md.
 
 - **`vi.doMock` + dynamic `import()`**: call `vi.resetModules()` in the test's own `beforeEach` (not global — it's expensive). See any test that swaps a module impl between cases.
 - **Production behavior**: tests run `DEV=true`/`PROD=false`; override per-test with `vi.stubEnv("PROD", true)`.
-- **Errors**: `await expect(fn()).rejects.toThrow("...")`.
+- **Errors**: assert the full error, not just that one was thrown. `expect(() => fn()).toThrow(new FooError(a, b))` — or `await expect(fn()).rejects.toThrow(new FooError(a, b))` for a rejected promise — deep-compares every property, so a wrong field fails the test. Prefer this over `toThrow(FooError)` (type only) or `toThrow("message")` (message only), which pass even when the code built the error with the wrong data. No need to catch the error and assert fields separately — the instance form already covers them.
 
 ## Backward compatibility for persisted data
 

--- a/packages/graph-explorer-proxy-server/src/allowed-db-origins.test.ts
+++ b/packages/graph-explorer-proxy-server/src/allowed-db-origins.test.ts
@@ -48,13 +48,21 @@ describe("assertAllowedDbOrigin", () => {
     const allowed = new Set(["https://neptune:8182"]);
     expect(() =>
       assertAllowedDbOrigin("https://neptune:8183", allowed),
-    ).toThrow(HttpError);
+    ).toThrow(
+      new HttpError(
+        403,
+        `Database origin "https://neptune:8183" is not in the allowed origins list. Contact your administrator.`,
+      ),
+    );
   });
 
   it("treats different schemes as different origins", () => {
     const allowed = new Set(["https://neptune:8182"]);
     expect(() => assertAllowedDbOrigin("http://neptune:8182", allowed)).toThrow(
-      HttpError,
+      new HttpError(
+        403,
+        `Database origin "http://neptune:8182" is not in the allowed origins list. Contact your administrator.`,
+      ),
     );
   });
 
@@ -62,7 +70,12 @@ describe("assertAllowedDbOrigin", () => {
     const allowed = new Set<string>();
     expect(() =>
       assertAllowedDbOrigin("https://neptune:8182", allowed),
-    ).toThrow(HttpError);
+    ).toThrow(
+      new HttpError(
+        403,
+        `Database origin "https://neptune:8182" is not in the allowed origins list. Contact your administrator.`,
+      ),
+    );
   });
 
   it("normalizes default ports (443 for https, 80 for http)", () => {

--- a/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
@@ -68,7 +68,7 @@ describe("fragment.id", () => {
 
   it("should throw for a numeric ID, which openCypher does not support", () => {
     expect(() => fragment.id(createVertexId(124))).toThrow(
-      UnsupportedValueTypeError,
+      new UnsupportedValueTypeError("openCypher", "id", createVertexId(124)),
     );
   });
 
@@ -82,7 +82,7 @@ describe("fragment.id", () => {
 
   it("should reject an unrepresentable string ID via the string guard", () => {
     expect(() => fragment.id(createVertexId("a\0b"))).toThrow(
-      UnrepresentableStringError,
+      new UnrepresentableStringError("a\0b"),
     );
   });
 });

--- a/packages/graph-explorer/src/connector/queryValueError.test.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.test.ts
@@ -186,7 +186,7 @@ describe("assertRepresentable", () => {
     ["a NUL alone", "\0"],
   ])("throws UnrepresentableStringError for %s", (_, value) => {
     expect(() => assertRepresentable(value)).toThrow(
-      UnrepresentableStringError,
+      new UnrepresentableStringError(value),
     );
   });
 

--- a/packages/graph-explorer/src/connector/representabilityGuard.test.ts
+++ b/packages/graph-explorer/src/connector/representabilityGuard.test.ts
@@ -4,7 +4,7 @@ import type { QueryFragment } from "./queryFragment";
 
 import { fragment as gremlin } from "./gremlin/fragments";
 import { fragment as openCypher } from "./openCypher/fragments";
-import { QueryValueError } from "./queryValueError";
+import { UnrepresentableStringError } from "./queryValueError";
 import { fragment as sparql } from "./sparql/fragments";
 
 const modules = { openCypher, gremlin, sparql };
@@ -20,11 +20,16 @@ describe.each(Object.entries(modules))(
       Object.entries(fragment) as [string, (value: string) => QueryFragment][]
     ).filter(([name]) => name !== "number");
 
-    it.each(constructors)("%s throws QueryValueError", (_, construct) => {
-      for (const value of ["a\uD800b", "a\0b"]) {
-        expect(() => construct(value)).toThrow(QueryValueError);
-      }
-    });
+    it.each(constructors)(
+      "%s throws UnrepresentableStringError",
+      (_, construct) => {
+        for (const value of ["a\uD800b", "a\0b"]) {
+          expect(() => construct(value)).toThrow(
+            new UnrepresentableStringError(value),
+          );
+        }
+      },
+    );
   },
 );
 
@@ -34,9 +39,10 @@ it("refuses any string carrying a NUL or lone surrogate", () => {
       fc.string(),
       fc.constantFrom("\0", "\uD800", "\uDC00"),
       (s, bad) => {
-        expect(() =>
-          openCypher.string(s.slice(0, 1) + bad + s.slice(1)),
-        ).toThrow(QueryValueError);
+        const value = s.slice(0, 1) + bad + s.slice(1);
+        expect(() => openCypher.string(value)).toThrow(
+          new UnrepresentableStringError(value),
+        );
       },
     ),
   );

--- a/packages/graph-explorer/src/connector/sparql/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fragments.test.ts
@@ -46,7 +46,7 @@ describe("fragment.iri", () => {
 
   it("should throw when the value is not a string, since an IRI is text", () => {
     expect(() => fragment.iri(createVertexId(124))).toThrow(
-      UnsupportedValueTypeError,
+      new UnsupportedValueTypeError("sparql", "IRI", createVertexId(124)),
     );
   });
 });

--- a/packages/graph-explorer/src/connector/sparql/vertexDetails.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/vertexDetails.test.ts
@@ -115,7 +115,9 @@ describe("vertexDetails", () => {
 
     await expect(
       vertexDetails(mockFetch, { vertexIds: [vertex.id] }),
-    ).rejects.toThrow(UnsupportedValueTypeError);
+    ).rejects.toThrow(
+      new UnsupportedValueTypeError("sparql", "IRI", vertex.id),
+    );
   });
 });
 

--- a/packages/graph-explorer/src/core/styling/stylingParser.test.ts
+++ b/packages/graph-explorer/src/core/styling/stylingParser.test.ts
@@ -546,6 +546,8 @@ describe("parseStylingPayloadForVersion", () => {
   test("throws loudly for a generation with no parser", () => {
     expect(() =>
       parseStylingPayloadForVersion(2, { vertices: {}, edges: {} }),
-    ).toThrow(FileEnvelopeError);
+    ).toThrow(
+      new FileEnvelopeError("No styling parser for format generation 2"),
+    );
   });
 });


### PR DESCRIPTION
## Description

Codifies a testing convention and applies it: **assert the full error instance in `toThrow`, not just its type or message.** Vitest v4's `toThrow(new FooError(...))` deep-compares every own enumerable property of the thrown error, so a wrong field fails the test — a genuine guarantee the code built the error correctly, which `toThrow(SomeError)` (type only) and `toThrow("message")` (message only) do not provide.

Three commits, each a distinct logical change:

1. **Doc rule** — one bullet in `docs/agents/testing.md` under *Special cases*.
2. **Sweep** — converts the 11 type-only `toThrow(SomeError)` assertions that throw a rich domain error (carrying `language`/`position`/`value`, an HTTP status + message, etc.) to full-instance form. Message-only assertions on bare `Error` (where the message *is* the whole identity), `expect.objectContaining` sites, and control-flow `catch` blocks were intentionally left — the rule only bites where there are fields to get wrong.
3. **ADR alignment** — the sweep tightened the reflective conformance sweep in `representabilityGuard.test.ts` from the base `QueryValueError` to the concrete `UnrepresentableStringError`. ADR `20260805` previously documented the base-class assertion as intentional; that rationale is updated to match, since representability is refused uniformly and a divergent subclass for an unrepresentable value would be a regression the sweep *should* catch.

Not in scope: no lint rule enforces this (oxlint 1.62 lacks `no-restricted-syntax` and any equivalent AST-selector rule; a blanket ban would false-positive on the many legitimate bare-`Error` message assertions). Left as a documented convention.

## Validation

- `pnpm checks` clean (types + lint + format).
- `pnpm test` green — 2524 tests, unchanged from baseline (assertions strengthened, none added or removed).

## How to read

1. [docs/agents/testing.md](https://github.com/aws/graph-explorer/pull/2056/files#diff-d00af24f807aed3edd173c6e7d4bcf4a694b2ccf26b17a19105e534d94f43164) — the rule being established
2. [packages/graph-explorer/src/connector/representabilityGuard.test.ts](https://github.com/aws/graph-explorer/pull/2056/files#diff-cdbc7d8f510fbbb5c592d54544413e316f201118d2017eca5ebea4e64ff0f050) — the one conversion that touched an invariant, paired with its ADR
3. [docs/adr/20260805-refuse-unrepresentable-query-values.md](https://github.com/aws/graph-explorer/pull/2056/files#diff-5ac6887e063e24c817d78d7946fadab4bea1c59140f27456efebdd7fefec55ea) — the reconciled rationale
4. The remaining `*.test.ts` files — mechanical type-only → instance conversions

## Related Issues

- Related to #1850

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
