### PR TITLE
Let app defaults win over explicitly undefined style fields

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.test.ts
@@ -118,8 +118,6 @@ describe("labelTextColorFor", () => {
     expect(labelTextColorFor("")).toBe("#FFFFFF");
   });
 
-  // The result is memoized in a module-level map, so a repeat call must not be
-  // able to return a different answer than the first.
   it("returns a stable answer across repeated calls", () => {
     expect(labelTextColorFor("#123456")).toBe(labelTextColorFor("#123456"));
     expect(labelTextColorFor("")).toBe(labelTextColorFor(""));

--- a/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphElementStyleData.ts
@@ -53,26 +53,18 @@ export type EdgeStyleData = {
 };
 
 /**
- * Memoized because parsing a color is the one non-trivial computation in this
- * module, and the number of distinct label colors in a graph is tiny next to
- * the number of edges asking about them.
- */
-const labelTextColors = new Map<string, "#FFFFFF" | "#000000">();
-
-/**
  * Picks white-on-dark / black-on-light for a label against its background color.
  * Falls back to the default label color when unset: an imported style file can
  * carry an empty `labelColor`, and `new Color("")` throws.
+ *
+ * Deliberately not memoized. Profiling this at 0.1ms over a 10s expansion put it
+ * far below the per-type resolution that dominates, so a module-level cache
+ * would only add global state shared across stores and tests.
  */
 export function labelTextColorFor(labelColor: string): "#FFFFFF" | "#000000" {
-  let textColor = labelTextColors.get(labelColor);
-  if (textColor === undefined) {
-    textColor = new Color(labelColor || appDefaultEdgeStyle.labelColor).isDark()
-      ? "#FFFFFF"
-      : "#000000";
-    labelTextColors.set(labelColor, textColor);
-  }
-  return textColor;
+  return new Color(labelColor || appDefaultEdgeStyle.labelColor).isDark()
+    ? "#FFFFFF"
+    : "#000000";
 }
 
 /** Precomputed cytoscape data-mapper fields for a rendered vertex. */

--- a/packages/graph-explorer/src/core/StateProvider/graphStyles.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphStyles.test.ts
@@ -3,6 +3,8 @@ import { useAtomValue } from "jotai";
 import { act } from "react";
 
 import { createEdgeType, createVertexType } from "@/core";
+import { RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
+import DEFAULT_ICON_URL from "@/utils/defaultIconUrl";
 import { DbState, renderHookWithState } from "@/utils/testing";
 
 import {
@@ -10,6 +12,8 @@ import {
   appDefaultVertexStyle,
   edgeStyleAtom,
   type EdgeStyleStorage,
+  resolveEdgeStyle,
+  resolveVertexStyle,
   useEdgeStyling,
   useVertexStyling,
   vertexStyleAtom,
@@ -36,7 +40,11 @@ function createExpectedEdge(existing: EdgeStyleStorage) {
 // deliberate and consumers stay trustworthy.
 describe("app default styles", () => {
   it("pins the default vertex style values", () => {
-    expect(appDefaultVertexStyle).toMatchObject({
+    expect(appDefaultVertexStyle).toStrictEqual({
+      displayNameAttribute: RESERVED_ID_PROPERTY,
+      longDisplayNameAttribute: RESERVED_TYPES_PROPERTY,
+      iconUrl: DEFAULT_ICON_URL,
+      iconImageType: "image/svg+xml",
       color: "#128EE5",
       shape: "ellipse",
       backgroundOpacity: 0.4,
@@ -47,9 +55,13 @@ describe("app default styles", () => {
   });
 
   it("pins the default edge style values", () => {
-    expect(appDefaultEdgeStyle).toMatchObject({
+    expect(appDefaultEdgeStyle).toStrictEqual({
+      displayNameAttribute: RESERVED_TYPES_PROPERTY,
       labelColor: "#17457b",
       labelBackgroundOpacity: 0.7,
+      labelBorderColor: "#17457b",
+      labelBorderStyle: "solid",
+      labelBorderWidth: 0,
       lineColor: "#b3b3b3",
       lineThickness: 2,
       lineStyle: "solid",
@@ -487,5 +499,48 @@ describe("edgeStyleAtom", () => {
     expect(result.current.get(edgeType)).toStrictEqual(
       createExpectedEdge({ type: edgeType }),
     );
+  });
+});
+
+// A style file can carry an optional key explicitly set to undefined. Spreading
+// it over the defaults would overwrite them, and the resulting `data()` mapper
+// has no missing-value fallback on the cytoscape side.
+describe("explicitly undefined optional fields", () => {
+  it("keeps the edge default rather than taking the undefined", () => {
+    const type = createEdgeType("knows");
+    const resolved = resolveEdgeStyle(type, {
+      type,
+      labelBackgroundOpacity: undefined,
+      lineColor: undefined,
+    });
+
+    expect(resolved.labelBackgroundOpacity).toBe(
+      appDefaultEdgeStyle.labelBackgroundOpacity,
+    );
+    expect(resolved.lineColor).toBe(appDefaultEdgeStyle.lineColor);
+  });
+
+  it("keeps the vertex default rather than taking the undefined", () => {
+    const type = createVertexType("Person");
+    const resolved = resolveVertexStyle(type, {
+      type,
+      color: undefined,
+      borderWidth: undefined,
+    });
+
+    expect(resolved.color).toBe(appDefaultVertexStyle.color);
+    expect(resolved.borderWidth).toBe(appDefaultVertexStyle.borderWidth);
+  });
+
+  it("still applies a defined override", () => {
+    const type = createEdgeType("knows");
+    const resolved = resolveEdgeStyle(type, {
+      type,
+      lineColor: "#abcdef",
+      labelColor: undefined,
+    });
+
+    expect(resolved.lineColor).toBe("#abcdef");
+    expect(resolved.labelColor).toBe(appDefaultEdgeStyle.labelColor);
   });
 });

--- a/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
@@ -225,6 +225,25 @@ export const edgeStyleAtom = atom<EdgeStyleLookup>(get => {
   };
 });
 
+/**
+ * Spreading `user` directly would let a key present but set to `undefined` — an
+ * imported style file can carry one — overwrite the default with `undefined`,
+ * which then reaches cytoscape as a `data()` mapper against a missing field and
+ * cannot fall back. Only keys with a value override.
+ */
+function withoutUndefined<T extends object>(user: T | undefined): Partial<T> {
+  if (user === undefined) {
+    return {};
+  }
+  const defined: Partial<T> = {};
+  for (const [key, value] of Object.entries(user)) {
+    if (value !== undefined) {
+      defined[key as keyof T] = value as T[keyof T];
+    }
+  }
+  return defined;
+}
+
 /** The user's vertex style overlaid on the app defaults. */
 export function resolveVertexStyle(
   type: VertexType,
@@ -233,7 +252,7 @@ export function resolveVertexStyle(
   return {
     type,
     ...appDefaultVertexStyle,
-    ...user,
+    ...withoutUndefined(user),
   } as const;
 }
 
@@ -245,7 +264,7 @@ export function resolveEdgeStyle(
   return {
     type,
     ...appDefaultEdgeStyle,
-    ...user,
+    ...withoutUndefined(user),
   } as const;
 }
 


### PR DESCRIPTION
## Description

`resolveVertexStyle` / `resolveEdgeStyle` spread the user's stored style over the app defaults. An imported styling file can carry an optional key that is *present but set to `undefined`* — spreading it overwrote the default with `undefined`. Before this branch that produced an unset stylesheet value; now it feeds a `data()` mapper against a missing field, which cytoscape cannot fall back from, so the element renders unstyled for that field. Only keys with a value override now.

A test that pinned this behaviour was deleted during the `data()` migration without replacement, which is how the change slipped through — three cases replace it.

Also drops the `labelTextColorFor` memo added in the first PR of this stack. Profiling put it at **0.1ms over a 10s expansion**, far below the per-type resolution that dominates, so the cache only bought module-level state shared across stores and test files. Two reviewers independently recommended removing it and the measurement agrees; a security pass separately ruled out the growth concern (hostile data can't drive the key space, because every unconfigured type resolves to the same default colour).

The default-style fixtures move from `toMatchObject` to `toStrictEqual`, since the new tests depend on them being trustworthy — `toMatchObject` left `iconUrl`, `iconImageType`, the display-name attributes and the label border fields unpinned.

## How to read

1. `graphStyles.ts` — `withoutUndefined` and the two resolvers.
2. `graphStyles.test.ts` — the three replacement cases and the tightened fixtures.