### PR TITLE
Enforce openCypher identifier rules and route bare template identifiers

### DIFF
--- a/docs/adr/20260805-opencypher-identifier-rules.md
+++ b/docs/adr/20260805-opencypher-identifier-rules.md
@@ -1,0 +1,27 @@
+# ADR — openCypher identifier rules and a full-failure schema sync
+
+- **Status:** Accepted
+- **Date:** 2026-08-05
+- **Related:** `connector/openCypher/fragments.ts` (`identifier()`); `connector/queryValueError.ts` (`EmptyIdentifierError`, `UnescapableValueError`); `connector/queryFragment.ts` (`FragmentPosition`). Issue #2020.
+
+## Context
+
+An openCypher identifier — a property key or a label — is delimited with backticks. A backtick inside the name is escaped by doubling it; there is no escape for anything else inside the delimiter. Two names cannot be carried at all: an empty name, which selects nothing, and a name carrying a C0 control character (U+0000–U+001F).
+
+The empty case is not a forbidden-character case: an empty backtick-quoted name emits ` ` ``, which reads as a different grammar position rather than as an identifier. The control-character case is genuinely a forbidden-character case, but on narrower grounds than an earlier draft assumed. That draft justified rejecting control characters because the whole-query whitespace pre-pass would strip a trailing control character and corrupt the name; #2055 dissolved that reasoning by splicing interpolated values in verbatim, so the pre-pass no longer touches them. The rejection stands on what remains: a control character in a node label is malformed data, and a backtick-quoted name spanning lines wrecks the legibility of the assembled query.
+
+Both label and property-key discovery run on a background schema-sync path, where a rejection propagates rather than surfacing at an interactive call site.
+
+## Decision
+
+`identifier()` refuses an empty name (`EmptyIdentifierError`) and a name carrying a control character (`UnescapableValueError`, the same class SPARQL's `iri()` throws for an IRI-forbidden character), and doubles an embedded backtick in the emitted text. The control-character check is a local collector mirroring SPARQL's `forbiddenIriCharacters`: the fragment module owns which characters the position forbids and passes the offenders to the error to report. This is deliberately stricter than the shared representability guard, which refuses only NUL among the controls; the identifier position forbids the whole control range, and both checks are kept.
+
+Empty and control names are **rejected, not coerced**. Dropping the offending characters or substituting a placeholder would query a different label than the graph holds — an identifier is a lookup key, so a silent rewrite returns the wrong entity.
+
+`FragmentPosition` gains `"identifier"` alongside `"IRI"` and `"id"`. This is a genuine grammar position in a query, unlike the `"number"` axis that was deliberately kept out of the error hierarchy as a value-kind masquerading as a position.
+
+A rejection on the background schema-sync path is an accepted **full failure** of the sync request — the latched failure state, not a skip-and-log that would drop the offending label and quietly present an incomplete schema. A better background-path experience is deferred.
+
+## Consequences
+
+The full-failure choice is hard to reverse and surprising: a reader who sees schema sync break on one odd label would reach for skip-and-log to keep the rest of the sync flowing. That is the wrong fix here — partial schema silently hides data — so the decision is recorded rather than left to inference. Because the forbidden set is grammar-specific, the openCypher fragment module owns it, exactly as the SPARQL module owns the IRI-forbidden set.

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -69,15 +69,15 @@ describe("OpenCypher > oneHopTemplate", () => {
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e]-(tgt:country) 
-        WHERE ID(v) = "12" 
-        WITH DISTINCT v, tgt 
-        ORDER BY toInteger(ID(tgt)) 
+        MATCH (v)-[e]-(tgt:\`country\`)
+        WHERE ID(v) = "12"
+        WITH DISTINCT v, tgt
+        ORDER BY toInteger(ID(tgt))
         LIMIT 10
         MATCH (v)-[e]-(tgt)
-        RETURN 
-          collect(DISTINCT tgt) AS vObjects, 
-          collect(e) AS eObjects 
+        RETURN
+          collect(DISTINCT tgt) AS vObjects,
+          collect(e) AS eObjects
       `,
     );
   });
