### PR TITLE
Cache proxy IAM credentials and sign with @smithy/signature-v4

### DIFF
--- a/packages/graph-explorer-proxy-server/package.json
+++ b/packages/graph-explorer-proxy-server/package.json
@@ -11,9 +11,11 @@
     "start": "NODE_ENV=production node src/node-server.ts"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/credential-providers": "^3.1071.0",
     "@graph-explorer/shared": "workspace:*",
-    "aws4": "^1.13.2",
+    "@smithy/protocol-http": "^5.5.1",
+    "@smithy/signature-v4": "^5.5.1",
     "body-parser": "^2.3.0",
     "compression": "^1.8.1",
     "cors": "^2.8.6",
@@ -28,7 +30,6 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/aws4": "^1.11.6",
     "@types/body-parser": "^1.19.6",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.19",

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -601,9 +601,9 @@ describe("createApp", () => {
         )
         .send({ query: "SELECT 1" });
 
-      // aws4 signing adds Authorization and X-Amz headers to the options
+      // SigV4 signing adds the authorization and x-amz-* headers to the options
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      expect(fetchOptions.headers).toHaveProperty("Authorization");
+      expect(fetchOptions.headers).toHaveProperty("authorization");
     });
 
     it("uses only the mocked credentials, never real ones", async () => {
@@ -621,7 +621,7 @@ describe("createApp", () => {
         .send({ query: "SELECT 1" });
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      const authHeader: string = fetchOptions.headers["Authorization"];
+      const authHeader: string = fetchOptions.headers["authorization"];
       // The Authorization header must reference our fake credential, proving
       // the mock intercepted the credential provider chain.
       expect(
@@ -644,7 +644,7 @@ describe("createApp", () => {
         .send({ query: "SELECT 1" });
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      expect(fetchOptions.headers).not.toHaveProperty("Authorization");
+      expect(fetchOptions.headers).not.toHaveProperty("authorization");
     });
   });
 
@@ -712,7 +712,7 @@ describe("createApp", () => {
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
       // The service appears in the SigV4 credential scope, not on the request.
-      expect(fetchOptions.headers["Authorization"]).toContain(
+      expect(fetchOptions.headers["authorization"]).toContain(
         "/us-east-1/neptune-db/aws4_request",
       );
     });
@@ -732,7 +732,7 @@ describe("createApp", () => {
         .send({ query: "SELECT 1" });
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      expect(fetchOptions.headers["Authorization"]).toContain(
+      expect(fetchOptions.headers["authorization"]).toContain(
         "/us-east-1/neptune-graph/aws4_request",
       );
     });
@@ -823,7 +823,7 @@ describe("createApp", () => {
       expect(fetchOptions.headers["accept"]).toBe(
         "application/sparql-results+json",
       );
-      expect(fetchOptions.headers["Authorization"]).toBeDefined();
+      expect(fetchOptions.headers["authorization"]).toBeDefined();
     });
   });
 

--- a/packages/graph-explorer-proxy-server/src/app.test.ts
+++ b/packages/graph-explorer-proxy-server/src/app.test.ts
@@ -711,7 +711,10 @@ describe("createApp", () => {
         .send({ query: "SELECT 1" });
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      expect(fetchOptions.service).toBe("neptune-db");
+      // The service appears in the SigV4 credential scope, not on the request.
+      expect(fetchOptions.headers["Authorization"]).toContain(
+        "/us-east-1/neptune-db/aws4_request",
+      );
     });
 
     it("uses provided service-type when IAM is enabled", async () => {
@@ -729,7 +732,9 @@ describe("createApp", () => {
         .send({ query: "SELECT 1" });
 
       const fetchOptions = mockFetch.mock.calls[0][1] as any;
-      expect(fetchOptions.service).toBe("neptune-graph");
+      expect(fetchOptions.headers["Authorization"]).toContain(
+        "/us-east-1/neptune-graph/aws4_request",
+      );
     });
   });
 

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -1,7 +1,9 @@
 import type { IncomingHttpHeaders } from "http";
 
+import { Sha256 } from "@aws-crypto/sha256-js";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
-import aws4 from "aws4";
+import { HttpRequest } from "@smithy/protocol-http";
+import { SignatureV4 } from "@smithy/signature-v4";
 import bodyParser from "body-parser";
 import compression from "compression";
 import cors from "cors";
@@ -129,28 +131,21 @@ export function createApp({
     return app.locals.logger;
   }
 
-  // Created once and reused: the SDK's node provider chain memoizes
-  // credentials, refreshes them near expiry, and single-flights concurrent
-  // refreshes. A new provider per request would defeat all three and re-query
-  // IMDS on every request.
-  const credentialProvider = fromNodeProviderChain();
-
-  // Function to get IAM headers for AWS4 signing process.
-  async function getIAMHeaders(options: string | aws4.Request) {
-    const creds = await credentialProvider();
-    return aws4.sign(options, {
-      accessKeyId: creds.accessKeyId,
-      secretAccessKey: creds.secretAccessKey,
-      ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
-    });
-  }
+  // One signer reused across requests. It holds the SDK's node provider chain,
+  // which memoizes credentials, refreshes them near expiry, and single-flights
+  // concurrent refreshes. Region and service vary per request, so they are
+  // passed as sign() overrides rather than fixed on the signer.
+  const signer = new SignatureV4({
+    service: DEFAULT_SERVICE_TYPE,
+    region: "",
+    credentials: fromNodeProviderChain(),
+    sha256: Sha256,
+  });
 
   const userAgent = version ? `graph-explorer/${version}` : "graph-explorer";
 
-  // Signs with the current (cached) credentials when IAM is enabled. The
-  // host/port/path/service fields are inputs to aws4 signing only; node-fetch
-  // derives the request from the URL, so they are absent from the returned
-  // RequestInit.
+  // node-fetch derives the request line from the URL, so only request-init
+  // fields are returned; the fields fed to the signer are signing inputs only.
   async function buildFetchOptions(
     url: URL,
     options: any,
@@ -160,16 +155,23 @@ export function createApp({
   ): Promise<RequestInit> {
     let headers = options.headers;
     if (isIamEnabled) {
-      const signed = await getIAMHeaders({
-        host: url.hostname,
-        port: url.port,
-        path: url.pathname + url.search,
-        service: serviceType,
-        region,
-        method: options.method,
-        body: options.body ?? undefined,
-        headers: options.headers,
-      });
+      const signed = await signer.sign(
+        new HttpRequest({
+          method: options.method,
+          protocol: url.protocol,
+          hostname: url.hostname,
+          port: url.port ? Number(url.port) : undefined,
+          path: url.pathname,
+          // Signed queries are single-valued by construction — the proxy's
+          // fixed endpoints only ever set mode, cancelQuery, or queryId once.
+          // Revisit if a repeated-key query is ever added (fromEntries would
+          // drop all but the last, diverging from the signed request).
+          query: Object.fromEntries(url.searchParams),
+          headers: { ...options.headers, host: url.host },
+          body: options.body ?? undefined,
+        }),
+        { signingRegion: region, signingService: serviceType },
+      );
       headers = signed.headers;
     }
     return {

--- a/packages/graph-explorer-proxy-server/src/app.ts
+++ b/packages/graph-explorer-proxy-server/src/app.ts
@@ -129,26 +129,57 @@ export function createApp({
     return app.locals.logger;
   }
 
+  // Created once and reused: the SDK's node provider chain memoizes
+  // credentials, refreshes them near expiry, and single-flights concurrent
+  // refreshes. A new provider per request would defeat all three and re-query
+  // IMDS on every request.
+  const credentialProvider = fromNodeProviderChain();
+
   // Function to get IAM headers for AWS4 signing process.
   async function getIAMHeaders(options: string | aws4.Request) {
-    const credentialProvider = fromNodeProviderChain();
     const creds = await credentialProvider();
-    if (creds === undefined) {
-      throw new Error(
-        "IAM is enabled but credentials cannot be found on the credential provider chain.",
-      );
-    }
-
-    const headers = aws4.sign(options, {
+    return aws4.sign(options, {
       accessKeyId: creds.accessKeyId,
       secretAccessKey: creds.secretAccessKey,
       ...(creds.sessionToken && { sessionToken: creds.sessionToken }),
     });
-
-    return headers;
   }
 
   const userAgent = version ? `graph-explorer/${version}` : "graph-explorer";
+
+  // Signs with the current (cached) credentials when IAM is enabled. The
+  // host/port/path/service fields are inputs to aws4 signing only; node-fetch
+  // derives the request from the URL, so they are absent from the returned
+  // RequestInit.
+  async function buildFetchOptions(
+    url: URL,
+    options: any,
+    isIamEnabled: boolean,
+    region: string | undefined,
+    serviceType: string,
+  ): Promise<RequestInit> {
+    let headers = options.headers;
+    if (isIamEnabled) {
+      const signed = await getIAMHeaders({
+        host: url.hostname,
+        port: url.port,
+        path: url.pathname + url.search,
+        service: serviceType,
+        region,
+        method: options.method,
+        body: options.body ?? undefined,
+        headers: options.headers,
+      });
+      headers = signed.headers;
+    }
+    return {
+      method: options.method,
+      body: options.body ?? undefined,
+      headers,
+      compress: false,
+      redirect: "error",
+    };
+  }
 
   // Function to retry fetch requests with exponential backoff.
   const retryFetch = async (
@@ -162,49 +193,20 @@ export function createApp({
   ) => {
     const logger = getLogger();
     for (let i = 0; i < refetchMaxRetries; i++) {
-      if (isIamEnabled) {
-        const data = await getIAMHeaders({
-          host: url.hostname,
-          port: url.port,
-          path: url.pathname + url.search,
-          service: serviceType,
-          region,
-          method: options.method,
-          body: options.body ?? undefined,
-          headers: options.headers,
-        });
-
-        options = {
-          host: url.hostname,
-          port: url.port,
-          path: url.pathname + url.search,
-          service: serviceType,
-          region,
-          method: options.method,
-          body: options.body ?? undefined,
-          headers: data.headers,
-        };
-      }
-      options = {
-        host: url.hostname,
-        port: url.port,
-        path: url.pathname + url.search,
-        service: serviceType,
-        method: options.method,
-        body: options.body ?? undefined,
-        headers: options.headers,
-        compress: false,
-        redirect: "error",
-      };
+      const fetchOptions = await buildFetchOptions(
+        url,
+        options,
+        isIamEnabled,
+        region,
+        serviceType,
+      );
 
       try {
-        const res = await fetch(url.href, options);
+        const res = await fetch(url.href, fetchOptions);
         if (!res.ok) {
           logger.error("!!Request failure!!");
-          return res;
-        } else {
-          return res;
         }
+        return res;
       } catch (err) {
         if (refetchMaxRetries === 1) {
           // Don't log about retries if retrying is not used

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,15 +541,21 @@ importers:
 
   packages/graph-explorer-proxy-server:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
       '@aws-sdk/credential-providers':
         specifier: ^3.1071.0
         version: 3.1071.0
       '@graph-explorer/shared':
         specifier: workspace:*
         version: link:../shared
-      aws4:
-        specifier: ^1.13.2
-        version: 1.13.2
+      '@smithy/protocol-http':
+        specifier: ^5.5.1
+        version: 5.5.16
+      '@smithy/signature-v4':
+        specifier: ^5.5.1
+        version: 5.5.1
       body-parser:
         specifier: ^2.3.0
         version: 2.3.0
@@ -587,9 +593,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@types/aws4':
-        specifier: ^1.11.6
-        version: 1.11.6
       '@types/body-parser':
         specifier: ^1.19.6
         version: 1.19.6
@@ -2895,6 +2898,10 @@ packages:
     resolution: {integrity: sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.1':
     resolution: {integrity: sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==}
     engines: {node: '>=18.0.0'}
@@ -2911,12 +2918,20 @@ packages:
     resolution: {integrity: sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/protocol-http@5.5.16':
+    resolution: {integrity: sha512-iPaxIe9mTyidyhM6WF2/gSLPezyCwSlZcqlDBj2KCoSS994iw4yf1se1xmZkWsY98ZpwjDR/ZMubOSVx+Nrokw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.5.1':
     resolution: {integrity: sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.0':
     resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -3104,9 +3119,6 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
-
-  '@types/aws4@1.11.6':
-    resolution: {integrity: sha512-5CnVUkHNyLGpD9AnOcK66YyP0qvIh6nhJJoeK8zSl5YKikUcUbdB7SlHevUYVqicgeh6j5AJa1qa/h08dSZHoA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -3381,9 +3393,6 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-
-  aws4@1.13.2:
-    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   babel-plugin-polyfill-corejs2@0.4.15:
     resolution: {integrity: sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==}
@@ -7779,6 +7788,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.1':
     dependencies:
       '@smithy/core': 3.25.1
@@ -7801,6 +7815,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/protocol-http@5.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.5.1':
     dependencies:
       '@smithy/core': 3.25.1
@@ -7808,6 +7827,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 
@@ -7978,10 +8001,6 @@ snapshots:
     optional: true
 
   '@types/aria-query@5.0.4': {}
-
-  '@types/aws4@1.11.6':
-    dependencies:
-      '@types/node': 24.13.3
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -8293,8 +8312,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
-
-  aws4@1.13.2: {}
 
   babel-plugin-polyfill-corejs2@0.4.15(@babel/core@7.29.7):
     dependencies:


### PR DESCRIPTION
## Description

The proxy created a new AWS credential provider on every IAM-signed request, so credentials were never cached and each request re-queried EC2 IMDS. Under load — e.g. a schema sync that fans out many requests — IMDS throttles and the proxy returns intermittent `500 "Could not load credentials from any providers"`.

This reuses a single `fromNodeProviderChain()` provider for the app's lifetime, letting the SDK memoize credentials, refresh them near expiry, and single-flight concurrent refreshes. It also switches SigV4 signing from `aws4` to the official `@smithy/signature-v4`, constructed once holding that provider, with region and service supplied as per-request signing overrides.

Two commits, best read in order:

1. **Cache credentials by reusing the SDK provider chain** — the core fix.
2. **Swap the signer to `@smithy/signature-v4`** — supporting change; also drops the `aws4` dependency.

## How to read

1. [packages/graph-explorer-proxy-server/src/app.ts](https://github.com/aws/graph-explorer/pull/2082/files#diff-e9e175e1668607b2a4ebb6de0d0f33a52336cd03b78f0dff51870edc6a0cbd53) — signer constructed once (holds the provider), `buildFetchOptions` signs per request, `retryFetch` simplified.
2. [packages/graph-explorer-proxy-server/package.json](https://github.com/aws/graph-explorer/pull/2082/files#diff-86ecce6c567ec8c574a588a2e925a0f5d72c42e04d5ededd6ba1bf46aa69fc07) — dependency swap (`aws4` → `@smithy/signature-v4`, `@smithy/protocol-http`, `@aws-crypto/sha256-js`).

## Validation

- `pnpm checks` and `pnpm test` pass (2614 tests).
- Signing verified end-to-end against a live IAM-enabled Neptune cluster: openCypher POST → HTTP 200; `pg/statistics/summary?mode=basic` GET → HTTP 200; `gremlin/status` cancel GET → signature accepted (application-level 400, not a signature error).

## Related Issues

- Closes #2075
- Related to #2080
- Related to #119

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
