### PR TITLE
fix: block neighbor expansion while the limit input is empty

### DIFF
--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandContent.tsx
@@ -92,10 +92,13 @@ function ExpansionOptions({
   );
   const [filters, setFilters] = useState<Array<NodeExpandFilter>>([]);
   const [limitEnabled, setLimitEnabled] = useState(Boolean(defaultLimit));
-  const [limit, setLimit] = useState<number>(defaultLimit ?? 100);
+  const [limit, setLimit] = useState<number | null>(defaultLimit ?? 100);
 
   const hasSelectedType = Boolean(selectedType);
   const hasUnfetchedNeighbors = (neighbors?.unfetched ?? 0) > 0;
+  // An empty or invalid limit must block expansion, otherwise the request
+  // would go out unlimited while the toggle still shows a limit is applied
+  const hasValidLimit = !limitEnabled || (limit != null && limit >= 1);
 
   // Reset filters when selected type changes
   const [prevSelectedType, setPrevSelectedType] = useState(selectedType);
@@ -129,7 +132,9 @@ function ExpansionOptions({
       />
       <PanelFooter className="sticky bottom-0 flex flex-row justify-end">
         <ExpandButton
-          isDisabled={!hasUnfetchedNeighbors || !hasSelectedType}
+          isDisabled={
+            !hasUnfetchedNeighbors || !hasSelectedType || !hasValidLimit
+          }
           vertexId={vertexId}
           filters={{
             filterByVertexTypes: [selectedType],

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.test.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/components";
+import { getAppStore } from "@/core";
+import { createQueryClient } from "@/core/queryClient";
+import { DbState, TestProvider } from "@/utils/testing";
+
+import NodeExpandFilters from "./NodeExpandFilters";
+
+function Harness({
+  onLimitChange,
+}: {
+  onLimitChange: (limit: number | null) => void;
+}) {
+  const [limit, setLimit] = useState<number | null>(100);
+  return (
+    <NodeExpandFilters
+      neighborsOptions={[{ label: "Person", value: "Person" }]}
+      selectedType="Person"
+      onSelectedTypeChange={() => {}}
+      filters={[]}
+      onFiltersChange={() => {}}
+      limit={limit}
+      onLimitChange={value => {
+        setLimit(value);
+        onLimitChange(value);
+      }}
+      limitEnabled={true}
+      onLimitEnabledToggle={() => {}}
+    />
+  );
+}
+
+function renderFilters(onLimitChange: (limit: number | null) => void) {
+  const state = new DbState();
+  const store = getAppStore();
+  state.applyTo(store);
+  render(
+    <TestProvider client={createQueryClient()} store={store}>
+      <TooltipProvider>
+        <Harness onLimitChange={onLimitChange} />
+      </TooltipProvider>
+    </TestProvider>,
+  );
+  return screen.getByLabelText("limit");
+}
+
+describe("NodeExpandFilters", () => {
+  it("reports null when the limit input is cleared", async () => {
+    const user = userEvent.setup();
+    const onLimitChange = vi.fn();
+    const input = renderFilters(onLimitChange);
+
+    await user.clear(input);
+
+    expect(onLimitChange).toHaveBeenLastCalledWith(null);
+    expect(input).toHaveValue(null);
+  });
+
+  it("reports the parsed number when the limit changes", async () => {
+    const user = userEvent.setup();
+    const onLimitChange = vi.fn();
+    const input = renderFilters(onLimitChange);
+
+    await user.clear(input);
+    await user.type(input, "50");
+
+    expect(onLimitChange).toHaveBeenLastCalledWith(50);
+    expect(input).toHaveValue(50);
+  });
+});

--- a/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
+++ b/packages/graph-explorer/src/modules/NodeExpand/NodeExpandFilters.tsx
@@ -37,8 +37,9 @@ export type NodeExpandFiltersProps = {
   onSelectedTypeChange(type: string): void;
   filters: Array<NodeExpandFilter>;
   onFiltersChange(filters: Array<NodeExpandFilter>): void;
-  limit: number;
-  onLimitChange(limit: number): void;
+  /** The neighbor limit, or null when the input is empty or invalid. */
+  limit: number | null;
+  onLimitChange(limit: number | null): void;
   limitEnabled: boolean;
   onLimitEnabledToggle(enabled: boolean): void;
 };
@@ -192,8 +193,11 @@ const NodeExpandFilters = ({
                 type="number"
                 min={1}
                 step={1}
-                value={limit}
-                onChange={e => onLimitChange(parseInt(e.target.value) ?? 0)}
+                value={limit ?? ""}
+                onChange={e => {
+                  const parsed = parseInt(e.target.value);
+                  onLimitChange(Number.isNaN(parsed) ? null : parsed);
+                }}
               />
             </motion.div>
           )}


### PR DESCRIPTION
Fixes #2068

Clearing the limit field stored `NaN`, because `parseInt("")` returns `NaN` and `??` only catches `null` or `undefined`. The expand request treats a falsy limit as no limit, so the request went out unlimited while the toggle still showed a limit was applied.

The limit state now stores `null` for an empty or invalid input, the field renders empty instead of `value={NaN}`, and the Expand button is disabled until a valid limit is entered or the toggle is turned off.

Verified against a local TinkerPop Gremlin Server through the proxy server, with a node seeded with 303 neighbors. With the field cleared, the outgoing Gremlin query on `main` had no `.range()` clause. With a valid limit of 10 on this branch, the query contains `.range(0, 10)` and exactly 10 neighbors arrive. Added a component test covering the cleared and repopulated input.

**Before, the setup**: limit toggle on, field cleared, Expand still enabled:

<img width="1280" height="800" alt="before-limit" src="https://github.com/user-attachments/assets/a263cfc4-5c22-4fe6-bb7c-7a6b74706318" />


**Before, the result**: one click pulls all 301 unfetched neighbors onto the canvas while the toggle says a limit is applied:

<img width="1280" height="800" alt="before-limit-flood" src="https://github.com/user-attachments/assets/9ffb8f49-9fd5-47e7-ae79-6a81e727b9be" />


**After**: same state, Expand is disabled until a valid limit is entered or the toggle is turned off:

<img width="1280" height="800" alt="after-limit" src="https://github.com/user-attachments/assets/d71557a1-0296-4c35-ac07-7388b07b68bd" />


**After, with a valid limit**: entering 10 and expanding adds exactly 10 neighbors, so the normal flow is unchanged:

<img width="1280" height="800" alt="after-limit-flood" src="https://github.com/user-attachments/assets/88172987-1f73-4476-a355-0975383e8183" />
