### PR TITLE
Support per-type label-badge styling for vertices, not just edges

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
+++ b/packages/graph-explorer/src/core/StateProvider/graphStyles.ts
@@ -58,12 +58,23 @@ export const ARROW_STYLES = [
 ] as const;
 export type ArrowStyle = (typeof ARROW_STYLES)[number];
 
+/** The visual appearance of a label badge (shared by edge and vertex labels). */
+export type LabelVisualStyle = {
+  labelColor: string;
+  labelBackgroundOpacity: number;
+  labelBorderColor: string;
+  labelBorderStyle: LineStyle;
+  labelBorderWidth: number;
+};
+
 /**
  * The visual appearance of a vertex — the fields that make sense for both a
  * per-type style and a type-less global default. Every field is required: this
- * is the resolved baseline shape a rendered vertex always has.
+ * is the resolved baseline shape a rendered vertex always has. Includes
+ * {@link LabelVisualStyle} so a vertex type can style its own label badge, the
+ * same way an edge type already can (see {@link EdgeVisualStyle}).
  */
-export type VertexVisualStyle = {
+export type VertexVisualStyle = LabelVisualStyle & {
   /** Color overwrite for vertex */
   color: string;
   /** Icon overwrite for vertex */
@@ -89,15 +100,6 @@ export type VertexTypeStyle = {
   displayNameAttribute: string;
   /** Vertex attribute to be used as description */
   longDisplayNameAttribute: string;
-};
-
-/** The visual appearance of a label badge (shared by edge and vertex labels). */
-export type LabelVisualStyle = {
-  labelColor: string;
-  labelBackgroundOpacity: number;
-  labelBorderColor: string;
-  labelBorderStyle: LineStyle;
-  labelBorderWidth: number;
 };
 
 /** The visual appearance of an edge, shared by per-type styles and defaults. */
@@ -135,7 +137,13 @@ export type EdgeStyle = Simplify<
   Readonly<EdgeVisualStyle & EdgeTypeStyle & { type: EdgeType }>
 >;
 
-/** The default values to use when no user provided value is given. */
+/**
+ * The default values to use when no user provided value is given. Label-badge
+ * fields mirror the node label config in
+ * `components/Graph/styles/defaultNodeStyle.ts` (`text.background` →
+ * `labelColor`, `text.opacity` → `labelBackgroundOpacity`) — keep in sync if
+ * that canvas style changes.
+ */
 export const appDefaultVertexStyle = {
   displayNameAttribute: RESERVED_ID_PROPERTY,
   longDisplayNameAttribute: RESERVED_TYPES_PROPERTY,
@@ -147,23 +155,20 @@ export const appDefaultVertexStyle = {
   borderWidth: 0,
   borderColor: "#128EE5",
   borderStyle: "solid",
-} as const satisfies Omit<VertexStyle, "type">;
-
-/**
- * The default appearance of a node's label badge. Nodes have no per-type label
- * styling (see {@link VertexVisualStyle}), so this is the single source for how
- * a node label looks. Values mirror the node label config in
- * `components/Graph/styles/defaultNodeStyle.ts` (`text.background` →
- * `labelColor`, `text.opacity` → `labelBackgroundOpacity`) — keep in sync if
- * that canvas style changes.
- */
-export const appDefaultNodeLabelStyle = {
   labelColor: "#1d2531",
   labelBackgroundOpacity: 0.7,
   labelBorderColor: "#1d2531",
   labelBorderStyle: "solid",
   labelBorderWidth: 0,
-} as const satisfies LabelVisualStyle;
+} as const satisfies Omit<VertexStyle, "type">;
+
+/**
+ * The default appearance of a node's label badge, for preview/legend UI that
+ * needs just the label fields (e.g. `VertexPreview.tsx`) — derived from
+ * {@link appDefaultVertexStyle}, which is now the single source of truth for
+ * a vertex type's label styling (see {@link VertexVisualStyle}).
+ */
+export const appDefaultNodeLabelStyle: LabelVisualStyle = appDefaultVertexStyle;
 
 /** The default values to use when no user provided value is given. */
 export const appDefaultEdgeStyle = {

--- a/packages/graph-explorer/src/core/styling/stylingParser.ts
+++ b/packages/graph-explorer/src/core/styling/stylingParser.ts
@@ -138,6 +138,11 @@ const vertexEntrySchema = z
     borderWidth: z.number().optional(),
     borderColor: z.string().optional(),
     borderStyle: z.enum(LINE_STYLES).optional(),
+    labelColor: z.string().optional(),
+    labelBackgroundOpacity: z.number().optional(),
+    labelBorderColor: z.string().optional(),
+    labelBorderStyle: z.enum(LINE_STYLES).optional(),
+    labelBorderWidth: z.number().optional(),
   })
   .transform(
     ({ icon, ...rest }): Omit<VertexStyleStorage, "type"> =>

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.test.tsx
@@ -66,6 +66,47 @@ describe("useGraphStyles", () => {
         shape: "ellipse",
         width: 24,
         height: 24,
+        color: "#FFFFFF",
+        "text-background-color": "#1d2531",
+        "text-background-opacity": 0.7,
+        "text-border-color": "#1d2531",
+        "text-border-style": "solid",
+        "text-border-width": 0,
+      });
+    });
+  });
+
+  it("should apply a vertex type's own label-badge style, not just the app default", async () => {
+    const vertexConfig = {
+      ...createRandomVertexTypeConfig(),
+      ...RASTER_ICON,
+      type: createVertexType("Person"),
+      color: "#128EE5",
+      backgroundOpacity: 0.8,
+      borderColor: "#000000",
+      borderWidth: 2,
+      borderStyle: "solid" as const,
+      shape: "ellipse" as const,
+      labelColor: "#f8fafc",
+      labelBackgroundOpacity: 0.94,
+      labelBorderColor: "#cbd5e1",
+      labelBorderWidth: 1,
+      labelBorderStyle: "solid" as const,
+    };
+    dbState.activeSchema.vertices = [vertexConfig];
+    dbState.addVertexStyle(vertexConfig.type, vertexConfig);
+
+    const { result } = renderHookWithState(() => useGraphStyles(), dbState);
+
+    await waitFor(() => {
+      const vertexStyle = getStyles(result)[`node[type="Person"]`] as any;
+      expect(vertexStyle).toMatchObject({
+        color: "#000000", // Black text for a light background
+        "text-background-color": "#f8fafc",
+        "text-background-opacity": 0.94,
+        "text-border-color": "#cbd5e1",
+        "text-border-width": 1,
+        "text-border-style": "solid",
       });
     });
   });