@@ -91,7 +91,7 @@ describe("OpenCypher > oneHopTemplate", () => {
     expect(template).toBe(
       query`
         MATCH (v)-[e]-(tgt)
-        WHERE ID(v) = "12" AND (v:country OR v:continent OR v:airport OR v:person)
+        WHERE ID(v) = "12" AND (v:\`country\` OR v:\`continent\` OR v:\`airport\` OR v:\`person\`)
         RETURN
           collect(DISTINCT tgt) AS vObjects,
           collect(e) AS eObjects
@@ -112,8 +112,8 @@ describe("OpenCypher > oneHopTemplate", () => {
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e]-(tgt:country)
-        WHERE ID(v) = "12" AND tgt.city CONTAINS "Sea" AND tgt.country CONTAINS "ES"
+        MATCH (v)-[e]-(tgt:\`country\`)
+        WHERE ID(v) = "12" AND tgt.\`city\` CONTAINS "Sea" AND tgt.\`country\` CONTAINS "ES"
         WITH DISTINCT v, tgt
         ORDER BY toInteger(ID(tgt)) 
         LIMIT 10
@@ -134,7 +134,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
     expect(template).toBe(
       query`
-        MATCH (v)-[e]-(tgt:airport)
+        MATCH (v)-[e]-(tgt:\`airport\`)
         WHERE ID(v) = "124"
         WITH DISTINCT v, tgt
         ORDER BY toInteger(ID(tgt))
@@ -153,7 +153,9 @@ describe("OpenCypher > oneHopTemplate", () => {
       filterByVertexTypes: ["country::capital", "city::town"],
     });
 
-    expect(template).toContain("(v:country OR v:capital OR v:city OR v:town)");
+    expect(template).toContain(
+      "(v:`country` OR v:`capital` OR v:`city` OR v:`town`)",
+    );
   });
 
   describe("attribute filters", () => {
@@ -166,7 +168,7 @@ describe("OpenCypher > oneHopTemplate", () => {
 
     it("matches an attribute containing the value", () => {
       expect(templateFor([{ name: "country", value: "ES" }])).toContain(
-        'tgt.country CONTAINS "ES"',
+        'tgt.`country` CONTAINS "ES"',
       );
     });
 
@@ -176,7 +178,7 @@ describe("OpenCypher > oneHopTemplate", () => {
           { name: "city", value: "Sea" },
           { name: "country", value: "US" },
         ]),
-      ).toContain('tgt.city CONTAINS "Sea" AND tgt.country CONTAINS "US"');
+      ).toContain('tgt.`city` CONTAINS "Sea" AND tgt.`country` CONTAINS "US"');
     });
 
     it("omits the filter condition when there are no filters", () => {

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
@@ -8,7 +8,7 @@ import { query } from "@/utils";
 import { fragment } from "../fragments";
 
 const attributeFilterTemplate = ({ name, value }: AttributeFilter): string =>
-  `tgt.${name} CONTAINS "${value}"`;
+  `tgt.${fragment.identifier(name)} CONTAINS ${fragment.string(value)}`;
 
 /**
  * @example
@@ -43,13 +43,15 @@ const oneHopTemplate = ({
     filterByVertexTypes.length > 1
       ? `(${filterByVertexTypes
           .flatMap((type: string) => type.split("::"))
-          .map((type: string) => `v:${type}`)
+          .map((type: string) => `v:${fragment.identifier(type)}`)
           .join(" OR ")})`
       : "";
 
   // Specify node type for target if provided and only one
   const targetMatch =
-    filterByVertexTypes.length == 1 ? `tgt:${filterByVertexTypes[0]}` : `tgt`;
+    filterByVertexTypes.length == 1
+      ? `tgt:${fragment.identifier(filterByVertexTypes[0])}`
+      : `tgt`;
 
   // Combine all the WHERE conditions
   const whereConditions = [

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.test.ts
@@ -1,3 +1,4 @@
+import { UnescapableValueError } from "../../queryValueError";
 import verticesSchemaTemplate from "./verticesSchemaTemplate";
 
 describe("OpenCypher > verticesSchemaTemplate", () => {
@@ -5,5 +6,11 @@ describe("OpenCypher > verticesSchemaTemplate", () => {
     const template = verticesSchemaTemplate({ type: "country" });
 
     expect(template).toBe("MATCH (v:`country`) RETURN v AS object LIMIT 1");
+  });
+
+  it("throws on a control-character label rather than emitting a malformed query", () => {
+    expect(() => verticesSchemaTemplate({ type: "coun\ntry" })).toThrow(
+      UnescapableValueError,
+    );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
@@ -3,6 +3,8 @@ import fc from "fast-check";
 import { createEdgeId, createVertexId } from "@/core";
 
 import {
+  EmptyIdentifierError,
+  UnescapableValueError,
   UnrepresentableStringError,
   UnsupportedValueTypeError,
 } from "../queryValueError";
@@ -54,6 +56,32 @@ describe("fragment.identifier", () => {
 
   it("should preserve spaces in the name", () => {
     expect(fragment.identifier("home airport")).toEqual("`home airport`");
+  });
+
+  it("should double an embedded backtick, how openCypher escapes it", () => {
+    expect(fragment.identifier("a`b")).toEqual("`a``b`");
+  });
+
+  it("should reject an empty name, which names nothing", () => {
+    expect(() => fragment.identifier("")).toThrow(EmptyIdentifierError);
+  });
+
+  it("should reject a newline, a control character an identifier cannot carry", () => {
+    expect(() => fragment.identifier("a\nb")).toThrow(
+      new UnescapableValueError("openCypher", "identifier", "a\nb", ["\n"]),
+    );
+  });
+
+  it("should reject a tab, a control character an identifier cannot carry", () => {
+    expect(() => fragment.identifier("a\tb")).toThrow(
+      new UnescapableValueError("openCypher", "identifier", "a\tb", ["\t"]),
+    );
+  });
+
+  it("should reject an unrepresentable name via the string guard", () => {
+    expect(() => fragment.identifier("a\0b")).toThrow(
+      UnrepresentableStringError,
+    );
   });
 });
 

