### PR TITLE
Stop interning a dead atom per node-set mutation

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.test.ts
@@ -14,10 +14,17 @@ import {
   createVertexId,
   createVertexType,
   type DisplayAttribute,
+  displayVerticesInCanvasSelector,
+  getAppStore,
   getRawId,
+  nodesAtom,
+  nodesSelectedIdsAtom,
   schemaAtom,
   type SchemaStorageModel,
+  toNodeMap,
   useDisplayVertexFromVertex,
+  useDisplayVerticesFromVertices,
+  useSelectedDisplayVertices,
   type Vertex,
 } from "@/core";
 import { formatDate, LABELS } from "@/utils";
@@ -237,4 +244,111 @@ describe("useDisplayVertexFromVertex", () => {
       store.set(activeConfigurationAtom, config.id);
     };
   }
+});
+
+describe("displayVerticesInCanvasSelector", () => {
+  it("should map every node in the canvas, keyed by id, in insertion order", () => {
+    const store = getAppStore();
+    const vertices = [
+      createRandomVertex(),
+      createRandomVertex(),
+      createRandomVertex(),
+    ];
+    store.set(nodesAtom, toNodeMap(vertices));
+
+    const result = store.get(displayVerticesInCanvasSelector);
+
+    expect(result.keys().toArray()).toStrictEqual(vertices.map(v => v.id));
+    for (const vertex of vertices) {
+      expect(result.get(vertex.id)?.original).toBe(vertex);
+    }
+  });
+
+  it("should be empty when the canvas is empty", () => {
+    const store = getAppStore();
+    expect(store.get(displayVerticesInCanvasSelector).size).toBe(0);
+  });
+
+  it("should reflect nodes added and removed across mutations", () => {
+    const store = getAppStore();
+    const first = createRandomVertex();
+    const second = createRandomVertex();
+
+    store.set(nodesAtom, toNodeMap([first]));
+    expect(
+      store.get(displayVerticesInCanvasSelector).keys().toArray(),
+    ).toStrictEqual([first.id]);
+
+    store.set(nodesAtom, toNodeMap([first, second]));
+    expect(
+      store.get(displayVerticesInCanvasSelector).keys().toArray(),
+    ).toStrictEqual([first.id, second.id]);
+
+    store.set(nodesAtom, toNodeMap([second]));
+    expect(
+      store.get(displayVerticesInCanvasSelector).keys().toArray(),
+    ).toStrictEqual([second.id]);
+  });
+
+  /**
+   * Pins the per-id caching that replaced the array-keyed atom family: an
+   * unchanged node must not be re-derived when other nodes are added.
+   */
+  it("should keep the same DisplayVertex instance for an unchanged node", () => {
+    const store = getAppStore();
+    const unchanged = createRandomVertex();
+
+    store.set(nodesAtom, toNodeMap([unchanged]));
+    const before = store.get(displayVerticesInCanvasSelector).get(unchanged.id);
+
+    store.set(nodesAtom, toNodeMap([unchanged, createRandomVertex()]));
+    const after = store.get(displayVerticesInCanvasSelector).get(unchanged.id);
+
+    expect(after).toBe(before);
+  });
+});
+
+describe("useSelectedDisplayVertices", () => {
+  it("should map only the selected nodes", () => {
+    const selected = createRandomVertex();
+    const notSelected = createRandomVertex();
+
+    const { result } = renderHookWithJotai(
+      useSelectedDisplayVertices,
+      store => {
+        store.set(nodesAtom, toNodeMap([selected, notSelected]));
+        store.set(nodesSelectedIdsAtom, new Set([selected.id]));
+      },
+    );
+
+    expect(result.current.map(v => v.id)).toStrictEqual([selected.id]);
+  });
+
+  it("should ignore selected ids that are no longer in the canvas", () => {
+    const missing = createRandomVertex();
+
+    const { result } = renderHookWithJotai(
+      useSelectedDisplayVertices,
+      store => {
+        store.set(nodesSelectedIdsAtom, new Set([missing.id]));
+      },
+    );
+
+    expect(result.current).toStrictEqual([]);
+  });
+});
+
+describe("useDisplayVerticesFromVertices", () => {
+  it("should map arbitrary vertices that are not in the canvas", () => {
+    const vertices = [createRandomVertex(), createRandomVertex()];
+
+    const { result } = renderHookWithJotai(() =>
+      useDisplayVerticesFromVertices(vertices),
+    );
+
+    expect(result.current.keys().toArray()).toStrictEqual(
+      vertices.map(v => v.id),
+    );
+    expect(result.current.get(vertices[0].id)?.original).toBe(vertices[0]);
+  });
 });

--- a/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
+++ b/packages/graph-explorer/src/core/StateProvider/displayVertex.ts
@@ -12,10 +12,11 @@ import {
   useVertex,
   type Vertex,
   type VertexId,
-  vertexStyleByTypeAtom,
+  vertexStyleAtom,
+  type VertexStyleLookup,
   type VertexType,
 } from "@/core";
