### PR TITLE
Add local-development-only warning to Gremlin Server sample config

### DIFF
--- a/samples/air_routes/README.md
+++ b/samples/air_routes/README.md
@@ -10,13 +10,15 @@
 
 This sample uses Gremlin Server 3.8 as the database pre-loaded with the [air routes dataset](https://tinkerpop.apache.org/docs/3.8.1/upgrade/#air-routes-dataset) and shows how to configure Graph Explorer to connect to it automatically with a default connection.
 
-> [!NOTE]
-> The data is not persisted between restarts of the Docker container.
-
 > [!WARNING]
-> This sample is intended for local development and evaluation only. Its
-> Gremlin Server is not hardened for production and should not be used as a
-> template for a production deployment.
+> **This sample is for local development and evaluation only.** Do not use it
+> as a template for a production deployment.
+>
+> - **No authentication** — anyone who can reach it has full access.
+> - **Not hardened** — it is configured for convenience, not security.
+> - **No persistence** — data is lost when the container restarts.
+>
+> Run it only on a trusted local network.
 
 ## Prerequisites
 

--- a/samples/air_routes/README.md
+++ b/samples/air_routes/README.md
@@ -13,6 +13,11 @@ This sample uses Gremlin Server 3.8 as the database pre-loaded with the [air rou
 > [!NOTE]
 > The data is not persisted between restarts of the Docker container.
 
+> [!WARNING]
+> This sample is intended for local development and evaluation only. Its
+> Gremlin Server is not hardened for production and should not be used as a
+> template for a production deployment.
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/) installed on your machine

--- a/samples/air_routes/README.md
+++ b/samples/air_routes/README.md
@@ -36,3 +36,5 @@ This sample uses Gremlin Server 3.8 as the database pre-loaded with the [air rou
    docker compose up
    ```
 4. Open the browser and navigate to: [http://localhost:8080/explorer](http://localhost:8080/explorer)
+
+Once it is running, the [Getting Started tutorial](../../docs/getting-started/README.md) walks you through exploring the air routes data step by step.

--- a/samples/air_routes/sample/conf/gremlin-server-air-routes.yaml
+++ b/samples/air_routes/sample/conf/gremlin-server-air-routes.yaml
@@ -19,10 +19,10 @@
 # WARNING: This is a sample Gremlin Server configuration intended for local
 # development and evaluation only. It is not hardened for production use.
 #
-# This server evaluates submitted Gremlin scripts, so it should only be run
-# against a trusted graph on a trusted local network. Do not use this file
+# It has no authentication and is configured for convenience, not security,
+# so it should only be run on a trusted local network. Do not use this file
 # as a template for a production deployment or expose it to untrusted
-# networks or data.
+# networks.
 # ---------------------------------------------------------------------------
 
 host: database

--- a/samples/air_routes/sample/conf/gremlin-server-air-routes.yaml
+++ b/samples/air_routes/sample/conf/gremlin-server-air-routes.yaml
@@ -15,6 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# ---------------------------------------------------------------------------
+# WARNING: This is a sample Gremlin Server configuration intended for local
+# development and evaluation only. It is not hardened for production use.
+#
+# This server evaluates submitted Gremlin scripts, so it should only be run
+# against a trusted graph on a trusted local network. Do not use this file
+# as a template for a production deployment or expose it to untrusted
+# networks or data.
+# ---------------------------------------------------------------------------
+
 host: database
 port: 8182
 evaluationTimeout: 30000


### PR DESCRIPTION
## Description

Adds a local-development-only warning to the bundled Gremlin Server sample so users don't treat it as a production-ready template.

- **`samples/air_routes/sample/conf/gremlin-server-air-routes.yaml`** — a `WARNING` comment banner after the Apache license header noting the config is for local development/evaluation only, has no authentication, is configured for convenience rather than security, and should run only on a trusted local network.
- **`samples/air_routes/README.md`** — a scannable `> [!WARNING]` admonition (no authentication, not hardened, no persistence) so readers of the sample instructions get the same "not a production template" signal. Also cross-links the sample to the Getting Started tutorial.

Comment/docs-only — no configuration values change, and the `scriptEngines` block is untouched.

## Validation

`pnpm checks` (lint + format + types) passes. No tests — the change is comment and prose only.

## Related Issues

<!-- none -->

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [ ] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
