### PR TITLE
Batch edge-connections discovery across all three connectors

### DIFF
--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -4,17 +4,33 @@ import { normalizeWithNoSpace as normalize } from "@/utils/testing";
 import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 
 describe("Gremlin > edgeConnectionsTemplate", () => {
-  it("should sample edges of the type and project the endpoint labels", () => {
-    const template = edgeConnectionsTemplate(createEdgeType("route"));
+  it("should scan a batch of edge types and group the endpoint labels by edge type", () => {
+    const template = edgeConnectionsTemplate({
+      types: [createEdgeType("route"), createEdgeType("contains")],
+    });
 
     expect(normalize(template)).toBe(
       normalize(`
-        g.E().hasLabel('route').limit(10000)
-          .project('sourceType', 'targetType')
-          .by(outV().label())
-          .by(inV().label())
-          .dedup()
+        g.E().hasLabel('route', 'contains')
+          .group()
+            .by(label())
+            .by(
+              limit(10000)
+                .project('sourceType', 'targetType')
+                .by(outV().label())
+                .by(inV().label())
+                .dedup()
+                .fold()
+            )
       `),
     );
+  });
+
+  it("should escape special characters in the edge type", () => {
+    const template = edgeConnectionsTemplate({
+      types: [createEdgeType("edge'with'quotes")],
+    });
+
+    expect(template).toContain("hasLabel('edge\\'with\\'quotes')");
   });
 });

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/edgeConnectionsTemplate.ts
@@ -5,18 +5,40 @@ import { DEFAULT_SAMPLE_SIZE, query } from "@/utils";
 import { fragment } from "../fragments";
 
 /**
- * Returns a Gremlin query to discover distinct edge connection patterns for a specific edge type.
- * Uses sampling with dedup to efficiently discover patterns in large databases.
+ * Returns a Gremlin query that discovers distinct edge connection patterns for a
+ * batch of edge types in a single request.
  *
- * The query samples edges of the given type and extracts the source and target vertex labels,
- * then deduplicates to find unique patterns.
+ * `g.E().hasLabel(...)` is a native, index-backed edge scan on Neptune; the
+ * `group().by(label())` reduction buckets the edges by edge type, and each
+ * bucket samples up to `DEFAULT_SAMPLE_SIZE` edges and projects the distinct
+ * (source label, target label) pairs. The caller regroups by the returned edge
+ * label.
+ *
+ * The `limit` sits inside the `group()` value traversal, which TinkerPop runs
+ * per group, so each edge type is sampled independently — no shared cap that
+ * starves rarer types. It bounds the per-type label-resolution and dedup work,
+ * not the initial edge scan: `group()` still enumerates every edge of the
+ * batched types to bucket them. A per-type scan cap is not expressible in one
+ * native TinkerPop 3.6.2 request.
  */
-export default function edgeConnectionsTemplate(edgeType: EdgeType) {
+export default function edgeConnectionsTemplate({
+  types,
+}: {
+  types: EdgeType[];
+}) {
+  const labels = types.map(fragment.identifier);
+
   return query`
-    g.E().hasLabel(${fragment.identifier(edgeType)}).limit(${DEFAULT_SAMPLE_SIZE})
-      .project('sourceType', 'targetType')
-      .by(outV().label())
-      .by(inV().label())
-      .dedup()
+    g.E().hasLabel(${labels.join(", ")})
+      .group()
+        .by(label())
+        .by(
+          limit(${DEFAULT_SAMPLE_SIZE})
+            .project('sourceType', 'targetType')
+            .by(outV().label())
+            .by(inV().label())
+            .dedup()
+            .fold()
+        )
   `;
 }

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.test.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.test.ts
@@ -1,26 +1,55 @@
 import { vi } from "vitest";
 
 import { createEdgeType, createVertexType } from "@/core";
+import {
+  createGList,
+  createGMap,
+  createGremlinResponse,
+} from "@/utils/testing";
 
 import fetchEdgeConnections from ".";
 
+/** A projected connection pair g:Map, source-then-target key order. */
+function pair(sourceType: string, targetType: string) {
+  return createGMap({ sourceType, targetType });
+}
+
+/**
+ * Builds the grouped GraphSON response produced by
+ * `group().by(label()).by(project(...).dedup().fold())`: a single g:Map keyed by
+ * edge label, each value a g:List of connection-pair g:Maps.
+ */
+function groupResponse(groups: Record<string, Array<[string, string]>>) {
+  return createGremlinResponse(
+    createGMap(
+      Object.fromEntries(
+        Object.entries(groups).map(([edgeType, pairs]) => [
+          edgeType,
+          createGList(pairs.map(([s, t]) => pair(s, t))),
+        ]),
+      ),
+    ),
+  );
+}
+
+const emptyResponse = createGremlinResponse(createGMap({}));
+
 describe("Gremlin > fetchEdgeConnections", () => {
-  it("should return edge connections from response", async () => {
-    const gremlinFetch = vi
-      .fn()
-      .mockResolvedValueOnce(routeResponse)
-      .mockResolvedValueOnce(containsResponse);
+  it("should batch all edge types into a single request and regroup by edge type", async () => {
+    const gremlinFetch = vi.fn().mockResolvedValueOnce(
+      groupResponse({
+        route: [["airport", "airport"]],
+        contains: [["country", "airport"]],
+      }),
+    );
 
     const result = await fetchEdgeConnections(gremlinFetch, {
       edgeTypes: [createEdgeType("route"), createEdgeType("contains")],
     });
 
-    expect(gremlinFetch).toHaveBeenCalledTimes(2);
+    expect(gremlinFetch).toHaveBeenCalledTimes(1);
     expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining("hasLabel('route')"),
-    );
-    expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining("hasLabel('contains')"),
+      expect.stringContaining("hasLabel('route', 'contains')"),
     );
     expect(result).toStrictEqual({
       edgeConnections: [
@@ -36,6 +65,29 @@ describe("Gremlin > fetchEdgeConnections", () => {
         },
       ],
     });
+  });
+
+  it("should split edge types into chunks of the batch size", async () => {
+    const gremlinFetch = vi.fn().mockResolvedValue(emptyResponse);
+    const edgeTypes = Array.from({ length: 250 }, (_, i) =>
+      createEdgeType(`edge${i}`),
+    );
+
+    await fetchEdgeConnections(gremlinFetch, { edgeTypes });
+
+    // 250 types at a batch size of 100 => 3 requests
+    expect(gremlinFetch).toHaveBeenCalledTimes(3);
+
+    const queries = gremlinFetch.mock.calls.map(call => call[0] as string);
+    // No request carries more than the batch size
+    for (const q of queries) {
+      expect((q.match(/'edge\d+'/g) ?? []).length).toBeLessThanOrEqual(100);
+    }
+    // Every input type is covered across the requests
+    const all = queries.join("\n");
+    for (const type of edgeTypes) {
+      expect(all).toContain(`'${type}'`);
+    }
   });
 
   it("should return empty array when no edge types provided", async () => {
@@ -62,26 +114,14 @@ describe("Gremlin > fetchEdgeConnections", () => {
   });
 
   it("should deduplicate edge connections within same edge type", async () => {
-    const duplicateResponse = {
-      requestId: "test-request-id",
-      status: { message: "", code: 200 },
-      result: {
-        data: {
-          "@type": "g:List",
-          "@value": [
-            {
-              "@type": "g:Map",
-              "@value": ["sourceType", "airport", "targetType", "airport"],
-            },
-            {
-              "@type": "g:Map",
-              "@value": ["sourceType", "airport", "targetType", "airport"],
-            },
-          ],
-        },
-      },
-    };
-    const gremlinFetch = vi.fn().mockResolvedValueOnce(duplicateResponse);
+    const gremlinFetch = vi.fn().mockResolvedValueOnce(
+      groupResponse({
+        route: [
+          ["airport", "airport"],
+          ["airport", "airport"],
+        ],
+      }),
+    );
 
     const result = await fetchEdgeConnections(gremlinFetch, {
       edgeTypes: [createEdgeType("route")],
@@ -108,40 +148,12 @@ describe("Gremlin > fetchEdgeConnections", () => {
     ).rejects.toThrow("Network error");
   });
 
-  it("should escape special characters in edge type", async () => {
-    const gremlinFetch = vi.fn().mockResolvedValue(emptyResponse);
-
-    await fetchEdgeConnections(gremlinFetch, {
-      edgeTypes: [createEdgeType("edge'with'quotes")],
-    });
-
-    expect(gremlinFetch).toHaveBeenCalledWith(
-      expect.stringContaining("hasLabel('edge\\'with\\'quotes')"),
-    );
-  });
-
   it("should handle Neptune multi-label vertices with :: delimiter", async () => {
-    const multiLabelResponse = {
-      requestId: "test-request-id",
-      status: { message: "", code: 200 },
-      result: {
-        data: {
-          "@type": "g:List",
-          "@value": [
-            {
-              "@type": "g:Map",
-              "@value": [
-                "sourceType",
-                "Person::Employee",
-                "targetType",
-                "Company::Organization",
-              ],
-            },
-          ],
-        },
-      },
-    };
-    const gremlinFetch = vi.fn().mockResolvedValueOnce(multiLabelResponse);
+    const gremlinFetch = vi.fn().mockResolvedValueOnce(
+      groupResponse({
+        worksAt: [["Person::Employee", "Company::Organization"]],
+      }),
+    );
 
     const result = await fetchEdgeConnections(gremlinFetch, {
       edgeTypes: [createEdgeType("worksAt")],
@@ -173,25 +185,17 @@ describe("Gremlin > fetchEdgeConnections", () => {
     });
   });
 
-  it("should handle reversed key order in GraphSON map", async () => {
-    const reversedKeyOrderResponse = {
-      requestId: "test-request-id",
-      status: { message: "", code: 200 },
-      result: {
-        data: {
-          "@type": "g:List",
-          "@value": [
-            {
-              "@type": "g:Map",
-              "@value": ["targetType", "airport", "sourceType", "country"],
-            },
-          ],
-        },
-      },
-    };
-    const gremlinFetch = vi
-      .fn()
-      .mockResolvedValueOnce(reversedKeyOrderResponse);
+  it("should handle reversed key order in the projected pair map", async () => {
+    const gremlinFetch = vi.fn().mockResolvedValueOnce(
+      createGremlinResponse(
+        createGMap({
+          contains: createGList([
+            // target-then-source key order
+            createGMap({ targetType: "airport", sourceType: "country" }),
+          ]),
+        }),
+      ),
+    );
 
     const result = await fetchEdgeConnections(gremlinFetch, {
       edgeTypes: [createEdgeType("contains")],
@@ -208,31 +212,18 @@ describe("Gremlin > fetchEdgeConnections", () => {
     });
   });
 
-  it("should skip entries with missing sourceType or targetType", async () => {
-    const missingKeysResponse = {
-      requestId: "test-request-id",
-      status: { message: "", code: 200 },
-      result: {
-        data: {
-          "@type": "g:List",
-          "@value": [
-            {
-              "@type": "g:Map",
-              "@value": ["sourceType", "airport"],
-            },
-            {
-              "@type": "g:Map",
-              "@value": ["targetType", "airport"],
-            },
-            {
-              "@type": "g:Map",
-              "@value": ["sourceType", "country", "targetType", "airport"],
-            },
-          ],
-        },
-      },
-    };
-    const gremlinFetch = vi.fn().mockResolvedValueOnce(missingKeysResponse);
+  it("should skip pairs with missing sourceType or targetType", async () => {
+    const gremlinFetch = vi.fn().mockResolvedValueOnce(
+      createGremlinResponse(
+        createGMap({
+          contains: createGList([
+            createGMap({ sourceType: "airport" }),
+            createGMap({ targetType: "airport" }),
+            createGMap({ sourceType: "country", targetType: "airport" }),
+          ]),
+        }),
+      ),
+    );
 
     const result = await fetchEdgeConnections(gremlinFetch, {
       edgeTypes: [createEdgeType("contains")],
@@ -249,46 +240,3 @@ describe("Gremlin > fetchEdgeConnections", () => {
     });
   });
 });
-
-const routeResponse = {
-  requestId: "test-request-id",
-  status: { message: "", code: 200 },
-  result: {
-    data: {
-      "@type": "g:List",
-      "@value": [
-        {
-          "@type": "g:Map",
-          "@value": ["sourceType", "airport", "targetType", "airport"],
-        },
-      ],
-    },
-  },
-};
-
-const containsResponse = {
-  requestId: "test-request-id",
-  status: { message: "", code: 200 },
-  result: {
-    data: {
-      "@type": "g:List",
-      "@value": [
-        {
-          "@type": "g:Map",
-          "@value": ["sourceType", "country", "targetType", "airport"],
-        },
-      ],
-    },
-  },
-};
-
-const emptyResponse = {
-  requestId: "test-request-id",
-  status: { message: "", code: 200 },
-  result: {
-    data: {
-      "@type": "g:List",
-      "@value": [],
-    },
-  },
-};

--- a/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.ts
+++ b/packages/graph-explorer/src/connector/gremlin/fetchEdgeConnections/index.ts
@@ -1,13 +1,18 @@
+import { chunk } from "lodash";
+
 import type {
   EdgeConnectionsRequest,
   EdgeConnectionsResponse,
 } from "@/connector/useGEFetchTypes";
 
 import { createEdgeType, createVertexType, type EdgeConnection } from "@/core";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
-import mapWithConcurrency from "@/utils/mapWithConcurrency";
+import {
+  DEFAULT_BATCH_REQUEST_SIZE,
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+  mapWithConcurrency,
+} from "@/utils";
 
-import type { GMapWithValue, GremlinFetch } from "../types";
+import type { GList, GMapWithValue, GremlinFetch } from "../types";
 
 import { parseGMap } from "../mappers/parseGMap";
 import { splitLabel } from "../splitLabel";
@@ -22,53 +27,76 @@ type RawEdgeConnectionsResponse = {
   result: {
     data: {
       "@type": "g:List";
-      "@value": Array<GMapWithValue<string, string>>;
+      // group().by(label()).by(...) returns a single g:Map keyed by edge label,
+      // each value a g:List of the projected {sourceType, targetType} g:Maps.
+      "@value": Array<GMapWithValue<string, GList>>;
     };
   };
 };
+
+/**
+ * Expands one edge type's folded pair list into edge connections, splitting
+ * Neptune `::` composite labels on both endpoints. Localizes the GraphSON pair
+ * cast to this boundary.
+ */
+function connectionsFromPairs(
+  edgeType: string,
+  pairs: GList,
+): EdgeConnection[] {
+  const connections: EdgeConnection[] = [];
+
+  for (const pair of pairs["@value"]) {
+    const map = parseGMap<string, string>(
+      pair as GMapWithValue<string, string>,
+    );
+    const sourceValue = map.get("sourceType");
+    const targetValue = map.get("targetType");
+
+    if (!sourceValue || !targetValue) {
+      continue;
+    }
+
+    for (const sourceType of splitLabel(sourceValue)) {
+      for (const targetType of splitLabel(targetValue)) {
+        connections.push({
+          sourceVertexType: createVertexType(sourceType),
+          edgeType: createEdgeType(edgeType),
+          targetVertexType: createVertexType(targetType),
+        });
+      }
+    }
+  }
+
+  return connections;
+}
 
 export default async function fetchEdgeConnections(
   gremlinFetch: GremlinFetch,
   req: EdgeConnectionsRequest,
 ): Promise<EdgeConnectionsResponse> {
-  const results = await mapWithConcurrency(
-    req.edgeTypes,
+  const batches = chunk(req.edgeTypes, DEFAULT_BATCH_REQUEST_SIZE);
+  const responses = await mapWithConcurrency(
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async edgeType => {
-      const template = edgeConnectionsTemplate(edgeType);
-      const data = await gremlinFetch<RawEdgeConnectionsResponse>(template);
-      return { edgeType, values: data.result.data["@value"] };
-    },
+    batch =>
+      gremlinFetch<RawEdgeConnectionsResponse>(
+        edgeConnectionsTemplate({ types: batch }),
+      ),
   );
 
   const seen = new Set<string>();
   const edgeConnections: EdgeConnection[] = [];
 
-  for (const { edgeType, values } of results) {
-    for (const item of values) {
-      const map = parseGMap(item);
-      const sourceValue = map.get("sourceType");
-      const targetValue = map.get("targetType");
-
-      if (!sourceValue || !targetValue) {
-        continue;
-      }
-
-      const sourceTypes = splitLabel(sourceValue);
-      const targetTypes = splitLabel(targetValue);
-
-      for (const sourceType of sourceTypes) {
-        for (const targetType of targetTypes) {
-          const key = `${sourceType}-${edgeType}-${targetType}`;
+  for (const data of responses) {
+    for (const group of data.result.data["@value"]) {
+      for (const [edgeType, pairs] of parseGMap<string, GList>(group)) {
+        for (const connection of connectionsFromPairs(edgeType, pairs)) {
+          const key = `${connection.sourceVertexType}-${connection.edgeType}-${connection.targetVertexType}`;
           if (seen.has(key)) {
             continue;
           }
           seen.add(key);
-          edgeConnections.push({
-            sourceVertexType: createVertexType(sourceType),
-            edgeType: createEdgeType(edgeType),
-            targetVertexType: createVertexType(targetType),
-          });
+          edgeConnections.push(connection);
         }
       }
     }

--- a/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -4,14 +4,49 @@ import { query } from "@/utils";
 import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 
 describe("OpenCypher > edgeConnectionsTemplate", () => {
-  it("should sample edges of the type and return distinct endpoint labels", () => {
-    const template = edgeConnectionsTemplate(createEdgeType("route"));
+  it("should sample edges of a single type and tag the rows with the edge type", () => {
+    const template = edgeConnectionsTemplate({
+      types: [createEdgeType("route")],
+    });
 
     expect(template).toBe(query`
       MATCH (s)-[e:\`route\`]->(t)
       WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
       LIMIT 10000
-      RETURN DISTINCT sourceLabels, targetLabels
+      RETURN DISTINCT "route" AS edgeType, sourceLabels, targetLabels
     `);
+  });
+
+  it("should join a batch of edge types with UNION ALL", () => {
+    const template = edgeConnectionsTemplate({
+      types: [createEdgeType("route"), createEdgeType("contains")],
+    });
+
+    expect(template).toBe(
+      [
+        query`
+          MATCH (s)-[e:\`route\`]->(t)
+          WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
+          LIMIT 10000
+          RETURN DISTINCT "route" AS edgeType, sourceLabels, targetLabels
+        `,
+        query`
+          MATCH (s)-[e:\`contains\`]->(t)
+          WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
+          LIMIT 10000
+          RETURN DISTINCT "contains" AS edgeType, sourceLabels, targetLabels
+        `,
+      ].join("\nUNION ALL\n"),
+    );
+  });
+
+  it("should escape special characters in the edge type", () => {
+    const template = edgeConnectionsTemplate({
+      types: [createEdgeType("edge`with`ticks")],
+    });
+
+    // Backtick doubled in the label, JSON-escaped in the literal column
+    expect(template).toContain("[e:`edge``with``ticks`]");
+    expect(template).toContain('"edge`with`ticks" AS edgeType');
   });
 });

--- a/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/edgeConnectionsTemplate.ts
@@ -5,17 +5,29 @@ import { DEFAULT_SAMPLE_SIZE, query } from "@/utils";
 import { fragment } from "../fragments";
 
 /**
- * Returns an openCypher query to discover distinct edge connection patterns for a specific edge type.
- * Uses sampling with DISTINCT to efficiently discover patterns in large databases.
+ * Returns an openCypher query that discovers distinct edge connection patterns
+ * for a batch of edge types in a single request.
  *
- * The query samples edges of the given type and extracts the source and target vertex labels,
- * returning full label arrays to support multi-label vertices.
+ * Each edge type contributes one `UNION ALL` block that samples its edges and
+ * returns the distinct endpoint label arrays, tagged with a literal `edgeType`
+ * column so the caller can regroup the rows by edge type. The per-type block is
+ * index-backed on Neptune (the edge type is pushed into the scan) and keeps a
+ * per-type `LIMIT` so a high-cardinality type cannot starve the sample of a
+ * rare one.
  */
-export default function edgeConnectionsTemplate(edgeType: EdgeType) {
-  return query`
-    MATCH (s)-[e:${fragment.identifier(edgeType)}]->(t)
-    WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
-    LIMIT ${DEFAULT_SAMPLE_SIZE}
-    RETURN DISTINCT sourceLabels, targetLabels
-  `;
+export default function edgeConnectionsTemplate({
+  types,
+}: {
+  types: EdgeType[];
+}) {
+  return types
+    .map(
+      type => query`
+        MATCH (s)-[e:${fragment.identifier(type)}]->(t)
+        WITH labels(s) AS sourceLabels, labels(t) AS targetLabels
+        LIMIT ${DEFAULT_SAMPLE_SIZE}
+        RETURN DISTINCT ${fragment.string(type)} AS edgeType, sourceLabels, targetLabels
+      `,
+    )
+    .join("\nUNION ALL\n");
 }

--- a/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/index.test.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/index.test.ts
@@ -5,22 +5,22 @@ import { createEdgeType, createVertexType } from "@/core";
 import fetchEdgeConnections from ".";
 
 describe("openCypher > fetchEdgeConnections", () => {
-  it("should return edge connections from response", async () => {
-    const openCypherFetch = vi
-      .fn()
-      .mockResolvedValueOnce(routeResponse)
-      .mockResolvedValueOnce(containsResponse);
+  it("should batch all edge types into a single request and regroup by edge type", async () => {
+    const openCypherFetch = vi.fn().mockResolvedValueOnce(batchedResponse);
 
     const result = await fetchEdgeConnections(openCypherFetch, {
       edgeTypes: [createEdgeType("route"), createEdgeType("contains")],
     });
 
-    expect(openCypherFetch).toHaveBeenCalledTimes(2);
+    expect(openCypherFetch).toHaveBeenCalledTimes(1);
     expect(openCypherFetch).toHaveBeenCalledWith(
       expect.stringContaining("[e:`route`]"),
     );
     expect(openCypherFetch).toHaveBeenCalledWith(
       expect.stringContaining("[e:`contains`]"),
+    );
+    expect(openCypherFetch).toHaveBeenCalledWith(
+      expect.stringContaining("UNION ALL"),
     );
     expect(result).toStrictEqual({
       edgeConnections: [
@@ -36,6 +36,31 @@ describe("openCypher > fetchEdgeConnections", () => {
         },
       ],
     });
+  });
+
+  it("should split edge types into chunks of the batch size", async () => {
+    const openCypherFetch = vi.fn().mockResolvedValue({ results: [] });
+    const edgeTypes = Array.from({ length: 250 }, (_, i) =>
+      createEdgeType(`edge${i}`),
+    );
+
+    await fetchEdgeConnections(openCypherFetch, { edgeTypes });
+
+    // 250 types at a batch size of 100 => 3 requests
+    expect(openCypherFetch).toHaveBeenCalledTimes(3);
+
+    const queries = openCypherFetch.mock.calls.map(call => call[0] as string);
+    // No request carries more than the batch size (one block per type)
+    for (const q of queries) {
+      expect((q.match(/RETURN DISTINCT/g) ?? []).length).toBeLessThanOrEqual(
+        100,
+      );
+    }
+    // Every input type is covered across the requests
+    const all = queries.join("\n");
+    for (const type of edgeTypes) {
+      expect(all).toContain(`[e:\`${type}\`]`);
+    }
   });
 
   it("should return empty array when no edge types provided", async () => {
@@ -97,8 +122,16 @@ describe("openCypher > fetchEdgeConnections", () => {
   it("should deduplicate edge connections within same edge type", async () => {
     const duplicateResponse = {
       results: [
-        { sourceLabels: ["airport"], targetLabels: ["airport"] },
-        { sourceLabels: ["airport"], targetLabels: ["airport"] },
+        {
+          edgeType: "route",
+          sourceLabels: ["airport"],
+          targetLabels: ["airport"],
+        },
+        {
+          edgeType: "route",
+          sourceLabels: ["airport"],
+          targetLabels: ["airport"],
+        },
       ],
     };
     const openCypherFetch = vi.fn().mockResolvedValueOnce(duplicateResponse);
@@ -122,6 +155,7 @@ describe("openCypher > fetchEdgeConnections", () => {
     const multiLabelResponse = {
       results: [
         {
+          edgeType: "worksAt",
           sourceLabels: ["Person", "Employee"],
           targetLabels: ["Company", "Organization"],
         },
@@ -160,18 +194,15 @@ describe("openCypher > fetchEdgeConnections", () => {
   });
 });
 
-const routeResponse = {
+const batchedResponse = {
   results: [
     {
+      edgeType: "route",
       sourceLabels: ["airport"],
       targetLabels: ["airport"],
     },
-  ],
-};
-
-const containsResponse = {
-  results: [
     {
+      edgeType: "contains",
       sourceLabels: ["country"],
       targetLabels: ["airport"],
     },
@@ -185,14 +216,17 @@ const emptyResponse = {
 const incompleteResponse = {
   results: [
     {
+      edgeType: "route",
       sourceLabels: ["airport"],
       targetLabels: ["airport"],
     },
     {
+      edgeType: "route",
       sourceLabels: [],
       targetLabels: ["airport"],
     },
     {
+      edgeType: "route",
       sourceLabels: ["country"],
       targetLabels: [],
     },

--- a/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/index.ts
+++ b/packages/graph-explorer/src/connector/openCypher/fetchEdgeConnections/index.ts
@@ -1,11 +1,16 @@
+import { chunk } from "lodash";
+
 import type {
   EdgeConnectionsRequest,
   EdgeConnectionsResponse,
 } from "@/connector/useGEFetchTypes";
 
 import { createEdgeType, createVertexType, type EdgeConnection } from "@/core";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
-import mapWithConcurrency from "@/utils/mapWithConcurrency";
+import {
+  DEFAULT_BATCH_REQUEST_SIZE,
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+  mapWithConcurrency,
+} from "@/utils";
 
 import type { OpenCypherFetch } from "../types";
 
@@ -13,6 +18,7 @@ import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 
 type RawEdgeConnectionsResponse = {
   results: Array<{
+    edgeType: string;
     sourceLabels: string[];
     targetLabels: string[];
   }>;
@@ -22,23 +28,29 @@ export default async function fetchEdgeConnections(
   openCypherFetch: OpenCypherFetch,
   req: EdgeConnectionsRequest,
 ): Promise<EdgeConnectionsResponse> {
-  const results = await mapWithConcurrency(
-    req.edgeTypes,
+  const batches = chunk(req.edgeTypes, DEFAULT_BATCH_REQUEST_SIZE);
+  const responses = await mapWithConcurrency(
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async edgeType => {
-      const template = edgeConnectionsTemplate(edgeType);
-      const data = await openCypherFetch<RawEdgeConnectionsResponse>(template);
-      return { edgeType, values: data.results || [] };
-    },
+    batch =>
+      openCypherFetch<RawEdgeConnectionsResponse>(
+        edgeConnectionsTemplate({ types: batch }),
+      ),
   );
 
   const seen = new Set<string>();
   const edgeConnections: EdgeConnection[] = [];
 
-  for (const { edgeType, values } of results) {
-    for (const item of values) {
-      const sourceLabels = item.sourceLabels || [];
-      const targetLabels = item.targetLabels || [];
+  for (const data of responses) {
+    for (const item of data.results ?? []) {
+      const edgeType = item.edgeType;
+      // The response type is an unchecked assertion on the fetch (no Zod at this
+      // boundary), so guard the field rather than trust the declared contract.
+      if (!edgeType) {
+        continue;
+      }
+      const sourceLabels = item.sourceLabels ?? [];
+      const targetLabels = item.targetLabels ?? [];
 
       // Create connections for each combination of source and target labels
       for (const sourceType of sourceLabels) {

--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.test.ts
@@ -3,23 +3,76 @@ import { query } from "@/utils";
 
 import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 
-describe("edgeConnectionsTemplate", () => {
-  it("should produce a subquery with LIMIT inside and DISTINCT outside", () => {
-    const predicate = createEdgeType("http://example.org/knows");
-
-    const result = edgeConnectionsTemplate(predicate);
+describe("SPARQL > edgeConnectionsTemplate", () => {
+  it("should project the predicate as ?edgeType with the sample LIMIT inside and DISTINCT outside", () => {
+    const result = edgeConnectionsTemplate({
+      predicates: [createEdgeType("http://example.org/knows")],
+    });
 
     expect(result).toBe(query`
-      SELECT DISTINCT ?sourceType ?targetType
+      SELECT DISTINCT ?edgeType ?sourceType ?targetType
       WHERE {
-        SELECT ?sourceType ?targetType
-        WHERE {
-          ?s <http://example.org/knows> ?o .
-          FILTER(!isLiteral(?o))
-          ?s a ?sourceType .
-          ?o a ?targetType .
+        {
+          SELECT (<http://example.org/knows> AS ?edgeType) ?sourceType ?targetType
+          WHERE {
+            {
+              SELECT ?sourceType ?targetType
+              WHERE {
+                ?s <http://example.org/knows> ?o .
+                FILTER(!isLiteral(?o))
+                ?s a ?sourceType .
+                ?o a ?targetType .
+              }
+              LIMIT 10000
+            }
+          }
         }
-        LIMIT 10000
+      }
+    `);
+  });
+
+  it("should join a batch of predicates into one UNION arm each", () => {
+    const result = edgeConnectionsTemplate({
+      predicates: [
+        createEdgeType("http://example.org/knows"),
+        createEdgeType("http://example.org/worksAt"),
+      ],
+    });
+
+    expect(result).toBe(query`
+      SELECT DISTINCT ?edgeType ?sourceType ?targetType
+      WHERE {
+        {
+          SELECT (<http://example.org/knows> AS ?edgeType) ?sourceType ?targetType
+          WHERE {
+            {
+              SELECT ?sourceType ?targetType
+              WHERE {
+                ?s <http://example.org/knows> ?o .
+                FILTER(!isLiteral(?o))
+                ?s a ?sourceType .
+                ?o a ?targetType .
+              }
+              LIMIT 10000
+            }
+          }
+        }
+        UNION
+        {
+          SELECT (<http://example.org/worksAt> AS ?edgeType) ?sourceType ?targetType
+          WHERE {
+            {
+              SELECT ?sourceType ?targetType
+              WHERE {
+                ?s <http://example.org/worksAt> ?o .
+                FILTER(!isLiteral(?o))
+                ?s a ?sourceType .
+                ?o a ?targetType .
+              }
+              LIMIT 10000
+            }
+          }
+        }
       }
     `);
   });

--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/edgeConnectionsTemplate.ts
@@ -5,24 +5,49 @@ import { DEFAULT_SAMPLE_SIZE, query } from "@/utils";
 import { fragment } from "../fragments";
 
 /**
- * Returns a SPARQL query to discover distinct edge connection patterns for a specific predicate.
- * Uses sampling to efficiently discover patterns in large databases.
+ * Returns a SPARQL query that discovers distinct edge connection patterns for a
+ * batch of predicates in a single request.
  *
- * The query finds distinct patterns of subject class -> object class
- * by sampling triples where both subject and object have rdf:type declarations.
+ * Each predicate contributes one `UNION` arm that samples its triples and
+ * returns the distinct subject-class/object-class pairs, tagged with the
+ * predicate IRI projected as `?edgeType` so the caller can regroup the rows by
+ * predicate. Each arm keeps its own inner `LIMIT` so the sample stays bounded
+ * per predicate — a high-volume predicate cannot starve a low-volume one, and
+ * intermediate results stay bounded by the chunk size rather than the graph.
  */
-export default function edgeConnectionsTemplate(predicate: EdgeType) {
-  return query`
-    SELECT DISTINCT ?sourceType ?targetType
-    WHERE {
+export default function edgeConnectionsTemplate({
+  predicates,
+}: {
+  predicates: EdgeType[];
+}) {
+  // Plain-string arms joined with a bare UNION, normalized once by the outer
+  // `query` tag. Nesting `query` inside `query` double-normalizes and leaves the
+  // output raggedly indented (cosmetic, but confusing when debugging).
+  const arms = predicates
+    .map(predicate => {
+      const iri = fragment.iri(predicate);
+      return `{
+  SELECT (${iri} AS ?edgeType) ?sourceType ?targetType
+  WHERE {
+    {
       SELECT ?sourceType ?targetType
       WHERE {
-        ?s ${fragment.iri(predicate)} ?o .
+        ?s ${iri} ?o .
         FILTER(!isLiteral(?o))
         ?s a ?sourceType .
         ?o a ?targetType .
       }
       LIMIT ${DEFAULT_SAMPLE_SIZE}
+    }
+  }
+}`;
+    })
+    .join("\nUNION\n");
+
+  return query`
+    SELECT DISTINCT ?edgeType ?sourceType ?targetType
+    WHERE {
+      ${arms}
     }
   `;
 }

--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/index.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/index.test.ts
@@ -4,12 +4,32 @@ import { createEdgeType, createVertexType } from "@/core";
 
 import fetchEdgeConnections from ".";
 
+function binding(edgeType: string, sourceType: string, targetType: string) {
+  return {
+    edgeType: { type: "uri", value: edgeType },
+    sourceType: { type: "uri", value: sourceType },
+    targetType: { type: "uri", value: targetType },
+  };
+}
+
 describe("SPARQL > fetchEdgeConnections", () => {
-  it("should return edge connections from response", async () => {
-    const sparqlFetch = vi
-      .fn()
-      .mockResolvedValueOnce(knowsResponse)
-      .mockResolvedValueOnce(worksAtResponse);
+  it("should batch all predicates into a single request and regroup by edge type", async () => {
+    const sparqlFetch = vi.fn().mockResolvedValueOnce({
+      results: {
+        bindings: [
+          binding(
+            "http://example.org/knows",
+            "http://example.org/Person",
+            "http://example.org/Person",
+          ),
+          binding(
+            "http://example.org/worksAt",
+            "http://example.org/Person",
+            "http://example.org/Company",
+          ),
+        ],
+      },
+    });
 
     const result = await fetchEdgeConnections(sparqlFetch, {
       edgeTypes: [
@@ -18,7 +38,7 @@ describe("SPARQL > fetchEdgeConnections", () => {
       ],
     });
 
-    expect(sparqlFetch).toHaveBeenCalledTimes(2);
+    expect(sparqlFetch).toHaveBeenCalledTimes(1);
     expect(sparqlFetch).toHaveBeenCalledWith(
       expect.stringContaining("<http://example.org/knows>"),
     );
@@ -39,6 +59,31 @@ describe("SPARQL > fetchEdgeConnections", () => {
         },
       ],
     });
+  });
+
+  it("should split predicates into chunks of the batch size", async () => {
+    const sparqlFetch = vi
+      .fn()
+      .mockResolvedValue({ results: { bindings: [] } });
+    const edgeTypes = Array.from({ length: 250 }, (_, i) =>
+      createEdgeType(`http://example.org/p${i}`),
+    );
+
+    await fetchEdgeConnections(sparqlFetch, { edgeTypes });
+
+    // 250 predicates at a batch size of 100 => 3 requests
+    expect(sparqlFetch).toHaveBeenCalledTimes(3);
+
+    const queries = sparqlFetch.mock.calls.map(call => call[0] as string);
+    // No request carries more than the batch size (one UNION arm per predicate)
+    for (const q of queries) {
+      expect((q.match(/AS \?edgeType/g) ?? []).length).toBeLessThanOrEqual(100);
+    }
+    // Every input predicate is covered across the requests
+    const all = queries.join("\n");
+    for (const type of edgeTypes) {
+      expect(all).toContain(`<${type}>`);
+    }
   });
 
   it("should return empty array when no edge types provided", async () => {
@@ -65,7 +110,22 @@ describe("SPARQL > fetchEdgeConnections", () => {
   });
 
   it("should filter out incomplete bindings", async () => {
-    const sparqlFetch = vi.fn().mockResolvedValue(incompleteResponse);
+    const sparqlFetch = vi.fn().mockResolvedValue({
+      results: {
+        bindings: [
+          binding(
+            "http://example.org/knows",
+            "http://example.org/Person",
+            "http://example.org/Person",
+          ),
+          {
+            edgeType: { type: "uri", value: "http://example.org/knows" },
+            sourceType: { type: "uri", value: "http://example.org/Person" },
+            // Missing targetType
+          },
+        ],
+      },
+    });
 
     const result = await fetchEdgeConnections(sparqlFetch, {
       edgeTypes: [createEdgeType("http://example.org/knows")],
@@ -93,21 +153,22 @@ describe("SPARQL > fetchEdgeConnections", () => {
   });
 
   it("should deduplicate edge connections within same edge type", async () => {
-    const duplicateResponse = {
+    const sparqlFetch = vi.fn().mockResolvedValueOnce({
       results: {
         bindings: [
-          {
-            sourceType: { type: "uri", value: "http://example.org/Person" },
-            targetType: { type: "uri", value: "http://example.org/Person" },
-          },
-          {
-            sourceType: { type: "uri", value: "http://example.org/Person" },
-            targetType: { type: "uri", value: "http://example.org/Person" },
-          },
+          binding(
+            "http://example.org/knows",
+            "http://example.org/Person",
+            "http://example.org/Person",
+          ),
+          binding(
+            "http://example.org/knows",
+            "http://example.org/Person",
+            "http://example.org/Person",
+          ),
         ],
       },
-    };
-    const sparqlFetch = vi.fn().mockResolvedValueOnce(duplicateResponse);
+    });
 
     const result = await fetchEdgeConnections(sparqlFetch, {
       edgeTypes: [createEdgeType("http://example.org/knows")],
@@ -126,35 +187,32 @@ describe("SPARQL > fetchEdgeConnections", () => {
 
   it("should handle resources with multiple rdf:type values", async () => {
     // In SPARQL, multiple types return as separate bindings
-    const multiTypeResponse = {
+    const sparqlFetch = vi.fn().mockResolvedValueOnce({
       results: {
         bindings: [
-          {
-            sourceType: { type: "uri", value: "http://example.org/Person" },
-            targetType: { type: "uri", value: "http://example.org/Company" },
-          },
-          {
-            sourceType: { type: "uri", value: "http://example.org/Person" },
-            targetType: {
-              type: "uri",
-              value: "http://example.org/Organization",
-            },
-          },
-          {
-            sourceType: { type: "uri", value: "http://example.org/Employee" },
-            targetType: { type: "uri", value: "http://example.org/Company" },
-          },
-          {
-            sourceType: { type: "uri", value: "http://example.org/Employee" },
-            targetType: {
-              type: "uri",
-              value: "http://example.org/Organization",
-            },
-          },
+          binding(
+            "http://example.org/worksAt",
+            "http://example.org/Person",
+            "http://example.org/Company",
+          ),
+          binding(
+            "http://example.org/worksAt",
+            "http://example.org/Person",
+            "http://example.org/Organization",
+          ),
+          binding(
+            "http://example.org/worksAt",
+            "http://example.org/Employee",
+            "http://example.org/Company",
+          ),
+          binding(
+            "http://example.org/worksAt",
+            "http://example.org/Employee",
+            "http://example.org/Organization",
+          ),
         ],
       },
-    };
-    const sparqlFetch = vi.fn().mockResolvedValueOnce(multiTypeResponse);
+    });
 
     const result = await fetchEdgeConnections(sparqlFetch, {
       edgeTypes: [createEdgeType("http://example.org/worksAt")],
@@ -187,45 +245,8 @@ describe("SPARQL > fetchEdgeConnections", () => {
   });
 });
 
-const knowsResponse = {
-  results: {
-    bindings: [
-      {
-        sourceType: { type: "uri", value: "http://example.org/Person" },
-        targetType: { type: "uri", value: "http://example.org/Person" },
-      },
-    ],
-  },
-};
-
-const worksAtResponse = {
-  results: {
-    bindings: [
-      {
-        sourceType: { type: "uri", value: "http://example.org/Person" },
-        targetType: { type: "uri", value: "http://example.org/Company" },
-      },
-    ],
-  },
-};
-
 const emptyResponse = {
   results: {
     bindings: [],
-  },
-};
-
-const incompleteResponse = {
-  results: {
-    bindings: [
-      {
-        sourceType: { type: "uri", value: "http://example.org/Person" },
-        targetType: { type: "uri", value: "http://example.org/Person" },
-      },
-      {
-        sourceType: { type: "uri", value: "http://example.org/Person" },
-        // Missing targetType
-      },
-    ],
   },
 };

--- a/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchEdgeConnections/index.ts
@@ -1,11 +1,16 @@
+import { chunk } from "lodash";
+
 import type {
   EdgeConnectionsRequest,
   EdgeConnectionsResponse,
 } from "@/connector/useGEFetchTypes";
 
 import { createEdgeType, createVertexType, type EdgeConnection } from "@/core";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
-import mapWithConcurrency from "@/utils/mapWithConcurrency";
+import {
+  DEFAULT_BATCH_REQUEST_SIZE,
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+  mapWithConcurrency,
+} from "@/utils";
 
 import type { SparqlFetch } from "../types";
 
@@ -14,6 +19,7 @@ import edgeConnectionsTemplate from "./edgeConnectionsTemplate";
 type RawEdgeConnectionsResponse = {
   results: {
     bindings: Array<{
+      edgeType: { type: string; value: string };
       sourceType: { type: string; value: string };
       targetType: { type: string; value: string };
     }>;
@@ -24,24 +30,25 @@ export default async function fetchEdgeConnections(
   sparqlFetch: SparqlFetch,
   req: EdgeConnectionsRequest,
 ): Promise<EdgeConnectionsResponse> {
-  const results = await mapWithConcurrency(
-    req.edgeTypes,
+  const batches = chunk(req.edgeTypes, DEFAULT_BATCH_REQUEST_SIZE);
+  const responses = await mapWithConcurrency(
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async edgeType => {
-      const template = edgeConnectionsTemplate(edgeType);
-      const data = await sparqlFetch<RawEdgeConnectionsResponse>(template);
-      return { edgeType, bindings: data.results?.bindings || [] };
-    },
+    batch =>
+      sparqlFetch<RawEdgeConnectionsResponse>(
+        edgeConnectionsTemplate({ predicates: batch }),
+      ),
   );
 
   const seen = new Set<string>();
   const edgeConnections: EdgeConnection[] = [];
 
-  for (const { edgeType, bindings } of results) {
-    for (const binding of bindings) {
+  for (const data of responses) {
+    for (const binding of data.results?.bindings ?? []) {
+      const edgeType = binding.edgeType?.value;
       const sourceType = binding.sourceType?.value;
       const targetType = binding.targetType?.value;
-      if (!sourceType || !targetType) {
+      if (!edgeType || !sourceType || !targetType) {
         continue;
       }
       const key = `${sourceType}-${edgeType}-${targetType}`;


### PR DESCRIPTION
## Description

Edge-connections discovery — which vertex types each edge type connects (`source → edge → target`) — issued **one request per edge type** in all three connectors. On a graph with ~9,500 edge types that's a second ~9,500-request storm after schema sync.

This batches the discovery into **one aggregated query per chunk** of `DEFAULT_BATCH_REQUEST_SIZE` (100) edge types, run through the existing `mapWithConcurrency` pool, and regrouped client-side by edge type. Request count drops from ~9,500 to ~95. The discovered `EdgeConnection[]` set is unchanged — this is a request-count change, not a behavior change.

All three query shapes were validated on live Neptune (1.2.1.0 / 1.3.5.0 / 1.4.7.0) and non-Neptune engines (TinkerPop Gremlin Server, Blazegraph) via `EXPLAIN`/`PROFILE`. Each keeps the existing per-type sampling cap (`LIMIT`/`limit` = 10000) so a high-cardinality type can't starve a rarer one:

- **openCypher** — `UNION ALL` of per-type blocks, each with a literal `edgeType` column (index-backed per type; the only shape portable across 1.2–1.4).
- **Gremlin** — `g.E().hasLabel(chunk).group().by(label()).by(limit(...)...)`; the `limit` inside the `group()` value traversal caps each type independently, native on the TinkerPop 3.6.2 floor.
- **SPARQL** — `UNION` of per-predicate `LIMIT` sub-selects, each projecting the predicate as `?edgeType`.

### How to read

1. [gremlin/…/edgeConnectionsTemplate.ts](https://github.com/aws/graph-explorer/pull/2100/files#diff-87fe2c1b8895b75c0ae7c495fdb6a7650d611cac40429472fb0a894a479c087d) — the most nuanced shape; the doc comment explains what the per-key `limit` bounds (and what it doesn't).
2. [gremlin/…/index.ts](https://github.com/aws/graph-explorer/pull/2100/files#diff-951bc4c85d68ec97abdaa791619a07f74d5103b0e15bcfac83cbfbfb6a716f05) — chunk → `mapWithConcurrency` → regroup the GraphSON map, dedup.
3. [openCypher/…/edgeConnectionsTemplate.ts](https://github.com/aws/graph-explorer/pull/2100/files#diff-7725f43070f570cd6c4535a9e50c5f316fb36ec7276b3570da1ae7807261627c) and [sparql/…/edgeConnectionsTemplate.ts](https://github.com/aws/graph-explorer/pull/2100/files#diff-19e4f2434e56439f68d75b9e4e999f491bfdf4b6dc3b7b271cf38c692b4fa906) — same pattern per language.

Each connector's `index.ts` follows the `chunk` + `mapWithConcurrency` pattern already used by `fetchSchema`.

### Known tradeoff (Gremlin)

Gremlin's `group()` enumerates every edge of the batched types to bucket them, so the per-type `limit` caps the sampling/label-resolution work but **not** the raw scan. A per-type *scan* cap isn't expressible in one native TinkerPop 3.6.2 request (verified: `union`/mid-traversal `E()` are 3.7+ and non-native on Neptune even at 3.7). Contained by the feature being deferred/best-effort — a slow chunk only degrades the Schema View (with Retry). Only pathological multi-million-edge single types are affected; typical types profile at ~1.2s.

## Validation

- `pnpm checks` (types, lint, format) and `pnpm test` pass (32 tests across the 6 changed files).
- Tests assert the request collapse (2 types → 1 request; 250 types → 3), per-request chunk size, full label coverage, dedup, and multi-label handling.
- Query shapes + `EXPLAIN`/`PROFILE` plans verified read-only against live Neptune 1.2.1.0 / 1.3.5.0 / 1.4.7.0, plus TinkerPop Gremlin Server 3.7.3 and Blazegraph 2.1.5.

## Related Issues

- Closes #2085
- Related to #2076
- Related to #2077
- Related to #2078

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.
