### PR TITLE
Commit color picker changes on a delay instead of per pointermove

### DIFF
--- a/packages/graph-explorer/src/components/ColorPopover.tsx
+++ b/packages/graph-explorer/src/components/ColorPopover.tsx
@@ -1,6 +1,10 @@
-import type { ComponentPropsWithRef, CSSProperties } from "react";
-
 import { PencilIcon } from "lucide-react";
+import {
+  type ComponentPropsWithRef,
+  type CSSProperties,
+  useEffect,
+  useState,
+} from "react";
 import { HexColorInput, HexColorPicker } from "react-colorful";
 
 import {
@@ -10,6 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components";
+import { useDebounceValue, usePrevious } from "@/hooks";
 import { cn } from "@/utils";
 
 export function ColorPopover({
@@ -30,20 +35,58 @@ export function ColorPopover({
         </Button>
       </PopoverTrigger>
       <PopoverContent side="bottom" align="end" className="flex flex-col gap-4">
-        <HexColorInput
-          alpha
-          color={color}
-          onChange={onColorChange}
-          className={cn(inputStyles())}
-          autoFocus
-        />
-        <HexColorPicker
-          onChange={onColorChange}
-          color={color}
-          className="block size-[200px] w-auto"
-        />
+        <ColorPicker color={color} onColorChange={onColorChange} />
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * Tracks the pointer locally and commits on a delay, following the same pattern
+ * as the display-name field in `modules/Styles/VertexStyleRow.tsx`.
+ *
+ * `react-colorful` fires `onChange` on every pointermove, and each committed
+ * style rebuilds every element's data and re-serializes the whole canvas — one
+ * dropped frame per commit, measured up to ~200ms on a 76 node graph. Local
+ * state keeps the swatch following the pointer at full rate regardless.
+ *
+ * Separate from `ColorPopover` so it mounts with the popover content, which
+ * Radix unmounts on close: the draft is therefore seeded from `color` on every
+ * open and cannot drift across openings.
+ */
+function ColorPicker({
+  color,
+  onColorChange,
+}: {
+  color: string;
+  onColorChange: (color: string) => void;
+}) {
+  const [draft, setDraft] = useState(color);
+  const debouncedDraft = useDebounceValue(draft, 150);
+  const previousDraft = usePrevious(debouncedDraft);
+
+  useEffect(() => {
+    if (previousDraft === null || previousDraft === debouncedDraft) {
+      return;
+    }
+    onColorChange(debouncedDraft);
+  }, [debouncedDraft, previousDraft, onColorChange]);
+
+  return (
+    <>
+      <HexColorInput
+        alpha
+        color={draft}
+        onChange={setDraft}
+        className={cn(inputStyles())}
+        autoFocus
+      />
+      <HexColorPicker
+        onChange={setDraft}
+        color={draft}
+        className="block size-[200px] w-auto"
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Description

`react-colorful` fires `onChange` on every pointermove, and the picker was wired straight to the style atom, so a colour drag committed at pointer rate. Each commit rebuilds every rendered element's data and re-serializes the whole canvas through `cy.json`.

**Measured:** one dropped frame per commit, **167-217ms** on a 76 node graph, reproduced twice. At ~60 commits/sec a drag cannot keep up.

The picker now tracks the pointer in local state and commits on a 150ms delay — the same shape as the display-name field in `modules/Styles/VertexStyleRow.tsx`, which carries the comment "Delayed update of display name to prevent input lag" for exactly this reason. The swatch and picker still follow the pointer at full rate; only the canvas lags.

`ColorPicker` is split out as its own component so it mounts with the popover content, which Radix unmounts on close. The draft is therefore seeded from `color` on every open and cannot drift across openings, with no resync effect (which would have tripped the `react-compiler/set-state-in-effect` rule).

> [!IMPORTANT]
> **The per-commit cost above is measured; the improvement is not.** Driving rapid trusted input at the picker is not reachable from the automation harness — synthetic pointer and key events are ignored by Radix/react-colorful, and real ones arrive far enough apart to clear the 150ms window — so the reduction in commit count is by construction rather than observed. Worth a manual drag to confirm it feels better before this leaves draft.
>
> Related: `9486ac90` removed `useDeferredValue` from the style path. Restoring deferral instead of debouncing was the reviewer's suggestion; debouncing was chosen because it is local, has an existing precedent in this repo, and does not change canvas scheduling for expansion. `useDeferredValue` on the rendered arrays remains an option if a manual drag still feels bad.

## How to read

`ColorPopover.tsx` is the whole change.