### PR TITLE
Extract the rendered entity ID codec out of renderedEntities

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/index.ts
+++ b/packages/graph-explorer/src/core/StateProvider/index.ts
@@ -10,6 +10,7 @@ export * from "./featureFlags";
 export * from "./neighbors";
 export * from "./nodes";
 export * from "./renderedEntities";
+export * from "./renderedEntityIds";
 export * from "./graphStyles";
 export * from "./graphElementStyleData";
 export * from "./styleDataResolvers";

--- a/packages/graph-explorer/src/core/StateProvider/renderedEntities.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/renderedEntities.test.ts
@@ -2,12 +2,7 @@
 import { waitFor } from "@testing-library/react";
 import { createStore } from "jotai";
 
-import {
-  createEdgeId,
-  createVertex,
-  createVertexId,
-  createVertexType,
-} from "@/core/entities";
+import { createVertex, createVertexType } from "@/core/entities";
 import { iconRegistry } from "@/core/icons";
 import { LABELS } from "@/utils";
 import {
@@ -18,82 +13,11 @@ import {
   renderHookWithJotai,
 } from "@/utils/testing";
 
+import { canvasVerticesAtom, useRenderedEntities } from "./renderedEntities";
 import {
-  canvasVerticesAtom,
   createRenderedEdgeId,
   createRenderedVertexId,
-  getEdgeIdFromRenderedEdgeId,
-  getVertexIdFromRenderedVertexId,
-  type RenderedEdgeId,
-  type RenderedVertexId,
-  useRenderedEntities,
-} from "./renderedEntities";
-
-describe("createRenderedVertexId", () => {
-  it("should create a rendered vertex id out of a string", () => {
-    const id = createRenderedVertexId(createVertexId("123"));
-    expect(id).toBe("(str)123");
-  });
-
-  it("should create a rendered vertex id out of a number", () => {
-    const id = createRenderedVertexId(createVertexId(123));
-    expect(id).toBe("(num)123");
-  });
-});
-
-describe("createRenderedEdgeId", () => {
-  it("should create a rendered edge id out of a string", () => {
-    const id = createRenderedEdgeId(createEdgeId("123"));
-    expect(id).toBe("(str)123");
-  });
-
-  it("should create a rendered edge id out of a number", () => {
-    const id = createRenderedEdgeId(createEdgeId(123));
-    expect(id).toBe("(num)123");
-  });
-});
-
-describe("getVertexIdFromRenderedVertexId", () => {
-  it("should return the raw string id without the prefix", () => {
-    const id = getVertexIdFromRenderedVertexId(
-      createRenderedVertexId(createVertexId("123")),
-    );
-    expect(id).toBe("123");
-  });
-
-  it("should return the raw number id without the prefix", () => {
-    const id = getVertexIdFromRenderedVertexId(
-      createRenderedVertexId(createVertexId(123)),
-    );
-    expect(id).toBe(123);
-  });
-
-  it("should return the id as is if it is not marked as a string or number", () => {
-    const id = getVertexIdFromRenderedVertexId("123" as RenderedVertexId);
-    expect(id).toBe("123");
-  });
-});
-
-describe("getEdgeIdFromRenderedEdgeId", () => {
-  it("should return the raw string id without the prefix", () => {
-    const id = getEdgeIdFromRenderedEdgeId(
-      createRenderedEdgeId(createEdgeId("123")),
-    );
-    expect(id).toBe("123");
-  });
-
-  it("should return the raw number id without the prefix", () => {
-    const id = getEdgeIdFromRenderedEdgeId(
-      createRenderedEdgeId(createEdgeId(123)),
-    );
-    expect(id).toBe(123);
-  });
-
-  it("should return the id as is if it is not marked as a string or number", () => {
-    const id = getEdgeIdFromRenderedEdgeId("123" as RenderedEdgeId);
-    expect(id).toBe("123");
-  });
-});
+} from "./renderedEntityIds";
 
 describe("canvasVerticesAtom", () => {
   it("should exclude vertices filtered by ID and by type", () => {

--- a/packages/graph-explorer/src/core/StateProvider/renderedEntities.ts
+++ b/packages/graph-explorer/src/core/StateProvider/renderedEntities.ts
@@ -1,7 +1,5 @@
 import { atom, useAtomValue } from "jotai";
 
-import type { Branded } from "@/utils";
-
 import {
   type DisplayEdge,
   type DisplayVertex,
@@ -10,7 +8,6 @@ import {
   edgesFilteredIdsAtom,
   edgeStyleAtom,
   edgesTypesFilteredAtom,
-  type EntityRawId,
   nodesFilteredIdsAtom,
   nodesTypesFilteredAtom,
   useAllNeighbors,
@@ -21,20 +18,16 @@ import {
   type VertexType,
 } from "@/core";
 
-import type { EdgeId } from "../entities/edge";
-
 import {
   type EdgeStyleData,
   edgeStyleData,
   type VertexStyleData,
 } from "./graphElementStyleData";
+import {
+  createRenderedEdgeId,
+  createRenderedVertexId,
+} from "./renderedEntityIds";
 import { useVertexStyleDataByType } from "./styleDataResolvers";
-
-/** A string representation of a vertex ID that encodes the original type. Cytoscape requires IDs to be strings. */
-export type RenderedVertexId = Branded<string, "RenderedVertexId">;
-
-/** A string representation of an edge ID that encodes the original type. Cytoscape requires IDs to be strings. */
-export type RenderedEdgeId = Branded<string, "RenderedEdgeId">;
 
 /** A representation of a vertex that Cytoscape can use. */
 export type RenderedVertex = ReturnType<typeof createRenderedVertex>;
@@ -150,69 +143,6 @@ export function useRenderedEntities() {
   const vertices = useRenderedVertices();
   const edges = useRenderedEdges();
   return { vertices, edges };
-}
-
-/** Maps a VertexId to a string with the original type prefixed. */
-export function createRenderedVertexId(id: VertexId): RenderedVertexId {
-  return prefixIdWithType(id) as RenderedVertexId;
-}
-
-/** Maps an EdgeId to a string with the original type prefixed. */
-export function createRenderedEdgeId(id: EdgeId): RenderedEdgeId {
-  return prefixIdWithType(id) as RenderedEdgeId;
-}
-
-/** Strips the ID type prefix from the given ID and returns the value as a VertexId. */
-export function getVertexIdFromRenderedVertexId(
-  id: RenderedVertexId,
-): VertexId {
-  if (isIdNumber(id)) {
-    return parseInt(stripIdTypePrefix(id)) as VertexId;
-  }
-  if (isIdString(id)) {
-    return stripIdTypePrefix(id) as VertexId;
-  }
-  return String(id) as VertexId;
-}
-
-/** Strips the ID type prefix from the given ID and returns the value as an EdgeId. */
-export function getEdgeIdFromRenderedEdgeId(id: RenderedEdgeId): EdgeId {
-  if (isIdNumber(id)) {
-    return parseInt(stripIdTypePrefix(id)) as EdgeId;
-  }
-  if (isIdString(id)) {
-    return stripIdTypePrefix(id) as EdgeId;
-  }
-  return String(id) as EdgeId;
-}
-
-const ID_TYPE_NUM_PREFIX = "(num)";
-const ID_TYPE_STR_PREFIX = "(str)";
-
-function prefixIdWithType(id: EntityRawId): string {
-  if (typeof id === "number") {
-    return `${ID_TYPE_NUM_PREFIX}${id}`;
-  }
-
-  return `${ID_TYPE_STR_PREFIX}${id}`;
-}
-
-function isIdNumber(id: string): boolean {
-  return id.startsWith(ID_TYPE_NUM_PREFIX);
-}
-
-function isIdString(id: string): boolean {
-  return id.startsWith(ID_TYPE_STR_PREFIX);
-}
-
-function stripIdTypePrefix(id: string): string {
-  if (isIdNumber(id)) {
-    return id.slice(ID_TYPE_NUM_PREFIX.length);
-  }
-  if (isIdString(id)) {
-    return id.slice(ID_TYPE_STR_PREFIX.length);
-  }
-  return id;
 }
 
 /**

--- a/packages/graph-explorer/src/core/StateProvider/renderedEntityIds.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/renderedEntityIds.test.ts
@@ -1,0 +1,76 @@
+import { createEdgeId, createVertexId } from "@/core/entities";
+
+import {
+  createRenderedEdgeId,
+  createRenderedVertexId,
+  getEdgeIdFromRenderedEdgeId,
+  getVertexIdFromRenderedVertexId,
+  type RenderedEdgeId,
+  type RenderedVertexId,
+} from "./renderedEntityIds";
+
+describe("createRenderedVertexId", () => {
+  it("should create a rendered vertex id out of a string", () => {
+    const id = createRenderedVertexId(createVertexId("123"));
+    expect(id).toBe("(str)123");
+  });
+
+  it("should create a rendered vertex id out of a number", () => {
+    const id = createRenderedVertexId(createVertexId(123));
+    expect(id).toBe("(num)123");
+  });
+});
+
+describe("createRenderedEdgeId", () => {
+  it("should create a rendered edge id out of a string", () => {
+    const id = createRenderedEdgeId(createEdgeId("123"));
+    expect(id).toBe("(str)123");
+  });
+
+  it("should create a rendered edge id out of a number", () => {
+    const id = createRenderedEdgeId(createEdgeId(123));
+    expect(id).toBe("(num)123");
+  });
+});
+
+describe("getVertexIdFromRenderedVertexId", () => {
+  it("should return the raw string id without the prefix", () => {
+    const id = getVertexIdFromRenderedVertexId(
+      createRenderedVertexId(createVertexId("123")),
+    );
+    expect(id).toBe("123");
+  });
+
+  it("should return the raw number id without the prefix", () => {
+    const id = getVertexIdFromRenderedVertexId(
+      createRenderedVertexId(createVertexId(123)),
+    );
+    expect(id).toBe(123);
+  });
+
+  it("should return the id as is if it is not marked as a string or number", () => {
+    const id = getVertexIdFromRenderedVertexId("123" as RenderedVertexId);
+    expect(id).toBe("123");
+  });
+});
+
+describe("getEdgeIdFromRenderedEdgeId", () => {
+  it("should return the raw string id without the prefix", () => {
+    const id = getEdgeIdFromRenderedEdgeId(
+      createRenderedEdgeId(createEdgeId("123")),
+    );
+    expect(id).toBe("123");
+  });
+
+  it("should return the raw number id without the prefix", () => {
+    const id = getEdgeIdFromRenderedEdgeId(
+      createRenderedEdgeId(createEdgeId(123)),
+    );
+    expect(id).toBe(123);
+  });
+
+  it("should return the id as is if it is not marked as a string or number", () => {
+    const id = getEdgeIdFromRenderedEdgeId("123" as RenderedEdgeId);
+    expect(id).toBe("123");
+  });
+});

--- a/packages/graph-explorer/src/core/StateProvider/renderedEntityIds.ts
+++ b/packages/graph-explorer/src/core/StateProvider/renderedEntityIds.ts
@@ -1,0 +1,80 @@
+/**
+ * The string encoding Cytoscape requires for element IDs. The prefix records
+ * whether the original ID was a number or a string so the raw ID can be
+ * round-tripped back out of the rendered ID.
+ */
+
+import type { Branded } from "@/utils";
+
+import type { EdgeId } from "../entities/edge";
+import type { EntityRawId } from "../entities/shared";
+import type { VertexId } from "../entities/vertex";
+
+/** A string representation of a vertex ID that encodes the original type. Cytoscape requires IDs to be strings. */
+export type RenderedVertexId = Branded<string, "RenderedVertexId">;
+
+/** A string representation of an edge ID that encodes the original type. Cytoscape requires IDs to be strings. */
+export type RenderedEdgeId = Branded<string, "RenderedEdgeId">;
+
+/** Maps a VertexId to a string with the original type prefixed. */
+export function createRenderedVertexId(id: VertexId): RenderedVertexId {
+  return prefixIdWithType(id) as RenderedVertexId;
+}
+
+/** Maps an EdgeId to a string with the original type prefixed. */
+export function createRenderedEdgeId(id: EdgeId): RenderedEdgeId {
+  return prefixIdWithType(id) as RenderedEdgeId;
+}
+
+/** Strips the ID type prefix from the given ID and returns the value as a VertexId. */
+export function getVertexIdFromRenderedVertexId(
+  id: RenderedVertexId,
+): VertexId {
+  if (isIdNumber(id)) {
+    return parseInt(stripIdTypePrefix(id)) as VertexId;
+  }
+  if (isIdString(id)) {
+    return stripIdTypePrefix(id) as VertexId;
+  }
+  return String(id) as VertexId;
+}
+
+/** Strips the ID type prefix from the given ID and returns the value as an EdgeId. */
+export function getEdgeIdFromRenderedEdgeId(id: RenderedEdgeId): EdgeId {
+  if (isIdNumber(id)) {
+    return parseInt(stripIdTypePrefix(id)) as EdgeId;
+  }
+  if (isIdString(id)) {
+    return stripIdTypePrefix(id) as EdgeId;
+  }
+  return String(id) as EdgeId;
+}
+
+const ID_TYPE_NUM_PREFIX = "(num)";
+const ID_TYPE_STR_PREFIX = "(str)";
+
+function prefixIdWithType(id: EntityRawId): string {
+  if (typeof id === "number") {
+    return `${ID_TYPE_NUM_PREFIX}${id}`;
+  }
+
+  return `${ID_TYPE_STR_PREFIX}${id}`;
+}
+
+function isIdNumber(id: string): boolean {
+  return id.startsWith(ID_TYPE_NUM_PREFIX);
+}
+
+function isIdString(id: string): boolean {
+  return id.startsWith(ID_TYPE_STR_PREFIX);
+}
+
+function stripIdTypePrefix(id: string): string {
+  if (isIdNumber(id)) {
+    return id.slice(ID_TYPE_NUM_PREFIX.length);
+  }
+  if (isIdString(id)) {
+    return id.slice(ID_TYPE_STR_PREFIX.length);
+  }
+  return id;
+}


### PR DESCRIPTION
## Description

`renderedEntities.ts` had accumulated four unrelated concerns: a pure string ID codec, the canvas visibility atom, the style scope, and the cytoscape render hooks. Only the last is what the module name describes.

The codec has no coupling to the rest — no React, no Jotai, no state — and was exactly the unit the first four test blocks covered, so it moves out whole along with them. 263 lines down to 193. Pure move: no behaviour, signature, or exported name changes, and the barrel keeps every symbol public at the same path.

No deep import paths needed updating; every consumer already imported through `@/core`.

## How to read

`renderedEntityIds.ts` and its test are the moved code. The diff on `renderedEntities.ts` is deletions plus one import.