### PR TITLE
Make safeSessionStorage fallback test independent of Node version

### DIFF
--- a/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
@@ -20,14 +20,29 @@ describe("createInMemorySessionStorage", () => {
 });
 
 describe("resolveSessionStorage", () => {
-  // The default test environment is non-DOM, so globalThis.sessionStorage is
-  // undefined and resolveSessionStorage exercises the in-memory fallback.
   test("warns and falls back to in-memory storage when sessionStorage is unavailable", () => {
-    const storage = resolveSessionStorage();
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    );
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: undefined,
+    });
 
-    expect(vi.mocked(logger.warn)).toHaveBeenCalledOnce();
-    storage.setItem("key", "value");
-    expect(storage.getItem("key")).toBe("value");
+    try {
+      const storage = resolveSessionStorage();
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledOnce();
+      storage.setItem("key", "value");
+      expect(storage.getItem("key")).toBe("value");
+    } finally {
+      if (original) {
+        Object.defineProperty(globalThis, "sessionStorage", original);
+      } else {
+        delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+      }
+    }
   });
 
   test("includes the thrown error in the warning when sessionStorage access throws", () => {

--- a/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
+++ b/packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts
@@ -21,28 +21,13 @@ describe("createInMemorySessionStorage", () => {
 
 describe("resolveSessionStorage", () => {
   test("warns and falls back to in-memory storage when sessionStorage is unavailable", () => {
-    const original = Object.getOwnPropertyDescriptor(
-      globalThis,
-      "sessionStorage",
-    );
-    Object.defineProperty(globalThis, "sessionStorage", {
-      configurable: true,
-      value: undefined,
-    });
+    vi.stubGlobal("sessionStorage", undefined);
 
-    try {
-      const storage = resolveSessionStorage();
+    const storage = resolveSessionStorage();
 
-      expect(vi.mocked(logger.warn)).toHaveBeenCalledOnce();
-      storage.setItem("key", "value");
-      expect(storage.getItem("key")).toBe("value");
-    } finally {
-      if (original) {
-        Object.defineProperty(globalThis, "sessionStorage", original);
-      } else {
-        delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
-      }
-    }
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledOnce();
+    storage.setItem("key", "value");
+    expect(storage.getItem("key")).toBe("value");
   });
 
   test("includes the thrown error in the warning when sessionStorage access throws", () => {


### PR DESCRIPTION
## Description

- Make the unavailable-sessionStorage test establish its own precondition instead of relying on the ambient Node.js runtime.
- Restore the original global property descriptor after the assertion so the test remains isolated on runtimes both with and without native sessionStorage.

## How to read

1. [packages/graph-explorer/src/core/StateProvider/safeSessionStorage.test.ts](https://github.com/aws/graph-explorer/pull/2148/files#diff-642d18c0f25b50d4f9f46275c9db4d212df27b079477e29e08b5d95e96c22f18) — the complete test-only change.

## Validation

- `pnpm test safeSessionStorage` — 3 tests passed
- `pnpm test` — 218 files and 2667 tests passed
- `pnpm check:types` — passed
- Lint — passed
- `git diff --check` — passed
- `pnpm checks` — passed

## Related Issues

- Closes #2146

### Check List

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I have verified `pnpm checks` passes with no errors.
- [x] I have verified `pnpm test` passes with no failures.
- [ ] I have covered new added functionality with unit tests if necessary.
- [x] I have updated documentation if necessary.