### PR TITLE
fix: truncate table header names with ellipsis instead of overlapping

### DIFF
--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.test.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ColumnDefinition } from "./useTabular";
+
+import Tabular from "./Tabular";
+
+type Row = { veryLongAttributeName: string; short: string };
+
+const data: Row[] = [{ veryLongAttributeName: "value", short: "v" }];
+
+function renderTable(columns: ColumnDefinition<Row>[]) {
+  render(<Tabular data={data} defaultColumn={{}} columns={columns} />);
+}
+
+describe("TabularHeader", () => {
+  it("truncates the header label and reveals the full name on hover", () => {
+    renderTable([
+      {
+        id: "veryLongAttributeName",
+        label: "A Very Long Attribute Name That Overflows",
+        accessor: "veryLongAttributeName",
+      },
+    ]);
+
+    const label = screen.getByTitle(
+      "A Very Long Attribute Name That Overflows",
+    );
+    expect(label).toHaveTextContent(
+      "A Very Long Attribute Name That Overflows",
+    );
+    expect(label.className).toContain("truncate");
+  });
+
+  it("omits the title when the header is not a plain string", () => {
+    renderTable([
+      {
+        id: "short",
+        label: "Short",
+        headerComponent: () => <span>Custom Header</span>,
+        accessor: "short",
+      },
+    ]);
+
+    expect(screen.getByText("Custom Header")).toBeInTheDocument();
+    expect(screen.queryByTitle("Short")).toBeNull();
+  });
+});

--- a/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
+++ b/packages/graph-explorer/src/components/Tabular/TabularHeader.tsx
@@ -41,9 +41,13 @@ const TabularHeader = <T extends object>({
             )}
           >
             <div
-              className="place-self-start overflow-hidden text-left data-[align='right']:text-right data-[overflow='ellipsis']:text-ellipsis"
+              className="w-full min-w-0 self-start truncate text-left data-[align='right']:text-right"
               data-align={column.align}
-              data-overflow={column.overflow}
+              title={
+                typeof column.Header === "string" && column.Header
+                  ? column.Header
+                  : undefined
+              }
             >
               {column.render("Header")}
             </div>


### PR DESCRIPTION
Fixes #2083

## Root Cause

Two stacked problems in `TabularHeader.tsx`:

1. The header label sits in a CSS grid cell without `min-w-0`, so the grid item cannot shrink below the label's min-content width. Shrinking a column makes the label overflow the header cell and overlap the neighboring column.
2. The `text-ellipsis` class was gated on a per-column `overflow` option that the Data Explorer never sets, and without `whitespace-nowrap` it had no effect even where it was set.

## Fix

Header labels now always truncate (`min-w-0` + `truncate`), and string headers carry a `title` attribute so hovering reveals the full name, as requested in the issue. Columns with a custom `headerComponent` are left untouched and get no title.

## Testing

- Added a component test asserting the title attribute and truncation class, and that custom header components get no title attribute.
- Reproduced the issue's exact steps against a local TinkerPop Gremlin Server seeded with long property names, resizing the header columns smaller. Screenshots below.
- The hover reveal uses the native browser tooltip via the `title` attribute, which headless screenshots cannot capture, so the capture log verifies the attribute in the DOM instead.

**Before** (resized columns, header names overlap):

<img width="1280" height="800" alt="before-header" src="https://github.com/user-attachments/assets/6f6b70f4-6bb4-43e9-b797-395650a28e8e" />


**After** (same columns, names truncate with an ellipsis; hover shows the full name):

<img width="1280" height="800" alt="after-header" src="https://github.com/user-attachments/assets/97033d8c-718e-4885-8824-51636e65a8a2" />
