### PR TITLE
Refuse empty Gremlin identifiers and surface a clear message

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.test.ts
@@ -1,6 +1,9 @@
 import { createEdgeId, createVertexId } from "@/core";
 
-import { UnrepresentableNumberError } from "../queryValueError";
+import {
+  EmptyIdentifierError,
+  UnrepresentableNumberError,
+} from "../queryValueError";
 import { ESCAPABLE_PATTERN, fragment, SHORT_ESCAPES } from "./fragments";
 
 /**
@@ -154,7 +157,16 @@ describe("fragment.identifier", () => {
     expect(fragment.identifier("wei$rd")).toEqual("'wei$rd'");
   });
 
-  it.each(awkwardStrings)("round-trips a name %j", value => {
+  it("should reject an empty name, which names nothing", () => {
+    expect(() => fragment.identifier("")).toThrow(
+      new EmptyIdentifierError("gremlin"),
+    );
+  });
+
+  // Empty is rejected above, so exclude it from the representable-identifier suites.
+  const awkwardIdentifiers = awkwardStrings.filter(value => value !== "");
+
+  it.each(awkwardIdentifiers)("round-trips a name %j", value => {
     expectRoundTrip(fragment.identifier(value), value);
   });
 
@@ -162,7 +174,7 @@ describe("fragment.identifier", () => {
   // `identifier` and `string` coincide. Nothing in a generated query reveals
   // which one a call site chose; if the two ever diverge, every call site's
   // choice has to be re-checked rather than assumed.
-  it.each(awkwardStrings)(
+  it.each(awkwardIdentifiers)(
     "should render %j identically to a string literal",
     value => {
       expect(fragment.identifier(value)).toBe(fragment.string(value));

--- a/packages/graph-explorer/src/connector/gremlin/fragments.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fragments.ts
@@ -3,6 +3,7 @@ import { type EdgeId, getRawId, type VertexId } from "@/core";
 import { type QueryFragment, toQueryFragment } from "../queryFragment";
 import {
   assertRepresentable,
+  EmptyIdentifierError,
   UnrepresentableNumberError,
 } from "../queryValueError";
 
@@ -91,6 +92,9 @@ export const fragment = {
    */
   identifier(name: string): QueryFragment {
     assertRepresentable(name);
+    if (name === "") {
+      throw new EmptyIdentifierError("gremlin");
+    }
     return toQueryFragment(`'${escapeStringLiteralBody(name)}'`);
   },
 

--- a/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fragments.test.ts
@@ -63,7 +63,9 @@ describe("fragment.identifier", () => {
   });
 
   it("should reject an empty name, which names nothing", () => {
-    expect(() => fragment.identifier("")).toThrow(EmptyIdentifierError);
+    expect(() => fragment.identifier("")).toThrow(
+      new EmptyIdentifierError("openCypher"),
+    );
   });
 
   it("should reject a newline, a control character an identifier cannot carry", () => {

--- a/packages/graph-explorer/src/utils/createDisplayError.test.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.test.ts
@@ -2,6 +2,7 @@
 import { z } from "zod";
 
 import {
+  EmptyIdentifierError,
   QueryValueError,
   UnescapableValueError,
   UnsupportedValueTypeError,
@@ -41,6 +42,17 @@ describe("createDisplayError", () => {
       message: "This value cannot be used in a query against this database.",
     });
   });
+
+  it.each(["gremlin", "openCypher"] as const)(
+    "Should give the same language-agnostic message for an empty %s identifier",
+    language => {
+      const result = createDisplayError(new EmptyIdentifierError(language));
+      expect(result).toStrictEqual({
+        title: "This identifier cannot be used",
+        message: "An empty identifier cannot be used in a query.",
+      });
+    },
+  );
 
   it("Should fall back to generic wording for an unescapable value failure", () => {
     const error = new UnescapableValueError("sparql", "IRI", "a b", [" "]);

--- a/packages/graph-explorer/src/utils/createDisplayError.ts
+++ b/packages/graph-explorer/src/utils/createDisplayError.ts
@@ -1,6 +1,7 @@
 import { ZodError } from "zod";
 
 import {
+  EmptyIdentifierError,
   QueryValueError,
   UnsupportedValueTypeError,
 } from "@/connector/queryValueError";
@@ -158,6 +159,13 @@ export function createDisplayError(error: any): DisplayError {
     return {
       title: "This value cannot be used",
       message: `The value "${String(error.value)}" cannot be used in a query against this database.`,
+    };
+  }
+
+  if (error instanceof EmptyIdentifierError) {
+    return {
+      title: "This identifier cannot be used",
+      message: "An empty identifier cannot be used in a query.",
     };
   }
 


### PR DESCRIPTION
## Description

Gremlin `fragment.identifier("")` previously emitted a quoted empty literal `''`, silently naming nothing in the generated query. It now refuses an empty identifier — throwing `EmptyIdentifierError("gremlin")` after `assertRepresentable` — bringing it to parity with the openCypher fragment, which already guards this case.

- **`connector/gremlin/fragments.ts`** — `identifier()` throws `EmptyIdentifierError("gremlin")` when the name is empty, mirroring openCypher's guard placement.
- **`utils/createDisplayError.ts`** — new language-agnostic branch maps `EmptyIdentifierError` to a specific message ("This identifier cannot be used") instead of the generic `QueryValueError` fallback. Fires for both engines, so openCypher's empty-identifier display message improves as a side effect.
- **Tests** — Gremlin fragment test asserts `identifier("")` throws; display test asserts both `gremlin` and `openCypher` yield the identical language-agnostic message.

## Validation

- `pnpm checks` passes (lint, format, types).
- `pnpm test` passes (2601 tests).

## Related Issues

- Part of #2020

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
