### PR TITLE
Update changelog for 3.2.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,36 @@
 # Graph Explorer Change Log
 
+## Release 3.2.2
+
+Release 3.2.2 is about scale. Connecting to a graph with thousands of node and edge types took thousands of requests during schema sync. This release batches them, removes one of the stalls that kept the Schema View from rendering, and fixes a proxy failure that surfaced under the same load.
+
+### Large Schemas
+
+- Schema sync now batches attribute and edge connection discovery instead of issuing one request per label or class. On a graph with roughly 10,000 edge types that is about 100 requests instead of 10,000, with the same results. Gremlin, openCypher, and SPARQL all benefit.
+- A single slow request no longer holds up the rest of the sync.
+- Loading icons for thousands of node types no longer stalls the Schema View. More improvements are coming in future releases.
+
+### Proxy Server
+
+- The proxy now caches IAM credentials instead of resolving them on every request. This fixes intermittent "Could not load credentials from any providers" errors under heavy load, such as a schema sync against an IAM authenticated Neptune cluster.
+
+### Bug Fixes
+
+- A styles file with a blank node color or border color now falls back to the default instead of rendering no background or a black icon.
+
+### All Changes
+
+- Replace fixed-batch barrier with an eager concurrency pool by @kmcginnes in https://github.com/aws/graph-explorer/pull/2096
+- Cache proxy IAM credentials and sign with @smithy/signature-v4 by @kmcginnes in https://github.com/aws/graph-explorer/pull/2082
+- Batch openCypher schema-sync attribute sampling into UNION ALL requests by @kmcginnes in https://github.com/aws/graph-explorer/pull/2099
+- Batch edge-connections discovery across all three connectors by @kmcginnes in https://github.com/aws/graph-explorer/pull/2100
+- Batch SPARQL schema-sync class attribute discovery into UNION requests by @kmcginnes in https://github.com/aws/graph-explorer/pull/2106
+- Resolve vertex icons through an icon registry to fix schema-view lockup by @kmcginnes in https://github.com/aws/graph-explorer/pull/2102
+- Bump version to 3.2.2 by @kmcginnes in https://github.com/aws/graph-explorer/pull/2115
+- Update dependencies to latest versions by @kmcginnes in https://github.com/aws/graph-explorer/pull/2117
+
+**Full Changelog**: https://github.com/aws/graph-explorer/compare/v3.2.1...v3.2.2
+
 ## Release 3.2.1
 
 Release 3.2.1 hardens how Graph Explorer builds queries, making value handling correct and consistent across Gremlin, openCypher, and SPARQL.


### PR DESCRIPTION
## Description

Adds the `Release 3.2.2` section to `Changelog.md`, covering the eight PRs merged since `v3.2.1`. Documentation only, no code changes.

The release is a scale story: schema sync now batches its discovery requests, one cause of the Schema View stall is removed, and a proxy IAM credential failure that surfaced under the same load is fixed.

Structured like the 3.2.1 section: a short summary, themed sections, then `### All Changes` with the full PR list and the compare link.

Two things worth a reviewer's attention:

1. **The Schema View claim is deliberately scoped.** #2102 fixed the TanStack Query fan-out stall. The separate Cytoscape stylesheet stall is not in this release, so the notes say icon loading no longer stalls the view and that more improvements are coming, rather than claiming the view is fixed on large schemas.
2. **The concurrency change is described by outcome only.** #2096 also lowered the in-flight limit from 10 to 4, so the notes say a slow request no longer holds up the sync rather than implying an unconditional speedup.

## Validation

- Documentation only; no code, dependency, or lockfile changes.
- `pnpm check:format` passes.
- PR titles, authors, and numbers in `### All Changes` verified against the merged PRs on `main`.
- Every user-facing claim checked against the merged implementation rather than the PR descriptions alone.

## Related Issues

None.

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.