--- a/packages/graph-explorer/src/connector/openCypher/fragments.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.ts
@@ -3,6 +3,8 @@ import { type EdgeId, getRawId, type VertexId } from "@/core";
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
 import {
   assertRepresentable,
+  EmptyIdentifierError,
+  UnescapableValueError,
   UnsupportedValueTypeError,
 } from "../queryValueError";
 
@@ -21,6 +23,16 @@ import {
  * its own.
  */
 
+function controlCharacters(name: string): string[] {
+  const offenders: string[] = [];
+  for (const char of name) {
+    if (char < " ") {
+      offenders.push(char);
+    }
+  }
+  return offenders;
+}
+
 export const fragment = {
   /**
    * An openCypher string literal, including the surrounding double quotes.
@@ -33,10 +45,28 @@ export const fragment = {
     return toQueryFragment(JSON.stringify(value));
   },
 
-  /** A property key or label, delimited by backticks. */
+  /**
+   * A property key or label, delimited by backticks. An embedded backtick is
+   * doubled — how openCypher escapes it within a backtick-quoted name. An empty
+   * name names nothing and is reported. A control character is reported rather
+   * than emitted: a control character in a label is malformed data, and a
+   * backtick-quoted name spanning lines is unreadable in the assembled query.
+   */
   identifier(name: string): QueryFragment {
     assertRepresentable(name);
-    return toQueryFragment(`\`${name}\``);
+    if (name === "") {
+      throw new EmptyIdentifierError("openCypher");
+    }
+    const offenders = controlCharacters(name);
+    if (offenders.length > 0) {
+      throw new UnescapableValueError(
+        "openCypher",
+        "identifier",
+        name,
+        offenders,
+      );
+    }
+    return toQueryFragment(`\`${name.replaceAll("`", "``")}\``);
   },
 
   /** An entity ID. openCypher only supports string IDs. */

--- a/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.test.ts
@@ -98,8 +98,8 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v)
-        WHERE (v:\`airport\` OR v:\`country\`) 
-          AND (v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
+        WHERE (v:\`airport\` OR v:\`country\`)
+          AND (v.\`city\` CONTAINS "JFK" OR v.\`code\` CONTAINS "JFK")
         RETURN v AS object
       `),
     );
@@ -116,7 +116,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v:\`airport\`)
-        WHERE (v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
+        WHERE (v.\`city\` CONTAINS "JFK" OR v.\`code\` CONTAINS "JFK")
         RETURN v AS object
       `),
     );
@@ -133,7 +133,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v:\`airport\`)
-        WHERE (v.city = "JFK" OR v.code = "JFK")
+        WHERE (v.\`city\` = "JFK" OR v.\`code\` = "JFK")
         RETURN v AS object
       `),
     );
@@ -183,7 +183,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v:\`airport\`)
-        WHERE (toString(id(v)) CONTAINS "JFK" OR v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
+        WHERE (toString(id(v)) CONTAINS "JFK" OR v.\`city\` CONTAINS "JFK" OR v.\`code\` CONTAINS "JFK")
         RETURN v AS object
       `),
     );
@@ -203,7 +203,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
       normalize(`
         MATCH (v)
         WHERE (v:\`airport\` OR v:\`country\`)
-          AND (toString(id(v)) CONTAINS "JFK" OR v.city CONTAINS "JFK" OR v.code CONTAINS "JFK")
+          AND (toString(id(v)) CONTAINS "JFK" OR v.\`city\` CONTAINS "JFK" OR v.\`code\` CONTAINS "JFK")
         RETURN v AS object
         SKIP 25 LIMIT 50
       `),