-import { textTransformSelector } from "@/hooks";
+import { type TextTransformer, textTransformSelector } from "@/hooks";
 import { LABELS, RESERVED_ID_PROPERTY, RESERVED_TYPES_PROPERTY } from "@/utils";
 
 /** Represents a vertex's display information after all transformations have been applied. */
@@ -46,101 +47,122 @@ export function useDisplayVerticesInCanvas() {
 
 /** Maps a `Vertex` instance to a `DisplayVertex` instance using the schema and any user styles. */
 export function useDisplayVertexFromVertex(vertex: Vertex) {
-  return useAtomValue(displayVertexSelector(vertex));
+  return toDisplayVertex(vertex, useAtomValue(displayVertexContextSelector));
 }
 
 /** Maps the `Vertex` instances to a `DisplayVertex` instances using the schema and any user styles. */
 export function useDisplayVerticesFromVertices(vertices: Vertex[]) {
-  return useAtomValue(displayVerticesSelector(vertices));
+  const context = useAtomValue(displayVertexContextSelector);
+  return new Map(vertices.map(v => [v.id, toDisplayVertex(v, context)]));
 }
 
-const selectedDisplayVerticesSelector = atom(get => {
-  const selectedIds = get(nodesSelectedIdsAtom);
-  return selectedIds
+const selectedDisplayVerticesSelector = atom(get =>
+  get(nodesSelectedIdsAtom)
     .values()
-    .map(id => get(nodeSelector(id)))
-    .filter(n => n != null)
-    .map(n => get(displayVertexSelector(n)))
-    .filter(n => n != null)
-    .toArray();
-});
+    .map(id => get(displayVertexSelector(id)))
+    .filter(v => v != null)
+    .toArray(),
+);
 
 /** Maps all `Vertex` instances which are selected in the graph canvas to `DisplayVertex` instances. */
 export function useSelectedDisplayVertices() {
   return useAtomValue(selectedDisplayVerticesSelector);
 }
 
-const displayVertexSelector = atomFamily((vertex: Vertex) =>
+/**
+ * Everything a `Vertex` needs to become a `DisplayVertex`, resolved once per
+ * store change instead of once per vertex.
+ */
+type DisplayVertexContext = {
+  textTransform: TextTransformer;
+  isSparql: boolean;
+  vertexStyles: VertexStyleLookup;
+};
+
+const displayVertexContextSelector = atom<DisplayVertexContext>(get => ({
+  textTransform: get(textTransformSelector),
+  isSparql: get(queryEngineSelector) === "sparql",
+  vertexStyles: get(vertexStyleAtom),
+}));
+
+/**
+ * Keyed by `VertexId` rather than the `Vertex` object so the family interns one
+ * entry per node instead of one per object identity, which `nodesAtom` mutations
+ * would otherwise leak on every recomputation.
+ */
+const displayVertexSelector = atomFamily((id: VertexId) =>
   atom(get => {
-    const textTransform = get(textTransformSelector);
-    const queryEngine = get(queryEngineSelector);
-    const isSparql = queryEngine === "sparql";
+    const vertex = get(nodeSelector(id));
+    if (!vertex) {
+      return null;
+    }
+    return toDisplayVertex(vertex, get(displayVertexContextSelector));
+  }),
+);
 
-    const rawStringId = String(getRawId(vertex.id));
-    const displayId = isSparql ? textTransform(rawStringId) : rawStringId;
+function toDisplayVertex(
+  vertex: Vertex,
+  { textTransform, isSparql, vertexStyles }: DisplayVertexContext,
+): DisplayVertex {
+  const rawStringId = String(getRawId(vertex.id));
+  const displayId = isSparql ? textTransform(rawStringId) : rawStringId;
 
-    // List all vertex types for displaying
-    const vertexTypes =
-      vertex.types && vertex.types.length > 0 ? vertex.types : [vertex.type];
-    const displayTypes = vertexTypes
-      .map(
-        type =>
-          get(vertexStyleByTypeAtom(type)).displayLabel ?? textTransform(type),
-      )
-      .join(", ");
+  // List all vertex types for displaying
+  const vertexTypes =
+    vertex.types && vertex.types.length > 0 ? vertex.types : [vertex.type];
+  const displayTypes = vertexTypes
+    .map(type => vertexStyles.get(type).displayLabel ?? textTransform(type))
+    .join(", ");
 
-    // Map all the attributes for displaying
-    const sortedAttributes = getSortedDisplayAttributes(vertex, textTransform);
+  // Map all the attributes for displaying
+  const sortedAttributes = getSortedDisplayAttributes(vertex, textTransform);
 
-    // Get the display name and description for the vertex
-    function getDisplayAttributeValueByName(name: string | undefined) {
-      if (name === RESERVED_ID_PROPERTY) {
-        return displayId;
-      } else if (name === RESERVED_TYPES_PROPERTY) {
-        return displayTypes;
-      } else if (name) {
-        return (
-          sortedAttributes.find(attr => attr.name === name)?.displayValue ??
-          LABELS.MISSING_VALUE
-        );
-      }
-
-      return LABELS.MISSING_VALUE;
+  // Get the display name and description for the vertex
+  function getDisplayAttributeValueByName(name: string | undefined) {
+    if (name === RESERVED_ID_PROPERTY) {
+      return displayId;
+    } else if (name === RESERVED_TYPES_PROPERTY) {
+      return displayTypes;
+    } else if (name) {
+      return (
+        sortedAttributes.find(attr => attr.name === name)?.displayValue ??
+        LABELS.MISSING_VALUE
+      );
     }
 
-    const vertexStyle = get(vertexStyleByTypeAtom(vertex.type));
-    const displayName = getDisplayAttributeValueByName(
-      vertexStyle.displayNameAttribute,
-    );
-    const displayDescription = getDisplayAttributeValueByName(
-      vertexStyle.longDisplayNameAttribute,
-    );
+    return LABELS.MISSING_VALUE;
+  }
 
-    const result: DisplayVertex = {
-      entityType: "vertex",
-      id: vertex.id,
-      primaryType: vertex.type,
-      types: vertexTypes,
-      displayId,
-      displayTypes,
-      displayName,
-      displayDescription,
-      attributes: sortedAttributes,
-      isBlankNode: vertex.isBlankNode ?? false,
-      original: vertex,
-    };
-    return result;
-  }),
+  const vertexStyle = vertexStyles.get(vertex.type);
+  const displayName = getDisplayAttributeValueByName(
+    vertexStyle.displayNameAttribute,
+  );
+  const displayDescription = getDisplayAttributeValueByName(
+    vertexStyle.longDisplayNameAttribute,
+  );
+
+  return {
+    entityType: "vertex",
+    id: vertex.id,
+    primaryType: vertex.type,
+    types: vertexTypes,
+    displayId,
+    displayTypes,
+    displayName,
+    displayDescription,
+    attributes: sortedAttributes,
+    isBlankNode: vertex.isBlankNode ?? false,
+    original: vertex,
+  };
+}
+
+export const displayVerticesInCanvasSelector = atom(
+  get =>
+    new Map(
+      get(nodesAtom)
+        .keys()
+        .map(id => get(displayVertexSelector(id)))
+        .filter(v => v != null)
+        .map(v => [v.id, v] as const),
+    ),
 );
-
-const displayVerticesSelector = atomFamily((vertices: Vertex[]) =>
-  atom(get => {
-    return new Map(
-      vertices.map(vertex => [vertex.id, get(displayVertexSelector(vertex))]),
-    );
-  }),
-);
-
-export const displayVerticesInCanvasSelector = atom(get => {
-  return get(displayVerticesSelector(get(nodesAtom).values().toArray()));
-});


### PR DESCRIPTION
## Description

**Unbounded memory growth driven by the app's most common interaction.**

`displayVerticesSelector` was an `atomFamily` keyed on a freshly allocated `Vertex[]`, and `displayVertexSelector` on `Vertex` object identity. `atomFamily` caches by parameter identity **forever** unless `remove` / `setShouldRemove` is called, and nothing in this codebase calls either. So every node expansion, add, or remove interned a new entry that could never be reached again, each retaining a `DisplayVertex` for every node on the canvas. Retained memory grew with mutations × nodes for the lifetime of the tab.

Not a crash — gradual growth during normal use.

The array-keyed family is deleted rather than bounded: `displayVerticesInCanvasSelector` iterates `nodesAtom` through the per-id family in a single pass. `displayVertexSelector` is keyed on `VertexId`, so it holds one entry per node.

Vertices that are **not** on the canvas can't be served by an id-keyed family — search results (`VertexSearchResult` passes `createVertex(...)`) and details for a vertex fetched on demand. The derivation is therefore extracted into a pure `toDisplayVertex(vertex, context)` over a non-family context atom, and those callers now intern nothing at all. No caller changes were needed.

Behaviour is preserved: same `Map<VertexId, DisplayVertex>`, same insertion order, same shape.

> [!IMPORTANT]
> **Retention itself is not asserted.** `atomFamily` exposes no size or introspection API, so "entry count does not grow" is not observable from a test. The added test pins the closest proxy — an unchanged node keeps its `DisplayVertex` identity across an unrelated mutation. Reviewers should treat the retention claim as reasoned from the `atomFamily` contract, not measured.

Three further instances of the same defect class are left alone and tracked in #2116, the highest priority being `neighbors.ts` — also array-keyed, also in the expansion path.

## How to read

`displayVertex.ts` is the whole change; start at `displayVerticesInCanvasSelector` at the bottom and work up.