### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "description": "Graph Explorer",
   "license": "Apache-2.0",

--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer-proxy-server",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Server to facilitate communication between the browser and the supported graph database.",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/graph-explorer/package.json
+++ b/packages/graph-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-explorer",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Graph Explorer",
   "license": "Apache-2.0",
   "author": "amazon",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graph-explorer/shared",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "description": "Shared types and functions across client and server.",
   "keywords": [],


### PR DESCRIPTION
## Description

Bump the workspace package version from 3.2.0 to 3.2.1 ahead of the patch release. Only the `version` field changes, in lockstep across all four packages:

- `package.json` (root)
- `packages/shared/package.json`
- `packages/graph-explorer-proxy-server/package.json`
- `packages/graph-explorer/package.json`

No cross-dependency pins or lockfile changes were required. The changelog entry ships separately.

## Validation

- Version-only diff; no dependency or lockfile changes.
- Type checking, linting, and the full test suite are covered by CI on this branch.

## Related Issues

- Closes #2021

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.