### PR TITLE
Attribute empty expand results to active filters, not exhaustion

### DIFF
--- a/packages/graph-explorer/src/hooks/useExpandNode.test.ts
+++ b/packages/graph-explorer/src/hooks/useExpandNode.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { act, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 
 import {
   defaultNeighborExpansionLimitAtom,
@@ -194,6 +195,63 @@ describe("useExpandNode", () => {
     );
   });
 
+  it("should show the generic exhausted message when expansion returns nothing and no filters were applied", async () => {
+    const vertex = createTestableVertex();
+    const neighbor = createTestableVertex();
+    const edge = createTestableEdge().withSource(vertex).withTarget(neighbor);
+
+    dbState.addTestableVertexToGraph(vertex);
+    explorer.addTestableEdge(edge);
+
+    vi.spyOn(explorer, "fetchNeighbors").mockResolvedValue({
+      vertices: [],
+      edges: [],
+    });
+
+    const { result } = renderHookExpandNode();
+
+    act(() => {
+      result.current.expandNode({ vertexId: vertex.id });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(toast.info).toHaveBeenCalledWith("No more neighbors to expand");
+  });
+
+  it("should show the filter-specific message when attribute filters excluded all neighbors", async () => {
+    const vertex = createTestableVertex();
+    const neighbor = createTestableVertex();
+    const edge = createTestableEdge().withSource(vertex).withTarget(neighbor);
+
+    dbState.addTestableVertexToGraph(vertex);
+    explorer.addTestableEdge(edge);
+
+    vi.spyOn(explorer, "fetchNeighbors").mockResolvedValue({
+      vertices: [],
+      edges: [],
+    });
+
+    const { result } = renderHookExpandNode();
+
+    act(() => {
+      result.current.expandNode({
+        vertexId: vertex.id,
+        attributeFilters: [{ name: "name", value: "no-match" }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "No neighbors matched your filters",
+    );
+  });
+
   describe("expandNodes (multiple)", () => {
     it("should expand multiple nodes in parallel", async () => {
       const vertex1 = createTestableVertex();
@@ -316,6 +374,49 @@ describe("useExpandNode", () => {
           filterByVertexTypes: ["Person"],
           limit: 10,
         }),
+      );
+    });
+
+    it("should show the filter-specific message when attribute filters excluded all neighbors", async () => {
+      const vertex1 = createTestableVertex();
+      const vertex2 = createTestableVertex();
+      const neighbor1 = createTestableVertex();
+      const neighbor2 = createTestableVertex();
+      const edge1 = createTestableEdge()
+        .withSource(vertex1)
+        .withTarget(neighbor1);
+      const edge2 = createTestableEdge()
+        .withSource(vertex2)
+        .withTarget(neighbor2);
+
+      dbState.addTestableVertexToGraph(vertex1);
+      dbState.addTestableVertexToGraph(vertex2);
+
+      explorer.addTestableEdge(edge1);
+      explorer.addTestableEdge(edge2);
+
+      vi.spyOn(explorer, "fetchNeighbors").mockResolvedValue({
+        vertices: [],
+        edges: [],
+      });
+
+      const { result } = renderHookExpandNode();
+
+      const request: ExpandNodesRequest = {
+        vertexIds: [vertex1.id, vertex2.id],
+        attributeFilters: [{ name: "name", value: "no-match" }],
+      };
+
+      act(() => {
+        result.current.expandNodes(request);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPending).toBe(false);
+      });
+
+      expect(toast.info).toHaveBeenCalledWith(
+        "No neighbors matched your filters",
       );
     });
   });

--- a/packages/graph-explorer/src/hooks/useExpandNode.tsx
+++ b/packages/graph-explorer/src/hooks/useExpandNode.tsx
@@ -94,7 +94,11 @@ export default function useExpandNode() {
 
       // No neighbors to add
       if (result.vertices.length + result.edges.length <= 0) {
-        toast.info("No more neighbors to expand");
+        toast.info(
+          request.attributeFilters?.length
+            ? "No neighbors matched your filters"
+            : "No more neighbors to expand",
+        );
         return;
       }
 
@@ -166,7 +170,11 @@ export default function useExpandNode() {
       const combined = await expandPromise;
 
       if (combined.vertices.length + combined.edges.length <= 0) {
-        toast.info("No more neighbors to expand");
+        toast.info(
+          filters.attributeFilters?.length
+            ? "No neighbors matched your filters"
+            : "No more neighbors to expand",
+        );
         return;
       }
 


### PR DESCRIPTION
Closes #2060

## What changed

`useExpandNode`'s toast message after an empty expansion result no longer always says "No more neighbors to expand." That message is only accurate when no filters were applied. When the request carried non-empty `attributeFilters` and the result came back empty, the toast now says "No neighbors matched your filters" instead, since the node may still have neighbors that the filter excluded.

Applied at both call sites (`expandNode` for a single node, `expandNodes` for multiple), since the fix path in the issue noted the multi-node path could gain filter support later.

## Verification

- Added tests covering both the generic exhausted case and the filtered-empty case, for both `expandNode` and `expandNodes`.
- `pnpm checks` (lint, format, types) passes.
- `pnpm test` passes except for one pre-existing, unrelated failure in `safeSessionStorage.test.ts` (confirmed it fails identically on `main` without this change).