### PR TITLE
Restructure 3.2.1 changelog into sections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,22 @@
 
 ## Release 3.2.1
 
-Release 3.2.1 hardens how Graph Explorer builds queries. User-supplied values — attribute names, labels, filter text, and IDs — are now escaped completely and consistently across Gremlin, openCypher, and SPARQL, and values no database can carry are refused up front with a clear error instead of silently returning wrong results. Composite Gremlin labels (Neptune's `::` convention) are now split consistently in one place, and empty Gremlin identifiers are refused with a clear message. It also fixes SPARQL neighbor-attribute filtering so multiple filters narrow results (all must match) and match your text literally rather than as a regular expression.
+Release 3.2.1 hardens how Graph Explorer builds queries, making value handling correct and consistent across Gremlin, openCypher, and SPARQL.
+
+### Query Input Sanitization
+
+- User-supplied values (attribute names, labels, filter text, and IDs) are now escaped completely and consistently across Gremlin, openCypher, and SPARQL.
+- Values that no database can store are rejected up front with a clear error message instead of silently returning incorrect results.
+
+### Gremlin & openCypher Improvements
+
+- Composite labels (Neptune's `::` convention) are now split in a single, consistent location.
+- Empty and invalid identifier names are rejected with a clear error message (Gremlin and openCypher).
+
+### SPARQL Fixes
+
+- Neighbor-attribute filtering now applies multiple filters as a conjunction (all must match).
+- Filter text is matched literally rather than interpreted as a regular expression.
 
 ### All Changes
 


### PR DESCRIPTION
## Description

Restructure the already-merged 3.2.1 changelog entry from a single summary paragraph into scannable sections. Same set of changes, regrouped by user-facing theme:

- **Query Input Sanitization** — cross-cutting value escaping + rejecting values no database can store.
- **Gremlin & openCypher Improvements** — composite `::` label split; empty/invalid identifier rejection (both engines).
- **SPARQL Fixes** — conjunctive neighbor-attribute filtering; literal (non-regex) filter matching.

A one-line intro leads the entry; the exhaustive **All Changes** PR list is unchanged. The openCypher identifier fix (#2057) gets explicit billing so the entry covers all three languages named in the intro.

## Validation

- Docs-only change to `Changelog.md`; no code touched.
- Wording reviewed against the merged entry and the shipped PRs.

## Related Issues

- Related to #2022

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified \`pnpm checks\` passes with no errors.
- [x] I have verified \`pnpm test\` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.