### PR TITLE
Split composite labels once at the Gremlin ingestion boundary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,10 @@ A classification of vertices. The schema, styling, filtering, and exploration al
 **Edge Type**:
 A classification of edges. UI label varies by query language: "Edge Label" (Gremlin), "Relationship Type" (openCypher), "Predicate" (SPARQL).
 
+**Composite Label**:
+A single string in which Amazon Neptune joins the multiple labels of one vertex with the reserved `::` delimiter (`g.addV("A::B")`). It appears only on the Gremlin wire (element label, `by(label)` keys, `label()` output); openCypher returns labels as an array and never uses `::`. Graph Explorer splits a composite label into its constituent Vertex Types once, at the Gremlin ingestion boundary — a Vertex Type is always a single label thereafter.
+_Avoid_: Multi-label (describes the vertex, not the joined string), Label list (it is a delimited string, not a list until split)
+
 **Neighbors**:
 Vertices directly connected to a given vertex (one hop away). Users "expand neighbors" to progressively discover the graph. Neighbor counts track total vs. unfetched to indicate how much remains unexplored.
 _Avoid_: Connections (ambiguous with Connection)

--- a/docs/adr/20260807-split-composite-labels-once-at-gremlin-ingestion.md
+++ b/docs/adr/20260807-split-composite-labels-once-at-gremlin-ingestion.md
@@ -1,0 +1,39 @@
+# ADR — Split composite labels once at the Gremlin ingestion boundary; keep the whole string when a segment is empty
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+- **Related:** Epic #2020 (Query Fragment initiative); supersedes the scattered `.split("::")` handling that PR #2036 would have unified. Complementary to the Gremlin `fragment.identifier` empty-identifier refusal (a separate change).
+
+## Context
+
+Amazon Neptune joins the multiple labels of a vertex with `::` (`g.addV("A::B")`), and its Gremlin API surfaces that composite as a single `::`-joined string in the element/`elementMap` label field, in `by(label)` group keys, and in `outV()/inV().label()`. Graph Explorer's own domain model holds only **single** labels — a `VertexType` is one label — because multi-labels are split apart at ingestion.
+
+Historically the `::` split was inlined at eight connector sites with two inconsistent handlings (`.split("::").filter(Boolean)` at some, bare `.split("::")` at others), and applied at sites that were splitting Graph Explorer's own already-single-label domain ids rather than a raw Neptune wire value.
+
+Two facts, verified live, shaped the decision:
+
+- **`::` is Neptune-specific and reserved.** Neptune reserves `::` as the multi-label delimiter, so a real segment is never empty and a single stored label can never contain `::`. Core TinkerPop (JanusGraph, Gremlin Server, TinkerGraph) mandates one immutable label per element with no reserved characters — there, a label may legitimately _be_ `foo::bar` or `foo::`. openCypher never exposes `::` at all; it returns labels as a JSON array.
+- **There is no reliable Neptune-vs-generic discriminator** at the split sites, and none is available to plumb in cheaply.
+
+## Decision
+
+**Split `::` exactly once, at the Gremlin ingestion boundary; domain `VertexType`s are single-label and are never re-split.**
+
+1. **One shared helper, `connector/gremlin/splitLabel.ts`.** It owns the `::` convention and the empty-segment rule. Gremlin-only — openCypher has no `::` on the wire, and the fragment modules are already strictly per-language.
+2. **Keep-whole on any empty segment.** If splitting yields any empty segment — trailing (`foo::`), leading (`::foo`), doubled (`a::::b`), or lone (`::`) — the helper discards the split and returns the original string as a single label. An empty segment signals that the `::` is not our delimiter (a generic-TinkerPop label, or otherwise unexpected input), so we do not guess a split that would misidentify the label.
+3. **Split only at the five ingestion sites** that consume raw Neptune wire labels: `mapApiVertex`, `fetchEdgeConnections`, `verticesSchemaTemplate`, `edgesSchemaTemplate`, `neighborCounts`.
+4. **Delete the split at the three sites that operated on domain ids** (Gremlin `fetchNeighbors/oneHopTemplate`, `keywordSearch/keywordSearchTemplate`, openCypher `fetchNeighbors/oneHopTemplate`). Their inputs (`filterByVertexTypes`, `vertexTypes`) are already single-label `VertexType` ids; re-splitting them was a no-op on real data and wrong for a generic backend.
+5. **The helper does not refuse the empty string.** `splitLabel("")` returns `[""]`; empty-identifier refusal is the fragment layer's job. The one exception is `mapApiVertex`, where an empty element label means _no labels_ and maps to `[]` at that boundary.
+
+## Considered Options
+
+- **Keep-whole on empty (chosen).** Least-harmful across vendors: a generic label `foo::` survives intact, and a Neptune composite still splits. Matches the intuition "an empty segment means `::` probably isn't our separator."
+- **`.filter(Boolean)` (drop empty segments).** Rejected: silently resolves `foo::` → `foo`, querying the wrong vertex type — the misidentification we set out to remove.
+- **Throw on any empty segment.** Rejected: for a generic TinkerPop backend, `foo::` is a _valid_ single label, so throwing would break a legitimate graph.
+- **Gate the split on the backend being Neptune.** Rejected for now: no reliable discriminator exists and plumbing one to the ingestion sites is a separate architectural change. Tracked as a follow-up, blocked by the connection database-type work (#1329, consuming #271).
+
+## Consequences
+
+- **The split is applied unconditionally, which is correct only for Neptune.** For a generic TinkerPop backend whose single label contains `::`, ingestion still breaks it apart. This is unchanged from prior behavior (the split was always unconditional) and is the known limitation the follow-up issue addresses.
+- **Contractual tests changed at the three delete sites.** Tests that asserted `country::capital` expanded to `hasLabel('country', 'capital')` now assert it is used verbatim, reflecting that these inputs are single-label domain ids.
+- **`mapApiVertex` treats an empty label as no labels** (`[]`), preserving prior `.filter(Boolean)` behavior for that specific boundary without reintroducing the `foo::` → `foo` bug.

--- a/docs/adr/20260807-split-composite-labels-once-at-gremlin-ingestion.md
+++ b/docs/adr/20260807-split-composite-labels-once-at-gremlin-ingestion.md
@@ -20,10 +20,11 @@ Two facts, verified live, shaped the decision:
 **Split `::` exactly once, at the Gremlin ingestion boundary; domain `VertexType`s are single-label and are never re-split.**
 
 1. **One shared helper, `connector/gremlin/splitLabel.ts`.** It owns the `::` convention and the empty-segment rule. Gremlin-only — openCypher has no `::` on the wire, and the fragment modules are already strictly per-language.
-2. **Keep-whole on any empty segment.** If splitting yields any empty segment — trailing (`foo::`), leading (`::foo`), doubled (`a::::b`), or lone (`::`) — the helper discards the split and returns the original string as a single label. An empty segment signals that the `::` is not our delimiter (a generic-TinkerPop label, or otherwise unexpected input), so we do not guess a split that would misidentify the label.
-3. **Split only at the five ingestion sites** that consume raw Neptune wire labels: `mapApiVertex`, `fetchEdgeConnections`, `verticesSchemaTemplate`, `edgesSchemaTemplate`, `neighborCounts`.
-4. **Delete the split at the three sites that operated on domain ids** (Gremlin `fetchNeighbors/oneHopTemplate`, `keywordSearch/keywordSearchTemplate`, openCypher `fetchNeighbors/oneHopTemplate`). Their inputs (`filterByVertexTypes`, `vertexTypes`) are already single-label `VertexType` ids; re-splitting them was a no-op on real data and wrong for a generic backend.
-5. **The helper does not refuse the empty string.** `splitLabel("")` returns `[""]`; empty-identifier refusal is the fragment layer's job. The one exception is `mapApiVertex`, where an empty element label means _no labels_ and maps to `[]` at that boundary.
+2. **The delimiter is precisely two colons.** A run of one, three, or more colons (`foo:bar`, `foo:::bar`) is part of a label and does not split — the helper splits only on a `::` with no adjacent colon.
+3. **Keep-whole on any empty segment.** If splitting yields any empty segment — trailing (`foo::`), leading (`::foo`), doubled (`a::::b`), or lone (`::`) — the helper discards the split and returns the original string as a single label. An empty segment signals that the `::` is not our delimiter (a generic-TinkerPop label, or otherwise unexpected input), so we do not guess a split that would misidentify the label.
+4. **Split only at the five ingestion sites** that consume raw Neptune wire labels: `mapApiVertex`, `fetchEdgeConnections`, `verticesSchemaTemplate`, `edgesSchemaTemplate`, `neighborCounts`.
+5. **Delete the split at the three sites that operated on domain ids** (Gremlin `fetchNeighbors/oneHopTemplate`, `keywordSearch/keywordSearchTemplate`, openCypher `fetchNeighbors/oneHopTemplate`). Their inputs (`filterByVertexTypes`, `vertexTypes`) are already single-label `VertexType` ids; re-splitting them was a no-op on real data and wrong for a generic backend.
+6. **The helper does not refuse the empty string.** `splitLabel("")` returns `[""]`; empty-identifier refusal is the fragment layer's job. The one exception is `mapApiVertex`, where an empty element label means _no labels_ and maps to `[]` at that boundary.
 
 ## Considered Options
 

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.ts
@@ -10,6 +10,7 @@ import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
 import type { GMapWithValue, GremlinFetch } from "../types";
 
 import { parseGMap } from "../mappers/parseGMap";
+import { splitLabel } from "../splitLabel";
 import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 
 type RawEdgeConnectionsResponse = {
@@ -53,9 +54,8 @@ export default async function fetchEdgeConnections(
         continue;
       }
 
-      // Neptune multi-label vertices use :: delimiter
-      const sourceTypes = sourceValue.split("::").filter(Boolean);
-      const targetTypes = targetValue.split("::").filter(Boolean);
+      const sourceTypes = splitLabel(sourceValue);
+      const targetTypes = splitLabel(targetValue);
 
       for (const sourceType of sourceTypes) {
         for (const targetType of targetTypes) {

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.test.ts
@@ -202,14 +202,16 @@ describe("Gremlin > oneHopTemplate", () => {
     );
   });
 
-  it("should expand a Neptune multi-label type into separate labels on '::'", () => {
+  // filterByVertexTypes carries VertexType ids that were already split apart at
+  // ingestion, so a value bearing :: must be used verbatim, not re-split.
+  it("uses each vertex type verbatim without splitting on '::'", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country::capital"],
     });
 
     expect(normalize(template)).toContain(
-      normalize(".both().hasLabel('country', 'capital').dedup()"),
+      normalize(".both().hasLabel('country::capital').dedup()"),
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchNeighbors/oneHopTemplate.ts
@@ -47,10 +47,9 @@ export default function oneHopTemplate({
   const idTemplate = fragment.id(vertexId);
   const range = limit > 0 ? `.range(0, ${fragment.number(limit)})` : "";
 
-  const vertexTypes = filterByVertexTypes.flatMap(type => type.split("::"));
   const vertexTypesTemplate =
-    vertexTypes.length > 0
-      ? `hasLabel(${vertexTypes.map(fragment.identifier).join(", ")})`
+    filterByVertexTypes.length > 0
+      ? `hasLabel(${filterByVertexTypes.map(fragment.identifier).join(", ")})`
       : ``;
 
   const attributeFiltersTemplate =

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/edgesSchemaTemplate.ts
@@ -3,6 +3,7 @@ import { uniq } from "lodash";
 import { query } from "@/utils";
 
 import { fragment } from "../fragments";
+import { splitLabel } from "../splitLabel";
 
 /**
  * Given a set of edge types, it returns a Gremlin template that contains
@@ -24,9 +25,7 @@ import { fragment } from "../fragments";
  * //   .by(V().bothE('contain').limit(1))
  */
 export default function edgesSchemaTemplate({ types }: { types: string[] }) {
-  const labels = uniq(types.flatMap(type => type.split("::"))).map(
-    fragment.identifier,
-  );
+  const labels = uniq(types.flatMap(splitLabel)).map(fragment.identifier);
 
   return query`
     g.V().limit(1)

--- a/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchSchema/verticesSchemaTemplate.ts
@@ -3,6 +3,7 @@ import { uniq } from "lodash";
 import { query } from "@/utils";
 
 import { fragment } from "../fragments";
+import { splitLabel } from "../splitLabel";
 
 /**
  * Given a set of nodes labels, it returns a Gremlin template that contains
@@ -24,9 +25,7 @@ import { fragment } from "../fragments";
  * //   .by(V().hasLabel('country').limit(1))
  */
 export default function verticesSchemaTemplate({ types }: { types: string[] }) {
-  const labels = uniq(types.flatMap(type => type.split("::"))).map(
-    fragment.identifier,
-  );
+  const labels = uniq(types.flatMap(splitLabel)).map(fragment.identifier);
 
   return query`
     g.V().limit(1)

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.test.ts
@@ -29,13 +29,15 @@ describe("Gremlin > keywordSearchTemplate", () => {
     );
   });
 
-  it("Should expand a Neptune multi-label type into separate labels on '::'", () => {
+  // vertexTypes carries VertexType ids that were already split apart at
+  // ingestion, so a value bearing :: must be used verbatim, not re-split.
+  it("uses each vertex type verbatim without splitting on '::'", () => {
     const template = keywordSearchTemplate({
       vertexTypes: ["country::capital"],
     });
 
     expect(normalize(template)).toBe(
-      normalize("g.V().hasLabel('country','capital')"),
+      normalize("g.V().hasLabel('country::capital')"),
     );
   });
 

--- a/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/keywordSearch/keywordSearchTemplate.ts
@@ -34,10 +34,7 @@ export default function keywordSearchTemplate({
   let template = "g.V()";
 
   if (vertexTypes.length !== 0) {
-    const hasLabelContent = vertexTypes
-      .flatMap(type => type.split("::"))
-      .map(fragment.identifier)
-      .join(",");
+    const hasLabelContent = vertexTypes.map(fragment.identifier).join(",");
     template += `.hasLabel(${hasLabelContent})`;
   }
 

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.test.ts
@@ -6,6 +6,7 @@ import {
   createRandomName,
 } from "@shared/utils/testing";
 
+import { createVertexType } from "@/core";
 import {
   createGDate,
   createGDouble,
@@ -81,7 +82,17 @@ describe("mapApiVertex", () => {
     expect(mappedVertex).toStrictEqual(vertex);
   });
 
-  it("should map a graphSON vertex without labels", () => {
+  it("splits a Neptune composite label into separate types", () => {
+    const vertex = createTestableVertex().asResult();
+    vertex.types = [createVertexType("country"), createVertexType("capital")];
+    const gVertex = createGVertex(vertex);
+
+    const mappedVertex = mapApiVertex(gVertex);
+
+    expect(mappedVertex.types).toStrictEqual(["country", "capital"]);
+  });
+
+  it("maps an empty label to no types", () => {
     const vertex = createTestableVertex().asResult();
     vertex.types = [];
     const gVertex = createGVertex(vertex);
@@ -89,6 +100,7 @@ describe("mapApiVertex", () => {
     const mappedVertex = mapApiVertex(gVertex);
 
     expect(mappedVertex).toStrictEqual(vertex);
+    expect(mappedVertex.types).toStrictEqual([]);
   });
 
   it("should map a graphSON vertex with name", () => {

--- a/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
+++ b/packages/graph-explorer/src/connector/gremlin/mappers/mapApiVertex.ts
@@ -1,12 +1,14 @@
 import type { GVertex } from "../types";
 
 import { createResultVertex } from "../../entities";
+import { splitLabel } from "../splitLabel";
 import { extractRawId } from "./extractRawId";
 import parsePropertiesValues from "./parsePropertiesValues";
 
 export default function mapApiVertex(apiVertex: GVertex, name?: string) {
-  // Split multi-label from Neptune and filter out empty strings
-  const types = apiVertex["@value"].label.split("::").filter(Boolean);
+  // An empty label means the vertex has no labels, not a label to split.
+  const label = apiVertex["@value"].label;
+  const types = label === "" ? [] : splitLabel(label);
 
   // If the properties are null then the vertex is a fragment
   const attributes = apiVertex["@value"].properties

--- a/packages/graph-explorer/src/connector/gremlin/neighborCounts.ts
+++ b/packages/graph-explorer/src/connector/gremlin/neighborCounts.ts
@@ -12,6 +12,7 @@ import isErrorResponse from "../utils/isErrorResponse";
 import { fragment } from "./fragments";
 import { extractRawId } from "./mappers/extractRawId";
 import { parseGMap } from "./mappers/parseGMap";
+import { splitLabel } from "./splitLabel";
 
 type GIdentifier = string | GInt64;
 
@@ -83,7 +84,7 @@ export async function neighborCounts(
       for (const [rawType, gValue] of countsByTypeMap.entries()) {
         const count = gValue["@value"];
         totalCount += count;
-        const types = rawType.split("::");
+        const types = splitLabel(rawType);
         for (const type of types) {
           const vertexType = createVertexType(type);
           countsByType.set(

--- a/packages/graph-explorer/src/connector/gremlin/splitLabel.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/splitLabel.test.ts
@@ -1,0 +1,35 @@
+import { splitLabel } from "./splitLabel";
+
+describe("splitLabel", () => {
+  it("returns a single-element array for a plain label", () => {
+    expect(splitLabel("foo")).toEqual(["foo"]);
+  });
+
+  it("splits a composite label on the :: delimiter", () => {
+    expect(splitLabel("foo::bar")).toEqual(["foo", "bar"]);
+  });
+
+  it("splits a composite label with more than two segments", () => {
+    expect(splitLabel("foo::bar::baz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("keeps a trailing :: verbatim rather than dropping the empty segment", () => {
+    expect(splitLabel("foo::")).toEqual(["foo::"]);
+  });
+
+  it("keeps a leading :: verbatim rather than dropping the empty segment", () => {
+    expect(splitLabel("::foo")).toEqual(["::foo"]);
+  });
+
+  it("keeps a doubled :: verbatim rather than dropping the empty segment", () => {
+    expect(splitLabel("a::::b")).toEqual(["a::::b"]);
+  });
+
+  it("keeps a lone :: verbatim", () => {
+    expect(splitLabel("::")).toEqual(["::"]);
+  });
+
+  it("returns the empty string unchanged", () => {
+    expect(splitLabel("")).toEqual([""]);
+  });
+});

--- a/packages/graph-explorer/src/connector/gremlin/splitLabel.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/splitLabel.test.ts
@@ -25,6 +25,22 @@ describe("splitLabel", () => {
     expect(splitLabel("a::::b")).toEqual(["a::::b"]);
   });
 
+  it("does not split on a single colon", () => {
+    expect(splitLabel("foo:bar")).toEqual(["foo:bar"]);
+  });
+
+  it("does not split on three colons", () => {
+    expect(splitLabel("foo:::bar")).toEqual(["foo:::bar"]);
+  });
+
+  it("does not split on four colons", () => {
+    expect(splitLabel("foo::::bar")).toEqual(["foo::::bar"]);
+  });
+
+  it("splits only on the run of exactly two colons", () => {
+    expect(splitLabel("a:::b::c")).toEqual(["a:::b", "c"]);
+  });
+
   it("keeps a lone :: verbatim", () => {
     expect(splitLabel("::")).toEqual(["::"]);
   });

--- a/packages/graph-explorer/src/connector/gremlin/splitLabel.ts
+++ b/packages/graph-explorer/src/connector/gremlin/splitLabel.ts
@@ -1,0 +1,18 @@
+/**
+ * Splits a Neptune composite label into its constituent labels on the `::`
+ * multi-label delimiter.
+ *
+ * `::` is Neptune's reserved delimiter for joining multiple labels on a single
+ * vertex (`g.addV("A::B")`), so a real segment is never empty. An empty segment
+ * therefore signals that the `::` is not our separator — either the backend is a
+ * generic TinkerPop server where `::` is an ordinary label character, or the
+ * label is otherwise unexpected. In that case we keep the whole string rather
+ * than guess at a split that would misidentify the label. See the ADR.
+ */
+export function splitLabel(label: string): string[] {
+  const segments = label.split("::");
+  if (segments.some(segment => segment === "")) {
+    return [label];
+  }
+  return segments;
+}

--- a/packages/graph-explorer/src/connector/gremlin/splitLabel.ts
+++ b/packages/graph-explorer/src/connector/gremlin/splitLabel.ts
@@ -10,9 +10,16 @@
  * than guess at a split that would misidentify the label. See the ADR.
  */
 export function splitLabel(label: string): string[] {
-  const segments = label.split("::");
+  const segments = label.split(DELIMITER);
   if (segments.some(segment => segment === "")) {
     return [label];
   }
   return segments;
 }
+
+/**
+ * Neptune's delimiter is precisely two colons, so a run of one, three, or more
+ * colons is part of a label and must not split. The lookarounds exclude a `::`
+ * that has another colon on either side.
+ */
+const DELIMITER = /(?<!:)::(?!:)/;

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.test.ts
@@ -147,15 +147,15 @@ describe("OpenCypher > oneHopTemplate", () => {
     );
   });
 
-  it("should expand Neptune multi-label types into separate labels on '::'", () => {
+  // filterByVertexTypes carries VertexType ids that were already split apart at
+  // ingestion, so a value bearing :: must be used verbatim, not re-split.
+  it("uses each vertex type verbatim without splitting on '::'", () => {
     const template = oneHopTemplate({
       vertexId: createVertexId("12"),
       filterByVertexTypes: ["country::capital", "city::town"],
     });
 
-    expect(template).toContain(
-      "(v:`country` OR v:`capital` OR v:`city` OR v:`town`)",
-    );
+    expect(template).toContain("(v:`country::capital` OR v:`city::town`)");
   });
 
   describe("attribute filters", () => {

--- a/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchNeighbors/oneHopTemplate.ts
@@ -42,8 +42,7 @@ const oneHopTemplate = ({
   const formattedVertexTypes =
     filterByVertexTypes.length > 1
       ? `(${filterByVertexTypes
-          .flatMap((type: string) => type.split("::"))
-          .map((type: string) => `v:${fragment.identifier(type)}`)
+          .map(type => `v:${fragment.identifier(type)}`)
           .join(" OR ")})`
       : "";
 


### PR DESCRIPTION
## Description

Amazon Neptune joins a vertex's multiple labels with the reserved `::` delimiter and surfaces the composite as a single string on the Gremlin wire. Graph Explorer's domain model holds only single labels, so the split belongs **once, at ingestion** — not scattered across sites, and not re-applied to values that are already single labels.

Previously the `::` split was inlined at eight connector sites with two inconsistent handlings (`.split("::").filter(Boolean)` at some, bare `.split("::")` at others), including sites that were re-splitting Graph Explorer's own already-single-label domain ids.

This PR:

- Adds a shared Gremlin `splitLabel` helper that owns the `::` convention and **keeps the whole string when any segment is empty** (`foo::`, `::foo`, `a::::b`, `::`), rather than silently resolving `foo::` to `foo` or emitting an empty label.
- Routes the **five genuine ingestion sites** (raw Neptune wire labels) through it: `mapApiVertex`, `fetchEdgeConnections`, `verticesSchemaTemplate`, `edgesSchemaTemplate`, `neighborCounts`.
- **Deletes** the split at the **three sites that operated on already-single-label domain ids** (`gremlin/fetchNeighbors/oneHopTemplate`, `keywordSearch/keywordSearchTemplate`, `openCypher/fetchNeighbors/oneHopTemplate`). Re-splitting these was a no-op on real data and wrong for a generic TinkerPop backend where `::` is an ordinary label character.
- `mapApiVertex` maps an empty element label to no types (`[]`), preserving prior behavior for that boundary without reintroducing the `foo:: → foo` bug.

The rationale, the live Neptune/TinkerPop evidence, and the known limitation (the split is unconditional and only correct for Neptune) are recorded in the ADR. Gremlin-only: openCypher returns labels as an array and never carries `::`.

## How to read

1. [packages/graph-explorer/src/connector/gremlin/splitLabel.ts](https://github.com/aws/graph-explorer/pull/2063/files#diff-bdaf9057861676f5fdff033211fbdbe8035c39348b6d435706218c6d8a54e2e5) — start here; the helper and the keep-whole-on-empty rule.
2. [docs/adr/20260807-split-composite-labels-once-at-gremlin-ingestion.md](https://github.com/aws/graph-explorer/pull/2063/files#diff-35ae6a3a35c4026e1d72da76382e4d42b3fb01d65a03acf0ed4a402d91db0c91) — why the split lives at ingestion, and the empty-segment decision.
3. The five ingestion call sites, then the three delete sites (with their tests flipped to verbatim assertions).

## Validation

- `pnpm checks` passes (types, lint, format).
- `pnpm test` passes (2609 tests). `splitLabel` has full awkward-input coverage; `mapApiVertex` gains composite-split and empty-label cases; the three delete-site tests assert verbatim behavior.

## Related Issues

- Related to #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.