### PR TITLE
Batch SPARQL schema-sync class attribute discovery into UNION requests

### DIFF
--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/index.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/index.test.ts
@@ -1,0 +1,153 @@
+import { vi } from "vitest";
+
+import { ClientLoggerConnector } from "@/connector/LoggerConnector";
+import {
+  createLiteralValue,
+  createUriValue,
+} from "@/utils/testing/sparqlHelpers";
+
+import type { GraphSummary } from "../types";
+
+import fetchSchema from ".";
+
+function summaryWithClasses(classes: string[]): GraphSummary {
+  return {
+    numDistinctSubjects: 0,
+    numDistinctPredicates: 0,
+    numQuads: 0,
+    numClasses: classes.length,
+    classes,
+    predicates: [],
+  };
+}
+
+function literalBinding(className: string, pred: string, datatype?: string) {
+  return {
+    class: createUriValue(className),
+    pred: createUriValue(pred),
+    sample: datatype
+      ? { ...createLiteralValue("sample"), datatype }
+      : createLiteralValue("sample"),
+  };
+}
+
+describe("SPARQL > fetchSchema > predicates by class", () => {
+  it("should batch classes into chunks of the batch size", async () => {
+    const sparqlFetch = vi
+      .fn()
+      .mockResolvedValue({ results: { bindings: [] } });
+    const classes = Array.from(
+      { length: 250 },
+      (_, i) => `http://example.org/Class${i}`,
+    );
+
+    await fetchSchema(
+      sparqlFetch,
+      new ClientLoggerConnector(),
+      summaryWithClasses(classes),
+    );
+
+    // 250 classes at a batch size of 100 => 3 requests
+    expect(sparqlFetch).toHaveBeenCalledTimes(3);
+
+    const queries = sparqlFetch.mock.calls.map(call => call[0] as string);
+    // No request carries more than the batch size (one UNION arm per class)
+    for (const q of queries) {
+      expect((q.match(/AS \?class/g) ?? []).length).toBeLessThanOrEqual(100);
+    }
+    // Every input class is covered across the requests
+    const all = queries.join("\n");
+    for (const className of classes) {
+      expect(all).toContain(`<${className}>`);
+    }
+  });
+
+  it("should regroup bindings by class into per-class attributes", async () => {
+    const sparqlFetch = vi.fn().mockResolvedValueOnce({
+      results: {
+        bindings: [
+          literalBinding(
+            "http://example.org/Airport",
+            "http://example.org/code",
+          ),
+          literalBinding(
+            "http://example.org/Airport",
+            "http://example.org/elevation",
+            "http://www.w3.org/2001/XMLSchema#integer",
+          ),
+          literalBinding(
+            "http://example.org/Country",
+            "http://example.org/name",
+          ),
+        ],
+      },
+    });
+
+    const schema = await fetchSchema(
+      sparqlFetch,
+      new ClientLoggerConnector(),
+      summaryWithClasses([
+        "http://example.org/Airport",
+        "http://example.org/Country",
+      ]),
+    );
+
+    expect(sparqlFetch).toHaveBeenCalledTimes(1);
+    const airport = schema.vertices.find(
+      v => v.type === "http://example.org/Airport",
+    );
+    const country = schema.vertices.find(
+      v => v.type === "http://example.org/Country",
+    );
+    expect(airport?.attributes).toStrictEqual([
+      { name: "http://example.org/code", dataType: "String" },
+      { name: "http://example.org/elevation", dataType: "Number" },
+    ]);
+    expect(country?.attributes).toStrictEqual([
+      { name: "http://example.org/name", dataType: "String" },
+    ]);
+  });
+
+  it("should still emit a vertex with no attributes for a class with no bindings", async () => {
+    const sparqlFetch = vi
+      .fn()
+      .mockResolvedValue({ results: { bindings: [] } });
+
+    const schema = await fetchSchema(
+      sparqlFetch,
+      new ClientLoggerConnector(),
+      summaryWithClasses(["http://example.org/Empty"]),
+    );
+
+    const empty = schema.vertices.find(
+      v => v.type === "http://example.org/Empty",
+    );
+    expect(empty).toBeDefined();
+    expect(empty?.attributes).toStrictEqual([]);
+  });
+
+  it("should skip bindings missing a class or predicate", async () => {
+    const sparqlFetch = vi.fn().mockResolvedValueOnce({
+      results: {
+        bindings: [
+          literalBinding("http://example.org/Airport", "http://example.org/ok"),
+          { class: { type: "uri", value: "http://example.org/Airport" } },
+          { pred: { type: "uri", value: "http://example.org/orphan" } },
+        ],
+      },
+    });
+
+    const schema = await fetchSchema(
+      sparqlFetch,
+      new ClientLoggerConnector(),
+      summaryWithClasses(["http://example.org/Airport"]),
+    );
+
+    const airport = schema.vertices.find(
+      v => v.type === "http://example.org/Airport",
+    );
+    expect(airport?.attributes).toStrictEqual([
+      { name: "http://example.org/ok", dataType: "String" },
+    ]);
+  });
+});

