### PR TITLE
Share one memoized label text color helper across canvas and previews

### DIFF
--- a/packages/graph-explorer/src/components/LabelPreview.test.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.test.tsx
@@ -20,9 +20,10 @@ function renderLabel(style: LabelVisualStyle, scale = 2) {
 
 describe("LabelPreview", () => {
   describe("text color follows label darkness for contrast", () => {
+    // Casing follows `labelTextColorFor`, the helper the canvas shares.
     it("uses white text on a dark label color", () => {
       const el = renderLabel(labelStyle({ labelColor: "#1d2531" }));
-      expect(el.style.color).toBe("#ffffff");
+      expect(el.style.color).toBe("#FFFFFF");
     });
 
     it("uses black text on a light label color", () => {

--- a/packages/graph-explorer/src/components/LabelPreview.tsx
+++ b/packages/graph-explorer/src/components/LabelPreview.tsx
@@ -1,9 +1,6 @@
 import type React from "react";
 
-import Color from "color";
-
-import type { LabelVisualStyle } from "@/core";
-
+import { type LabelVisualStyle, labelTextColorFor } from "@/core";
 import { cn } from "@/utils";
 
 /**
@@ -31,8 +28,8 @@ interface LabelPreviewProps {
 
 /**
  * A label badge preview that faithfully matches cytoscape's canvas rendering
- * at any scale. Text color is derived from `labelColor` darkness (white on dark,
- * black on light) — same logic as `useGraphStyles.ts`.
+ * at any scale. Text color comes from `labelTextColorFor`, the same helper the
+ * canvas uses, so a preview cannot drift from what gets drawn.
  *
  * Used for both vertex and edge label previews.
  */
@@ -53,9 +50,7 @@ export function LabelPreview({
         fontSize: FONT_SIZE * scale,
         padding: PADDING * scale,
         borderRadius: BORDER_RADIUS * scale,
-        color: new Color(labelStyle.labelColor).isDark()
-          ? "#ffffff"
-          : "#000000",
+        color: labelTextColorFor(labelStyle.labelColor),
         backgroundColor: `color-mix(in srgb, ${labelStyle.labelColor} ${labelStyle.labelBackgroundOpacity * 100}%, transparent)`,
         borderWidth: labelStyle.labelBorderWidth * scale || undefined,
         borderStyle:

--- a/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.test.ts
@@ -117,4 +117,15 @@ describe("labelTextColorFor", () => {
     expect(() => labelTextColorFor("")).not.toThrow();
     expect(labelTextColorFor("")).toBe("#FFFFFF");
   });
+
+  // The result is memoized in a module-level map, so a repeat call must not be
+  // able to return a different answer than the first.
+  it("returns a stable answer across repeated calls", () => {
+    expect(labelTextColorFor("#123456")).toBe(labelTextColorFor("#123456"));
+    expect(labelTextColorFor("")).toBe(labelTextColorFor(""));
+  });
+
+  it("keys the memo per color rather than sharing one answer", () => {
+    expect(labelTextColorFor("#000000")).not.toBe(labelTextColorFor("#ffffff"));
+  });
 });

--- a/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.ts
@@ -1,6 +1,11 @@
 import Color from "color";
 
-import type { EdgeStyle, LineStyle, VertexStyle } from "./graphStyles";
+import {
+  appDefaultEdgeStyle,
+  type EdgeStyle,
+  type LineStyle,
+  type VertexStyle,
+} from "./graphStyles";
 
 /**
  * Per-element style data pushed onto cytoscape `ele.data()` so a single
@@ -11,11 +16,11 @@ import type { EdgeStyle, LineStyle, VertexStyle } from "./graphStyles";
  * dash-pattern remap so the style loop stays pure `data()`.
  */
 
-const LINE_PATTERN: Record<LineStyle, readonly number[] | undefined> = {
-  solid: undefined,
-  dashed: [5, 6],
-  dotted: [1, 2],
-};
+/** A `Map` so a type name colliding with `Object.prototype` cannot resolve to a function. */
+const LINE_PATTERN = new Map<LineStyle, readonly number[]>([
+  ["dashed", [5, 6]],
+  ["dotted", [1, 2]],
+]);
 
 /** Data-mapper fields set on every rendered vertex. Feeds the single `node` rule. */
 export type VertexStyleData = {
@@ -48,12 +53,26 @@ export type EdgeStyleData = {
 };
 
 /**
+ * Memoized because parsing a color is the one non-trivial computation in this
+ * module, and the number of distinct label colors in a graph is tiny next to
+ * the number of edges asking about them.
+ */
+const labelTextColors = new Map<string, "#FFFFFF" | "#000000">();
+
+/**
  * Picks white-on-dark / black-on-light for a label against its background color.
  * Falls back to the default label color when unset: an imported style file can
  * carry an empty `labelColor`, and `new Color("")` throws.
  */
 export function labelTextColorFor(labelColor: string): "#FFFFFF" | "#000000" {
-  return new Color(labelColor || "#17457b").isDark() ? "#FFFFFF" : "#000000";
+  let textColor = labelTextColors.get(labelColor);
+  if (textColor === undefined) {
+    textColor = new Color(labelColor || appDefaultEdgeStyle.labelColor).isDark()
+      ? "#FFFFFF"
+      : "#000000";
+    labelTextColors.set(labelColor, textColor);
+  }
+  return textColor;
 }
 
 /** Precomputed cytoscape data-mapper fields for a rendered vertex. */
@@ -80,7 +99,7 @@ export function vertexStyleData(
 export function edgeStyleData(style: EdgeStyle): EdgeStyleData {
   const lineStyle: LineStyle =
     style.lineStyle === "dotted" ? "dashed" : style.lineStyle;
-  const dashPattern = LINE_PATTERN[style.lineStyle];
+  const dashPattern = LINE_PATTERN.get(style.lineStyle);
   const data: EdgeStyleData = {
     ge_lineColor: style.lineColor,
     ge_lineStyle: lineStyle,


### PR DESCRIPTION
## Description

`LabelPreview` inlined its own `new Color(labelStyle.labelColor).isDark()` with no guard for the empty `labelColor` an imported styling file can carry, so the preview could throw where the canvas does not. Both surfaces now call `labelTextColorFor`, which already has that guard — a near-duplicate of the crash the helper exists to prevent is gone, and a preview can no longer drift from what gets drawn.

Two smaller hardening changes ride along in the same file:

- The empty-`labelColor` fallback reads `appDefaultEdgeStyle.labelColor` instead of repeating the hex, so changing the default can't leave the contrast calculation comparing against the old one.
- `LINE_PATTERN` becomes a `Map`. As an object literal, a `lineStyle` colliding with `Object.prototype` (`"constructor"`, `"toString"`) resolved to a **function**, which passed the `!== undefined` gate and was written onto every edge's cytoscape data. Reaching it needs same-origin IndexedDB write access, so this is hardening rather than a live bug.

`labelTextColorFor` returns uppercase `#FFFFFF`, where the preview previously produced lowercase, so one assertion in `LabelPreview.test.tsx` moves with it. Same rendered colour.

## How to read

1. `graphElementStyleData.ts` — the helper, the default reference, and the `Map`.
2. `LabelPreview.tsx` — now a caller rather than a second implementation.

## Stack

Targets `schema-view-style-perf` (#2112), which is left exactly as it is. Nine further PRs stack on this one so each change can be merged individually.