### PR TITLE
Batch openCypher schema-sync attribute sampling into UNION ALL requests

### DIFF
--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/edgeSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/edgeSchemaTemplate.test.ts
@@ -1,11 +1,23 @@
+import { normalize } from "@/utils/testing";
+
 import edgesSchemaTemplate from "./edgesSchemaTemplate";
 
 describe("OpenCypher > edgesSchemaTemplate", () => {
-  it("Should return a template with the projection of each type", () => {
-    const template = edgesSchemaTemplate({ type: "route" });
+  it("returns one directed sample block per edge type, joined by UNION ALL", () => {
+    const template = edgesSchemaTemplate({ types: ["route", "contains"] });
 
-    expect(template).toBe(
-      `MATCH () -[e:\`route\`]- () RETURN e AS object LIMIT 1`,
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH () -[e:\`route\`]-> () RETURN e AS object LIMIT 1
+        UNION ALL
+        MATCH () -[e:\`contains\`]-> () RETURN e AS object LIMIT 1
+      `),
+    );
+  });
+
+  it("returns a single block for a single type", () => {
+    expect(edgesSchemaTemplate({ types: ["route"] })).toBe(
+      "MATCH () -[e:`route`]-> () RETURN e AS object LIMIT 1",
     );
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/edgesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/edgesSchemaTemplate.ts
@@ -1,18 +1,23 @@
-/**
- * Given an edge type, it returns an OpenCypher template that contains
- * one sample of the edge.
- *
- * @example
- * type = "route"
- *
- * MATCH() -[e:`route`]- ()
- * RETURN e AS object
- * LIMIT 1`
- */
+import { query } from "@/utils";
+
 import { fragment } from "../fragments";
 
-const edgesSchemaTemplate = ({ type }: { type: string }) => {
-  return `MATCH () -[e:${fragment.identifier(type)}]- () RETURN e AS object LIMIT 1`;
-};
-
-export default edgesSchemaTemplate;
+/**
+ * Given a set of edge types, returns an openCypher query that samples one edge
+ * per type in a single request: a `UNION ALL` of type-scoped blocks. The match
+ * is directed (`-[e]->`) so each type is scanned once; an undirected `-[e]-`
+ * would scan both directions and add a self-loop filter for the same sample.
+ *
+ * @example
+ * edgesSchemaTemplate({ types: ["route", "contains"] })
+ * // MATCH () -[e:`route`]-> () RETURN e AS object LIMIT 1
+ * // UNION ALL
+ * // MATCH () -[e:`contains`]-> () RETURN e AS object LIMIT 1
+ */
+export default function edgesSchemaTemplate({ types }: { types: string[] }) {
+  const blocks = types.map(
+    type =>
+      `MATCH () -[e:${fragment.identifier(type)}]-> () RETURN e AS object LIMIT 1`,
+  );
+  return query`${blocks.join("\nUNION ALL\n")}`;
+}

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/index.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/index.test.ts
@@ -4,6 +4,7 @@ import type { SchemaResponse } from "@/connector/useGEFetchTypes";
 
 import { ClientLoggerConnector } from "@/connector/LoggerConnector";
 import { createEdgeType, createVertexType } from "@/core";
+import { normalize } from "@/utils/testing";
 
 import fetchSchema from ".";
 
@@ -14,8 +15,7 @@ describe("OpenCypher > fetchSchema", () => {
       .mockResolvedValueOnce(allVertexLabelsResponse)
       .mockResolvedValueOnce(airportPropertiesResponse)
       .mockResolvedValueOnce(allEdgesResponse)
-      .mockResolvedValueOnce(routeEdgePropertiesResponse)
-      .mockResolvedValueOnce(containsEdgePropertiesResponse)
+      .mockResolvedValueOnce(batchedEdgePropertiesResponse)
       .mockImplementation(query => {
         throw new Error(query);
       });
@@ -410,48 +410,85 @@ describe("OpenCypher > fetchSchema", () => {
     expect(schema.edges.length).toBe(1);
   });
 
-  it("Should request properties for edges where labels are strings", async () => {
+  it("Should sample all edge types in a single batched request when labels are strings", async () => {
     const openCypherFetchFn = vi
       .fn()
       .mockResolvedValueOnce(allVertexLabelsResponse)
       .mockResolvedValueOnce(airportPropertiesResponse)
       .mockResolvedValueOnce(allEdgesResponse)
-      .mockResolvedValueOnce(routeEdgePropertiesResponse)
-      .mockResolvedValueOnce(containsEdgePropertiesResponse)
+      .mockResolvedValueOnce(batchedEdgePropertiesResponse)
       .mockImplementation(query => {
         throw new Error(query);
       });
 
     await fetchSchema(openCypherFetchFn, new ClientLoggerConnector());
 
-    expect(openCypherFetchFn.mock.calls[3][0]).toStrictEqual(
-      "MATCH () -[e:`route`]- () RETURN e AS object LIMIT 1",
-    );
-    expect(openCypherFetchFn.mock.calls[4][0]).toStrictEqual(
-      "MATCH () -[e:`contains`]- () RETURN e AS object LIMIT 1",
+    expect(normalize(openCypherFetchFn.mock.calls[3][0])).toBe(
+      normalize(`
+        MATCH () -[e:\`route\`]-> () RETURN e AS object LIMIT 1
+        UNION ALL
+        MATCH () -[e:\`contains\`]-> () RETURN e AS object LIMIT 1
+      `),
     );
   });
 
-  it("Should request properties for edges where labels are arrays of strings", async () => {
+  it("Should sample all edge types in a single batched request when labels are arrays of strings", async () => {
     const openCypherFetchFn = vi
       .fn()
       .mockResolvedValueOnce(allVertexLabelsResponse)
       .mockResolvedValueOnce(airportPropertiesResponse)
       .mockResolvedValueOnce(allEdgesLabelsInArrayResponse)
-      .mockResolvedValueOnce(routeEdgePropertiesResponse)
-      .mockResolvedValueOnce(containsEdgePropertiesResponse)
+      .mockResolvedValueOnce(batchedEdgePropertiesResponse)
       .mockImplementation(query => {
         throw new Error(query);
       });
 
     await fetchSchema(openCypherFetchFn, new ClientLoggerConnector());
 
-    expect(openCypherFetchFn.mock.calls[3][0]).toStrictEqual(
-      "MATCH () -[e:`route`]- () RETURN e AS object LIMIT 1",
+    expect(normalize(openCypherFetchFn.mock.calls[3][0])).toBe(
+      normalize(`
+        MATCH () -[e:\`route\`]-> () RETURN e AS object LIMIT 1
+        UNION ALL
+        MATCH () -[e:\`contains\`]-> () RETURN e AS object LIMIT 1
+      `),
     );
-    expect(openCypherFetchFn.mock.calls[4][0]).toStrictEqual(
-      "MATCH () -[e:`contains`]- () RETURN e AS object LIMIT 1",
+  });
+
+  it("Should batch attribute sampling into one request per DEFAULT_BATCH_REQUEST_SIZE labels", async () => {
+    const labelCount = 250;
+    const vertexLabels = Array.from(
+      { length: labelCount },
+      (_, i) => `Vertex${i}`,
     );
+    const edgeLabels = Array.from({ length: labelCount }, (_, i) => `Edge${i}`);
+
+    const openCypherFetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: vertexLabels.map(label => ({ label, count: 1 })),
+      })
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({
+        results: edgeLabels.map(label => ({ label, count: 1 })),
+      })
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [] })
+      .mockResolvedValueOnce({ results: [] })
+      .mockImplementation(query => {
+        throw new Error(query);
+      });
+
+    await fetchSchema(openCypherFetchFn, new ClientLoggerConnector());
+
+    // 250 labels / 100 per batch = 3 attribute requests each, plus the two
+    // label-count queries = 8 requests total (not 250 + 250 + 2).
+    expect(openCypherFetchFn).toHaveBeenCalledTimes(8);
+
+    const firstVertexBatch = openCypherFetchFn.mock.calls[1][0] as string;
+    expect(firstVertexBatch.match(/LIMIT 1/g)).toHaveLength(100);
+    expect(firstVertexBatch).toContain("UNION ALL");
   });
 });
 
@@ -546,5 +583,13 @@ const containsEdgePropertiesResponse = {
         "~properties": {},
       },
     },
+  ],
+};
+
+// One batched request returns a sample per edge type in a single `results` array.
+const batchedEdgePropertiesResponse = {
+  results: [
+    routeEdgePropertiesResponse.results[0],
+    containsEdgePropertiesResponse.results[0],
   ],
 };

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/index.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/index.ts
@@ -1,3 +1,5 @@
+import { chunk } from "lodash";
+
 import type { LoggerConnector } from "@/connector/LoggerConnector";
 import type { SchemaResponse } from "@/connector/useGEFetchTypes";
 
@@ -7,8 +9,11 @@ import {
   mapEdgeToTypeConfig,
   mapVertexToTypeConfigs,
 } from "@/core";
-import { mapWithConcurrency } from "@/utils";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
+import {
+  mapWithConcurrency,
+  DEFAULT_BATCH_REQUEST_SIZE,
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+} from "@/utils";
 
 import type { OCEdge, OCVertex } from "../types";
 import type { GraphSummary, OpenCypherFetch } from "../types";
@@ -40,25 +45,11 @@ type RawEdgeLabelsResponse = {
 };
 
 type RawVerticesSchemaResponse = {
-  results:
-    | [
-        {
-          object: OCVertex;
-        },
-      ]
-    | []
-    | undefined;
+  results?: Array<{ object: OCVertex }>;
 };
 
 type RawEdgesSchemaResponse = {
-  results:
-    | [
-        {
-          object: OCEdge;
-        },
-      ]
-    | []
-    | undefined;
+  results?: Array<{ object: OCEdge }>;
 };
 
 // Fetches all vertex labels and their counts
@@ -108,36 +99,30 @@ const fetchVerticesAttributes = async (
   }
 
   remoteLogger.info("[openCypher Explorer] Fetching vertices attributes...");
-  const responses = await mapWithConcurrency(
-    labels,
+  const batches = chunk(labels, DEFAULT_BATCH_REQUEST_SIZE);
+  const batchResults = await mapWithConcurrency(
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async label => {
-      const verticesTemplate = verticesSchemaTemplate({
-        type: label,
+    async batch => {
+      const response = await openCypherFetch<RawVerticesSchemaResponse>(
+        verticesSchemaTemplate({ types: batch }),
+      );
+
+      return (response.results ?? []).flatMap(({ object: ocVertex }) => {
+        // verify response has the info we need
+        if (!ocVertex || !ocVertex["~labels"]) {
+          return [];
+        }
+
+        const vertex = createVertex(mapApiVertex(ocVertex));
+        return mapVertexToTypeConfigs(vertex).map(vertexTypeConfig => ({
+          ...vertexTypeConfig,
+          total: countsByLabel[vertexTypeConfig.type],
+        }));
       });
-
-      const response =
-        await openCypherFetch<RawVerticesSchemaResponse>(verticesTemplate);
-
-      return response.results ? response.results[0]?.object : null;
     },
   );
-
-  const vertices = responses
-    .flatMap(ocVertex => {
-      // verify response has the info we need
-      if (!ocVertex || !ocVertex["~labels"]) {
-        return null;
-      }
-
-      const vertex = createVertex(mapApiVertex(ocVertex));
-      const vertexTypeConfigs = mapVertexToTypeConfigs(vertex);
-      return vertexTypeConfigs.map(vertexTypeConfig => ({
-        ...vertexTypeConfig,
-        total: countsByLabel[vertexTypeConfig.type],
-      }));
-    })
-    .filter(vertexSchema => vertexSchema != null);
+  const vertices = batchResults.flat();
 
   remoteLogger.info(
     `[openCypher Explorer] Found ${vertices.flatMap(v => v.attributes).length} vertex attributes across ${vertices.length} vertex types.`,
@@ -214,37 +199,30 @@ const fetchEdgesAttributes = async (
   }
 
   remoteLogger.info("[openCypher Explorer] Fetching edges attributes...");
-  const responses = await mapWithConcurrency(
-    labels,
+  const batches = chunk(labels, DEFAULT_BATCH_REQUEST_SIZE);
+  const batchResults = await mapWithConcurrency(
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async label => {
-      const edgesTemplate = edgesSchemaTemplate({
-        type: label,
+    async batch => {
+      const response = await openCypherFetch<RawEdgesSchemaResponse>(
+        edgesSchemaTemplate({ types: batch }),
+      );
+
+      return (response.results ?? []).flatMap(({ object: ocEdge }) => {
+        // verify response has the info we need
+        if (!ocEdge || !ocEdge["~entityType"] || !ocEdge["~type"]) {
+          return [];
+        }
+
+        const edge = createEdge(mapApiEdge(ocEdge));
+        const edgeTypeConfig = mapEdgeToTypeConfig(edge);
+        return [
+          { ...edgeTypeConfig, total: countsByLabel[edgeTypeConfig.type] },
+        ];
       });
-
-      const response =
-        await openCypherFetch<RawEdgesSchemaResponse>(edgesTemplate);
-
-      return response.results ? response.results[0]?.object : null;
     },
   );
-
-  const edges = responses
-    .map(ocEdge => {
-      // verify response has the info we need
-      if (!ocEdge || !ocEdge["~entityType"] || !ocEdge["~type"]) {
-        return null;
-      }
-
-      const edge = createEdge(mapApiEdge(ocEdge));
-      const edgeTypeConfig = mapEdgeToTypeConfig(edge);
-
-      return {
-        ...edgeTypeConfig,
-        total: countsByLabel[edgeTypeConfig.type],
-      };
-    })
-    .filter(edgeSchema => edgeSchema != null);
+  const edges = batchResults.flat();
 
   remoteLogger.info(
     `[openCypher Explorer] Found ${edges.flatMap(e => e.attributes).length} edge attributes across ${edges.length} edge types.`,

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.test.ts
@@ -1,15 +1,29 @@
+import { normalize } from "@/utils/testing";
+
 import { UnescapableValueError } from "../../queryValueError";
 import verticesSchemaTemplate from "./verticesSchemaTemplate";
 
 describe("OpenCypher > verticesSchemaTemplate", () => {
-  it("Should return a template with the projection of each type", () => {
-    const template = verticesSchemaTemplate({ type: "country" });
+  it("returns one index-scoped sample block per label, joined by UNION ALL", () => {
+    const template = verticesSchemaTemplate({ types: ["airport", "country"] });
 
-    expect(template).toBe("MATCH (v:`country`) RETURN v AS object LIMIT 1");
+    expect(normalize(template)).toBe(
+      normalize(`
+        MATCH (v:\`airport\`) RETURN v AS object LIMIT 1
+        UNION ALL
+        MATCH (v:\`country\`) RETURN v AS object LIMIT 1
+      `),
+    );
+  });
+
+  it("returns a single block for a single label", () => {
+    expect(verticesSchemaTemplate({ types: ["country"] })).toBe(
+      "MATCH (v:`country`) RETURN v AS object LIMIT 1",
+    );
   });
 
   it("throws on a control-character label rather than emitting a malformed query", () => {
-    expect(() => verticesSchemaTemplate({ type: "coun\ntry" })).toThrow(
+    expect(() => verticesSchemaTemplate({ types: ["coun\ntry"] })).toThrow(
       UnescapableValueError,
     );
   });

--- a/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchSchema/verticesSchemaTemplate.ts
@@ -1,7 +1,22 @@
+import { query } from "@/utils";
+
 import { fragment } from "../fragments";
 
-const verticesSchemaTemplate = ({ type }: { type: string }) => {
-  return `MATCH (v:${fragment.identifier(type)}) RETURN v AS object LIMIT 1`;
-};
-
-export default verticesSchemaTemplate;
+/**
+ * Given a set of node labels, returns an openCypher query that samples one node
+ * per label in a single request: a `UNION ALL` of index-scoped blocks. `UNION
+ * ALL` (not `UNION`) keeps one row per block — de-duplication would drop a
+ * sample shared by two labels.
+ *
+ * @example
+ * verticesSchemaTemplate({ types: ["airport", "country"] })
+ * // MATCH (v:`airport`) RETURN v AS object LIMIT 1
+ * // UNION ALL
+ * // MATCH (v:`country`) RETURN v AS object LIMIT 1
+ */
+export default function verticesSchemaTemplate({ types }: { types: string[] }) {
+  const blocks = types.map(
+    type => `MATCH (v:${fragment.identifier(type)}) RETURN v AS object LIMIT 1`,
+  );
+  return query`${blocks.join("\nUNION ALL\n")}`;
+}


### PR DESCRIPTION
## Description

openCypher schema discovery issued **one HTTP request per label** — thousands of requests per sync on graphs with many labels (a real customer graph with ~9,456 edge labels produced ~9,500 requests). This samples attributes for a whole batch of labels in a single `UNION ALL` of index-scoped per-label blocks, chunked into `DEFAULT_BATCH_REQUEST_SIZE` (100) groups and run through the concurrency pool from the base PR. Edge blocks use a directed match (`-[e]->`) so each type is scanned once.

The query shape was chosen from `EXPLAIN` plans on live Neptune: `UNION ALL` of per-label `MATCH` blocks is the only index-backed shape portable across every supported engine (1.2.1.0–1.4.7.0). `CALL {}` subqueries fail below 1.4, and single-scan variants full-scan the vertex table. The resulting `SchemaResponse` is unchanged — this is a request-count change, not a behavior change.

## Validation

- `pnpm checks` (types, lint, format) passes; `pnpm test` passes.
- New test asserts ⌈N / 100⌉ attribute requests (250 labels ⇒ 8 requests, not 502) and that a batch is one `UNION ALL` of 100 blocks.
- Query shapes and `EXPLAIN` plans verified read-only against live Neptune 1.2.1.0 / 1.3.5.0 / 1.4.7.0.

## Related Issues

- Builds on #2096 (eager concurrency pool), already merged to `main`.
- Closes #2076
- Related to #2077
- Related to #2078
- Related to #2079

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.