--- a/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
+++ b/packages/graph-explorer/src/modules/GraphViewer/useGraphStyles.ts
@@ -58,6 +58,12 @@ function createGraphStyles(
       shape: vtConfig.shape,
       width: 24,
       height: 24,
+      color: new Color(vtConfig.labelColor).isDark() ? "#FFFFFF" : "#000000",
+      "text-background-opacity": vtConfig.labelBackgroundOpacity,
+      "text-background-color": vtConfig.labelColor,
+      "text-border-width": vtConfig.labelBorderWidth,
+      "text-border-color": vtConfig.labelBorderColor,
+      "text-border-style": vtConfig.labelBorderStyle,
     };
   }
 


### PR DESCRIPTION
## Description

Closes #2135.

Edge types can already style their own label badge per type — `labelColor`, `labelBackgroundOpacity`, `labelBorderColor`, `labelBorderWidth`, and `labelBorderStyle` are all part of `EdgeVisualStyle`, accepted by the styling file's `edgeEntrySchema`, and read by the per-type Cytoscape rule in `useGraphStyles.ts` (`edge[type="..."]`) to set `text-background-color`, `text-background-opacity`, `text-border-*`, etc.

Vertex types have no equivalent. `VertexVisualStyle` carried no label fields, `vertexEntrySchema` silently dropped any `labelColor`/etc a user added to a vertex entry in a styling file, and the per-type node rule (`node[type="..."]`) only ever emitted `background-image/color/opacity`, `border-color/width/opacity/style`, `shape`, `width`, `height` — never any `text-*` property. Node label appearance was therefore stuck on a single hardcoded canvas-wide default (`components/Graph/styles/defaultNodeStyle.ts`), with no way to make one vertex type's label look different from another's, even though the exact same mechanism already worked for edges.

This PR brings vertex label styling up to parity with edges:

- **`core/StateProvider/graphStyles.ts`**: folds the existing `LabelVisualStyle` type into `VertexVisualStyle`, the same way `EdgeVisualStyle` already does (`EdgeVisualStyle = LabelVisualStyle & {...}`). `appDefaultVertexStyle` now carries the label defaults directly (previously split out into a separate, hand-synced `appDefaultNodeLabelStyle` constant used only by preview/legend UI, disconnected from the real canvas default). `appDefaultNodeLabelStyle` is kept as an export — used by `VertexPreview.tsx` and a test — but is now derived from `appDefaultVertexStyle` instead of duplicating its values by hand.
- **`core/styling/stylingParser.ts`**: adds the matching optional fields (`labelColor`, `labelBackgroundOpacity`, `labelBorderColor`, `labelBorderStyle`, `labelBorderWidth`) to `vertexEntrySchema`, matching `edgeEntrySchema` exactly, so a styling file can now set them per vertex type and have them round-trip on export.
- **`modules/GraphViewer/useGraphStyles.ts`**: the per-type node rule now emits the same `text-*` Cytoscape properties the edge rule already does, computing label text color from `labelColor` the same way (`new Color(...).isDark() ? "#FFFFFF" : "#000000"`).

**Not changed:** node shape, background, and border resolution are untouched; this only adds the previously-missing label-badge fields alongside them, following the existing per-type/app-default resolution pattern (`resolveVertexStyle`) already used for everything else on `VertexStyle`.

## Validation

- `pnpm run check:types` — passes
- `pnpm run check:lint` — 0 warnings, 0 errors
- `pnpm run check:format` — passes
- `pnpm run test` — full suite passes (one pre-existing, unrelated failure in `safeSessionStorage.test.ts` reproduces identically on `main` with no changes — a `vi.mocked(logger.warn)` assertion that appears environment-dependent, not something this PR touches)
- New test in `useGraphStyles.test.tsx` (`should apply a vertex type's own label-badge style, not just the app default`) asserts a vertex type's `labelColor`/`labelBackgroundOpacity`/`labelBorderColor`/`labelBorderWidth`/`labelBorderStyle` produce the corresponding `text-*` Cytoscape properties and the correct computed text color, mirroring the existing edge-side test; the existing vertex-style test was updated for the now-present label fields in its expected output.

### Related Issues

- Closes #2135
- 
### Check List

<!--
  ATTENTION
  Please follow this check list to ensure that you've followed all items before opening this PR
  You can check the items by adding an `x` between the brackets, like this: `[x]`
-->

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I have verified `pnpm checks` passes with no errors.
- [X] I have verified `pnpm test` passes with no failures.
- [X] I have covered new added functionality with unit tests if necessary.
- [X] I have updated documentation if necessary.
