### PR TITLE
Enforce the style data producer/consumer lockstep structurally

### DIFF
--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -1,6 +1,14 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 
+import {
+  createEdgeType,
+  createVertexType,
+  edgeStyleData,
+  type EdgeStyle,
+  vertexStyleData,
+  type VertexStyle,
+} from "@/core";
 import { renderHookWithState } from "@/utils/testing";
 
 import useGraphStyles from "./useGraphStyles";
@@ -51,5 +59,86 @@ describe("useGraphStyles", () => {
     const { result } = renderHookWithState(() => useGraphStyles());
     const nodeRule = result.current["node"] as Record<string, unknown>;
     expect(nodeRule["background-image"]).toBe("data(ge_iconUrl)");
+  });
+});
+
+// Producer and consumer must stay in lockstep: a ge_* field added to
+// graphElementStyleData without a matching data() mapper (or the reverse)
+// silently drops the style. See docs/adr/20260813-element-data-style-mappers.md.
+describe("style data round trip", () => {
+  const vertexStyle: VertexStyle = {
+    type: createVertexType("Person"),
+    displayLabel: "Human",
+    displayNameAttribute: "name",
+    longDisplayNameAttribute: "bio",
+    color: "#123456",
+    iconUrl: "/icons/person.svg",
+    iconImageType: "image/svg+xml",
+    shape: "diamond",
+    backgroundOpacity: 0.42,
+    borderWidth: 3,
+    borderColor: "#654321",
+    borderStyle: "dashed",
+  };
+
+  const edgeStyle: EdgeStyle = {
+    type: createEdgeType("knows"),
+    displayLabel: "Knows",
+    displayNameAttribute: "since",
+    lineColor: "#0a0b0c",
+    lineThickness: 4,
+    lineStyle: "dotted",
+    sourceArrowStyle: "circle",
+    targetArrowStyle: "tee",
+    labelColor: "#abcdef",
+    labelBackgroundOpacity: 0.73,
+    labelBorderColor: "#fedcba",
+    labelBorderStyle: "dashed",
+    labelBorderWidth: 2,
+  };
+
+  function producedKeys() {
+    return new Set([
+      ...Object.keys(vertexStyleData(vertexStyle, vertexStyle.iconUrl)),
+      ...Object.keys(edgeStyleData(edgeStyle)),
+    ]);
+  }
+
+  function mappedKeys(styles: ReturnType<typeof useGraphStyles>) {
+    const keys = new Set<string>();
+    for (const rule of Object.values(styles)) {
+      for (const value of Object.values(rule as Record<string, unknown>)) {
+        for (const [, key] of String(value).matchAll(/data\(([^)]+)\)/g)) {
+          keys.add(key);
+        }
+      }
+    }
+    return keys;
+  }
+
+  it("has a data() mapper for every key the producers emit", () => {
+    const { result } = renderHookWithState(() => useGraphStyles());
+    const mapped = mappedKeys(result.current);
+    const unmapped = [...producedKeys()].filter(key => !mapped.has(key)).sort();
+
+    expect(
+      unmapped,
+      "style data keys produced with no data() mapper in the stylesheet",
+    ).toEqual([]);
+  });
+
+  it("emits style data for every ge_ mapper in the stylesheet", () => {
+    const { result } = renderHookWithState(() => useGraphStyles());
+    const produced = producedKeys();
+    // Non-ge_ mappers (e.g. displayName) come from the rendered entity, not these
+    // producers, so only ge_ keys are the producers' contract.
+    const unproduced = [...mappedKeys(result.current)]
+      .filter(key => key.startsWith("ge_") && !produced.has(key))
+      .sort();
+
+    expect(
+      unproduced,
+      "ge_ mappers in the stylesheet that no producer emits",
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Description

The ADR from #2112 records this as a Consequence:

> **Producer and consumer must stay in lockstep.** A new per-type style property must be added in two places together — the `ge_*` field + its producer, and the matching `data(…)` mapper. Editing one side alone silently drops the style.

Nothing enforced it, and the migration had already dropped assertions for `ge_labelBackgroundOpacity`, `ge_labelBackgroundColor`, `ge_labelBorderWidth`, `ge_labelBorderColor`, `ge_labelBorderStyle` and the arrow-colour / distance mappings — asserted nowhere.

This closes the loop by comparing **key sets** rather than listing field names, so it cannot rot the way a hand-written list does. Both directions:

- every `ge_*` key the producers emit appears as a `data(...)` mapper somewhere in the stylesheet
- every `ge_*` mapper corresponds to a key a producer emits

Non-`ge_*` mappers (`displayName`) come from the rendered entity rather than these producers, so they're excluded by prefix, not by name. It walks every rule rather than hardcoding `node` / `edge`, so a legitimately re-added gated selector is still covered.

Verified by deliberate probe: adding a bogus mapper and a bogus producer field each failed the expected direction, then both probes were reverted.

## How to read

One new `describe` block at the end of `useGraphStyles.test.tsx`.