### PR TITLE
Update documentation link to GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Understand your data model at a glance. See node types, their relationships, and
 
 ## Documentation
 
-See the [full documentation](./docs) for features, guides, references, and more.
+See the [full documentation](https://aws.github.io/graph-explorer/) for features, guides, references, and more.
 
 ## Community
 


### PR DESCRIPTION
## Description

Update the README documentation link from the local `./docs` folder to the deployed GitHub Pages site at `https://aws.github.io/graph-explorer/`.

## How to read

1. [README.md](https://github.com/aws/graph-explorer/pull/2139/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) — the documentation link change

## Validation

The link now points to the deployed documentation site instead of the local docs folder.

## Related Issues

- Related to #1754

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [ ] I have updated documentation if necessary.