@@ -236,7 +236,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
       normalize(`
         MATCH (v)
         WHERE (labels(v) = [])
-          AND (v.name CONTAINS "test" OR v.value CONTAINS "test")
+          AND (v.\`name\` CONTAINS "test" OR v.\`value\` CONTAINS "test")
         RETURN v AS object
       `),
     );
@@ -253,7 +253,7 @@ describe("OpenCypher > keywordSearchTemplate", () => {
     expect(normalize(template)).toBe(
       normalize(`
         MATCH (v:\`airport\`)
-        WHERE (v.code CONTAINS "JF\\"K")
+        WHERE (v.\`code\` CONTAINS "JF\\"K")
         RETURN v AS object
       `),
     );

--- a/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/keywordSearch/keywordSearchTemplate.ts
@@ -61,8 +61,8 @@ const keywordSearchTemplate = ({
         }
 
         return exactMatch === true
-          ? `v.${attr} = ${searchLiteral}`
-          : `v.${attr} CONTAINS ${searchLiteral}`;
+          ? `v.${fragment.identifier(attr)} = ${searchLiteral}`
+          : `v.${fragment.identifier(attr)} CONTAINS ${searchLiteral}`;
       })
       .join(" OR ");
 

--- a/packages/graph-explorer/src/connector/queryFragment.ts
+++ b/packages/graph-explorer/src/connector/queryFragment.ts
@@ -21,6 +21,6 @@ export function toQueryFragment(text: string): QueryFragment {
 
 /**
  * The positions within a query whose value type the query language constrains:
- * an entity ID and a SPARQL IRI.
+ * an entity ID, a SPARQL IRI, and an openCypher identifier.
  */
-export type FragmentPosition = "IRI" | "id";
+export type FragmentPosition = "IRI" | "identifier" | "id";

--- a/packages/graph-explorer/src/connector/queryValueError.ts
+++ b/packages/graph-explorer/src/connector/queryValueError.ts
@@ -125,6 +125,27 @@ export class UnsupportedValueTypeError extends QueryValueError {
 }
 
 /**
+ * An identifier that names nothing. An empty property key or label cannot select
+ * anything, and emitting an empty delimited name would silently match a
+ * different position.
+ */
+export class EmptyIdentifierError extends QueryValueError {
+  readonly language: QueryEngine;
+
+  constructor(language: QueryEngine) {
+    super(
+      "EmptyIdentifierError",
+      `An empty ${language} identifier cannot be used in a query.`,
+    );
+    this.language = language;
+  }
+
+  get details() {
+    return { language: this.language };
+  }
+}
+
+/**
  * The value cannot be escaped for this position — the position's grammar offers
  * no escape mechanism for the characters it carries, so there is no faithful
  * query text to emit. Position-specific rather than an `UnrepresentableValueError`,


### PR DESCRIPTION
## Description

openCypher's `identifier()` fragment constructor now enforces the rules the backtick-delimited identifier position actually requires, and the remaining bare identifier positions in the neighbor and keyword-search templates route through the fragment constructors instead of interpolating raw text.

- `identifier()` doubles an embedded backtick (`` a`b `` → `` `a``b` ``), how openCypher escapes it inside a backtick-quoted name.
- An empty name is rejected with a new `EmptyIdentifierError` — an empty delimited name selects nothing and reads as a different grammar position.
- A name carrying a control character (U+0000–U+001F) is rejected with `UnescapableValueError`, mirroring the pattern SPARQL's `iri()` already uses for an IRI-forbidden character: a local collector returns the offending characters, which the error reports as codepoint labels.
- `FragmentPosition` widens to add `"identifier"` alongside `"IRI"` and `"id"`.
- `oneHopTemplate` (attribute-filter key and value, multi-label split, single target label) and `keywordSearchTemplate` (attribute keys in the `=` and `CONTAINS` branches) now route their identifiers through `fragment.identifier`, so the emitted query backtick-delimits them.

An `identifier()` rejection on the background schema-sync path is a full failure of the sync request rather than a skip-and-log; the rationale is recorded in a new ADR.

## Validation

- `pnpm checks` passes (types, lint, format).
- `pnpm test` passes — full suite green. Added unit tests cover backtick doubling, empty-name and control-character rejection, and that a control-character label in a schema-sync template throws; the neighbor and keyword-search characterization tests were updated in place to expect the backtick-delimited output.

## Related Issues

- Part of #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