--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/index.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/index.ts
@@ -1,3 +1,5 @@
+import { chunk } from "lodash";
+
 import type { LoggerConnector } from "@/connector/LoggerConnector";
 import type {
   EdgeSchemaResponse,
@@ -11,8 +13,11 @@ import {
   type VertexType,
 } from "@/core";
 import { defaultVertexTypeConfig } from "@/core/StateProvider/configuration";
-import { mapWithConcurrency } from "@/utils";
-import { DEFAULT_CONCURRENT_REQUESTS_LIMIT } from "@/utils/constants";
+import {
+  DEFAULT_BATCH_REQUEST_SIZE,
+  DEFAULT_CONCURRENT_REQUESTS_LIMIT,
+  mapWithConcurrency,
+} from "@/utils";
 
 import type { GraphSummary, SparqlFetch, SparqlValue } from "../types";
 
@@ -31,6 +36,7 @@ type RawClassesWCountsResponse = {
 type RawPredicatesSamplesResponse = {
   results: {
     bindings: Array<{
+      class: SparqlValue;
       pred: SparqlValue;
       sample: SparqlValue;
     }>;
@@ -84,57 +90,65 @@ const fetchPredicatesByClass = async (
   classes: Array<VertexType>,
   countsByClass: Record<VertexType, number>,
 ) => {
+  remoteLogger.info(
+    `[SPARQL Explorer] Fetching predicates for ${classes.length} classes...`,
+  );
+  const batches = chunk(classes, DEFAULT_BATCH_REQUEST_SIZE);
   const responses = await mapWithConcurrency(
-    classes,
+    batches,
     DEFAULT_CONCURRENT_REQUESTS_LIMIT,
-    async resourceClass => {
-      const classPredicatesTemplate = predicatesByClassTemplate({
-        class: resourceClass,
-      });
-      remoteLogger.info(
-        `[SPARQL Explorer] Fetching predicates by class ${resourceClass}...`,
-      );
-      const predicatesResponse =
-        await sparqlFetch<RawPredicatesSamplesResponse>(
-          classPredicatesTemplate,
-        );
-
-      const attributes = new Map(
-        predicatesResponse.results.bindings
-          .map(
-            item =>
-              ({
-                name: item.pred.value,
-                dataType: TYPE_MAP[item.sample.datatype || ""] || "String",
-              }) satisfies AttributeConfig,
-          )
-          .map(a => [a.name, a]),
-      );
-
-      return {
-        attributes,
-        resourceClass,
-      };
-    },
+    batch =>
+      sparqlFetch<RawPredicatesSamplesResponse>(
+        predicatesByClassTemplate({ classes: batch }),
+      ),
   );
 
-  return responses.map(({ attributes, resourceClass }) => ({
-    type: createVertexType(resourceClass),
-    total: countsByClass[resourceClass],
-    displayNameAttribute:
-      displayNameCandidates
-        .values()
-        .map(c => attributes.get(c)?.name)
-        .filter(n => n != null)
-        .next().value ?? defaultVertexTypeConfig.displayNameAttribute,
-    longDisplayNameAttribute:
-      displayDescCandidates
-        .values()
-        .map(c => attributes.get(c)?.name)
-        .filter(n => n != null)
-        .next().value ?? defaultVertexTypeConfig.longDisplayNameAttribute,
-    attributes: attributes.values().toArray(),
-  }));
+  // Regroup the flat (class, pred, sample) rows into a per-class attribute map,
+  // keyed by the class IRI the arm projected. The response contract is an
+  // unchecked assertion (no Zod at this boundary; see #2078), so guard each
+  // field before use.
+  const attributesByClass = new Map<string, Map<string, AttributeConfig>>();
+  for (const response of responses) {
+    for (const item of response.results?.bindings ?? []) {
+      const resourceClass = item.class?.value;
+      const name = item.pred?.value;
+      if (!resourceClass || !name) {
+        continue;
+      }
+      let attributes = attributesByClass.get(resourceClass);
+      if (!attributes) {
+        attributes = new Map<string, AttributeConfig>();
+        attributesByClass.set(resourceClass, attributes);
+      }
+      attributes.set(name, {
+        name,
+        dataType: TYPE_MAP[item.sample?.datatype || ""] || "String",
+      });
+    }
+  }
+
+  return classes.map(resourceClass => {
+    const attributes =
+      attributesByClass.get(resourceClass) ??
+      new Map<string, AttributeConfig>();
+    return {
+      type: createVertexType(resourceClass),
+      total: countsByClass[resourceClass],
+      displayNameAttribute:
+        displayNameCandidates
+          .values()
+          .map(c => attributes.get(c)?.name)
+          .filter(n => n != null)
+          .next().value ?? defaultVertexTypeConfig.displayNameAttribute,
+      longDisplayNameAttribute:
+        displayDescCandidates
+          .values()
+          .map(c => attributes.get(c)?.name)
+          .filter(n => n != null)
+          .next().value ?? defaultVertexTypeConfig.longDisplayNameAttribute,
+      attributes: attributes.values().toArray(),
+    };
+  });
 };
 
 const fetchClassesSchema = async (
@@ -203,9 +217,8 @@ const fetchPredicatesSchema = async (
  * Fetch the database shape.
  * It follows this process:
  * 1. Fetch all distinct classes their counts
- * 2. For each class,
- *    - fetch all predicates to literals
- *    - and map those predicates to know the shape of the class
+ * 2. Discover each class's literal predicates by sampling one instance per
+ *    class, batching the classes into a few requests
  * 3. Fetch all predicates to non-literals and their counts
  * 4. Generate prefixes using the received URIs
  */

--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.test.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.test.ts
@@ -4,26 +4,77 @@ import { query } from "@/utils";
 import predicatesByClassTemplate from "./predicatesByClassTemplate";
 
 describe("SPARQL > predicatesByClassTemplate", () => {
-  it("should select literal predicates for a sample subject of the class", () => {
+  it("should project the class as ?class with the sample subject LIMIT inside and aggregate outside", () => {
     const template = predicatesByClassTemplate({
-      class: createVertexType("http://example.org/Airport"),
+      classes: [createVertexType("http://example.org/Airport")],
     });
 
     expect(template).toBe(query`
       # Return all predicates which are connected from the given class
-      SELECT ?pred (SAMPLE(?object) as ?sample)
+      SELECT ?class ?pred (SAMPLE(?object) as ?sample)
       WHERE {
         {
-          SELECT ?subject
+          SELECT (<http://example.org/Airport> AS ?class) ?pred ?object
           WHERE {
-            ?subject a <http://example.org/Airport>.
+            {
+              SELECT ?subject
+              WHERE {
+                ?subject a <http://example.org/Airport>.
+              }
+              LIMIT 1
+            }
+            ?subject ?pred ?object.
+            FILTER(!isBlank(?object) && isLiteral(?object))
           }
-          LIMIT 1
         }
-        ?subject ?pred ?object.
-        FILTER(!isBlank(?object) && isLiteral(?object))
       }
-      GROUP BY ?pred
+      GROUP BY ?class ?pred
+    `);
+  });
+
+  it("should join a batch of classes into one UNION arm each", () => {
+    const template = predicatesByClassTemplate({
+      classes: [
+        createVertexType("http://example.org/Airport"),
+        createVertexType("http://example.org/Country"),
+      ],
+    });
+
+    expect(template).toBe(query`
+      # Return all predicates which are connected from the given class
+      SELECT ?class ?pred (SAMPLE(?object) as ?sample)
+      WHERE {
+        {
+          SELECT (<http://example.org/Airport> AS ?class) ?pred ?object
+          WHERE {
+            {
+              SELECT ?subject
+              WHERE {
+                ?subject a <http://example.org/Airport>.
+              }
+              LIMIT 1
+            }
+            ?subject ?pred ?object.
+            FILTER(!isBlank(?object) && isLiteral(?object))
+          }
+        }
+        UNION
+        {
+          SELECT (<http://example.org/Country> AS ?class) ?pred ?object
+          WHERE {
+            {
+              SELECT ?subject
+              WHERE {
+                ?subject a <http://example.org/Country>.
+              }
+              LIMIT 1
+            }
+            ?subject ?pred ?object.
+            FILTER(!isBlank(?object) && isLiteral(?object))
+          }
+        }
+      }
+      GROUP BY ?class ?pred
     `);
   });
 });

--- a/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.ts
+++ b/packages/graph-explorer/src/connector/sparql/fetchSchema/predicatesByClassTemplate.ts
@@ -4,24 +4,52 @@ import { query } from "@/utils";
 
 import { fragment } from "../fragments";
 
-// Return all predicates which are connected from the given class
-export default function predicatesByClassTemplate(props: {
-  class: VertexType;
+/**
+ * Returns a SPARQL query that discovers the literal-valued predicates for a
+ * batch of classes in a single request.
+ *
+ * Each class contributes one `UNION` arm that samples a single instance of the
+ * class (`LIMIT 1` subject) and returns that instance's literal predicates with
+ * a sample object for datatype inference, tagged with the class IRI projected as
+ * `?class` so the caller can regroup the rows by class. Keeping the inner
+ * `LIMIT 1` subject correlated with the predicate scan inside each arm bounds
+ * the sample per class — a global `VALUES ?class` shape de-correlates the scan
+ * and scans every instance of every class instead.
+ */
+export default function predicatesByClassTemplate({
+  classes,
+}: {
+  classes: VertexType[];
 }) {
+  // Plain-string arms joined with a bare UNION, normalized once by the outer
+  // `query` tag. Nesting `query` inside `query` double-normalizes and leaves the
+  // output raggedly indented (cosmetic, but confusing when debugging).
+  const arms = classes
+    .map(resourceClass => {
+      const iri = fragment.iri(resourceClass);
+      return `{
+  SELECT (${iri} AS ?class) ?pred ?object
+  WHERE {
+    {
+      SELECT ?subject
+      WHERE {
+        ?subject a ${iri}.
+      }
+      LIMIT 1
+    }
+    ?subject ?pred ?object.
+    FILTER(!isBlank(?object) && isLiteral(?object))
+  }
+}`;
+    })
+    .join("\nUNION\n");
+
   return query`
     # Return all predicates which are connected from the given class
-    SELECT ?pred (SAMPLE(?object) as ?sample)
+    SELECT ?class ?pred (SAMPLE(?object) as ?sample)
     WHERE {
-      {
-        SELECT ?subject
-        WHERE {
-          ?subject a ${fragment.iri(props.class)}.
-        }
-        LIMIT 1
-      }
-      ?subject ?pred ?object.
-      FILTER(!isBlank(?object) && isLiteral(?object))
+      ${arms}
     }
-    GROUP BY ?pred
+    GROUP BY ?class ?pred
   `;
 }


### PR DESCRIPTION
## Description

SPARQL schema sync ran one attribute-discovery request per class (~10k classes → ~10k requests). This PR batches the classes into UNION-of-per-class-arm requests (chunks of 100), each arm keeping its own `LIMIT 1` sample subject correlated with the predicate scan and projecting the class IRI as `?class` for client-side regrouping — mirroring the pattern shipped for edge-connections in #2100.

Request count collapses from N to ⌈N/100⌉ while preserving identical per-class sampling semantics and bounded query plans on Neptune.

## How to read

1. [`predicatesByClassTemplate.ts`](https://github.com/aws/graph-explorer/pull/2106/files#diff-f78c1197018e0254ae9332b339096a6e22bdcdd0ba456926666080aac32157d6) — the new batched template (UNION arms + outer aggregation)
2. [`index.ts`](https://github.com/aws/graph-explorer/pull/2106/files#diff-c572dea6e962e253c2acbaf84b8fb4e7688535279a9a4549d66b918347ad1ed1) — the driver: `chunk` + `mapWithConcurrency` + client-side regroup loop
3. [`predicatesByClassTemplate.test.ts`](https://github.com/aws/graph-explorer/pull/2106/files#diff-ea0e5712a6a74c6484bb68174986917a3c73c41d86b28601659b0f1cfd90b9bb) — exact whole-query assertions (1-class + 2-class)
4. [`index.test.ts`](https://github.com/aws/graph-explorer/pull/2106/files#diff-583e7d5e7a3e3a8b20d58ec677a6e55280a5aa761ea4f3bc720b874ea496c67c) — integration: request-count collapse, regrouping, guards

## Validation

- `pnpm checks` passes (types + lint + format)
- `pnpm test` passes (247 sparql connector tests, 6 new)
- Verified live against Neptune 1.4.7.0 with ~10k synthetic classes: 100-class chunks complete in ~2s with bounded plans (100 `Slice limit=1` operators, max 13 intermediate rows per arm)

## Related Issues

- Closes #2101
- Related to #2085
- Related to #2076

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [x] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.